### PR TITLE
content: weekly updates 2026-06-02 (quinn approval)

### DIFF
--- a/apps/website/src/content/releases.json
+++ b/apps/website/src/content/releases.json
@@ -23,7 +23,7 @@
     "title": "Weekly content review pipeline",
     "slug": "weekly-content-review-pipeline",
     "releasedAt": "2026-06-01",
-    "summary": "An automated workflow that collects daily ops notes, distils them into a weekly review file, and creates structured content tasks ready for authoring and publication.",
+    "summary": "An automated workflow that collects daily ops notes, distils them into a weekly review file, and creates structured content tasks ready for authoring and publication to this website.",
     "type": "system",
     "links": [],
     "evidence": "Pipeline shipped 2026-06-01: daily ops note capture runs on each heartbeat cycle, weekly cron produces the review file and downstream content tasks.",

--- a/apps/website/src/content/releases.json
+++ b/apps/website/src/content/releases.json
@@ -18,5 +18,15 @@
     "links": [],
     "evidence": "Public homepage ships this as an existing release signal.",
     "visibility": "published"
+  },
+  {
+    "title": "Weekly content review pipeline",
+    "slug": "weekly-content-review-pipeline",
+    "releasedAt": "2026-06-01",
+    "summary": "An automated workflow that collects daily ops notes, distils them into a weekly review file, and creates structured content tasks ready for authoring and publication.",
+    "type": "system",
+    "links": [],
+    "evidence": "Pipeline shipped 2026-06-01: daily ops note capture runs on each heartbeat cycle, weekly cron produces the review file and downstream content tasks.",
+    "visibility": "published"
   }
 ]

--- a/apps/website/src/content/releases.json
+++ b/apps/website/src/content/releases.json
@@ -30,3 +30,4 @@
     "visibility": "published"
   }
 ]
+

--- a/apps/website/src/content/stacks.json
+++ b/apps/website/src/content/stacks.json
@@ -66,7 +66,7 @@
     "whyWeUseIt": "It gives agent work a shared operational backbone instead of scattered notes.",
     "status": "core",
     "links": [],
-    "updatedAt": "2026-05-28",
+    "updatedAt": "2026-06-01",
     "visibility": "published"
   },
   {

--- a/apps/website/src/content/systems.json
+++ b/apps/website/src/content/systems.json
@@ -7,8 +7,8 @@
     "summary": "The operating layer for agents, memory, tools, messaging, and human-in-the-loop work.",
     "problem": "Delegated agent work needs continuity, tools, memory, and human review boundaries to become operationally useful.",
     "howItWorks": "OpenClaw connects agents to workspace files, skills, messaging, tasks, and runtime context so work can move through explicit handoffs.",
-    "proof": "Used as the active operating layer for SIndustries agents and task execution.",
-    "updatedAt": "2026-05-28",
+    "proof": "Active operating layer for SIndustries agents, task execution, daily ops note capture, and weekly content review workflows.",
+    "updatedAt": "2026-06-01",
     "links": [],
     "image": "/brand/systems/openclaw-lobster.jpg",
     "visibility": "published"
@@ -35,8 +35,8 @@
     "summary": "Task state, ownership, comments, reviews, and heartbeat-driven operating discipline.",
     "problem": "Agent work needs a shared source of truth for ownership, status, review, and handoff.",
     "howItWorks": "The Tasks API tracks tasks, comments, tags, readiness, and status transitions for SIndustries work.",
-    "proof": "Current SIndustries implementation tasks are tracked through the API and used by agent heartbeat workflows.",
-    "updatedAt": "2026-05-28",
+    "proof": "SIndustries tasks are tracked through the API and driven by agent heartbeat and cron workflows. Task automation tooling is now maintained in the SIndustries repo as the canonical location.",
+    "updatedAt": "2026-06-01",
     "links": [],
     "image": "/brand/systems/tasks-api-hero.png",
     "visibility": "published"


### PR DESCRIPTION
## Weekly Content Updates — 2026-06-02

**Task:** 41ccd66c-69b8-4ba7-85af-256f7b2f679e
**Approver:** Quinn
**Source:** brain/content/sindustries-weekly-content/2026-06-02.md

---

## Acceptance Criteria

- [x] ADD release — "Weekly content review pipeline" (system, releasedAt: 2026-06-01): automated workflow now turns ops notes into website content review files.
- [x] EDIT system/openclaw — update proof: reference daily ops note capture and weekly content review as active OpenClaw operating workflows.
- [x] EDIT system/tasks-api — update proof: note tasks-api-ops tooling is now canonical inside the SIndustries repo and used by heartbeat/cron workflows.
- [x] EDIT stack/Tasks API — bump updatedAt to 2026-06-01 after centralising task automation scripts and skills in the SIndustries repo.

---

## Changes

- `releases.json` — added entry for "Weekly content review pipeline" (type: system, releasedAt: 2026-06-01, visibility: published)
- `systems.json` — OpenClaw proof updated to reference daily ops note capture and weekly content review; updatedAt bumped to 2026-06-01
- `systems.json` — Tasks API proof updated to note canonical task automation tooling location; updatedAt bumped to 2026-06-01
- `stacks.json` — Tasks API updatedAt bumped to 2026-06-01