### PR TITLE
feat(tasks-api): add Ivy as a valid task assignee

### DIFF
--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -7,7 +7,7 @@ const MAX_LIMIT = 10000;
 
 const validStatuses = new Set(['open', 'ready', 'doing', 'acceptance', 'done']);
 const validPriorities = new Set(['low', 'medium', 'high', 'urgent']);
-const validAssignees = new Set(['Tom', 'Quinn', 'Rowan', 'Lox']);
+const validAssignees = new Set(['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy']);
 const validSorts = new Set(['priority', 'createdAt', 'updatedAt', 'dueAt', 'statusChangedAt']);
 
 const priorityOrder = {


### PR DESCRIPTION
## Summary

- Adds `Ivy` to the `validAssignees` set in the Tasks API
- Required for the content-task Lobster workflow to assign tasks to Ivy on `open → ready` transition
- This is blocking CI on Ivy's content PRs

## Test plan

- [ ] `PATCH /tasks/:id` with `assignee: "Ivy"` returns 200
- [ ] Tasks API tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)