### PR TITLE
fix(ingest): capture note_tweet text from quoted tweets

### DIFF
--- a/agents/skills/x-bookmark-ingest/scripts/x/fetch.cjs
+++ b/agents/skills/x-bookmark-ingest/scripts/x/fetch.cjs
@@ -132,7 +132,7 @@ async function enrichQuotedTweetArticles(bookmarks, accessToken) {
 
     try {
       const resp = await fetch(
-        `https://api.x.com/2/tweets/${quotedReference.id}?tweet.fields=text,article,entities`,
+        `https://api.x.com/2/tweets/${quotedReference.id}?tweet.fields=text,note_tweet,article,entities`,
         { headers: { 'Authorization': `Bearer ${accessToken}` } }
       );
       if (!resp.ok) {
@@ -145,7 +145,16 @@ async function enrichQuotedTweetArticles(bookmarks, accessToken) {
       const payload = await resp.json();
       bookmark.quotedTweet = payload?.data || null;
       const quotedArticle = bookmark.quotedTweet?.article;
-      if (!quotedArticle?.plain_text) continue;
+      if (!quotedArticle?.plain_text) {
+        // Regular or note tweet (no X article) — capture the full text so the
+        // markdown includes a Quoted Tweet section. Prefer note_tweet.text for
+        // long-form tweets where text is truncated at 280 chars.
+        const fullText = bookmark.quotedTweet?.note_tweet?.text || bookmark.quotedTweet?.text;
+        if (fullText) {
+          bookmark.quotedTweetText = fullText;
+        }
+        continue;
+      }
 
       // Keep bookmark.text as the tweet text only. The article body is
       // surfaced via bookmark.linkedArticle and rendered in the bookmark

--- a/agents/skills/x-bookmark-ingest/scripts/x/process.cjs
+++ b/agents/skills/x-bookmark-ingest/scripts/x/process.cjs
@@ -379,6 +379,10 @@ async function processBookmark(bookmark) {
   const date = new Date().toISOString().split('T')[0];
   const safeTags = normalizeTags(metadata.tags);
 
+  const quotedTweetSection = bookmark.quotedTweetText
+    ? `\n\n**Quoted Tweet:**\n${bookmark.quotedTweetText}`
+    : '';
+
   const linkedArticleSection = quotedArticle
     ? `
 
@@ -411,7 +415,7 @@ tags: [${safeTags.map(t => `"${t}"`).join(', ')}]
 
 **Original Tweet:**
 ${bookmark.text || 'N/A'}
-${linkedArticleSection}
+${quotedTweetSection}${linkedArticleSection}
 `;
 
   const filename = path.join(BOOKMARKS_DIR, `${slugify(metadata.title || String(bookmark.id))}.md`);


### PR DESCRIPTION
## Summary

- `process.cjs` was missing the `quotedTweetSection` render block — quoted tweet text was fetched but never written to the markdown file
- `fetch.cjs` `enrichQuotedTweetArticles` only requested `text,article,entities` from the X API, so long-form note_tweets returned the 280-char truncated `text` field instead of the full body
- Both changes together: now requests `note_tweet` in quoted tweet lookups and prefers `note_tweet.text` over the truncated `text`

**Root cause found via:** a bookmark (`i-m-done-with-traditional-session-compaction-with-`) that quoted a bradmillscan note_tweet about lossless-claw/DAG — the 1700-char article body was completely absent from the archived bookmark.

## Test plan

- [ ] Bookmark a tweet that quotes a note_tweet and run ingest — verify "Quoted Tweet:" section appears with full body
- [ ] Bookmark a tweet that quotes a regular tweet — verify "Quoted Tweet:" section still works
- [ ] Bookmark a tweet that quotes an X article — verify "Linked Article:" section still works (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)