### PR TITLE
fix(pr_transition): auto-inject Ivy PR URLs into task description heading blocks

### DIFF
--- a/agents/skills/content-authoring/SKILL.md
+++ b/agents/skills/content-authoring/SKILL.md
@@ -1,0 +1,152 @@
+# content-authoring skill
+
+## Purpose
+
+Produce publication-ready SIndustries website content from raw notes and source material.
+
+Used by Ivy. Can also be invoked directly by Quinn for one-off content tasks.
+
+---
+
+## Inputs
+
+Provide all of these before starting. If any are missing, ask before proceeding.
+
+| Input | Description | Required |
+|---|---|---|
+| `raw_notes` | Source material — task notes, weekly review item, release description, internal doc | yes |
+| `target_type` | One of: `experiment`, `system`, `release`, `story`, `stack` | yes |
+| `audience` | Who will read this. Default: "technically literate, curious builders" | no |
+| `evidence_links` | URLs or internal paths that back up claims | no |
+| `desired_tone` | E.g. "matter-of-fact", "founder note", "punchy one-liner" | no |
+| `approval_risk_level` | `low`, `medium`, or `high` (see below) | yes |
+
+### Approval risk levels (Approver)
+
+- **low (Quinn approves)** — factual metadata, stack list update, experiment status change backed by task evidence, `currentLearning` additions with evidence
+- **medium (Tom approves)** — release entry, system summary, story that references internal work without claiming external validation
+- **high (Tom approves)** — first-person Tom voice, public strategic claim, revenue/customer/employer reference
+
+---
+
+## Outputs
+
+Produce all of these, labelled clearly:
+
+### 1. Card copy
+Short text for homepage/listing card. Max 2 sentences. Specific and concrete — no filler.
+
+### 2. Long-form draft
+Full detail page body. Use headings where useful. Length matched to content type:
+- experiment: 150–400 words
+- system: 200–500 words
+- release: 100–250 words
+- story: 400–1200 words
+- stack: 50–150 words
+
+### 3. Meta description
+1–2 sentences for SEO/sharing. Under 160 characters. No clickbait.
+
+### 4. Suggested title and dek
+- **Title:** Short. States what it is.
+- **Dek:** One sentence. States why it matters or what's interesting.
+
+### 5. Claim-risk notes
+Flag each claim that needs evidence or approval. Format:
+
+```
+CLAIM: [exact text]
+RISK: low | medium | high
+REASON: [why it's risky or needs backing]
+ACTION: [delete / add evidence link / needs Tom approval]
+```
+
+### 6. Review questions for Tom
+Only include questions Tom genuinely needs to answer. Do not pad this section.
+Examples:
+- "Do you want to use first-person voice for this story, or keep it third-person?"
+- "The current learning section references the NZ banking app — is that ready to mention publicly?"
+- "Approval risk on the revenue line: should I remove it or do you want it in?"
+
+---
+
+## Copy principles
+
+These are non-negotiable:
+
+1. **Specific beats clever.** "Reduced deploy time from 45 min to 8 min" beats "dramatically faster deploys".
+2. **Proof beats promise.** Link evidence. If there's no evidence, say so rather than imply it.
+3. **No fake certainty.** Don't write "proven" or "best-in-class" without data.
+4. **No first-person Tom copy without explicit approval.** Write in third person by default.
+5. **No startup theater.** No "disrupting", "revolutionising", "game-changing".
+6. **No private context.** Don't mention inMusic, family, salary, or anything that isn't already public.
+
+---
+
+## Content type field mappings
+
+Content files live in the sindustries repo at:
+```
+/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/apps/website/src/content/
+```
+
+Each output maps to a JSON file in that directory:
+
+| Type | File | Required fields |
+|---|---|---|
+| experiment | `experiments.json` | title, slug, status, summary, why, successCriteria, updatedAt, visibility |
+| system | `systems.json` | title, slug, status, summary, problem, howItWorks, updatedAt, visibility |
+| release | `releases.json` | title, slug, releasedAt, summary, type, visibility |
+| story | `stories/[slug].json` | title, slug, dek, body, source, visibility |
+| stack | `stacks.json` | title, slug, category, summary, updatedAt, visibility |
+
+All new content starts with `visibility: "draft"` unless Tom explicitly sets it to `"published"`.
+
+---
+
+## Approval routing
+
+After producing the outputs, route content to the correct PR:
+
+Both PRs target the **sindustries repo** (`Stoffer-Industries/sindustries`), branching from `main`.
+Branch names: `content/YYYY-MM-DD-tom` and `content/YYYY-MM-DD-quinn`.
+
+**Tom-approval PR** — contains items with `approval_risk_level: medium` or `high`, or any first-person copy.
+**Quinn-approval PR** — contains items with `approval_risk_level: low` only.
+
+If a single content item has both low and high risk elements, split it: put the high-risk lines in the Tom PR and the safe version (with those lines removed or redacted) in the Quinn PR.
+
+---
+
+## Worked example
+
+**Input:**
+```
+raw_notes: "Shipped content-ops Phase 1 last week — extracted all content from hardcoded JSX into JSON files. Took about 3 days of Rowan work. 4 content types now live."
+target_type: release
+approval_risk_level: low
+```
+
+**Card copy:**
+> Content files extracted from JSX. Experiments, systems, releases, and stacks now live in JSON — editable without touching app code.
+
+**Long-form draft:**
+> Phase 1 of the SIndustries content ops build extracted all website content from hardcoded JSX into structured JSON files. Experiments, systems, releases, and stacks now have their own content files under `apps/website/src/content/`, editable independently of the app.
+>
+> This is the foundation for the content update loop — weekly reviews, Ivy-authored PRs, and eventual CMS tooling all depend on content being separable from code.
+
+**Meta description:**
+> SIndustries website content extracted to JSON. Updates no longer require code changes.
+
+**Title:** Content files extracted from JSX
+**Dek:** The first step in the SIndustries content ops loop — content is now code-independent.
+
+**Claim-risk notes:**
+```
+CLAIM: "editable without touching app code"
+RISK: low
+REASON: factual — JSON files are in src/content, not JSX
+ACTION: none
+```
+
+**Review questions for Tom:** (none for this item)

