### PR TITLE
fix(bookmark): lobster_summarize skips items with existing summaryDoc

### DIFF
--- a/agents/workflows/bookmark/lobster_list_curate_candidates.py
+++ b/agents/workflows/bookmark/lobster_list_curate_candidates.py
@@ -28,6 +28,18 @@ CURRENT_REVIEW_STATUSES = {
     "revision_requested",
     "revision_staged",
     "tasked",
+    "approved",
+    "declined",
+}
+
+# Terminal post-approval states. Once an item reaches one of these, the
+# pipeline is done with it — the lobster shouldn't try to re-curate, re-spec,
+# or re-derive approval state from it. `tasked` is the "approved + work in
+# flight" terminal; `approved` is the "Tom said yes, no tasks needed"
+# terminal. Both are downstream of the approval flow.
+POST_APPROVAL_TERMINAL = {
+    "tasked",
+    "approved",
     "declined",
 }
 
@@ -158,7 +170,7 @@ def main() -> int:
             inferred = inferred_specs_by_key.get(key, [])
             if inferred:
                 item["specDocs"] = sorted(inferred)
-                if (item.get("specProposals") or []) and item.get("reviewStatus") not in {"approval_pending", "revision_staged"} and not item.get("taskIds"):
+                if (item.get("specProposals") or []) and item.get("reviewStatus") not in {"approval_pending", "revision_staged"} and item.get("reviewStatus") not in POST_APPROVAL_TERMINAL and not item.get("taskIds"):
                     previous_status = item.get("reviewStatus")
                     item["reviewStatus"] = "spec_created"
                     log_transition(key, previous_status, "spec_created", "inferred specs found on disk; restoring spec_created", transitions_path=transition_log_path(STATE_PATH))
@@ -221,7 +233,7 @@ def main() -> int:
                         # hasn't happened yet, keep bookmark in pipeline for approval packaging.
                         has_unmaterialized_spec_work = (
                             (existing.get("specProposals") or [])
-                            and existing.get("reviewStatus") not in {"approval_pending", "revision_staged", "declined"}
+                            and existing.get("reviewStatus") not in {"approval_pending", "revision_staged", "declined", "approved"}
                             and existing.get("approvalStatus") != "declined"
                             and not (existing.get("taskIds") or [])
                         )

--- a/agents/workflows/bookmark/lobster_list_curations.py
+++ b/agents/workflows/bookmark/lobster_list_curations.py
@@ -16,7 +16,7 @@ Inputs:
 
 Routing rules:
   - reviewed:
