### PR TITLE
cod—audit: sindustries weekly review 2026-W25

### DIFF
--- a/docs/repo-audits/2026-W25.md
+++ b/docs/repo-audits/2026-W25.md
@@ -1,0 +1,106 @@
+# Repo Audit — Week 25, 2026 (2026-06-16 → 2026-06-22)
+
+**Generated:** 2026-06-19
+**Type:** Drift-hazard capture (not a full four-phase audit)
+**Source PR:** [#69 — feat(design): integrate Pencil design system](https://github.com/Stoffer-Industries/sindustries/pull/69)
+**Reviewer:** Rowan (auto-generated via PR review)
+
+---
+
+## Executive Summary
+
+This is a focused drift-hazard note, not a full four-phase audit. Five small drift hazards surfaced during code review of PR #69 (the Pencil design system integration). Tom decided to track them here rather than address them in the PR, so they are captured with citations and suggested fixes for follow-up. No blockers, no `Critical`/`High` findings — all five are `Low`/`Medium` and concern latent coupling or config drift between two files in the same package. The next full audit runs Friday 2026-06-19 at 12:00 NZST on schedule.
+
+## Source PR
+
+PR #69 (`feat/design-system-pencil`) integrates the `@sindustries/ui` Pencil design system library, the token pipeline (tokens.json → CSS / TS / Pencil variables), and migrates both `apps/tasks` and `apps/website` off ad-hoc CSS onto the new kit. The five findings below were posted as inline review comments (review id `4528881056`) with verdict `COMMENTED` — Tom is otherwise happy to merge.
+
+## Findings
+
+### F1 — `KIT_TABS` hardcoded in `DesignSystemPage.jsx` (Low)
+
+**File:** `packages/ui/src/specimen/DesignSystemPage.jsx:11`
+**Severity:** Low
+**Problem:** `KIT_TABS` is hardcoded with ids (`tokens`, `pulse-react`, `brand-react`) and labels that duplicate what `SPECIMEN_PAGES` already carries (generated from `specimen-layout.json`). If a page is renamed, reordered, or added in the layout JSON, the tab strip silently drifts — either a tab points at no page, or a page has no tab.
+**Suggested fix:** Derive the tabs directly from `SPECIMEN_PAGES`, with an optional `tabLabel` field for short labels:
+```js
+const KIT_TABS = SPECIMEN_PAGES.map((p) => ({ id: p.id, label: p.tabLabel ?? p.title }));
+```
+**Why tracked here:** the drift is latent and only manifests when the layout JSON changes. Capturing now means the next person to touch `specimen-layout.json` sees the trap.
+
+### F2 — Initial theme defaults to `'dark'` in `DesignSystemPage.jsx` (Low)
+
+**File:** `packages/ui/src/specimen/DesignSystemPage.jsx:19`
+**Severity:** Low
+**Problem:** Initial `theme` is hardcoded to `'dark'`, but pages can declare their own `theme` (e.g. `brand-react` has `theme: 'light'`). Works today because `SPECIMEN_PAGES[0]` is the tokens page with no `theme` field, but if the first page ever had `theme: 'light'`, the initial render would briefly show dark mode until the user clicks a tab.
+**Suggested fix:**
+```js
+const initialPage = SPECIMEN_PAGES[0];
+const [activePageId, setActivePageId] = useState(initialPage?.id ?? 'tokens');
+const [theme, setTheme] = useState(initialPage?.theme ?? 'dark');
+```
+**Why tracked here:** coupled with F1 — both come from the same "the specimen page hardcodes things it should derive from the layout JSON" root cause.
+
+### F3 — Redundant `[data-si-theme='light']` block in `variables.css` (Low)
+
+**File:** `apps/tasks/src/styles/variables.css:16`
+**Severity:** Low
+**Problem:** The `[data-si-theme='light']` block defines `--si-canvas-gradient` with the exact same expression as the dark block, and the gradient only references already-themed CSS variables (`--si-color-bg-section`, `--si-color-bg-canvas`). The light override is redundant — the gradient already re-resolves correctly when the theme switches, because its inputs do.
+**Suggested fix:** Drop the light block and keep just the `:root, [data-si-theme='dark']` definition (or move it to a non-themed `:root` block entirely).
+**Why tracked here:** cosmetic — dead CSS that will confuse future readers.
+
+### F4 — Alias drift between `vite.config.js` and `vitest.config.js` (Medium)
+
+**File:** `apps/tasks/vitest.config.js:11`
+**Severity:** Medium (latent — no test exercises this today)
+**Problem:** The vitest aliases are a strict subset of the ones in `apps/tasks/vite.config.js`. `@sindustries/ui/specimen` and `@sindustries/ui/specimen/styles.css` are missing from vitest. No test imports the specimen entry today, so this passes — but the day someone writes a test that touches `DesignSystemPage`, vitest will fail to resolve while `vite dev` keeps working.
+**Suggested fix:** Either drop the aliases entirely and let `packages/ui/package.json#exports` handle resolution (Node's exports map is already configured), or share them between configs (extract a `vite.shared.js`).
+**Why tracked here:** medium severity because the failure mode is silent — `vite build` works, tests fail mysteriously. Better to fix before the first specimen test exists.
+
+### F5 — `priorityVariant` duplicates `PRIORITIES` in `TaskCardSummary.jsx` (Low)
+
+**File:** `apps/tasks/src/components/TaskCardSummary.jsx:5`
+**Severity:** Low
+**Problem:** The priority list is hardcoded here (`['urgent', 'high', 'medium', 'low']`) and duplicates `PRIORITIES` from `../utils/constants.js`. If priorities are added/removed/reordered, this falls out of sync and an unrecognized priority silently renders as `'neutral'`.
+**Suggested fix:**
+```js
+import { PRIORITIES } from '../utils/constants.js';
+
+function priorityVariant(priority) {
+  return PRIORITIES.includes(priority) ? priority : 'neutral';
+}
+```
+**Why tracked here:** classic drift hazard — same pattern as F1/F2. Worth fixing in a sweep across `apps/tasks` for any other places where constants get duplicated locally.
+
+## Strengths
+
+PR #69 is genuinely strong. Calling out what's right:
+
+- **Token pipeline** (`tokens.json` → CSS / TS / Pencil variables) is clean and well-tested. The `check-design-sync.mjs` script enforces React exports ↔ `component-catalog.json` parity and runs `git diff --quiet` on generated outputs — that's the kind of forcing function that prevents drift over time.
+- **`packages/ui` package layout** — base / pulse / brand CSS layers with a `cx` helper, `data-si-pack` shells, and `forwardRef` where it matters. Reads well.
+- **Specimen page wiring** — `DesignSystemPage` is impressively set up to drive a `/tokens` specimen from `specimen-layout.json` (which is why F1/F2 are even visible: the underlying infrastructure is solid, only the consumer is hardcoding).
+- **Test coverage** — strong on the new code: `DesignSystemPage.test.jsx`, `pen-document.test.mjs`, `pen-refs.test.mjs`, plus app-level tests on `App.jsx` / `TaskEditor.jsx` / `helpers.test.js`. The new `design-system-sync` CI job will keep generated artifacts honest.
+- **Migration consistency** — `Card`, `Button`, `Field`, etc. replace ad-hoc HTML in both `apps/tasks` and `apps/website` with matching tests added. No half-migrated components.
+
+The five findings above are minor follow-up material, not critique of the work.
+
+## Improvement Strategy
+
+This is a small finding set; no new themes are warranted. The implicit theme across F1, F2, and F5 is **"derive configuration from the source of truth rather than duplicate it inline"** — worth keeping in mind when reviewing the next design-system PR. F3 is a one-line CSS cleanup. F4 needs the alias config extracted or removed before it bites someone.
+
+## Task Plan
+
+| Task | Severity | Effort | Suggested owner |
+|------|----------|--------|-----------------|
+| T1 — F3 cleanup (drop redundant `[data-si-theme='light']` block) | Low | Trivial | Rowan, in a follow-up PR |
+| T2 — F5 cleanup (`TaskCardSummary` import `PRIORITIES`) | Low | Trivial | Rowan, in a follow-up PR |
+| T3 — F1 + F2 (derive `KIT_TABS` and initial theme from `SPECIMEN_PAGES`) | Low | Small | Rowan, in a follow-up PR |
+| T4 — F4 (resolve alias drift between vite and vitest configs) | Medium | Small | Rowan, requires a test to verify |
+
+These are intentionally not created as Tasks API tasks — Tom flagged this pattern in the repo-audit SKILL guidance (no auto-tasks from audits). They'll come back if/when Tom wants to schedule them.
+
+## Open Questions
+
+- **F4 fix path:** does Tom want the aliases dropped entirely (relying on `package.json#exports`), or extracted into a shared `vite.shared.js`? Both work; the first is leaner but requires a smoke test to confirm Node's exports resolution behaves correctly in vitest.
+- **Specimen `tabLabel`:** if F1's fix is taken, do we want short labels (`Tokens` / `Pulse` / `Brand`) different from full titles? That determines whether `specimen-layout.json` needs a new `tabLabel` field.
+- **Full audit cadence:** Friday-noon cron is now scheduled. Should this drift-hazard doc be replaced by next week's full audit, or kept as a parallel lightweight log of PR-time findings?


### PR DESCRIPTION
## Summary

Drift-hazard capture for 5 review findings from PR #69 (`feat/design-system-pencil`). These were flagged by Rowan in his PR review but Tom decided to track them here rather than address them in the design system PR.

**Type:** focused drift-hazard note (not a full four-phase audit).
**Severity range:** Low–Medium. No blockers.
**Source:** [PR #69 review (id 4528881056)](https://github.com/Stoffer-Industries/sindustries/pull/69#pullrequestreview-4528881056)

## Findings

1. `packages/ui/src/specimen/DesignSystemPage.jsx:11` — `KIT_TABS` hardcoded, drifts from generated `SPECIMEN_PAGES`.
2. `packages/ui/src/specimen/DesignSystemPage.jsx:19` — initial theme hardcoded to `'dark'`, ignores `SPECIMEN_PAGES[0].theme`.
3. `apps/tasks/src/styles/variables.css:16` — redundant `[data-si-theme='light']` block defines `--si-canvas-gradient` identically to dark.
4. `apps/tasks/vitest.config.js:11` — vitest aliases are a strict subset of vite aliases; specimen aliases missing.
5. `apps/tasks/src/components/TaskCardSummary.jsx:5` — `priorityVariant` duplicates `PRIORITIES` from constants.

Full audit doc: [`docs/repo-audits/2026-W25.md`](docs/repo-audits/2026-W25.md)

## Next

The full four-phase repo audit cron is now scheduled Friday 12:00 NZST on `claude-fable-5`. Next week's audit (2026-W26) will be a full audit; this week's doc is a focused drift-hazard capture, intentionally lighter than the standard audit shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