--- a/agents/workflows/content-task/pr_transition.py
+++ b/agents/workflows/content-task/pr_transition.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+from common import (
+    PR_HEADING_RE,
+    dump_json,
+    extract_ivy_pr_urls,
+    extract_pr_urls_from_text,
+    gh_pr_body,
+    gh_pr_ci_checks,
+    gh_pr_ci_state,
+    is_at,
+    is_past,
+    move_task,
+    patch_task,
+    pr_heading_block_url_failures,
+    read_first_json_value,
+    refresh_task,
+    status,
+    task_acceptance_criteria,
+    transition_result,
+    write_lobster_state,
+)
+
+
+def normalize_ac_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value or "").strip().lower()
+
+
+def checked_pr_acceptance_criteria(pr_body: str) -> set[str]:
+    checked: set[str] = set()
+    for match in re.finditer(r"^\s*-\s*\[[xX]\]\s+(.+\S)\s*$", pr_body or "", re.M):
+        checked.add(normalize_ac_text(match.group(1)))
+    return checked
+
+
+def pr_heading_urls(task: dict) -> list[str]:
+    return extract_pr_urls_from_text(task.get("description") or "")
+
+
+def inject_pr_urls_into_description(description: str, pr_urls: list[str]) -> str:
+    """Append any missing PR URLs to the first PR heading block that lacks a URL."""
+    if not pr_urls or not description:
+        return description
+    result = description
+    for url in pr_urls:
+        if url in result:
+            continue
+        # Find the first PR heading block that has no GitHub URL yet
+        matches = list(PR_HEADING_RE.finditer(result))
+        injected = False
+        for idx, match in enumerate(matches):
+            start = match.end()
+            end = matches[idx + 1].start() if idx + 1 < len(matches) else len(result)
+            block = result[start:end]
+            if not extract_pr_urls_from_text(match.group(0) + "\n" + block):
+                # Insert URL on the line immediately after the heading
+                result = result[:start] + f"\n{url}" + result[start:]
+                injected = True
+                break
+        if not injected:
+            # No suitable heading found — append to end
+            result = result.rstrip() + f"\n\n{url}\n"
+    return result
+
+
+def ci_failures_for_pr(url: str) -> tuple[list[str], list[dict[str, str]]]:
+    ci_state = gh_pr_ci_state(url)
+    checks = gh_pr_ci_checks(url)
+    if ci_state == "SUCCESS":
+        return [], checks
+    if not checks:
+        return [f"{url} has no CI status checks or CI status is unknown."], checks
+    failures = []
+    for check in checks:
+        state = check.get("state") or "UNKNOWN"
+        if state != "SUCCESS":
+            failures.append(f"{url} CI check `{check.get('name') or 'unnamed check'}` is {state}.")
+    if not failures:
+        failures.append(f"{url} CI status is {ci_state}.")
+    return failures, checks
+
+
+def ac_failures_for_pr(url: str, task_acs: list[str]) -> tuple[list[str], dict]:
+    body = gh_pr_body(url)
+    checked = checked_pr_acceptance_criteria(body)
+    missing = [ac for ac in task_acs if normalize_ac_text(ac) not in checked]
+    details = {"url": url, "checkedAcceptanceCriteria": sorted(checked), "missingAcceptanceCriteria": missing}
+    return [f"{url} PR description has unchecked/missing AC: {ac}" for ac in missing], details
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Doing -> Acceptance transition for Ivy PR detection")
+    parser.add_argument("--base-url", default="")
+    parser.add_argument("--dry-run", default="false")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    if args.base_url:
+        os.environ["TASKS_API_BASE_URL"] = args.base_url
+
+    data = read_first_json_value(sys.stdin)
+    task = data["task"]
+    state = dict(data.get("lobster_state") or {})
+    description = task.get("description") or ""
+
+    detected = extract_ivy_pr_urls(task)
+    existing = [url for url in state.get("prUrls") or [] if isinstance(url, str)]
+    pr_urls = existing[:]
+    for url in detected:
+        if url not in pr_urls:
+            pr_urls.append(url)
+    state["prUrls"] = pr_urls
+
+    # Inject Ivy's PR URLs into the task description heading blocks if missing
+    updated_description = inject_pr_urls_into_description(description, pr_urls)
+    if updated_description != description and str(args.dry_run).lower() != "true":
+        patch_task(str(task["id"]), {"description": updated_description})
+        task = refresh_task(str(task["id"]))
+        description = updated_description
+
+    failures: list[str] = []
+    pr_heading_failures = pr_heading_block_url_failures(description)
+    if pr_heading_failures:
+        failures.extend(pr_heading_failures)
+
+    heading_urls = pr_heading_urls(task)
+    for url in pr_urls:
+        if url not in heading_urls:
+            failures.append(f"{url} is recorded in Lobster state but missing from the task description PR heading blocks.")
+
+    if not pr_urls:
+        failures.append("No `[ivy-prs]` task comment with a GitHub PR URL has been detected.")
+
+    task_acs = task_acceptance_criteria(description)
+    pr_ci: list[dict] = []
+    pr_ac_details: list[dict] = []
+    if not task_acs:
+        failures.append("Task body has no acceptance criteria checkboxes to verify against PR descriptions.")
+
+    for url in pr_urls:
+        try:
+            ci_failures, checks = ci_failures_for_pr(url)
+            pr_ci.append({"url": url, "checks": checks})
+            failures.extend(ci_failures)
+        except Exception as exc:
+            failures.append(f"Could not inspect CI for {url}: {exc}")
+            pr_ci.append({"url": url, "error": str(exc)})
+        if task_acs:
+            try:
+                ac_failures, ac_details = ac_failures_for_pr(url, task_acs)
+                pr_ac_details.append(ac_details)
+                failures.extend(ac_failures)
+            except Exception as exc:
+                failures.append(f"Could not inspect PR description for {url}: {exc}")
+                pr_ac_details.append({"url": url, "error": str(exc)})
+
+    criteria_met = not failures
+    already_past = is_past(task, "doing")
+    action = "none"
+
+    if pr_urls != existing:
+        if str(args.dry_run).lower() != "true":
+            write_lobster_state(str(task["id"]), state, note="Detected Ivy PR URL(s): " + ", ".join(pr_urls))
+            task = refresh_task(str(task["id"]))
+        action = "recorded_pr_urls"
+
+    if criteria_met and is_at(task, "doing"):
+        if str(args.dry_run).lower() == "true":
+            action = "dry_run_move_doing_to_acceptance"
+        else:
+            task = move_task(task, "acceptance", "Ivy PR URL criteria are met.", state)
+            action = "moved_doing_to_acceptance"
+    elif not criteria_met and already_past:
+        if str(args.dry_run).lower() == "true":
+            action = "dry_run_move_back_to_doing"
+        else:
+            task = move_task(task, "doing", "Ivy PR criteria are no longer met: " + "; ".join(failures), state)
+            action = "moved_back_to_doing"
+    elif not criteria_met and is_at(task, "doing"):
+        action = "criteria_not_met"
+    elif criteria_met and already_past:
+        action = action if action != "none" else "already_past"
+    elif criteria_met:
+        action = action if action != "none" else "criteria_met"
+    else:
+        action = action if action != "none" else "criteria_not_met"
+
+    dump_json(
+        transition_result(
+            criteria_met,
+            already_past,
+            action,
+            task,
+            lobster_state=state,
+            failures=failures,
+            prUrls=pr_urls,
+            prHeadingUrls=heading_urls,
+            acceptanceCriteria=task_acs,
+            prCi=pr_ci,
+            prAcceptanceCriteria=pr_ac_details,
+            current_status=status(task),
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/grafana/provisioning/dashboards/json/openclaw-diagnostics.json
+++ b/infra/grafana/provisioning/dashboards/json/openclaw-diagnostics.json
@@ -39,7 +39,7 @@
         {
           "expr": "sum(openclaw_message_processed_total)",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -82,7 +82,7 @@
         {
           "expr": "sum(openclaw_tokens_total)",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -125,7 +125,7 @@
         {
           "expr": "sum(openclaw_cost_usd_total)",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -169,7 +169,7 @@
         {
           "expr": "sum(openclaw_message_queued_total)",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -212,7 +212,7 @@
         {
           "expr": "sum(openclaw_webhook_error_total)",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -259,7 +259,7 @@
         {
           "expr": "sum(openclaw_session_stuck_total)",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -319,14 +319,14 @@
           "expr": "sum(increase(openclaw_tokens_total{openclaw_token=~\"input|cache_read\"}[$__rate_interval]))",
           "legendFormat": "input",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         },
         {
           "expr": "sum(increase(openclaw_tokens_total{openclaw_token=\"output\"}[$__rate_interval]))",
           "legendFormat": "output",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -364,7 +364,7 @@
           "expr": "sum(rate(openclaw_cost_usd_total[5m])) by (model)",
           "legendFormat": "{{model}}",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -402,14 +402,14 @@
           "expr": "histogram_quantile(0.50, sum(rate(openclaw_context_tokens_bucket[$__rate_interval])) by (le, openclaw_context))",
           "legendFormat": "p50",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         },
         {
           "expr": "histogram_quantile(0.95, sum(rate(openclaw_context_tokens_bucket[$__rate_interval])) by (le, openclaw_context))",
           "legendFormat": "p95",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -447,7 +447,7 @@
           "expr": "sum(increase(openclaw_tokens_total[$__rate_interval])) by (openclaw_model)",
           "legendFormat": "{{model}}",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -497,14 +497,14 @@
           "expr": "sum(rate(openclaw_message_queued_total[1m]))",
           "legendFormat": "queued",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         },
         {
           "expr": "sum(rate(openclaw_message_processed_total[1m])) by (outcome)",
           "legendFormat": "{{outcome}}",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -542,21 +542,21 @@
           "expr": "histogram_quantile(0.50, rate(openclaw_message_duration_ms_milliseconds_bucket[5m]))",
           "legendFormat": "p50",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         },
         {
           "expr": "histogram_quantile(0.95, rate(openclaw_message_duration_ms_milliseconds_bucket[5m]))",
           "legendFormat": "p95",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         },
         {
           "expr": "histogram_quantile(0.99, rate(openclaw_message_duration_ms_milliseconds_bucket[5m]))",
           "legendFormat": "p99",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -594,7 +594,7 @@
           "expr": "histogram_quantile(0.95, rate(openclaw_queue_depth_bucket[1m]))",
           "legendFormat": "p95 depth",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -631,14 +631,14 @@
           "expr": "sum(rate(openclaw_queue_lane_enqueue_total[1m])) by (lane)",
           "legendFormat": "enqueue {{lane}}",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         },
         {
           "expr": "sum(rate(openclaw_queue_lane_dequeue_total[1m])) by (lane)",
           "legendFormat": "dequeue {{lane}}",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -676,14 +676,14 @@
           "expr": "histogram_quantile(0.50, rate(openclaw_queue_wait_ms_milliseconds_bucket[5m]))",
           "legendFormat": "p50",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         },
         {
           "expr": "histogram_quantile(0.95, rate(openclaw_queue_wait_ms_milliseconds_bucket[5m]))",
           "legendFormat": "p95",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -733,21 +733,21 @@
           "expr": "histogram_quantile(0.50, sum(rate(openclaw_run_duration_ms_milliseconds_bucket[$__rate_interval])) by (le))",
           "legendFormat": "p50",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         },
         {
           "expr": "histogram_quantile(0.95, sum(rate(openclaw_run_duration_ms_milliseconds_bucket[$__rate_interval])) by (le))",
           "legendFormat": "p95",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         },
         {
           "expr": "histogram_quantile(0.99, sum(rate(openclaw_run_duration_ms_milliseconds_bucket[$__rate_interval])) by (le))",
           "legendFormat": "p99",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -785,7 +785,7 @@
           "expr": "sum(rate(openclaw_run_attempt_total[5m])) by (attempt)",
           "legendFormat": "attempt {{attempt}}",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -835,7 +835,7 @@
           "expr": "sum(openclaw_session_state_total) by (state)",
           "legendFormat": "{{state}}",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -872,7 +872,7 @@
           "expr": "sum(openclaw_session_stuck_total) by (state)",
           "legendFormat": "{{state}}",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -910,7 +910,7 @@
           "expr": "histogram_quantile(0.95, rate(openclaw_session_stuck_age_ms_bucket[5m]))",
           "legendFormat": "p95 stuck age",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -961,14 +961,14 @@
           "expr": "sum(rate(openclaw_webhook_received_total[1m])) by (channel)",
           "legendFormat": "received {{channel}}",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         },
         {
           "expr": "sum(rate(openclaw_webhook_error_total[1m])) by (channel)",
           "legendFormat": "error {{channel}}",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],
@@ -1006,14 +1006,14 @@
           "expr": "histogram_quantile(0.50, rate(openclaw_webhook_duration_ms_milliseconds_bucket[5m]))",
           "legendFormat": "p50",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         },
         {
           "expr": "histogram_quantile(0.95, rate(openclaw_webhook_duration_ms_milliseconds_bucket[5m]))",
           "legendFormat": "p95",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           }
         }
       ],

--- a/infra/grafana/provisioning/dashboards/json/openclaw-diagnostics.json
+++ b/infra/grafana/provisioning/dashboards/json/openclaw-diagnostics.json
@@ -1,0 +1,1359 @@
+{
+  "title": "OpenClaw diagnostics-otel",
+  "uid": "openclaw-diag",
+  "tags": [
+    "openclaw",
+    "diagnostics-otel"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 100,
+      "title": "📊 Overview",
+      "type": "row",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 1,
+      "title": "Messages Processed",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(openclaw_message_processed_total)",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Token Usage",
+      "type": "stat",
+      "gridPos": {
+        "x": 4,
+        "y": 1,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(openclaw_tokens_total)",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Estimated Cost (USD)",
+      "type": "stat",
+      "gridPos": {
+        "x": 8,
+        "y": 1,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(openclaw_cost_usd_total)",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Messages Queued",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 1,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(openclaw_message_queued_total)",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Webhook Errors",
+      "type": "stat",
+      "gridPos": {
+        "x": 16,
+        "y": 1,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(openclaw_webhook_error_total)",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Stuck Sessions",
+      "type": "stat",
+      "gridPos": {
+        "x": 20,
+        "y": 1,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(openclaw_session_stuck_total)",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 101,
+      "title": "💰 Tokens & Cost",
+      "type": "row",
+      "gridPos": {
+        "x": 0,
+        "y": 5,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 7,
+      "title": "Token Usage by Type",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(openclaw_tokens_total{openclaw_token=~\"input|cache_read\"}[$__rate_interval]))",
+          "legendFormat": "input",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "sum(increase(openclaw_tokens_total{openclaw_token=\"output\"}[$__rate_interval]))",
+          "legendFormat": "output",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Cost Over Time",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 6,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(openclaw_cost_usd_total[5m])) by (model)",
+          "legendFormat": "{{model}}",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 9,
+      "title": "Context Window Usage (p50/p95)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(openclaw_context_tokens_bucket[$__rate_interval])) by (le, openclaw_context))",
+          "legendFormat": "p50",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(openclaw_context_tokens_bucket[$__rate_interval])) by (le, openclaw_context))",
+          "legendFormat": "p95",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Token Usage by Model",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 14,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(openclaw_tokens_total[$__rate_interval])) by (openclaw_model)",
+          "legendFormat": "{{model}}",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 102,
+      "title": "📨 Messages & Queue",
+      "type": "row",
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 11,
+      "title": "Message Processing Rate",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 23,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(openclaw_message_queued_total[1m]))",
+          "legendFormat": "queued",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "sum(rate(openclaw_message_processed_total[1m])) by (outcome)",
+          "legendFormat": "{{outcome}}",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 12,
+      "title": "Message Duration (p50/p95/p99)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 8,
+        "y": 23,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(openclaw_message_duration_ms_milliseconds_bucket[5m]))",
+          "legendFormat": "p50",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(openclaw_message_duration_ms_milliseconds_bucket[5m]))",
+          "legendFormat": "p95",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(openclaw_message_duration_ms_milliseconds_bucket[5m]))",
+          "legendFormat": "p99",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 13,
+      "title": "Queue Depth (p95)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 16,
+        "y": 23,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(openclaw_queue_depth_bucket[1m]))",
+          "legendFormat": "p95 depth",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 14,
+      "title": "Queue Lane Throughput",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 31,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(openclaw_queue_lane_enqueue_total[1m])) by (lane)",
+          "legendFormat": "enqueue {{lane}}",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "sum(rate(openclaw_queue_lane_dequeue_total[1m])) by (lane)",
+          "legendFormat": "dequeue {{lane}}",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 15,
+      "title": "Queue Wait Time (p50/p95)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 31,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(openclaw_queue_wait_ms_milliseconds_bucket[5m]))",
+          "legendFormat": "p50",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(openclaw_queue_wait_ms_milliseconds_bucket[5m]))",
+          "legendFormat": "p95",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 103,
+      "title": "🤖 Agent Runs",
+      "type": "row",
+      "gridPos": {
+        "x": 0,
+        "y": 39,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 16,
+      "title": "Run Duration (p50/p95/p99)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 40,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(openclaw_run_duration_ms_milliseconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(openclaw_run_duration_ms_milliseconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "p95",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(openclaw_run_duration_ms_milliseconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "p99",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 17,
+      "title": "Run Attempts",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 40,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(openclaw_run_attempt_total[5m])) by (attempt)",
+          "legendFormat": "attempt {{attempt}}",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 104,
+      "title": "👥 Sessions",
+      "type": "row",
+      "gridPos": {
+        "x": 0,
+        "y": 48,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 18,
+      "title": "Session States",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 49,
+        "w": 24,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(openclaw_session_state_total) by (state)",
+          "legendFormat": "{{state}}",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 19,
+      "title": "Stuck Sessions",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 57,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(openclaw_session_stuck_total) by (state)",
+          "legendFormat": "{{state}}",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 20,
+      "title": "Stuck Session Age (p95)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 57,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(openclaw_session_stuck_age_ms_bucket[5m]))",
+          "legendFormat": "p95 stuck age",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 105,
+      "title": "🔗 Webhooks",
+      "type": "row",
+      "gridPos": {
+        "x": 0,
+        "y": 65,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 21,
+      "title": "Webhook Received/Error Rate",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 66,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(openclaw_webhook_received_total[1m])) by (channel)",
+          "legendFormat": "received {{channel}}",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "sum(rate(openclaw_webhook_error_total[1m])) by (channel)",
+          "legendFormat": "error {{channel}}",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "title": "Webhook Duration (p50/p95)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 66,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(openclaw_webhook_duration_ms_milliseconds_bucket[5m]))",
+          "legendFormat": "p50",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(openclaw_webhook_duration_ms_milliseconds_bucket[5m]))",
+          "legendFormat": "p95",
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 106,
+      "title": "🔍 Traces (Gateway-level)",
+      "type": "row",
+      "gridPos": {
+        "x": 0,
+        "y": 74,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 23,
+      "title": "Span Volume",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 75,
+        "w": 14,
+        "h": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${DS_OPENSEARCH_TRACES}"
+          },
+          "query": "",
+          "timeField": "startTime",
+          "metrics": [
+            {
+              "type": "count",
+              "id": "1"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "type": "terms",
+              "field": "name",
+              "id": "3",
+              "settings": {
+                "size": "10",
+                "order": "desc",
+                "orderBy": "1"
+              }
+            },
+            {
+              "type": "date_histogram",
+              "field": "startTime",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": "0"
+              }
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 24,
+      "title": "Top Span Types",
+      "type": "barchart",
+      "gridPos": {
+        "x": 14,
+        "y": 75,
+        "w": 10,
+        "h": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${DS_OPENSEARCH_TRACES}"
+          },
+          "query": "",
+          "timeField": "startTime",
+          "metrics": [
+            {
+              "type": "count",
+              "id": "1"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "type": "terms",
+              "field": "name",
+              "id": "2",
+              "settings": {
+                "size": "10",
+                "order": "desc",
+                "orderBy": "1"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 107,
+      "title": "📝 Logs",
+      "type": "row",
+      "gridPos": {
+        "x": 0,
+        "y": 83,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 25,
+      "title": "Log Volume",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 84,
+        "w": 16,
+        "h": 6
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${DS_OPENSEARCH_LOGS}"
+          },
+          "query": "",
+          "timeField": "@timestamp",
+          "metrics": [
+            {
+              "type": "count",
+              "id": "1"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "type": "date_histogram",
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": "0"
+              }
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "title": "Log Levels",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 16,
+        "y": 84,
+        "w": 8,
+        "h": 6
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${DS_OPENSEARCH_LOGS}"
+          },
+          "query": "",
+          "timeField": "@timestamp",
+          "metrics": [
+            {
+              "type": "count",
+              "id": "1"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "type": "terms",
+              "field": "severityText.keyword",
+              "id": "3",
+              "settings": {
+                "size": "10",
+                "order": "desc",
+                "orderBy": "1"
+              }
+            },
+            {
+              "type": "date_histogram",
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": "0"
+              }
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 27,
+      "title": "Log Stream",
+      "type": "logs",
+      "gridPos": {
+        "x": 0,
+        "y": 90,
+        "w": 24,
+        "h": 14
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${DS_OPENSEARCH_LOGS}"
+          },
+          "query": "",
+          "timeField": "@timestamp",
+          "metrics": [
+            {
+              "type": "logs",
+              "id": "1"
+            }
+          ],
+          "bucketAggs": []
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending"
+      }
+    }
+  ],
+  "__requires__": [
+    {
+      "type": "datasource",
+      "id": "${DS_PROMETHEUS}",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-opensearch-datasource",
+      "name": "OpenSearch",
+      "version": "1.0.0"
+    }
+  ],
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "prometheus with metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_OPENSEARCH_LOGS",
+      "label": "OpenSearch-Logs",
+      "description": "opensearch with logs",
+      "type": "datasource",
+      "pluginId": "grafana-opensearch-datasource",
+      "pluginName": "OpenSearch"
+    },
+    {
+      "name": "DS_OPENSEARCH_TRACES",
+      "label": "OpenSearch-Traces",
+      "description": "opensearch with traces",
+      "type": "datasource",
+      "pluginId": "grafana-opensearch-datasource",
+      "pluginName": "OpenSearch"
+    }
+  ],
+  "gnetId": 25068,
+  "description": "openclaw dashboard with opensearch & prometheus as datasource"
+}


### PR DESCRIPTION
## Summary

- Lobster now patches the task description to embed `[ivy-prs]` URLs into the matching PR heading block automatically
- Removes the need for Ivy to edit the task body herself — she posts the comment, Lobster moves the URL up
- Only the real CI/AC failures remain as blockers for `doing → acceptance`

## Test plan

- [ ] Run `pr_transition.py` on a task where Ivy has posted `[ivy-prs]` comment but task description has no PR URL in heading — confirm URL gets injected
- [ ] Confirm no regression when PR URL is already present in description

🤖 Generated with [Claude Code](https://claude.com/claude-code)