-      - reviewStatus in {tasked, declined, approval_pending,
+      - reviewStatus in {tasked, approved, declined, approval_pending,
         revision_staged, revision_requested, needs_research}
         → terminal, no action
   - needs_research:
@@ -54,6 +54,7 @@ DEFAULT_THRESHOLD = 7
 
 TERMINAL_STATUSES = {
     "tasked",
+    "approved",
     "declined",
     "approval_pending",
     "revision_staged",

--- a/agents/workflows/bookmark/lobster_resolve_spec_request.py
+++ b/agents/workflows/bookmark/lobster_resolve_spec_request.py
@@ -67,7 +67,14 @@ def main() -> int:
             if args.decision == "decline":
                 next_status = "declined"
             else:
-                next_status = "tasked" if merged_task_ids else "spec_created"
+                # Approve path. `tasked` means the spec has proposals and
+                # task IDs were created — work is in flight. `approved` is
+                # the terminal state for specs that Tom approved but
+                # generated no tasks (the spec is the artifact, no work
+                # needs to happen downstream). The dashboard buckets these
+                # distinctly so Tom can see at a glance what's done vs
+                # what's actively being worked.
+                next_status = "tasked" if merged_task_ids else "approved"
             state_item.update({
                 "approvalStatus": resolution_status,
                 "approvalResolvedAt": timestamp,

--- a/agents/workflows/bookmark/lobster_summarize.py
+++ b/agents/workflows/bookmark/lobster_summarize.py
@@ -165,18 +165,40 @@ def main() -> int:
         bookmark_key = record["bookmarkKey"]
         topic = record.get("topic") or "general"
 
-        # Skip if already summarised and summary doc exists
+        # Skip if upstream signalled no review, or the item already has a
+        # summary doc on disk. The previous check only matched when
+        # reviewStatus == "summarized" — items in any downstream state
+        # (spec_created, approval_pending, tasked, approved, declined) that
+        # have a summaryDoc were being re-summarized every run, which rewound
+        # their reviewStatus to "summarized" and triggered noisy re-promote
+        # cycles through lobster_request_spec_approval.
         existing = items.get(bookmark_key, {})
-        if existing.get("reviewStatus") == "summarized" and existing.get("summaryDoc"):
+        if record.get("skipReview") is True:
+            existing_summary = existing.get("summary")
+            generated.append({
+                "bookmarkKey": bookmark_key,
+                "path": record["path"],
+                "topic": topic,
+                "reviewStatus": existing.get("reviewStatus") or "summarized",
+                "summaryDoc": existing.get("summaryDoc"),
+                "title": record["title"],
+                "summary": existing_summary,
+                "skipped": True,
+            })
+            continue
+
+        if existing.get("summaryDoc"):
             summary_path = WORKSPACE / existing["summaryDoc"]
             if summary_path.exists():
                 generated.append({
                     "bookmarkKey": bookmark_key,
                     "path": record["path"],
                     "topic": topic,
-                    "reviewStatus": "summarized",
+                    "reviewStatus": existing.get("reviewStatus") or "summarized",
                     "summaryDoc": existing["summaryDoc"],
                     "title": record["title"],
+                    "summary": existing.get("summary"),
+                    "skipped": True,
                 })
                 continue
 

--- a/tests/test_approved_state.py
+++ b/tests/test_approved_state.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Focused tests for the `approved` terminal state in lobster_resolve_spec_request.
+
+These tests run in isolation so they don't trip over the (pre-existing) rot
+in test_bookmark_workflow.py. They cover the four outcomes of the resolver:
+
+  - approve + no created tasks  -> `approved`  (NEW — was `spec_created`)
+  - approve + created tasks     -> `tasked`
+  - decline                    -> `declined`
+  - already resolved (skipped)  -> unchanged
+"""
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "agents" / "workflows" / "bookmark"))
+sys.path.insert(0, str(REPO / "agents" / "skills" / "tasks-api-ops"))
+
+import common  # noqa: E402
+import lobster_resolve_spec_request as resolve_spec_request  # noqa: E402
+
+
+class ApprovedStateTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.state_path = self.root / "brain" / "state" / "bookmark-review-state.json"
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        self.bookmark = {
+            "bookmarkKey": "abc123bookmark",
+            "path": "brain/bookmarks/x/test.md",
+            "topic": "infra",
+            "source": "x",
+            "title": "Test bookmark",
+        }
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def _seed(self, **overrides):
+        state = common.state_template()
+        item = {
+            "bookmarkKey": self.bookmark["bookmarkKey"],
+            "path": self.bookmark["path"],
+            "topic": self.bookmark["topic"],
+            "source": self.bookmark["source"],
+            "title": self.bookmark["title"],
+            "reviewStatus": "approval_pending",
+            "approvalTopic": "infra",
+            "specDocs": ["brain/specs/infra/test-abc123bookmark.md"],
+            "taskIds": [],
+        }
+        item.update(overrides)
+        state["items"][self.bookmark["bookmarkKey"]] = item
+        common.save_state(state, self.state_path)
+
+    def _run(self, decision: str, approvals: list, created: list) -> dict:
+        stdin = io.StringIO(json.dumps({"approvals": approvals, "created": created}))
+        stdout = io.StringIO()
+        with patch.object(resolve_spec_request, "STATE_PATH", self.state_path):
+            with patch("sys.stdin", stdin), patch("sys.stdout", stdout), \
+                 patch.object(sys, "argv", ["lobster_resolve_spec_request.py", "--decision", decision, "--json"]):
+                rc = resolve_spec_request.main()
+        self.assertEqual(rc, 0)
+        return json.loads(stdout.getvalue())
+
+    def _reload(self) -> dict:
+        return common.load_state(self.state_path)["items"][self.bookmark["bookmarkKey"]]
+
+    def test_approve_no_proposals_marks_approved(self):
+        """The new state: Tom approves a spec that produced no tasks."""
+        self._seed()
+        payload = self._run("approve", [{
+            "topic": "infra",
+            "items": [{"bookmarkKey": self.bookmark["bookmarkKey"]}],
+        }], created=[])
+
+        self.assertEqual(payload["decision"], "approved")
+        self.assertEqual(payload["resolved"][0]["items"][0]["reviewStatus"], "approved")
+
+        item = self._reload()
+        self.assertEqual(item["approvalStatus"], "approved")
+        self.assertEqual(item["reviewStatus"], "approved")
+        self.assertEqual(item["taskIds"], [])
+        self.assertIsNotNone(item.get("approvalResolvedAt"))
+        self.assertIsNone(item.get("approvalResumeToken"))
+
+    def test_approve_with_proposals_marks_tasked(self):
+        """The existing path: approved + work in flight."""
+        self._seed()
+        payload = self._run("approve", [{
+            "topic": "infra",
+            "items": [{"bookmarkKey": self.bookmark["bookmarkKey"]}],
+        }], created=[{
+            "bookmarkKey": self.bookmark["bookmarkKey"],
+            "taskId": "task-001",
+        }])
+
+        self.assertEqual(payload["decision"], "approved")
+        self.assertEqual(payload["resolved"][0]["items"][0]["reviewStatus"], "tasked")
+
+        item = self._reload()
+        self.assertEqual(item["approvalStatus"], "approved")
+        self.assertEqual(item["reviewStatus"], "tasked")
+        self.assertEqual(item["taskIds"], ["task-001"])
+
+    def test_decline_marks_declined(self):
+        self._seed()
+        payload = self._run("decline", [{
+            "topic": "infra",
+            "items": [{"bookmarkKey": self.bookmark["bookmarkKey"]}],
+        }], created=[])
+
+        self.assertEqual(payload["decision"], "declined")
+        item = self._reload()
+        self.assertEqual(item["approvalStatus"], "declined")
+        self.assertEqual(item["reviewStatus"], "declined")
+
+    def test_already_resolved_item_is_skipped(self):
+        """An item no longer in approval_pending must not be re-touched."""
+        self._seed(reviewStatus="approved")
+        payload = self._run("approve", [{
+            "topic": "infra",
+            "items": [{"bookmarkKey": self.bookmark["bookmarkKey"]}],
+        }], created=[])
+
+        self.assertEqual(len(payload["skipped"]), 1)
+        self.assertEqual(payload["skipped"][0]["reason"], "item is not currently approval_pending")
+        item = self._reload()
+        self.assertEqual(item["reviewStatus"], "approved")  # unchanged
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bookmark_workflow.py
+++ b/tests/test_bookmark_workflow.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "agents/workflows/bookmark"))
 
 import common
-import create_tasks_from_proposals
+import lobster_create_tasks_from_proposals as create_tasks_from_proposals
 import list_review_candidates
 import list_spec_requests
 import migrate_flat_paths
@@ -1876,7 +1876,12 @@ class BookmarkWorkflowTests(unittest.TestCase):
         item = updated_state["items"][self.bookmark["bookmarkKey"]]
         self.assertEqual(item["reviewStatus"], "approval_pending")
 
-    def test_resolve_spec_request_approve_without_created_tasks_returns_to_spec_created(self):
+    def test_resolve_spec_request_approve_without_created_tasks_marks_approved(self):
+        # Approving a spec that produced no proposals must land the item in
+        # the `approved` terminal state — the spec is the artifact, no work
+        # to kick off downstream. Distinct from `tasked` (approved + work in
+        # flight) so the dashboard can show at a glance which approvals need
+        # follow-up vs. which are simply done.
         state = common.state_template()
         state["items"][self.bookmark["bookmarkKey"]] = {
             "bookmarkKey": self.bookmark["bookmarkKey"],
@@ -1906,11 +1911,14 @@ class BookmarkWorkflowTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload["decision"], "approved")
+        self.assertEqual(payload["resolved"][0]["items"][0]["reviewStatus"], "approved")
 
         updated_state = common.load_state(self.state_path)
         item = updated_state["items"][self.bookmark["bookmarkKey"]]
         self.assertEqual(item["approvalStatus"], "approved")
-        self.assertEqual(item["reviewStatus"], "spec_created")
+        self.assertEqual(item["reviewStatus"], "approved")
+        self.assertEqual(item["taskIds"], [])
+        self.assertIsNotNone(item.get("approvalResolvedAt"))
 
 
 

--- a/tests/test_lobster_summarize_skip.py
+++ b/tests/test_lobster_summarize_skip.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Tests for lobster_summarize.py's skip behaviour.
+
+Covers the rewind bug where items in a downstream reviewStatus
+(spec_created, approval_pending, tasked, approved, declined) with an
+existing summaryDoc were being re-summarized on every run, which clobbered
+their reviewStatus back to "summarized".
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "agents/workflows/bookmark"))
+
+import common
+import lobster_summarize as summarize_mod
+
+
+class LobsterSummarizeSkipTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.state_path = self.root / "brain" / "state" / "bookmark-review-state.json"
+        self.reviews_root = self.root / "brain" / "bookmarks" / "summaries"
+        self.reviews_root.mkdir(parents=True, exist_ok=True)
+        common.save_state(common.state_template(), self.state_path)
+        # Path used by the LLM invoker — make sure the patcher redirects it.
+        # Patch both common.WORKSPACE (so load_state/save_state resolve to the
+        # tempdir) and summarize_mod.WORKSPACE (since the script imported the
+        # name at module load time and has its own binding).
+        self.workspace_patcher = patch.object(common, "WORKSPACE", self.root)
+        self.workspace_patcher.start()
+        self.summarize_workspace_patcher = patch.object(summarize_mod, "WORKSPACE", self.root)
+        self.summarize_workspace_patcher.start()
+        self.addCleanup(self.workspace_patcher.stop)
+        self.addCleanup(self.summarize_workspace_patcher.stop)
+        self.state_path_patcher = patch.object(summarize_mod, "STATE_PATH", self.state_path)
+        self.state_path_patcher.start()
+        self.addCleanup(self.state_path_patcher.stop)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def _write_summary_doc(self, bookmark_key: str) -> str:
+        rel = f"brain/bookmarks/summaries/sample-{bookmark_key}.md"
+        (self.root / rel).parent.mkdir(parents=True, exist_ok=True)
+        (self.root / rel).write_text(
+            "# Summary — Sample\n\nAn existing summary doc.\n",
+            encoding="utf-8",
+        )
+        return rel
+
+    def _candidates_input(self, candidates: list[dict]) -> str:
+        return json.dumps({"ok": True, "count": len(candidates), "candidates": candidates})
+
+    def _make_record(self, bookmark_key: str, **overrides) -> dict:
+        record = {
+            "bookmarkKey": bookmark_key,
+            "path": f"brain/bookmarks/infra/{bookmark_key}.md",
+            "topic": "infra",
+            "source": "x",
+            "title": f"Sample {bookmark_key}",
+            "link": "https://example.com/post",
+            "tags": ["infra"],
+            "type": "infra",
+            "dateArchived": "2026-06-16",
+            "bodyExcerpt": "excerpt",
+            "body": "body",
+        }
+        record.update(overrides)
+        return record
+
+    def test_spec_created_item_with_summary_doc_is_not_rewound(self):
+        """An item in spec_created with an existing summaryDoc must be skipped
+        without clobbering reviewStatus back to summarized.
+        """
+        bookmark_key = "spec-created-key"
+        summary_rel = self._write_summary_doc(bookmark_key)
+        state = common.load_state(self.state_path)
+        state["items"][bookmark_key] = {
+            "bookmarkKey": bookmark_key,
+            "reviewStatus": "spec_created",
+            "summaryDoc": summary_rel,
+            "summary": {"headline": "existing", "problem": "p", "approach": "a", "valueProposition": "v", "keyDetails": [], "relevantTo": "r"},
+            "specDocs": ["brain/bookmarks/specs/sample.md"],
+            "taskIds": [],
+        }
+        common.save_state(state, self.state_path)
+
+        candidates = [self._make_record(bookmark_key)]
+
+        # invoke_llm_json is the only place the LLM is called. If the fix is
+        # wrong, the LLM will be invoked and the test will hit this mock and
+        # fail.
+        with patch.object(summarize_mod, "invoke_llm_json", side_effect=AssertionError("LLM should not be called for already-summarized items")):
+            with patch("sys.stdin", io.StringIO(self._candidates_input(candidates))):
+                with patch.object(sys, "argv", ["lobster_summarize.py", "--json", "--reviews-root", str(self.reviews_root)]):
+                    rc = summarize_mod.main()
+
+        self.assertEqual(rc, 0)
+        after = common.load_state(self.state_path)["items"][bookmark_key]
+        self.assertEqual(after["reviewStatus"], "spec_created", "reviewStatus must not be rewound")
+        self.assertEqual(after["summaryDoc"], summary_rel)
+
+    def test_skip_review_flag_skips_without_invoking_llm(self):
+        """An item with skipReview=True is skipped regardless of state."""
+        bookmark_key = "skip-review-key"
+        state = common.load_state(self.state_path)
+        state["items"][bookmark_key] = {
+            "bookmarkKey": bookmark_key,
+            "reviewStatus": "summarized",
+        }
+        common.save_state(state, self.state_path)
+
+        candidates = [self._make_record(bookmark_key, skipReview=True)]
+
+        with patch.object(summarize_mod, "invoke_llm_json", side_effect=AssertionError("LLM should not be called when skipReview is true")):
+            with patch("sys.stdin", io.StringIO(self._candidates_input(candidates))):
+                with patch.object(sys, "argv", ["lobster_summarize.py", "--json", "--reviews-root", str(self.reviews_root)]):
+                    rc = summarize_mod.main()
+
+        self.assertEqual(rc, 0)
+        after = common.load_state(self.state_path)["items"][bookmark_key]
+        self.assertEqual(after["reviewStatus"], "summarized", "skipReview should leave state alone")
+
+    def test_fresh_item_without_summary_invokes_llm_and_writes_doc(self):
+        """Sanity check: a brand-new item still goes through the LLM path."""
+        bookmark_key = "fresh-key"
+        record = self._make_record(bookmark_key)
+        candidates = [record]
+
+        llm_payload = {
+            "headline": "h",
+            "problem": "p",
+            "approach": "a",
+            "valueProposition": "v",
+            "keyDetails": ["k1"],
+            "relevantTo": "r",
+            "constraints": [],
+        }
+
+        with patch.object(summarize_mod, "invoke_llm_json", return_value=llm_payload) as llm_mock, \
+             patch.object(summarize_mod, "llm_provenance", return_value={"path": "test", "model": "test"}):
+            with patch("sys.stdin", io.StringIO(self._candidates_input(candidates))):
+                with patch.object(sys, "argv", ["lobster_summarize.py", "--json", "--reviews-root", str(self.reviews_root)]):
+                    rc = summarize_mod.main()
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(llm_mock.call_count, 1)
+        after = common.load_state(self.state_path)["items"][bookmark_key]
+        self.assertEqual(after["reviewStatus"], "summarized")
+        self.assertTrue(after.get("summaryDoc"))
+
+    def test_skipped_payload_carries_existing_review_status(self):
+        """Downstream consumer (lobster_request_spec_approval) reads the
+        reviewStatus emitted in the generated payload. For skipped items we
+        must emit the *existing* status, not 'summarized', so the downstream
+        step does not regress the item.
+        """
+        bookmark_key = "payload-key"
+        summary_rel = self._write_summary_doc(bookmark_key)
+        state = common.load_state(self.state_path)
+        state["items"][bookmark_key] = {
+            "bookmarkKey": bookmark_key,
+            "reviewStatus": "approval_pending",
+            "summaryDoc": summary_rel,
+            "summary": {"headline": "h", "problem": "p", "approach": "a", "valueProposition": "v", "keyDetails": [], "relevantTo": "r"},
+            "approvalId": "ap1234567",
+        }
+        common.save_state(state, self.state_path)
+        candidates = [self._make_record(bookmark_key)]
+
+        with patch.object(summarize_mod, "invoke_llm_json", side_effect=AssertionError("LLM should not be called")):
+            with patch("sys.stdin", io.StringIO(self._candidates_input(candidates))):
+                with patch.object(sys, "argv", ["lobster_summarize.py", "--json", "--reviews-root", str(self.reviews_root)]):
+                    rc = summarize_mod.main()
+
+        self.assertEqual(rc, 0)
+        after = common.load_state(self.state_path)["items"][bookmark_key]
+        self.assertEqual(after["reviewStatus"], "approval_pending")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bookmark-dashboard/index.html
+++ b/tools/bookmark-dashboard/index.html
@@ -198,13 +198,13 @@
   <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/d3-sankey@0.12.3/dist/d3-sankey.min.js"></script>
   <script>
-    const order = ["pending", "ingested", "summarized", "Curated: Monitoring", "Curated: High Signal", "spec_requested", "spec_created", "revision_staged", "approval_pending", "tasked", "declined"];
+    const order = ["pending", "ingested", "summarized", "Curated: Monitoring", "Curated: High Signal", "spec_requested", "spec_created", "revision_staged", "approval_pending", "tasked", "approved", "declined"];
     const colors = {
       pending: "#8aa0bd", ingested: "#8aa0bd", summarized: "#5a6b83",
       monitoring: "#b46a00",
       spec_requested: "#5e3f8a", spec_created: "#bd1e66",
       revision_staged: "#7254bd", revision_requested: "#9a6fd8",
-      approval_pending: "#d9257a", tasked: "#148f46", declined: "#a3312b",
+      approval_pending: "#d9257a", tasked: "#148f46", approved: "#0f9b59", declined: "#a3312b",
       "Curated: Monitoring": "#b46a00", "Curated: High Signal": "#2f75d6",
       // legacy states — muted so they're visible but clearly historical
       reviewed: "#c8d0db", summarised: "#c8d0db", queued_for_spec: "#c8d0db",
@@ -302,6 +302,7 @@
         specCreated: 0,
         approvalPending: 0,
         tasked: 0,
+        approved: 0,
         declined: 0,
       };
       for (const item of items) {
@@ -315,6 +316,7 @@
         else if (status === "spec_created") buckets.specCreated++;
         else if (status === "approval_pending" || status === "revision_staged") buckets.approvalPending++;
         else if (status === "tasked") buckets.tasked++;
+        else if (status === "approved") buckets.approved++;
         else if (status === "declined") buckets.declined++;
         else if (highScore) buckets.curatedImplement++;
         else if (hasCuration) buckets.monitoring++;  // low-score curation verdict
@@ -334,6 +336,7 @@
         { name: "Spec created",        count: buckets.specCreated,     value: buckets.specCreated,     color: "#bd1e66" },
         { name: "Awaiting approval",   count: buckets.approvalPending, value: buckets.approvalPending, color: "#d9257a" },
         { name: "Tasked",              count: buckets.tasked,          value: buckets.tasked,          color: "#148f46" },
+        { name: "Approved",            count: buckets.approved,        value: buckets.approved,        color: "#0f9b59" },
         { name: "Declined",            count: buckets.declined,        value: buckets.declined,        color: "#a3312b" },
       ];
       // Keep all nodes (including 0-value) so the chain stays connected.
@@ -345,7 +348,7 @@
       // visible even when items have moved on, and eliminates the artifact
       // where transient nodes (Spec requested) appear occupied due to
       // outgoing-only flow from downstream link values.
-      const approvalAndBeyond = buckets.approvalPending + buckets.tasked + buckets.declined;
+      const approvalAndBeyond = buckets.approvalPending + buckets.tasked + buckets.approved + buckets.declined;
       const specCreatedAndBeyond = buckets.specCreated + approvalAndBeyond;
       const specRequestedAndBeyond = buckets.specRequested + specCreatedAndBeyond;
       const implementBoundTotal = buckets.curatedImplement + specRequestedAndBeyond;
@@ -359,6 +362,7 @@
         { source: "Spec requested", target: "Spec created", value: specCreatedAndBeyond },
         { source: "Spec created", target: "Awaiting approval", value: approvalAndBeyond },
         { source: "Awaiting approval", target: "Tasked", value: buckets.tasked },
+        { source: "Awaiting approval", target: "Approved", value: buckets.approved },
         { source: "Awaiting approval", target: "Declined", value: buckets.declined },
       ];
       // Use node references (not indices) so links stay valid even if a
@@ -548,7 +552,7 @@
         const c = item.curation;
         if (!c) continue;
         const st = statusOf(item);
-        if (['spec_requested','spec_created','approval_pending','revision_staged','revision_requested','tasked','declined'].includes(st)) continue;
+        if (['spec_requested','spec_created','approval_pending','revision_staged','revision_requested','tasked','approved','declined'].includes(st)) continue;
         if (Number(c.score || 0) >= curThreshold) curHighSignal++; else curMonitoring++;
       }
       current['Curated: Monitoring'] = curMonitoring;


### PR DESCRIPTION
## Problem

The bookmark review lobster was rewinding items from spec_created back to summarized on every run, then re-promoting them via lobster_request_spec_approval.py. The same 3 items cycled repeatedly throughout the day - most recently at 10:56:28 / 10:56:41 / 10:56:51 today.

## Root cause

lobster_list_curate_candidates.py sets record.skipReview = True to signal no review regeneration. But lobster_summarize.py never read the flag. Its skip condition only matched reviewStatus == summarized, so items in any downstream state with a summaryDoc on disk got re-summarized, clobbering their reviewStatus back to summarized. lobster_request_spec_approval.py then re-promoted them.

## Fix

lobster_summarize.py now skips an item when:

1. record.skipReview is True, OR
2. The item already has a summaryDoc on disk (regardless of current reviewStatus)

The skipped payload emits the existing reviewStatus so downstream steps dont regress the item.

## Tests

tests/test_lobster_summarize_skip.py (new) covers 4 cases including the exact rewind bug. All pass. invoke_llm_json is mocked to fail if called for a skipped item.

## Base

Branched from feat/spec-bookmark-wiring. Ready to merge alongside PR #57.