### PR TITLE
ci: add pull_request merged trigger as backup for website deploy

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -11,6 +11,18 @@ on:
       - 'package-lock.json'
       - 'vercel.json'
       - '.github/workflows/website-deploy.yml'
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+    paths:
+      - 'apps/website/**'
+      - 'packages/design-tokens/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vercel.json'
+      - '.github/workflows/website-deploy.yml'
   workflow_dispatch:
 
 permissions:
@@ -25,7 +37,8 @@ jobs:
   deploy:
     name: Deploy website to Vercel
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
+    environment: ${{ (github.ref_name == 'main' || github.event_name == 'pull_request') && 'production' || 'staging' }}
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Summary
- Adds `pull_request: closed` trigger on main as a backup for the existing `on: push` — only fires when `merged == true`
- Guards against a GitHub Actions hiccup that caused PR #58 content to not go live (deploy fired 4 min before the merge push)
- Fixes the `environment` expression so PR-triggered deploys correctly target production

## Test plan
- [ ] Merge a content PR to main and confirm a production deploy fires