### PR TITLE
content(weekly-2026-06-02): Quinn-executable updates (release, system proofs, stack bump)

### DIFF
--- a/apps/website/src/content/releases.json
+++ b/apps/website/src/content/releases.json
@@ -18,5 +18,15 @@
     "links": [],
     "evidence": "Public homepage ships this as an existing release signal.",
     "visibility": "published"
+  },
+  {
+    "title": "Weekly content review pipeline",
+    "slug": "weekly-content-review-pipeline",
+    "releasedAt": "2026-06-01",
+    "summary": "Daily ops notes are now distilled into a weekly content review file and a Tasks API content task, which the content-task workflow picks up automatically.",
+    "type": "system",
+    "links": [],
+    "evidence": "Pipeline runs via codebases/sindustries/agents/crons/sindustries-weekly-content/ and produced the first review at brain/content/sindustries-weekly-content/2026-06-02.md.",
+    "visibility": "draft"
   }
 ]

--- a/apps/website/src/content/stacks.json
+++ b/apps/website/src/content/stacks.json
@@ -66,7 +66,7 @@
     "whyWeUseIt": "It gives agent work a shared operational backbone instead of scattered notes.",
     "status": "core",
     "links": [],
-    "updatedAt": "2026-05-28",
+    "updatedAt": "2026-06-01",
     "visibility": "published"
   },
   {

--- a/apps/website/src/content/systems.json
+++ b/apps/website/src/content/systems.json
@@ -7,8 +7,8 @@
     "summary": "The operating layer for agents, memory, tools, messaging, and human-in-the-loop work.",
     "problem": "Delegated agent work needs continuity, tools, memory, and human review boundaries to become operationally useful.",
     "howItWorks": "OpenClaw connects agents to workspace files, skills, messaging, tasks, and runtime context so work can move through explicit handoffs.",
-    "proof": "Used as the active operating layer for SIndustries agents and task execution.",
-    "updatedAt": "2026-05-28",
+    "proof": "Used as the active operating layer for SIndustries agents, task execution, daily ops note capture, and the weekly content review.",
+    "updatedAt": "2026-06-01",
     "links": [],
     "image": "/brand/systems/openclaw-lobster.jpg",
     "visibility": "published"
@@ -35,8 +35,8 @@
     "summary": "Task state, ownership, comments, reviews, and heartbeat-driven operating discipline.",
     "problem": "Agent work needs a shared source of truth for ownership, status, review, and handoff.",
     "howItWorks": "The Tasks API tracks tasks, comments, tags, readiness, and status transitions for SIndustries work.",
-    "proof": "Current SIndustries implementation tasks are tracked through the API and used by agent heartbeat workflows.",
-    "updatedAt": "2026-05-28",
+    "proof": "SIndustries implementation tasks are tracked through the API and used by agent heartbeat and cron workflows; tasks-api-ops tooling (tasks_api_client.py, task_transition_check.py) is now canonical inside the SIndustries repo.",
+    "updatedAt": "2026-06-01",
     "links": [],
     "image": "/brand/systems/tasks-api-hero.png",
     "visibility": "published"


### PR DESCRIPTION
## Summary

Applies the four Quinn-executable changes from the 2026-06-02 weekly content review:
- ADD release entry: **"Weekly content review pipeline"** (system, `releasedAt: 2026-06-01`)
- EDIT `system/openclaw` — `proof` now references daily ops note capture and the weekly content review as active OpenClaw operating workflows
- EDIT `system/tasks-api` — `proof` notes that `tasks-api-ops` tooling is now canonical inside the SIndustries repo and used by heartbeat/cron workflows
- EDIT `stack/Tasks API` — `updatedAt` bumped to `2026-06-01`

The two Tom-approval items from the same review (new `system/content-ops-pipeline` and new `story/content-review-pipeline`) are split into a separate Tom-approval PR.

## Source

- Review: `brain/content/sindustries-weekly-content/2026-06-02.md`
- Task: `41ccd66c-69b8-4ba7-85af-256f7b2f679e`

## Approval risk

Low — factual metadata updates, status bumps, and a release entry for already-operating infrastructure. No first-person voice, no revenue/customer/employer/family references, no strategic claims. Quinn-approval path only; no Tom PR required for this set.

## Acceptance Criteria

All ACs under the task body's "Quinn can execute" section are addressed in this PR:

- [x] ADD release — "Weekly content review pipeline" (system, releasedAt: 2026-06-01): automated workflow now turns ops notes into website content review files.
  - Release entry appended to `apps/website/src/content/releases.json` with `type: "system"`, `releasedAt: "2026-06-01"`, `visibility: "draft"`, and `evidence` pointing to the cron and the first produced review file.
- [x] EDIT system/openclaw — update proof: reference daily ops note capture and weekly content review as active OpenClaw operating workflows.
  - `proof` updated to: "Used as the active operating layer for SIndustries agents, task execution, daily ops note capture, and the weekly content review." `updatedAt` bumped to `2026-06-01`.
- [x] EDIT system/tasks-api — update proof: note tasks-api-ops tooling is now canonical inside the SIndustries repo and used by heartbeat/cron workflows.
  - `proof` updated to: "SIndustries implementation tasks are tracked through the API and used by agent heartbeat and cron workflows; tasks-api-ops tooling (tasks_api_client.py, task_transition_check.py) is now canonical inside the SIndustries repo." `updatedAt` bumped to `2026-06-01`.
- [x] EDIT stack/Tasks API — bump updatedAt to 2026-06-01 after centralising task automation scripts and skills in the SIndustries repo.
  - `updatedAt` bumped from `2026-05-28` to `2026-06-01`. All other fields preserved.

## Validation

- `npm --workspace apps/website test` passes (4/4)
- AJV validation runs on import of the content module
- New release entry visibility is `draft` until this PR is merged
- Existing `published` items are unchanged

## Claim-risk notes

```
CLAIM: release "releasedAt": "2026-06-01"
RISK: low
REASON: matches the daily note in brain/ops/notes/2026-06-01.md that records the pipeline build
ACTION: none

CLAIM: "tasks-api-ops tooling (tasks_api_client.py, task_transition_check.py) is now canonical inside the SIndustries repo"
RISK: low
REASON: matches the documented move in the 2026-06-01 ops note ("tasks-api-ops skill and scripts ... moved from workspace into sindustries repo")
ACTION: none
```

## Review questions

None — all four ACs are factual and source-backed.
