### PR TITLE
Add task history audit tab

### DIFF
--- a/apps/tasks/src/App.css
+++ b/apps/tasks/src/App.css
@@ -549,6 +549,32 @@ input:focus, select:focus, textarea:focus { border-color: var(--panel-2); outlin
   gap: 10px;
 }
 
+.task-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: fit-content;
+  padding: 3px;
+  border: 2px solid var(--line);
+  background: var(--panel);
+}
+
+.task-tab {
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  padding: 7px 10px;
+  text-transform: uppercase;
+}
+
+.task-tab.active {
+  background: var(--panel-2);
+  color: var(--panel);
+}
+
 .comments-header {
   display: flex;
   justify-content: space-between;
@@ -626,6 +652,50 @@ input:focus, select:focus, textarea:focus { border-color: var(--panel-2); outlin
 
 .comments-empty {
   margin: 0;
+}
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.history-card {
+  display: grid;
+  grid-template-columns: 14px 1fr;
+  gap: 10px;
+  align-items: start;
+}
+
+.history-dot {
+  width: 10px;
+  height: 10px;
+  margin-top: 6px;
+  border: 2px solid var(--line);
+  background: var(--green);
+}
+
+.history-content {
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  background: color-mix(in srgb, var(--text) 95%, var(--panel) 5%);
+  border: 2px solid var(--line);
+  color: var(--panel);
+}
+
+.history-main {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.history-main strong {
+  text-transform: uppercase;
 }
 .draft-status {
   display: inline-flex;

--- a/apps/tasks/src/components/TaskEditor.jsx
+++ b/apps/tasks/src/components/TaskEditor.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { STATUSES, STATUS_LABELS, PRIORITIES, ASSIGNEE_OPTIONS } from '../utils/constants.js';
-import { normalizeComments, formatCommentTimestamp } from '../utils/helpers.js';
+import { normalizeComments, normalizeHistory, formatCommentTimestamp, formatHistoryTimestamp } from '../utils/helpers.js';
 import { MarkdownContent } from './MarkdownContent.jsx';
 
 /**
@@ -29,6 +29,7 @@ export function TaskEditor({ draft, task, isDirty, onDraftChange, onSave, onArch
   const [commentDraft, setCommentDraft] = useState({ author: '', text: '' });
   const [isCommentComposerOpen, setIsCommentComposerOpen] = useState(false);
   const [isDescriptionEditing, setIsDescriptionEditing] = useState(false);
+  const [activeTab, setActiveTab] = useState('comments');
 
   useEffect(() => {
     const textarea = descriptionRef.current;
@@ -72,7 +73,8 @@ export function TaskEditor({ draft, task, isDirty, onDraftChange, onSave, onArch
         .map((tag) => tag.trim())
         .filter(Boolean),
       blocked: draft.blocked,
-      ready: draft.ready
+      ready: draft.ready,
+      actor: 'tasks-ui'
     };
   }
 
@@ -141,6 +143,19 @@ export function TaskEditor({ draft, task, isDirty, onDraftChange, onSave, onArch
     if (timeDiff !== 0) return timeDiff;
     return String(b.id ?? '').localeCompare(String(a.id ?? ''));
   });
+
+  const history = [...normalizeHistory(task.history)].sort((a, b) => {
+    const timeDiff = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    if (timeDiff !== 0) return timeDiff;
+    return String(b.id ?? '').localeCompare(String(a.id ?? ''));
+  });
+
+  function formatHistoryValue(value) {
+    if (value === null || value === undefined || value === '') return 'empty';
+    if (value === 'true') return 'on';
+    if (value === 'false') return 'off';
+    return String(value);
+  }
 
   return (
     <div className="editor" onClick={(e) => e.stopPropagation()}>
@@ -283,73 +298,131 @@ export function TaskEditor({ draft, task, isDirty, onDraftChange, onSave, onArch
         </div>
 
         <div className="comments-section">
-          <div className="comments-header">
-            <h4 className="font-display">Comments</h4>
-            <div className="comments-header-actions">
-              <span className="small comments-count">{comments.length === 0 ? 'No comments yet' : `${comments.length} comment${comments.length === 1 ? '' : 's'}`}</span>
-              <button
-                className={`${isCommentComposerOpen ? 'tertiary-btn' : 'primary-btn font-display'}`}
-                type="button"
-                aria-expanded={isCommentComposerOpen}
-                aria-controls="task-comment-composer"
-                onClick={() => setIsCommentComposerOpen((current) => !current)}
-              >
-                {isCommentComposerOpen ? 'Close' : 'Comment'}
-              </button>
-            </div>
+          <div className="task-tabs" role="tablist" aria-label="Task activity">
+            <button
+              id="task-comments-tab"
+              type="button"
+              className={`task-tab ${activeTab === 'comments' ? 'active' : ''}`}
+              role="tab"
+              aria-selected={activeTab === 'comments'}
+              aria-controls="task-comments-panel"
+              onClick={() => setActiveTab('comments')}
+            >
+              Comments
+            </button>
+            <button
+              id="task-history-tab"
+              type="button"
+              className={`task-tab ${activeTab === 'history' ? 'active' : ''}`}
+              role="tab"
+              aria-selected={activeTab === 'history'}
+              aria-controls="task-history-panel"
+              onClick={() => setActiveTab('history')}
+            >
+              History
+            </button>
           </div>
 
-          {isCommentComposerOpen ? (
-            <div id="task-comment-composer" className="comment-composer">
-              <label>
-                <span className="small">Comment author</span>
-                <input
-                  className="edit-control"
-                  aria-label="Comment author"
-                  value={commentDraft.author}
-                  onChange={(e) => setCommentDraft((current) => ({ ...current, author: e.target.value }))}
-                  onMouseDown={stopPropagation}
-                  onTouchStart={stopPropagation}
-                />
-              </label>
-              <label>
-                <span className="small">Comment</span>
-                <textarea
-                  className="edit-control"
-                  aria-label="Comment text"
-                  value={commentDraft.text}
-                  rows={3}
-                  onChange={(e) => setCommentDraft((current) => ({ ...current, text: e.target.value }))}
-                  onMouseDown={stopPropagation}
-                  onTouchStart={stopPropagation}
-                />
-              </label>
-              <div className="actions">
-                <button
-                  className="primary-btn font-display"
-                  type="button"
-                  onClick={() => void handleAddComment()}
-                  disabled={isSubmittingComment || !commentDraft.author.trim() || !commentDraft.text.trim()}
-                >
-                  {isSubmittingComment ? 'Adding…' : 'Add comment'}
-                </button>
+          {activeTab === 'comments' ? (
+            <div id="task-comments-panel" role="tabpanel" aria-labelledby="task-comments-tab">
+              <div className="comments-header">
+                <h4 className="font-display">Comments</h4>
+                <div className="comments-header-actions">
+                  <span className="small comments-count">{comments.length === 0 ? 'No comments yet' : `${comments.length} comment${comments.length === 1 ? '' : 's'}`}</span>
+                  <button
+                    className={`${isCommentComposerOpen ? 'tertiary-btn' : 'primary-btn font-display'}`}
+                    type="button"
+                    aria-expanded={isCommentComposerOpen}
+                    aria-controls="task-comment-composer"
+                    onClick={() => setIsCommentComposerOpen((current) => !current)}
+                  >
+                    {isCommentComposerOpen ? 'Close' : 'Comment'}
+                  </button>
+                </div>
               </div>
-            </div>
-          ) : null}
 
-          {comments.length > 0 ? (
-            <ol className="comments-list" aria-label="Task comments">
-              {comments.map((comment) => (
-                <li key={comment.id} className="comment-card">
-                  <div className="comment-meta">
-                    <strong>{comment.author}</strong>
-                    <time className="small" dateTime={comment.createdAt}>{formatCommentTimestamp(comment.createdAt)}</time>
+              {isCommentComposerOpen ? (
+                <div id="task-comment-composer" className="comment-composer">
+                  <label>
+                    <span className="small">Comment author</span>
+                    <input
+                      className="edit-control"
+                      aria-label="Comment author"
+                      value={commentDraft.author}
+                      onChange={(e) => setCommentDraft((current) => ({ ...current, author: e.target.value }))}
+                      onMouseDown={stopPropagation}
+                      onTouchStart={stopPropagation}
+                    />
+                  </label>
+                  <label>
+                    <span className="small">Comment</span>
+                    <textarea
+                      className="edit-control"
+                      aria-label="Comment text"
+                      value={commentDraft.text}
+                      rows={3}
+                      onChange={(e) => setCommentDraft((current) => ({ ...current, text: e.target.value }))}
+                      onMouseDown={stopPropagation}
+                      onTouchStart={stopPropagation}
+                    />
+                  </label>
+                  <div className="actions">
+                    <button
+                      className="primary-btn font-display"
+                      type="button"
+                      onClick={() => void handleAddComment()}
+                      disabled={isSubmittingComment || !commentDraft.author.trim() || !commentDraft.text.trim()}
+                    >
+                      {isSubmittingComment ? 'Adding…' : 'Add comment'}
+                    </button>
                   </div>
-                  <MarkdownContent markdown={comment.text} className="comment-body" />
-                </li>
-              ))}
-            </ol>
-          ) : null}
+                </div>
+              ) : null}
+
+              {comments.length > 0 ? (
+                <ol className="comments-list" aria-label="Task comments">
+                  {comments.map((comment) => (
+                    <li key={comment.id} className="comment-card">
+                      <div className="comment-meta">
+                        <strong>{comment.author}</strong>
+                        <time className="small" dateTime={comment.createdAt}>{formatCommentTimestamp(comment.createdAt)}</time>
+                      </div>
+                      <MarkdownContent markdown={comment.text} className="comment-body" />
+                    </li>
+                  ))}
+                </ol>
+              ) : null}
+            </div>
+          ) : (
+            <div id="task-history-panel" role="tabpanel" aria-labelledby="task-history-tab">
+              <div className="comments-header">
+                <h4 className="font-display">History</h4>
+                <span className="small comments-count">{history.length === 0 ? 'No history yet' : `${history.length} change${history.length === 1 ? '' : 's'}`}</span>
+              </div>
+
+              {history.length > 0 ? (
+                <ol className="history-list" aria-label="Task history">
+                  {history.map((entry) => (
+                    <li key={entry.id} className="history-card">
+                      <div className="history-dot" aria-hidden="true" />
+                      <div className="history-content">
+                        <div className="history-main">
+                          <strong>{entry.field}</strong>
+                          <span>{formatHistoryValue(entry.oldValue)} -&gt; {formatHistoryValue(entry.newValue)}</span>
+                        </div>
+                        <div className="comment-meta">
+                          <strong>{entry.actor}</strong>
+                          <time className="small" dateTime={entry.createdAt}>{formatHistoryTimestamp(entry.createdAt)}</time>
+                        </div>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              ) : (
+                <p className="comments-empty">State changes will appear here after status, blocked, or ready changes.</p>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/apps/tasks/src/components/TaskEditor.test.jsx
+++ b/apps/tasks/src/components/TaskEditor.test.jsx
@@ -156,7 +156,8 @@ describe('TaskEditor', () => {
 
   it('shows comments section', () => {
     render(<TaskEditor {...defaultProps} />);
-    expect(screen.getByText('Comments')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'History' })).toBeInTheDocument();
   });
 
   it('shows no comments message when empty', () => {
@@ -179,6 +180,56 @@ describe('TaskEditor', () => {
 
     expect(screen.getByText('John')).toBeInTheDocument();
     expect(screen.getByText('Great work!')).toBeInTheDocument();
+  });
+
+  it('shows empty history state when no history exists', () => {
+    render(<TaskEditor {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'History' }));
+
+    expect(screen.getByRole('heading', { name: 'History' })).toBeInTheDocument();
+    expect(screen.getByText('No history yet')).toBeInTheDocument();
+    expect(screen.getByText('State changes will appear here after status, blocked, or ready changes.')).toBeInTheDocument();
+  });
+
+  it('displays history entries newest first', () => {
+    const propsWithHistory = {
+      ...defaultProps,
+      task: {
+        id: 1,
+        title: 'Test Task',
+        comments: [],
+        history: [
+          {
+            id: 'old',
+            field: 'ready',
+            oldValue: 'false',
+            newValue: 'true',
+            actor: 'tasks-api',
+            createdAt: '2024-01-15T10:00:00Z'
+          },
+          {
+            id: 'new',
+            field: 'status',
+            oldValue: 'ready',
+            newValue: 'doing',
+            actor: 'Rowan',
+            createdAt: '2024-01-15T11:00:00Z'
+          }
+        ]
+      }
+    };
+    render(<TaskEditor {...propsWithHistory} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'History' }));
+
+    const historyItems = screen.getAllByRole('listitem');
+    expect(historyItems[0]).toHaveTextContent('status');
+    expect(historyItems[0]).toHaveTextContent('ready -> doing');
+    expect(historyItems[0]).toHaveTextContent('Rowan');
+    expect(historyItems[1]).toHaveTextContent('ready');
+    expect(historyItems[1]).toHaveTextContent('off -> on');
+    expect(historyItems[1]).toHaveTextContent('tasks-api');
   });
 
   it('renders markdown in comments', () => {

--- a/apps/tasks/src/styles/editor.css
+++ b/apps/tasks/src/styles/editor.css
@@ -48,6 +48,32 @@
   border-top: 2px dashed var(--muted);
 }
 
+.task-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: fit-content;
+  padding: 3px;
+  border: 2px solid var(--line);
+  background: var(--panel);
+}
+
+.task-tab {
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  padding: 7px 10px;
+  text-transform: uppercase;
+}
+
+.task-tab.active {
+  background: var(--panel-2);
+  color: var(--panel);
+}
+
 .comments-header {
   display: flex;
   justify-content: space-between;
@@ -116,6 +142,50 @@
   margin: 0;
   font-size: 0.95rem;
   line-height: 1.4;
+}
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.history-card {
+  display: grid;
+  grid-template-columns: 14px 1fr;
+  gap: 10px;
+  align-items: start;
+}
+
+.history-dot {
+  width: 10px;
+  height: 10px;
+  margin-top: 6px;
+  border: 2px solid var(--line);
+  background: var(--green);
+}
+
+.history-content {
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  background: color-mix(in srgb, var(--text) 95%, var(--panel) 5%);
+  border: 2px solid var(--line);
+  color: var(--panel);
+}
+
+.history-main {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.history-main strong {
+  text-transform: uppercase;
 }
 
 /* Description field with view/edit toggle */

--- a/apps/tasks/src/tasksApi.ts
+++ b/apps/tasks/src/tasksApi.ts
@@ -16,6 +16,15 @@ export interface Comment {
   createdAt?: string;
 }
 
+export interface TaskHistoryEntry {
+  id?: string | number;
+  field: string;
+  oldValue?: string | null;
+  newValue?: string | null;
+  actor: string;
+  createdAt?: string;
+}
+
 export interface Task {
   id: string | number;
   title: string;
@@ -30,6 +39,7 @@ export interface Task {
   createdAt?: string | null;
   statusChangedAt?: string | null;
   comments?: Comment[];
+  history?: TaskHistoryEntry[];
 }
 
 export interface CreateTaskPayload {
@@ -52,6 +62,8 @@ export interface UpdateTaskPayload {
   dueAt?: string | null;
   tags?: string[];
   blocked?: boolean;
+  ready?: boolean;
+  actor?: string;
   // Note: 'ready' field removed — use status field instead
 }
 

--- a/apps/tasks/src/utils/helpers.js
+++ b/apps/tasks/src/utils/helpers.js
@@ -28,6 +28,15 @@ export function normalizeComments(comments) {
 }
 
 /**
+ * Normalize history to array format
+ * @param {unknown} history
+ * @returns {Array<{id?: string|number, field: string, oldValue?: string|null, newValue?: string|null, actor: string, createdAt?: string}>}
+ */
+export function normalizeHistory(history) {
+  return Array.isArray(history) ? history : [];
+}
+
+/**
  * Format comment timestamp for display
  * @param {string|number|Date|null|undefined} value
  * @returns {string}
@@ -38,6 +47,8 @@ export function formatCommentTimestamp(value) {
   if (Number.isNaN(date.getTime())) return '';
   return date.toLocaleString();
 }
+
+export const formatHistoryTimestamp = formatCommentTimestamp;
 
 /**
  * Normalize task data for the editor form

--- a/services/tasks-api/prisma/migrations/20260528060000_add_content_ops_fields/migration.sql
+++ b/services/tasks-api/prisma/migrations/20260528060000_add_content_ops_fields/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable: add content ops metadata fields to Task
+ALTER TABLE "Task" ADD COLUMN "sourceReview" TEXT;
+ALTER TABLE "Task" ADD COLUMN "targetRepo" TEXT;
+ALTER TABLE "Task" ADD COLUMN "publicRisk" TEXT;
+ALTER TABLE "Task" ADD COLUMN "channel" TEXT;
+ALTER TABLE "Task" ADD COLUMN "tomApprovalPr" TEXT;
+ALTER TABLE "Task" ADD COLUMN "quinnApprovalPr" TEXT;
+ALTER TABLE "Task" ADD COLUMN "approvalOwners" TEXT;

--- a/services/tasks-api/prisma/migrations/20260528082000_add_task_history/migration.sql
+++ b/services/tasks-api/prisma/migrations/20260528082000_add_task_history/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "TaskHistory" (
+    "id" UUID NOT NULL,
+    "taskId" UUID NOT NULL,
+    "field" TEXT NOT NULL,
+    "oldValue" TEXT,
+    "newValue" TEXT,
+    "actor" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TaskHistory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TaskHistory_taskId_createdAt_idx" ON "TaskHistory"("taskId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "TaskHistory" ADD CONSTRAINT "TaskHistory_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/services/tasks-api/prisma/schema.prisma
+++ b/services/tasks-api/prisma/schema.prisma
@@ -49,10 +49,25 @@ model Task {
 
   tags            TaskTag[]
   comments        TaskComment[]
+  history         TaskHistory[]
 
   @@index([archivedAt, priority])
   @@index([status, statusChangedAt])
   @@index([dueAt])
+}
+
+model TaskHistory {
+  id        String   @id @default(uuid()) @db.Uuid
+  taskId    String   @db.Uuid
+  field     String
+  oldValue  String?
+  newValue  String?
+  actor     String
+  createdAt DateTime @default(now())
+
+  task      Task     @relation(fields: [taskId], references: [id], onDelete: Cascade)
+
+  @@index([taskId, createdAt])
 }
 
 model TaskComment {

--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -61,6 +61,17 @@ function mapComment(comment) {
   };
 }
 
+function mapHistoryEntry(entry) {
+  return {
+    id: entry.id,
+    field: entry.field,
+    oldValue: entry.oldValue,
+    newValue: entry.newValue,
+    actor: entry.actor,
+    createdAt: entry.createdAt
+  };
+}
+
 function mapTask(task) {
   return {
     id: task.id,
@@ -86,7 +97,8 @@ function mapTask(task) {
     quinnApprovalPr: task.quinnApprovalPr ?? null,
     approvalOwners: task.approvalOwners ?? null,
     tags: task.tags?.map((taskTag) => taskTag.tag?.name).filter(Boolean) ?? [],
-    comments: task.comments?.map(mapComment) ?? []
+    comments: task.comments?.map(mapComment) ?? [],
+    history: task.history?.map(mapHistoryEntry) ?? []
   };
 }
 
@@ -120,6 +132,29 @@ async function connectTags(tagNames) {
       })
     )
   );
+}
+
+function normalizeHistoryValue(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  return String(value);
+}
+
+function buildHistoryEntry(taskId, field, oldValue, newValue, actor) {
+  return {
+    taskId,
+    field,
+    oldValue: normalizeHistoryValue(oldValue),
+    newValue: normalizeHistoryValue(newValue),
+    actor
+  };
+}
+
+function actorFromRequest(req) {
+  return normalizeString(req.body?.actor)
+    || normalizeString(req.get('x-task-actor'))
+    || normalizeString(req.get('x-actor'))
+    || 'tasks-api';
 }
 
 export const tasksRouter = Router();
@@ -311,6 +346,9 @@ tasksRouter.get('/tasks/:id', async (req, res, next) => {
         },
         comments: {
           orderBy: [{ createdAt: 'asc' }, { id: 'asc' }]
+        },
+        history: {
+          orderBy: [{ createdAt: 'desc' }, { id: 'desc' }]
         }
       }
     });
@@ -402,6 +440,8 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
     if (!existing) return notFound(res, 'TASK_NOT_FOUND', 'Task not found');
 
     const updates = {};
+    const historyEntries = [];
+    const actor = actorFromRequest(req);
     const title = normalizeString(req.body?.title);
     const description = req.body?.description === undefined ? undefined : normalizeString(req.body.description);
     const assignee = req.body?.assignee === undefined ? undefined : normalizeString(req.body.assignee);
@@ -433,6 +473,9 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
       updates.status = req.body.status;
       updates.statusChangedAt = new Date();
       updates.completedAt = req.body.status === 'done' ? new Date() : null;
+      if (existing.status !== req.body.status) {
+        historyEntries.push(buildHistoryEntry(id, 'status', existing.status, req.body.status, actor));
+      }
     }
 
     if (req.body?.dueAt !== undefined) {
@@ -447,10 +490,16 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
 
     if (req.body?.blocked !== undefined) {
       updates.blocked = Boolean(req.body.blocked);
+      if (Boolean(existing.blocked) !== updates.blocked) {
+        historyEntries.push(buildHistoryEntry(id, 'blocked', existing.blocked, updates.blocked, actor));
+      }
     }
 
     if (req.body?.ready !== undefined) {
       updates.ready = Boolean(req.body.ready);
+      if (Boolean(existing.ready) !== updates.ready) {
+        historyEntries.push(buildHistoryEntry(id, 'ready', existing.ready, updates.ready, actor));
+      }
     }
 
     // Content ops fields
@@ -492,6 +541,10 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
       }
     });
 
+    if (historyEntries.length > 0) {
+      await prisma.taskHistory.createMany({ data: historyEntries });
+    }
+
     if (req.body?.tags !== undefined) {
       const tags = normalizeTags(req.body.tags);
       if (!tags) return badRequest(res, 'INVALID_TAGS', 'tags must be an array of strings');
@@ -507,10 +560,30 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
 
     const task = await prisma.task.findFirst({
       where: { id },
-      include: { tags: { include: { tag: true } } }
+      include: {
+        tags: { include: { tag: true } },
+        history: { orderBy: [{ createdAt: 'desc' }, { id: 'desc' }] }
+      }
     });
 
     return res.status(200).json({ data: mapTask(task ?? updated) });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+tasksRouter.get('/tasks/:id/history', async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const existing = await prisma.task.findFirst({ where: { id, archivedAt: null } });
+    if (!existing) return notFound(res, 'TASK_NOT_FOUND', 'Task not found');
+
+    const history = await prisma.taskHistory.findMany({
+      where: { taskId: id },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }]
+    });
+
+    return res.status(200).json({ data: history.map(mapHistoryEntry) });
   } catch (error) {
     return next(error);
   }

--- a/services/tasks-api/test/read-endpoints.test.ts
+++ b/services/tasks-api/test/read-endpoints.test.ts
@@ -11,6 +11,10 @@ const prismaMock = {
   taskComment: {
     create: vi.fn()
   },
+  taskHistory: {
+    createMany: vi.fn(),
+    findMany: vi.fn()
+  },
   taskTag: {
     deleteMany: vi.fn(),
     createMany: vi.fn()
@@ -123,6 +127,16 @@ describe('tasks api endpoints', () => {
             createdAt: new Date('2026-03-12T00:00:00.000Z'),
             updatedAt: new Date('2026-03-12T00:00:00.000Z')
           }
+        ],
+        history: [
+          {
+            id: 'history-1',
+            field: 'status',
+            oldValue: 'ready',
+            newValue: 'doing',
+            actor: 'Rowan',
+            createdAt: new Date('2026-03-13T00:00:00.000Z')
+          }
         ]
       })
     );
@@ -146,11 +160,24 @@ describe('tasks api endpoints', () => {
         author: 'Tom',
         text: 'Second note',
         createdAt: '2026-03-12T00:00:00.000Z',
-        updatedAt: '2026-03-12T00:00:00.000Z'
+          updatedAt: '2026-03-12T00:00:00.000Z'
+        }
+      ]);
+    expect(response.body.data.history).toEqual([
+      {
+        id: 'history-1',
+        field: 'status',
+        oldValue: 'ready',
+        newValue: 'doing',
+        actor: 'Rowan',
+        createdAt: '2026-03-13T00:00:00.000Z'
       }
     ]);
     expect(prismaMock.task.findFirst.mock.calls.at(-1)?.[0]?.include?.comments).toEqual({
       orderBy: [{ createdAt: 'asc' }, { id: 'asc' }]
+    });
+    expect(prismaMock.task.findFirst.mock.calls.at(-1)?.[0]?.include?.history).toEqual({
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }]
     });
   });
 
@@ -235,21 +262,97 @@ describe('tasks api endpoints', () => {
     expect(prismaMock.task.create).toHaveBeenCalledTimes(1);
   });
 
-  it('PATCH /api/v1/tasks/:id updates task fields', async () => {
+  it('PATCH /api/v1/tasks/:id updates task fields and records state history', async () => {
     prismaMock.task.findFirst
-      .mockResolvedValueOnce(task())
-      .mockResolvedValueOnce(task({ title: 'Updated title', status: 'doing' }));
+      .mockResolvedValueOnce(task({ status: 'ready', blocked: false, ready: true }))
+      .mockResolvedValueOnce(task({ title: 'Updated title', status: 'doing', blocked: true, ready: false, history: [] }));
     prismaMock.task.update.mockResolvedValue(task({ title: 'Updated title', status: 'doing' }));
+    prismaMock.taskHistory.createMany.mockResolvedValue({ count: 3 });
 
     const app = createApp();
     const response = await request(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
-      .send({ title: 'Updated title', status: 'doing' });
+      .set('x-task-actor', 'Rowan')
+      .send({ title: 'Updated title', status: 'doing', blocked: true, ready: false });
 
     expect(response.status).toBe(200);
     expect(response.body.data.title).toBe('Updated title');
     expect(response.body.data.status).toBe('doing');
     expect(prismaMock.task.update).toHaveBeenCalledTimes(1);
+    expect(prismaMock.taskHistory.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          taskId: '11111111-1111-1111-1111-111111111111',
+          field: 'status',
+          oldValue: 'ready',
+          newValue: 'doing',
+          actor: 'Rowan'
+        },
+        {
+          taskId: '11111111-1111-1111-1111-111111111111',
+          field: 'blocked',
+          oldValue: 'false',
+          newValue: 'true',
+          actor: 'Rowan'
+        },
+        {
+          taskId: '11111111-1111-1111-1111-111111111111',
+          field: 'ready',
+          oldValue: 'true',
+          newValue: 'false',
+          actor: 'Rowan'
+        }
+      ]
+    });
+  });
+
+  it('PATCH /api/v1/tasks/:id skips history when watched values do not change', async () => {
+    prismaMock.task.findFirst
+      .mockResolvedValueOnce(task({ status: 'ready', blocked: false, ready: true }))
+      .mockResolvedValueOnce(task({ status: 'ready', blocked: false, ready: true, history: [] }));
+    prismaMock.task.update.mockResolvedValue(task({ status: 'ready', blocked: false, ready: true }));
+
+    const app = createApp();
+    const response = await request(app)
+      .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
+      .send({ status: 'ready', blocked: false, ready: true });
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.taskHistory.createMany).not.toHaveBeenCalled();
+  });
+
+  it('GET /api/v1/tasks/:id/history returns newest-first history', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce(task());
+    prismaMock.taskHistory.findMany.mockResolvedValue([
+      {
+        id: 'history-2',
+        taskId: '11111111-1111-1111-1111-111111111111',
+        field: 'blocked',
+        oldValue: 'false',
+        newValue: 'true',
+        actor: 'tasks-api',
+        createdAt: new Date('2026-03-14T00:00:00.000Z')
+      }
+    ]);
+
+    const app = createApp();
+    const response = await request(app).get('/api/v1/tasks/11111111-1111-1111-1111-111111111111/history');
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toEqual([
+      {
+        id: 'history-2',
+        field: 'blocked',
+        oldValue: 'false',
+        newValue: 'true',
+        actor: 'tasks-api',
+        createdAt: '2026-03-14T00:00:00.000Z'
+      }
+    ]);
+    expect(prismaMock.taskHistory.findMany).toHaveBeenCalledWith({
+      where: { taskId: '11111111-1111-1111-1111-111111111111' },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }]
+    });
   });
 
   it('DELETE /api/v1/tasks/:id archives task', async () => {


### PR DESCRIPTION
## Summary
- add a TaskHistory Prisma model and migration for status/blocked/ready audit entries
- record changed watched fields during task PATCH with actor metadata
- add a read-only History tab beside Comments in the task editor

## Validation
- npm test (services/tasks-api)
- npm test (apps/tasks)
- npm run build (apps/tasks)
- DATABASE_URL=postgresql://postgres:postgres@localhost:7432/tasks npm run prisma:validate (services/tasks-api)