### PR TITLE
cod—audit: sindustries weekly review 2026-W25

### DIFF
--- a/docs/repo-audits/2026-W25.md
+++ b/docs/repo-audits/2026-W25.md
@@ -1,106 +1,279 @@
-# Repo Audit — Week 25, 2026 (2026-06-16 → 2026-06-22)
+# Repo Audit — sindustries — 2026-W25 (2026-06-15 → 2026-06-21)
 
-**Generated:** 2026-06-19
-**Type:** Drift-hazard capture (not a full four-phase audit)
-**Source PR:** [#69 — feat(design): integrate Pencil design system](https://github.com/Stoffer-Industries/sindustries/pull/69)
-**Reviewer:** Rowan (auto-generated via PR review)
+**Generated:** 2026-06-19 (Friday weekly cron)
+**Auditor:** Rowan (Staff Engineer)
+**Target:** `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`
+**Type:** Full four-phase audit (replaces the 2026-W25 drift-hazard capture)
 
 ---
 
 ## Executive Summary
 
-This is a focused drift-hazard note, not a full four-phase audit. Five small drift hazards surfaced during code review of PR #69 (the Pencil design system integration). Tom decided to track them here rather than address them in the PR, so they are captured with citations and suggested fixes for follow-up. No blockers, no `Critical`/`High` findings — all five are `Low`/`Medium` and concern latent coupling or config drift between two files in the same package. The next full audit runs Friday 2026-06-19 at 12:00 NZST on schedule.
+The sindustries monorepo is a **small but maturing internal product platform**: a Tasks API + React app, a public website, a shared UI/design-tokens kit, and OpenTelemetry plumbing — wrapped in dev/prodlike mode discipline and a credible CI lane. Architecture, monorepo boundaries, and dev ergonomics are genuinely strong (clear `apps/`/`services/`/`packages/`/`infra/` split, mode-aware `make` wrappers, port↔DB pairing guard, prodlike seed guard). The honest weak spots are: (a) the Tasks API’s read endpoint pages-then-sorts in memory, silently breaking `nextCursor` for non-default sorts; (b) the React app fetches `limit=10000` every 3 s, making pagination a fiction and scaling unattractive; (c) 28 npm advisories (1 High `@grpc/grpc-js`, plus a DOMPurify sanitizer-bypass that touches the markdown render path); (d) the “real” e2e job in CI boots Postgres + the API and then immediately replaces all API calls with `page.route()` mocks, contradicting `docs/architecture.md` and weakening the AC-coverage promise in `CONTRIBUTING.md`; (e) `App.jsx` has grown to 952 lines and now owns view state, filters, drag/drop, confetti, Web Audio, drafts, and DOM scrolling. None of these are launch blockers — V1 is single-user/internal — but they will compound. **Overall health: B (solid foundations, two real correctness/perf bugs and a credible-tests problem).** Top 3 risks: pagination/perf bug pair, mocked-but-claimed-real e2e, vulnerable dependencies in the live render path. Top 3 opportunities: (1) replace hand-rolled validation with a shared schema, (2) split `App.jsx` and fix pagination once, (3) make one e2e lane actually hit the real stack so CI matches the docs.
 
-## Source PR
+## Repo Map
 
-PR #69 (`feat/design-system-pencil`) integrates the `@sindustries/ui` Pencil design system library, the token pipeline (tokens.json → CSS / TS / Pencil variables), and migrates both `apps/tasks` and `apps/website` off ad-hoc CSS onto the new kit. The five findings below were posted as inline review comments (review id `4528881056`) with verdict `COMMENTED` — Tom is otherwise happy to merge.
+**Purpose:** Mono-repo for Stoffer Industries product surfaces (Tasks app + public website), the services that back them, and shared design/observability packages. README is candid: *"Current repo state is early implementation: documentation plus Milestone 1 backend foundation in `services/tasks-api`."*
 
-## Findings
+**Stack:**
+- Node 22, npm workspaces (`package.json:9-12`)
+- Apps: React 18 + Vite 8 (`apps/tasks`, `apps/website`)
+- Service: Express 4 + Prisma 5 + Postgres 16 (`services/tasks-api`)
+- Shared: `@sindustries/ui` (React component kit + Pencil specimen), `@sindustries/design-tokens` (Style Dictionary–like pipeline), `@sindustries/otel-node` (OTel auto-instrumentation)
+- Tests: Vitest everywhere, Playwright for e2e, `node --test` for the design-tokens pipeline, Python `unittest` for the agents/workflows lane
+- Local runtime: Docker Compose Postgres + Tilt orchestrating host-run API/app; CI on GitHub Actions with a service-container Postgres
 
-### F1 — `KIT_TABS` hardcoded in `DesignSystemPage.jsx` (Low)
-
-**File:** `packages/ui/src/specimen/DesignSystemPage.jsx:11`
-**Severity:** Low
-**Problem:** `KIT_TABS` is hardcoded with ids (`tokens`, `pulse-react`, `brand-react`) and labels that duplicate what `SPECIMEN_PAGES` already carries (generated from `specimen-layout.json`). If a page is renamed, reordered, or added in the layout JSON, the tab strip silently drifts — either a tab points at no page, or a page has no tab.
-**Suggested fix:** Derive the tabs directly from `SPECIMEN_PAGES`, with an optional `tabLabel` field for short labels:
-```js
-const KIT_TABS = SPECIMEN_PAGES.map((p) => ({ id: p.id, label: p.tabLabel ?? p.title }));
+**Architecture sketch (data/control flow):**
 ```
-**Why tracked here:** the drift is latent and only manifests when the layout JSON changes. Capturing now means the next person to touch `specimen-layout.json` sees the trap.
-
-### F2 — Initial theme defaults to `'dark'` in `DesignSystemPage.jsx` (Low)
-
-**File:** `packages/ui/src/specimen/DesignSystemPage.jsx:19`
-**Severity:** Low
-**Problem:** Initial `theme` is hardcoded to `'dark'`, but pages can declare their own `theme` (e.g. `brand-react` has `theme: 'light'`). Works today because `SPECIMEN_PAGES[0]` is the tokens page with no `theme` field, but if the first page ever had `theme: 'light'`, the initial render would briefly show dark mode until the user clicks a tab.
-**Suggested fix:**
-```js
-const initialPage = SPECIMEN_PAGES[0];
-const [activePageId, setActivePageId] = useState(initialPage?.id ?? 'tokens');
-const [theme, setTheme] = useState(initialPage?.theme ?? 'dark');
+React (apps/tasks)
+  └─ tasksApi.ts ── fetch ──▶ Express (services/tasks-api)
+                                  └─ Prisma ──▶ Postgres (schema: tasks_api)
+                                  └─ OTel SDK ──▶ OTLP HTTP ──▶ Tempo/Prometheus
+React (apps/website)  (static content from src/content/*.json + markdown)
 ```
-**Why tracked here:** coupled with F1 — both come from the same "the specimen page hardcodes things it should derive from the layout JSON" root cause.
 
-### F3 — Redundant `[data-si-theme='light']` block in `variables.css` (Low)
+**Key directories:**
+- `apps/tasks/` — first product surface (Backlog + Kanban + drafts + markdown)
+- `apps/website/` — public site; long-scroll narrative + Vercel deploy
+- `apps/mission-control/` — placeholder (README only)
+- `services/tasks-api/` — Express+Prisma REST API for tasks/tags/comments
+- `packages/ui/` — `@sindustries/ui/react` kit + `@sindustries/ui/specimen` design-system page
+- `packages/design-tokens/` — `tokens.json` → CSS/TS/Pencil pipeline with sync checks
+- `packages/otel-node/` — shared OTel bootstrap (`startOtel` + CJS `register`)
+- `infra/` — Compose, Tilt, Grafana/Tempo/Prometheus/OTel-collector configs
+- `scripts/dev/` — mode-aware `up/down/reset-db/migrate-db/bootstrap`
+- `agents/` — workflows + Python skills (bookmark pipeline, content-task, tasks-api ops)
+- `tests/` — Python unit tests for the agents/workflows lane (not the product code)
+- `docs/specs/`, `docs/architecture.md`, `docs/repo-audits/` — spec-first artefacts
 
-**File:** `apps/tasks/src/styles/variables.css:16`
-**Severity:** Low
-**Problem:** The `[data-si-theme='light']` block defines `--si-canvas-gradient` with the exact same expression as the dark block, and the gradient only references already-themed CSS variables (`--si-color-bg-section`, `--si-color-bg-canvas`). The light override is redundant — the gradient already re-resolves correctly when the theme switches, because its inputs do.
-**Suggested fix:** Drop the light block and keep just the `:root, [data-si-theme='dark']` definition (or move it to a non-themed `:root` block entirely).
-**Why tracked here:** cosmetic — dead CSS that will confuse future readers.
+**Surprises during discovery:**
+- The “real” e2e CI job (`tasks-app-e2e`) brings up Postgres and `tasks-api` and then runs Playwright tests that mock all API calls with `page.route('**/api/v1/tasks**', …)` (`apps/tasks/test/e2e/happy-path.spec.js:21`). The infra is real but the test is not.
+- `apps/tasks/src/tasksApi.ts:99` fetches `limit=10000` every 3 s (`useTasks.js:4`) — pagination at the API layer is silently bypassed at the client.
+- `services/tasks-api/src/routes/tasks.ts:8-11` only **validates** assignees against `{Tom,Quinn,Rowan,Lox,Ivy}`, but `apps/tasks/src/utils/constants.js:14`’s `ASSIGNEE_OPTIONS = ['Quinn','Rowan','Lox','Tom']` is missing `Ivy`. Frontend dropdown and backend allowlist disagree.
+- `services/tasks-api/prisma/migrate-todo-to-ready.ts` is a one-shot script that lives in `prisma/` and would not be re-runnable; it’s dead weight that future readers will be tempted to run.
+- `services/tasks-api/tsconfig.json:5` has `"strict": false`. The route files are `.ts` but parameters are untyped — TS is effectively cosmetic.
+- 28 npm audit advisories (1 High `@grpc/grpc-js`, 27 Moderate including a DOMPurify sanitizer-bypass that affects the markdown render path used to display task descriptions).
+- `.gitignore` excludes `.env`, `.env.dev`, `.env.prodlike` but **not** `.env*.bak`. A `services/tasks-api/.env.prodlike.bak` already exists locally (`git status`) and is one stray `git add -A` from being committed.
+- `apps/tasks/src/App.jsx` has grown to **952 lines** and owns ~12 concerns (state machines, filters, drag/drop, confetti, Web Audio, scroll targeting, drafts).
 
-### F4 — Alias drift between `vite.config.js` and `vitest.config.js` (Medium)
+## Audit Report
 
-**File:** `apps/tasks/vitest.config.js:11`
-**Severity:** Medium (latent — no test exercises this today)
-**Problem:** The vitest aliases are a strict subset of the ones in `apps/tasks/vite.config.js`. `@sindustries/ui/specimen` and `@sindustries/ui/specimen/styles.css` are missing from vitest. No test imports the specimen entry today, so this passes — but the day someone writes a test that touches `DesignSystemPage`, vitest will fail to resolve while `vite dev` keeps working.
-**Suggested fix:** Either drop the aliases entirely and let `packages/ui/package.json#exports` handle resolution (Node's exports map is already configured), or share them between configs (extract a `vite.shared.js`).
-**Why tracked here:** medium severity because the failure mode is silent — `vite build` works, tests fail mysteriously. Better to fix before the first specimen test exists.
+Findings are evidence-based. Each is flagged **Fact** (verifiable from the code as written) or **Judgment** (interpretation of risk/quality). Severity grades: `Critical`, `High`, `Medium`, `Low`. Carried-over findings from the 2026-W25 drift-hazard capture (PR #69) are still present and re-listed at the end of this section as **Low**.
 
-### F5 — `priorityVariant` duplicates `PRIORITIES` in `TaskCardSummary.jsx` (Low)
+### Architecture & design
 
-**File:** `apps/tasks/src/components/TaskCardSummary.jsx:5`
-**Severity:** Low
-**Problem:** The priority list is hardcoded here (`['urgent', 'high', 'medium', 'low']`) and duplicates `PRIORITIES` from `../utils/constants.js`. If priorities are added/removed/reordered, this falls out of sync and an unrecognized priority silently renders as `'neutral'`.
-**Suggested fix:**
-```js
-import { PRIORITIES } from '../utils/constants.js';
+- **A1 — `apps/tasks/src/App.jsx` is a 952-line god component.** *(Judgment, Medium.)* It owns view persistence, theme, filters, status multi-select, draft store, drag-and-drop, scroll-to-card, confetti, Web Audio, and beforeunload — all in one file. Concrete consequence: future feature changes touch a single hotspot, hurting reviewability and reuse. See `apps/tasks/src/App.jsx:40` through `:952`. The two child components (`TaskEditor.jsx`, `TaskCardSummary.jsx`) are crisp; the parent is where the rot is forming.
+- **A2 — `services/tasks-api/src/routes/tasks.ts` mixes validation, query building, sorting and mapping in a 517-line file.** *(Fact, Medium.)* `validStatuses`, `validPriorities`, `validAssignees` and `priorityOrder` are inline (`tasks.ts:8-18`). One module is the entire write surface plus the entire read surface plus all sort policy. Same change-set risk as A1.
 
-function priorityVariant(priority) {
-  return PRIORITIES.includes(priority) ? priority : 'neutral';
-}
-```
-**Why tracked here:** classic drift hazard — same pattern as F1/F2. Worth fixing in a sweep across `apps/tasks` for any other places where constants get duplicated locally.
+**Strengths:** the monorepo boundary discipline is genuine — `apps/`, `services/`, `packages/`, `infra/`, `docs/` separation is clean (`README.md:7-13`), and `docs/architecture.md:54-63` keeps cross-service tables off-limits.
 
-## Strengths
+### Code quality
 
-PR #69 is genuinely strong. Calling out what's right:
+- **C1 — Duplicated priority/status/assignee constants drift between client and server.** *(Fact, Medium.)* Priority order lives in `services/tasks-api/src/routes/tasks.ts:13-18` and `apps/tasks/src/utils/constants.js:14` (`PRIORITY_SCORE`) and is used again in `apps/tasks/src/App.jsx:212` and `:226`. Assignee allowlist is `{Tom,Quinn,Rowan,Lox,Ivy}` in `tasks.ts:10` but `ASSIGNEE_OPTIONS = ['Quinn','Rowan','Lox','Tom']` in `constants.js:15` — **`Ivy` is unselectable in the frontend dropdown today** (`App.jsx:601-614`).
+- **C2 — TaskEditor cannot edit `taskType` after creation.** *(Fact, Medium.)* `App.jsx:114,247,723` set `taskType` on the create form and POST it. `apps/tasks/src/components/TaskEditor.jsx` never references `taskType`; `buildSavePayload()` (`TaskEditor.jsx:63-77`) omits the field entirely. Consequence: a wrong content-type at create time is unfixable from the UI; content workflows that route on `taskType` will silently miss tasks.
+- **C3 — Dead one-shot migration script left in `prisma/`.** *(Fact, Low.)* `services/tasks-api/prisma/migrate-todo-to-ready.ts` is a January-era data migration. It’s not in the Prisma migration history and will fail (`status='todo'` no longer exists). Should move to `tools/` or be deleted.
+- **C4 — `marked.setOptions` is deprecated in `marked` v17.** *(Fact, Low.)* `apps/tasks/src/utils/markdown.js:4` uses `marked.setOptions({ gfm: true, breaks: true })`; v17 prefers `marked.use({ gfm: true, breaks: true })`. Works today; will warn or regress on next major bump.
+- **C5 — Hand-rolled validation is repeated across each endpoint without a schema.** *(Judgment, Medium.)* `tasks.ts:120-160`, `:330-341`, `:401-437`, `tags.ts:24-28` all roll their own checks. Error codes are inline strings duplicated between POST/PATCH (`INVALID_ASSIGNEE` text is hand-copied at `:340` and `:396`). A single Zod schema per request would compress ~150 LOC and eliminate drift like C1.
 
-- **Token pipeline** (`tokens.json` → CSS / TS / Pencil variables) is clean and well-tested. The `check-design-sync.mjs` script enforces React exports ↔ `component-catalog.json` parity and runs `git diff --quiet` on generated outputs — that's the kind of forcing function that prevents drift over time.
-- **`packages/ui` package layout** — base / pulse / brand CSS layers with a `cx` helper, `data-si-pack` shells, and `forwardRef` where it matters. Reads well.
-- **Specimen page wiring** — `DesignSystemPage` is impressively set up to drive a `/tokens` specimen from `specimen-layout.json` (which is why F1/F2 are even visible: the underlying infrastructure is solid, only the consumer is hardcoding).
-- **Test coverage** — strong on the new code: `DesignSystemPage.test.jsx`, `pen-document.test.mjs`, `pen-refs.test.mjs`, plus app-level tests on `App.jsx` / `TaskEditor.jsx` / `helpers.test.js`. The new `design-system-sync` CI job will keep generated artifacts honest.
-- **Migration consistency** — `Card`, `Button`, `Field`, etc. replace ad-hoc HTML in both `apps/tasks` and `apps/website` with matching tests added. No half-migrated components.
+### Security
 
-The five findings above are minor follow-up material, not critique of the work.
+- **S1 — High-severity advisory in `@grpc/grpc-js@1.14.0–1.14.3`.** *(Fact, High.)* `npm audit --omit=dev` reports `GHSA-5375-pq7m-f5r2` and `GHSA-99f4-grh7-6pcq` — malformed message DoS — pulled in via `@opentelemetry/auto-instrumentations-node` (`packages/otel-node/package.json:19`). The OTel SDK runs in the tasks-api process, so a remote attacker who can talk to the OTLP gRPC port (or get the SDK to call back to a hostile server) could crash the API. `npm audit fix` is available; resolution is non-breaking.
+- **S2 — DOMPurify 3.3.3 has a moderate sanitizer-bypass (`GHSA-cmwh-pvxp-8882`).** *(Fact, High.)* `apps/tasks/package.json:13` pins `dompurify ^3.3.3`. DOMPurify is the only thing standing between Markdown task descriptions and `dangerouslySetInnerHTML` in `apps/tasks/src/components/MarkdownContent.jsx:15`. Even single-user mode, a task created by a future agent or pasted from elsewhere can carry crafted HTML. Bump to `>= 3.4.11`.
+- **S3 — Tasks API is fully unauthenticated and unthrottled.** *(Fact, High, but accepted by V1 spec.)* `services/tasks-api/src/app.ts` has CORS but no auth, no rate limiting, no `helmet`, no request-size cap. `docs/specs/tasks-one-pager.md:25` calls out “**V1 auth:** no auth for now (internal/single-user mode).” That is a known business decision; the risk is that the vite config (`apps/tasks/vite.config.js:11-16`) already opens the dev server to Tailscale (`toms-mac-mini.tail78ceba.ts.net`, `100.106.176.15`) — so the same posture in production would expose every endpoint, including `DELETE /api/v1/tasks/:id`, to anyone on the tailnet. Decide before any prod-like exposure.
+- **S4 — `.env.prodlike.bak` is not git-ignored.** *(Fact, Medium.)* `.gitignore` lists `.env`, `.env.dev`, `.env.prodlike` but not `*.bak`. `services/tasks-api/.env.prodlike.bak` currently exists locally and contains a DB URL (`services/tasks-api/.env.prodlike.bak:3`). One `git add -A` would publish it. Add `**/.env*.bak` to `.gitignore`.
+- **S5 — No request body size limit on `express.json()`.** *(Fact, Medium.)* `services/tasks-api/src/app.ts:46` uses defaults. Express 4 defaults to 100kb but does not cap nested object depth; task descriptions are unbounded text and `comments` payloads accept arbitrary author + text strings (`tasks.ts:481-499`). Set `express.json({ limit: '64kb' })` and consider `helmet`.
+
+### Testing
+
+- **T1 — “e2e” tests mock every API call.** *(Fact, High.)* All four files in `apps/tasks/test/e2e/` install `page.route('**/api/v1/tasks**', …)` and return canned JSON (`happy-path.spec.js:21`, `priority-filter.spec.js`, `assignee-filter.spec.js`, `assignee-dropdown.spec.js`). The CI job `tasks-app-e2e` (`.github/workflows/ci.yml:118-190`) brings up Postgres, applies migrations, seeds, starts `tasks-api`, waits for `/health` — and the tests then route past all of it. `docs/architecture.md:98-102` promises “real app -> API -> Postgres flow (no route mocks).” `CONTRIBUTING.md:84-85` asserts every AC needs an e2e test; today no AC actually traverses the live API. This is the largest credible-tests problem in the repo.
+- **T2 — In-memory sort defeats cursor pagination for non-default sorts.** *(Fact, High.)* `tasks.ts:234-272`: `prisma.task.findMany` orders by `createdAt DESC, id DESC` and uses the cursor `(createdAt, id)` for the next page. Then the response is **re-sorted in JS** by `priority` / `dueAt` / arbitrary key. The `nextCursor` is computed from the last item of the JS-sorted slice (`:275-281`). For `sort=priority`, “last by createdAt within page” ≠ “last by priority within page,” so the next page can drop tasks or repeat them. Caught today only because the client requests `limit=10000` and rarely paginates. No test covers this — `read-endpoints.test.ts` only checks `nextCursor=null` cases.
+- **T3 — Aggressive 3 s auto-refresh + `limit=10000` is the de facto product behavior.** *(Fact, Medium.)* `apps/tasks/src/useTasks.js:4` defaults `refreshIntervalMs=3000`; `apps/tasks/src/App.jsx:158` passes that default; `apps/tasks/src/tasksApi.ts:99` requests `limit=10000`. Today’s task counts hide the load; with 10× growth this is a 5×/min cold cursor query plus full-payload JSON over the wire.
+- **T4 — `prisma-validate.test.ts` shells out to `npx prisma validate`.** *(Fact, Low.)* It runs `execSync` synchronously inside Vitest (`services/tasks-api/test/prisma-validate.test.ts:11-22`). Useful, but adds ~2 s and a global filesystem dependency to the unit lane. Move to a `prebuild` script or a dedicated CI step.
+
+**Strengths:** the design-tokens lane uses `node --test` cleanly (`packages/design-tokens/scripts/*.test.mjs`), the integration test `db-integration.test.ts` does a real end-to-end through Express+Prisma+Postgres in CI, and unit coverage on helpers (`storage.test.js`, `helpers.test.js`, `markdown.test.js`, `useDebounce.test.js`, `useToast.test.js`) is genuinely good.
+
+### Performance
+
+- **P1 — `connectTags` upserts tags one round-trip at a time.** *(Fact, Low → Medium under load.)* `tasks.ts:103-115` issues N parallel `tag.upsert` calls per create/patch. Fine for ≤5 tags; replace with `tag.findMany({ where: { name: { in: names } } })` + a `createMany({ skipDuplicates: true })` for the unknown remainder, in one transaction.
+- **P2 — No transaction wraps `task.update` + `taskTag.deleteMany` + `taskTag.createMany`.** *(Fact, Medium.)* `tasks.ts:439-462`: a partial failure (e.g., a tag upsert succeeds, the `createMany` fails) leaves task fields written but tag relations half-rebuilt. Wrap in `prisma.$transaction`.
+- **P3 — Repeated `findFirst → update → findFirst → findFirst` per PATCH.** *(Fact, Low.)* `tasks.ts:380, 439, 464` — three queries plus the update. Two of those reads can collapse into a single returning-shape Prisma call. Minor.
+
+### Dependencies
+
+- **D1 — `npm audit --omit=dev` reports 28 advisories** (1 High, 27 Moderate). *(Fact, High overall.)* Beyond S1/S2: every OpenTelemetry sub-package is on a vulnerable `core` (`<2.8.0`, `GHSA-8988-4f7v-96qf`, unbounded memory in W3C baggage). `npm audit fix --force` jumps OTel to a breaking 0.219.0 line; coordinate a deliberate upgrade rather than a forced fix.
+- **D2 — Express 4 is end-of-life-soon; Express 5 is GA.** *(Fact, Low.)* `services/tasks-api/package.json:14` pins `express ^4.21.0`. Not urgent; mention it before adding more route surface.
+- **D3 — `apps/tasks` depends on React 18 runtime but `@types/react` is on **19**.** *(Fact, Low.)* `apps/tasks/package.json:18` lists `react@^18.3.1` while `@types/react@^19.2.14`. Types drift from the actual runtime; one day a `useId`/`use`/`useActionState` JSDoc lands in an editor IntelliSense and gets used in code that crashes in production. Pin types to the runtime line.
+
+### DevEx & operations
+
+- **DX1 — No lint/format configuration anywhere in the repo.** *(Fact, Medium.)* No `eslint.config.*`, `.prettierrc*`, `biome.json`, or equivalent at root or in any workspace. CI (`.github/workflows/ci.yml`) runs no static analysis. Conventions live only in `CONTRIBUTING.md` prose. The 952-line `App.jsx` and the duplicated assignee list (C1) are exactly the class of drift a linter catches.
+- **DX2 — `console.error(error)` is the only error channel.** *(Fact, Medium.)* `services/tasks-api/src/app.ts:57` logs the raw error and returns a generic 500. With OTel already running, structured logs joined to `trace_id` would close the “follow-up” loop the README explicitly calls out (`README.md:69-71`). At minimum: log a request id and the route path with the error.
+- **DX3 — `make test` does not match what CI tests.** *(Fact, Low.)* `make test` runs `test-api`, `test-app`, `test-e2e`. CI also runs `python-workflow-tests`, `otel-node-tests`, `website-app-tests`, `design-system-sync`, and the `check:content-links` step. A developer running `make test` cleanly can still break CI on the Python or design-sync lanes. Add a `make test-ci` or `make test-all`.
+- **DX4 — `tsconfig.json` has `"strict": false` in `services/tasks-api`.** *(Fact, Medium.)* The `apps/tasks/tsconfig.json` is strict (`apps/tasks/tsconfig.json:18`) — but the service that handles all task writes opts out. Most route functions take `(req, res, next)` with no type annotation; the file is `.ts` only for the import-extension trick. Either commit to strict TS service-side, or be honest and rename the routes back to `.js`.
+
+### Documentation
+
+- **DOC1 — `docs/architecture.md` contradicts the e2e implementation.** *(Fact, Medium.)* Lines 98-102 promise Playwright tests run against “real app -> API -> Postgres flow (no route mocks)” but the spec files do exactly the opposite (T1).
+- **DOC2 — `docs/specs/tasks-one-pager.md` still lists `todo, doing, done` (`:42, :49`)** as the V1 status flow, while the actual enum is `open, ready, doing, acceptance, done` (`schema.prisma:10-16`). The one-pager is the cited source of truth and is now wrong. Update or annotate as superseded.
+- **DOC3 — `README.md` documents the local migration auto-recovery in detail (`:95-105`)** — that’s a strength. Keep.
+
+### Carried-over drift hazards (from 2026-W25 drift-hazard capture)
+
+All five findings logged 2026-06-17 in the prior `docs/repo-audits/2026-W25.md` are still present in `HEAD` and re-tracked here so they don’t fall off the list when this audit replaces that file:
+
+- **F1 (Low)** — `KIT_TABS` hardcoded in `packages/ui/src/specimen/DesignSystemPage.jsx:7-11`; should derive from `SPECIMEN_PAGES`. *(Verified unchanged.)*
+- **F2 (Low)** — Initial theme defaults to `'dark'` in `DesignSystemPage.jsx:19`; should derive from `SPECIMEN_PAGES[0]?.theme`.
+- **F3 (Low)** — Redundant `[data-si-theme='light']` block at `apps/tasks/src/styles/variables.css:10-17`; same expression as the dark block.
+- **F4 (Medium)** — Alias drift: `apps/tasks/vitest.config.js:11` is a subset of `apps/tasks/vite.config.js:21-27` (missing the `specimen` aliases). Silent vitest failure waiting for the first specimen test.
+- **F5 (Low)** — `priorityVariant` in `apps/tasks/src/components/TaskCardSummary.jsx:5` hardcodes `['urgent','high','medium','low']` instead of importing `PRIORITIES`. Same root cause as C1.
+
+### Strengths (what this repo does well)
+
+- **Monorepo discipline.** `apps/`, `services/`, `packages/`, `infra/`, `docs/`, `agents/` boundaries are real and consistent (`README.md:7-13`, `docs/architecture.md:3-21`).
+- **Mode-aware local stack with safety rails.** `assertApiPortDbPortPairing` (`server.ts:14-40`) and `assertSafeSeedTarget` (`prisma/seed.js:9-36`) refuse to start or seed against the wrong DB. `scripts/dev/reset-db.sh:32-36` blocks accidental prodlike seeding.
+- **CI matrix that exercises real infra where it matters.** `tasks-api tests (unit + db integration)` (`.github/workflows/ci.yml:46-93`) actually runs Prisma migrations + integration tests against a real Postgres service container.
+- **Design-token forcing function.** `npm run check:design-sync` (`.github/workflows/ci.yml:238`) git-diffs generated artefacts and fails CI on drift — exactly the kind of guard rail this stack needs more of.
+- **Spec-first culture is real.** `docs/specs/` has nine living specs, and `CONTRIBUTING.md:30-66` is direct about how non-trivial work must be done.
+- **OpenTelemetry plumbing is properly wired.** `packages/otel-node/src/register.cjs:8-37` correctly preloads via `--require` so Express/pg are patched before app code loads.
+- **Strong unit/component test coverage on the front-end helpers.** `helpers.test.js`, `storage.test.js`, `markdown.test.js`, `useDebounce.test.js`, `useToast.test.js`, `TaskEditor.test.jsx`, `App.test.jsx` are all real.
 
 ## Improvement Strategy
 
-This is a small finding set; no new themes are warranted. The implicit theme across F1, F2, and F5 is **"derive configuration from the source of truth rather than duplicate it inline"** — worth keeping in mind when reviewing the next design-system PR. F3 is a one-line CSS cleanup. F4 needs the alias config extracted or removed before it bites someone.
+Four themes explain most of the findings.
+
+### Theme 1 — Make the API contract the source of truth
+
+**Target state:** One schema (Zod) per route defines accepted/returned shape, and a generated type fans out to the React client. `validStatuses` / `validPriorities` / `validAssignees` / priority order live in `packages/types` (or `packages/contracts`) and are imported on both ends.
+
+**Principle:** Drift between client and server is the dominant defect class here (C1 missing Ivy, C2 missing taskType, DOC2 stale statuses, F5 hardcoded priorities, the deprecated `ready` filter still living in `tasksApi.ts:9`).
+
+**Trade-off:** This is a real refactor (M-XL) that doesn’t deliver user-visible value. Cost is justified only because every subsequent feature pays for the absence of this — the audit alone surfaced five drift bugs.
+
+**Done signal:** `validAssignees`, `PRIORITIES`, status enum, and request schemas all live in one location and are referenced from at least `tasks.ts`, `tasksApi.ts`, `App.jsx`, `constants.js`. No duplicate enum lists grep-able in the repo. New e2e gate that confirms the Ivy assignee selectable in the dropdown.
+
+### Theme 2 — Tests should test what we ship
+
+**Target state:** The `tasks-app-e2e` job actually hits the live API and DB; the in-process mocked variant gets renamed to `tasks-app-component-e2e` (or moved to vitest) so the “real” lane is honestly real. Cursor pagination has dedicated coverage that breaks T2 today.
+
+**Principle:** A green CI that doesn’t exercise the real wire is an active hazard — it lets `taskType` quietly disappear (C2) and pagination silently corrupt (T2) without raising any flag.
+
+**Trade-off:** Real e2e is slower, flakier, and harder to write. Solution is one happy-path real-e2e spec, not migrating all four files.
+
+**Done signal:** at least one Playwright spec creates → updates → archives a task through the real API; `docs/architecture.md:98-102` becomes true; one vitest case asserts that `nextCursor` is meaningful for `sort=priority`.
+
+### Theme 3 — Right-size the security & supply-chain posture for an internal-but-real product
+
+**Target state:** `npm audit` is clean (S1, S2, D1). `helmet`, body-size cap, and (in production) a minimal token check or BasicAuth gate sit in front of the API (S3). `.gitignore` covers `*.bak` (S4). One short ADR captures “no auth in V1 is intentional **until the API leaves Tailscale**.”
+
+**Principle:** The product is internal today, but the deploy plumbing (Vercel, Tailscale hostnames in vite config) is already production-shaped. Closing the gap when it’s 5 lines of code is cheap; closing it after a leak is not.
+
+**Trade-off:** Add `helmet` and a body limit now (Quick wins). Defer real auth until a non-Tom human is on the system — but ship an ADR so the deferral is visible.
+
+**Done signal:** `npm audit --omit=dev` reports 0 High. `helmet`, `express.json({limit})` and `.env*.bak` ignored in `.gitignore`. ADR `docs/specs/2026-WW-tasks-api-auth-decision.md` exists with a trigger for revisit.
+
+### Theme 4 — Decompose `App.jsx` and isolate the route module
+
+**Target state:** `App.jsx` → `<TasksRoute />` shell + `useFilters`, `useThemeView`, `useTaskBoardActions`, `useCelebration` hooks; `routes/tasks.ts` → `tasks.read.ts`, `tasks.write.ts`, `tasks.sort.ts`, `tasks.validation.ts`. Files are testable in isolation.
+
+**Principle:** Both files have grown past the “one screenful” heuristic; both are the highest-risk change-set surface in the repo. Splitting now is cheap; splitting later is a sweep that touches every PR for a week.
+
+**Trade-off:** Mid-effort refactor with no user-visible payoff. Pair it with Theme 1 (extract validation while you split) to amortize.
+
+**Done signal:** `App.jsx` ≤300 LOC, `tasks.ts` ≤200 LOC, each split file unit-tested.
+
+### Explicit non-goals
+
+- **Don’t** introduce a microservice split or a “mission-control orchestrator” yet — `apps/mission-control` is a README; YAGNI.
+- **Don’t** migrate to Express 5 in this cycle (D2) — pin and defer.
+- **Don’t** harden the `bookmark` / `content-task` Python workflows in this audit. They are off the product path; flagged for a separate pass.
+- **Don’t** replace Prisma. The current code uses it well.
 
 ## Task Plan
 
-| Task | Severity | Effort | Suggested owner |
-|------|----------|--------|-----------------|
-| T1 — F3 cleanup (drop redundant `[data-si-theme='light']` block) | Low | Trivial | Rowan, in a follow-up PR |
-| T2 — F5 cleanup (`TaskCardSummary` import `PRIORITIES`) | Low | Trivial | Rowan, in a follow-up PR |
-| T3 — F1 + F2 (derive `KIT_TABS` and initial theme from `SPECIMEN_PAGES`) | Low | Small | Rowan, in a follow-up PR |
-| T4 — F4 (resolve alias drift between vite and vitest configs) | Medium | Small | Rowan, requires a test to verify |
+### Milestone 0 — Safety net (1 day)
 
-These are intentionally not created as Tasks API tasks — Tom flagged this pattern in the repo-audit SKILL guidance (no auto-tasks from audits). They'll come back if/when Tom wants to schedule them.
+| ID | Task | Files | Effort | Risk | Depends on |
+|----|------|-------|--------|------|------------|
+| M0.1 | Add `**/.env*.bak` to `.gitignore` and delete the local `.bak` after capturing the diff in a runbook note | `.gitignore`, `services/tasks-api/.env.prodlike.bak` | S | Trivial | — |
+| M0.2 | Add a Vitest spec for cursor pagination semantics on `sort=priority` that asserts the bug exists today, then track its red status | `services/tasks-api/test/read-endpoints.test.ts` | S | Low | — |
+| M0.3 | Add a top-level `eslint` config (`@eslint/js` + a couple of repo rules: no-duplicate-string-enum, max-lines for routes/components) and wire to CI as **warnings**; flip to `error` after Theme-1 work lands | root, `.github/workflows/ci.yml` | M | Low | — |
+
+### Milestone 1 — Critical / High fixes
+
+| ID | Task | Files | Effort | Risk | Depends on |
+|----|------|-------|--------|------|------------|
+| M1.1 | `npm audit fix` — accept the non-breaking remediations, raise OTel/grpc separately | `package-lock.json`, possibly `packages/otel-node/package.json` | M | Medium (verify CI still green; OTel SDK lane may surface breakages) | — |
+| M1.2 | Bump `dompurify` to `^3.4.11` and add a Vitest case that exercises the GHSA payload class on `renderMarkdown` | `apps/tasks/package.json`, `apps/tasks/src/utils/markdown.test.js` | S | Low | — |
+| M1.3 | Fix cursor-pagination + memory-sort bug: do the priority/dueAt sort in the DB (`orderBy` Prisma input keyed off `sort`), and encode the cursor against the same key | `services/tasks-api/src/routes/tasks.ts` | M | Medium (touches every list call) | M0.2 |
+| M1.4 | Cap client list size: drop `limit=10000` to a real page (e.g., 200), keep auto-refresh, add a “Load more” when `hasNextPage` is true | `apps/tasks/src/tasksApi.ts`, `apps/tasks/src/useTasks.js`, `apps/tasks/src/App.jsx` | M | Medium (verify Kanban + Backlog under filter combos) | M1.3 |
+| M1.5 | Make one e2e spec real: keep `happy-path.spec.js` mocked **or** point it at the live API + DB, but not both. Document the chosen split | `apps/tasks/test/e2e/happy-path.spec.js`, `apps/tasks/playwright.config.js`, `docs/architecture.md` | M | Medium | — |
+| M1.6 | Wrap `PATCH /tasks/:id` in `prisma.$transaction` so tag re-link + task update are atomic | `services/tasks-api/src/routes/tasks.ts` | S | Low | — |
+| M1.7 | Add `express.json({ limit: '64kb' })` and `helmet` (+ defaults safe for current API) to `app.ts` | `services/tasks-api/src/app.ts`, `services/tasks-api/package.json` | S | Low | — |
+
+### Milestone 2 — High-leverage improvements
+
+| ID | Task | Files | Effort | Risk | Depends on |
+|----|------|-------|--------|------|------------|
+| M2.1 | Extract shared types/enums to `packages/contracts` (statuses, priorities, assignees) and import on both ends | `packages/contracts/`, `services/tasks-api/src/routes/tasks.ts`, `apps/tasks/src/utils/constants.js`, `apps/tasks/src/tasksApi.ts` | L | Medium | — |
+| M2.2 | Replace hand-rolled validation with Zod schemas per route | `services/tasks-api/src/routes/*.ts` | M | Low | M2.1 |
+| M2.3 | Decompose `App.jsx` into `useFilters`, `useThemeView`, `useTaskBoardActions`, `useCelebration` and a sub-`<NewTaskCard />` | `apps/tasks/src/App.jsx`, `apps/tasks/src/hooks/`, new `apps/tasks/src/components/NewTaskCard.jsx` | L | Medium | — |
+| M2.4 | Make `taskType` editable in `TaskEditor.jsx` (form field + include in `buildSavePayload`) | `apps/tasks/src/components/TaskEditor.jsx` | S | Low | — |
+| M2.5 | Add `ADR-2026-W25-tasks-api-auth.md` documenting the “no auth until non-Tom user” decision and the trigger to revisit | `docs/specs/` | S | Trivial | — |
+| M2.6 | Make `services/tasks-api/tsconfig.json` strict; add request/response types | `services/tasks-api/tsconfig.json`, all of `services/tasks-api/src/**` | M | Medium | M2.2 |
+| M2.7 | Carry-over fixes F1–F5 in one PR | `packages/ui/src/specimen/DesignSystemPage.jsx`, `apps/tasks/src/styles/variables.css`, `apps/tasks/vitest.config.js`, `apps/tasks/src/components/TaskCardSummary.jsx` | S | Low | — |
+
+### Milestone 3 — Quality & polish
+
+| ID | Task | Files | Effort | Risk |
+|----|------|-------|--------|------|
+| M3.1 | Delete `services/tasks-api/prisma/migrate-todo-to-ready.ts` (or move to `tools/` with a runbook note) | `services/tasks-api/prisma/migrate-todo-to-ready.ts` | S | Trivial |
+| M3.2 | Replace deprecated `marked.setOptions` with `marked.use({…})` | `apps/tasks/src/utils/markdown.js` | S | Trivial |
+| M3.3 | Replace N-call `connectTags` with `findMany` + `createMany({skipDuplicates:true})` inside the M1.6 transaction | `services/tasks-api/src/routes/tasks.ts` | S | Low |
+| M3.4 | Bring `make test` in line with CI (`make test-ci` that fans out to every workflow lane) | `Makefile`, `package.json` | S | Low |
+| M3.5 | Pin `@types/react` to the React runtime line | `apps/tasks/package.json`, `apps/website/package.json`, `packages/ui/package.json` | S | Trivial |
+| M3.6 | Replace `console.error` in error middleware with a structured logger that emits `trace_id` from OTel context | `services/tasks-api/src/app.ts`, `services/tasks-api/src/lib/log.ts` (new) | M | Low |
+| M3.7 | Update `docs/specs/tasks-one-pager.md` status flow to match `open/ready/doing/acceptance/done` or annotate as superseded | `docs/specs/tasks-one-pager.md` | S | Trivial |
+
+### Quick wins (do today, ≤ S effort each)
+
+- **M0.1** `.env*.bak` gitignore
+- **M1.2** bump DOMPurify
+- **M1.6** wrap PATCH in a transaction
+- **M1.7** `helmet` + `express.json({limit})`
+- **M2.4** make `taskType` editable in TaskEditor
+- **M2.7** F1–F5 sweep
+- **M3.1** drop the dead `migrate-todo-to-ready.ts`
+- **M3.5** pin `@types/react` to v18
+
+### Implementation sketches — top 3 tasks
+
+**M1.3 — Fix cursor pagination + sort.**
+1. Map the requested `sort` to a Prisma `orderBy` array, e.g.
+   - `priority` → `[{ priority: 'asc' }, { createdAt: 'desc' }, { id: 'desc' }]` (note: Postgres enum order matches the Prisma enum order, which is `low/medium/high/urgent`; either flip the enum or use a derived `priorityRank` column).
+   - `dueAt` → `[{ dueAt: { sort: 'asc', nulls: 'last' } }, { createdAt: 'desc' }, { id: 'desc' }]`.
+   - `createdAt`/`updatedAt`/`statusChangedAt` → that column DESC plus `id` DESC tiebreaker.
+2. Encode the cursor against the **same keys** the DB sorted by — switch `encodeCursor` from `(createdAt, id)` to `(sortKeyValue, createdAt, id)` and roundtrip through `base64url`.
+3. Move the sort entirely to the DB; delete the JS `sortedTasks = …` block (`tasks.ts:247-271`).
+4. Gotcha: priority is currently a Postgres enum with declaration order `low/medium/high/urgent`. Easiest fix that doesn’t require a migration is to keep using an in-DB `CASE` expression (Prisma `Prisma.sql`) or compute a `priorityRank` generated column. Pick one, document the choice in M1.3’s PR.
+
+**M1.5 — One real e2e.**
+1. Keep three specs as mocked “component e2e” under `apps/tasks/test/component-e2e/` so they remain fast and stable.
+2. Move/rewrite `happy-path.spec.js` so it points Playwright at the running app (no `page.route`) and asserts against a real Postgres-backed API. `playwright.config.js` already drives `vite dev` against `VITE_TASKS_API_BASE_URL=http://127.0.0.1:4000/api/v1` — that’s the unit of plumbing CI already builds for `tasks-app-e2e`.
+3. Update `docs/architecture.md:98-102` to describe the split honestly; update `CONTRIBUTING.md:84-85` to reflect that the “e2e” requirement maps to either the real or component lane.
+4. Gotcha: real e2e creates rows; the seeded DB will be mutated. Either reset per test via a Prisma transaction wrapper, or scope tests to titles prefixed with `e2e-` and clean them up in `afterAll`.
+
+**M2.1 — Extract `packages/contracts`.**
+1. New workspace package `packages/contracts` exporting `STATUSES`, `PRIORITIES`, `ASSIGNEES`, `TASK_TYPES`, and one Zod schema per request/response.
+2. `services/tasks-api/src/routes/tasks.ts` consumes `parseTaskCreateBody`, `parseTaskListQuery`, etc. (Zod) instead of the inline `validStatuses.has(...)` checks.
+3. `apps/tasks/src/tasksApi.ts` re-exports the same TypeScript types from `@sindustries/contracts` so `Task`, `CreateTaskPayload`, `UpdateTaskPayload` derive from the same place.
+4. Update `apps/tasks/src/utils/constants.js`’s `ASSIGNEE_OPTIONS` to import `ASSIGNEES` from contracts — fixes the missing-Ivy bug (C1) as a side effect.
+5. Gotcha: tasks.ts is still `.ts` with `"strict": false`, so the Zod inference will need an explicit type or a temporary `as any` shim until M2.6 lands. Keep the shim list documented in the M2.1 PR description so it’s not forgotten.
 
 ## Open Questions
 
-- **F4 fix path:** does Tom want the aliases dropped entirely (relying on `package.json#exports`), or extracted into a shared `vite.shared.js`? Both work; the first is leaner but requires a smoke test to confirm Node's exports resolution behaves correctly in vitest.
-- **Specimen `tabLabel`:** if F1's fix is taken, do we want short labels (`Tokens` / `Pulse` / `Brand`) different from full titles? That determines whether `specimen-layout.json` needs a new `tabLabel` field.
-- **Full audit cadence:** Friday-noon cron is now scheduled. Should this drift-hazard doc be replaced by next week's full audit, or kept as a parallel lightweight log of PR-time findings?
+1. **Auth posture before next non-Tom user.** Spec says “no auth in V1.” Tailscale hostnames are already in `vite.config.js`. What’s the minimum gate before another human reaches the API — a shared bearer? A reverse-proxy auth in front of Vercel? An ADR + revisit trigger is the right artefact; pick one of the two paths so M2.5 isn’t blocked.
+2. **Cursor pagination contract.** Do we want a typed “sort + cursor” surface where the cursor opaque-encodes the sort key, or are we content to fix the default and document non-default sorts as “best effort, paginated by createdAt”? The cheaper fix is option B; option A is correct.
+3. **e2e split.** When `tasks-app-e2e` (currently mocked) is renamed to component-e2e, do we want a *new, slower* real-e2e lane on PR only, or only on `main` after merge? Performance vs feedback loop.
+4. **Mission Control.** `apps/mission-control` is a README. Is this audit cycle the right time to either delete the placeholder or commit to a spec? Carrying it without movement is a silent invitation to scope creep.
+5. **OTel SDK upgrade.** D1 includes a high-grpc-js advisory pulled through OTel. The safe fix (`npm audit fix --force`) bumps `@opentelemetry/exporter-trace-otlp-http@0.219.0`. Is the OTel ecosystem stable enough at that version that we want to take it now, or pin and wait for 1.0 of `sdk-node`?
+6. **`docs/specs/tasks-one-pager.md` source-of-truth status.** The one-pager still lists `todo/doing/done`. Is the one-pager the spec-of-record (and now stale), or has it been superseded by the migrations themselves? Either annotate it or rewrite.


### PR DESCRIPTION
## Executive Summary

The sindustries monorepo is a **small but maturing internal product platform**: a Tasks API + React app, a public website, a shared UI/design-tokens kit, and OpenTelemetry plumbing — wrapped in dev/prodlike mode discipline and a credible CI lane. Architecture, monorepo boundaries, and dev ergonomics are genuinely strong (clear `apps/`/`services/`/`packages/`/`infra/` split, mode-aware `make` wrappers, port↔DB pairing guard, prodlike seed guard). The honest weak spots are: (a) the Tasks API’s read endpoint pages-then-sorts in memory, silently breaking `nextCursor` for non-default sorts; (b) the React app fetches `limit=10000` every 3 s, making pagination a fiction and scaling unattractive; (c) 28 npm advisories (1 High `@grpc/grpc-js`, plus a DOMPurify sanitizer-bypass that touches the markdown render path); (d) the “real” e2e job in CI boots Postgres + the API and then immediately replaces all API calls with `page.route()` mocks, contradicting `docs/architecture.md` and weakening the AC-coverage promise in `CONTRIBUTING.md`; (e) `App.jsx` has grown to 952 lines and now owns view state, filters, drag/drop, confetti, Web Audio, drafts, and DOM scrolling. None of these are launch blockers — V1 is single-user/internal — but they will compound. **Overall health: B (solid foundations, two real correctness/perf bugs and a credible-tests problem).** Top 3 risks: pagination/perf bug pair, mocked-but-claimed-real e2e, vulnerable dependencies in the live render path. Top 3 opportunities: (1) replace hand-rolled validation with a shared schema, (2) split `App.jsx` and fix pagination once, (3) make one e2e lane actually hit the real stack so CI matches the docs.

Full audit: [docs/repo-audits/2026-W25.md](docs/repo-audits/2026-W25.md)
