### PR TITLE
cod—audit: sindustries weekly review 2026-W26

### DIFF
--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -1,0 +1,323 @@
+# Repo Audit — sindustries — 2026-W26 (2026-06-22 → 2026-06-28)
+
+**Generated:** 2026-06-22 (Monday weekly cron)
+**Auditor:** Quinn (Chief of Staff)
+**Target:** `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`
+**Type:** Full four-phase audit
+
+---
+
+## Executive Summary
+
+**Health grade: B** (solid foundations persist; key structural defects from W25 remain unresolved and one new security escalation).
+
+The sindustries monorepo is actively shipping: since the W25 audit (2026-06-15), content publishing, X ingest fixes, morning-brief enhancements, and website story updates all landed cleanly. The architecture, dual-mode dev/prodlike discipline, and CI pipeline remain strong. However, the three structural problems flagged in W25 are unchanged: (1) GET `/tasks` pages by cursor then sorts the result in memory, making `nextCursor` unreliable for any non-default sort; (2) `App.jsx` remains a 952-line god component; (3) all four E2E tests fully mock the API with `page.route()`, giving no real integration coverage despite CI docs claiming otherwise. New this week: npm advisories climbed from 28 to 31 with 3 High vulnerabilities (up from 1), and a frontend/API assignee drift was confirmed — `Ivy` is valid for the API but absent from the frontend `ASSIGNEE_OPTIONS` dropdown, making Ivy-assigned tasks unassignable through the UI. A live third-party API key sits in `infra/plano/.env` (gitignored, not in history, but present on disk).
+
+**Top 3 risks:** (1) Mocked E2E tests produce false green CI — any real API regression is undetected; (2) Pagination/in-memory-sort bug silently corrupts large task lists when sort ≠ `priority`; (3) 3 High npm advisories (up from 1) on packages in the active dependency tree, including the DOMPurify sanitizer-bypass on the markdown render path.
+
+**Top 3 opportunities:** (1) Fix the E2E lane to test the real API stack — it is already wired in CI, just needs the `page.route()` mocks removed; (2) Fix the pagination sort to run in the DB and drop the `limit=10000` hack in the client; (3) Decompose `App.jsx` into feature modules before it reaches 1,200 lines.
+
+---
+
+## Repo Map
+
+**Purpose:** Mono-repo for Stoffer Industries product surfaces — a Tasks API and React app, a public-facing website, shared UI/design-token/OTel packages, and an AI agent operations layer (bookmark pipeline, content skills, cron definitions).
+
+**Stack:**
+- Node 22, npm workspaces (`package.json:5-12`)
+- Apps: React 18 + Vite 8 (`apps/tasks`, `apps/website`)
+- Service: Express 4 + Prisma 5 + PostgreSQL 16 (`services/tasks-api`)
+- Shared packages: `@sindustries/ui` (component kit), `@sindustries/design-tokens` (token pipeline), `@sindustries/otel-node` (OTel auto-instrumentation)
+- Tests: Vitest everywhere; Playwright for e2e; Python `unittest` for agent workflows
+- Local runtime: Docker Compose (Postgres) + Tilt (host-run API/app); CI on GitHub Actions with a service-container Postgres
+- Agent ops: `agents/skills/` (bookmark curation, spec authoring, content authoring, repo-audit); `agents/crons/prompts/` (cron definitions); `agents/workflows/bookmark/` (lobster pipeline scripts)
+
+**Architecture sketch:**
+```
+React (apps/tasks)
+  └─ tasksApi.ts ── fetch ──▶ Express (services/tasks-api)
+                                   └─ Prisma ──▶ Postgres (schema: tasks_api)
+                                   └─ OTel SDK ──▶ OTLP ──▶ Tempo/Prometheus
+
+React (apps/website) [static JSON-driven content; Vercel deploy]
+
+AI agents (agents/)
+  └─ tasks-api-ops skill ── HTTP ──▶ tasks-api
+  └─ lobster bookmark pipeline ── state JSON + tasks-api
+```
+
+**Key directories:**
+- `apps/tasks/` — Kanban + backlog task manager; main product surface
+- `apps/website/` — Public website; JSON-file CMS (stories, experiments, stacks, systems)
+- `services/tasks-api/` — Express API backed by Prisma/Postgres; Tasks CRUD + tags/comments
+- `packages/ui/` — Shared component library (React + Pencil specimen)
+- `packages/design-tokens/` — Token pipeline; syncs Pencil → CSS variables
+- `packages/otel-node/` — OTel SDK bootstrap; auto-instrumentation for Node services
+- `infra/` — Docker Compose (dev/prodlike), Tilt file, Prometheus/Grafana/Tempo config
+- `agents/` — AI skill definitions, cron prompts, bookmark pipeline orchestration
+- `docs/` — Architecture, specs, audit history
+
+**Surprises from discovery:**
+- `agents/` is a large, mature, autonomous operation system (bookmark review → spec → tasks pipeline) that now rivals the product surface in code volume.
+- `infra/plano/.env` contains a live Minimax API key — gitignored, not in history, but present on disk.
+- `tasksApi.ts:15` type comment lists `triage` as a valid status; the Prisma schema `TaskStatus` enum and API `validStatuses` do not include it.
+- `ASSIGNEE_OPTIONS` in the frontend lists 4 assignees; `validAssignees` in the API lists 5 (Ivy is missing from the UI).
+
+---
+
+## Audit Report
+
+### Strengths
+
+- **Monorepo boundaries are clean.** `apps/`, `services/`, `packages/`, `infra/`, `agents/` have clear semantics and the actual code respects them (`README.md:7-13`).
+- **Dual-mode dev/prodlike discipline is excellent.** Port–DB pairing guard (`server.ts:23-45`), prodlike seed guard, mode-env source-of-truth, and Makefile wrappers work coherently.
+- **API input validation is consistent.** All write routes validate enums before touching the DB, return structured `{ error: { code, message } }` errors, and pass exceptions to Express middleware.
+- **CI is comprehensive in scope.** `.github/workflows/ci.yml` covers Python agent tests, otel-node unit tests, tasks-api unit + DB integration tests, tasks-app unit/component tests, Playwright e2e, and website build.
+- **OTel instrumentation is well-integrated.** `packages/otel-node` cleanly wraps SDK bootstrap; `OTEL_SDK_DISABLED` flag prevents noise in CI and no-collector local setups.
+- **Spec-first workflow is documented and evidenced.** `docs/specs/` has 8 spec docs; `CONTRIBUTING.md` defines clear gates for non-trivial work.
+- **Draft persistence in localStorage** (`useTaskDrafts.js`) sanitizes stored state and handles version mismatches — a thoughtful correctness detail.
+- **DB integration tests hit a real Postgres.** `test/db-integration.test.ts` creates, updates, comments, and archives a task end-to-end through Express + Prisma + Postgres in CI.
+
+---
+
+### Architecture & Design
+
+**[High] GET /tasks pages by cursor then sorts in memory — nextCursor is unreliable** *(persists from W25)*
+
+- `services/tasks-api/src/routes/tasks.ts:107-136` — `findMany` uses `orderBy: [{ createdAt: 'desc' }, { id: 'desc' }]` regardless of the `?sort=` parameter.
+- `tasks.ts:140-162` — After fetching `limit + 1` records keyed to the cursor window, the route re-sorts the result in JavaScript.
+- `tasks.ts:165` — `nextCursor` is then encoded from `lastTask` in the *sorted* slice, but the cursor encodes `(createdAt, id)` — the anchor for the *next* DB-level query. For `sort=dueAt` or `sort=statusChangedAt`, the cursor and sort order are misaligned, producing gaps or repeated items across pages.
+- **Consequence (fact):** Calling `/tasks?sort=dueAt&cursor=X` does not return the correct continuation. Currently masked because the client requests `limit=10000` and never paginates.
+
+**[Medium] tasksApi.ts fetches limit=10000 on every auto-refresh, bypassing pagination** *(persists from W25)*
+
+- `apps/tasks/src/tasksApi.ts:96` — `query.set('limit', '10000')` is hardcoded.
+- `apps/tasks/src/useTasks.js:7` — `DEFAULT_REFRESH_INTERVAL_MS = 3000` triggers a full-table scan + JSON payload every 3 seconds.
+- **Consequence (fact):** The API's pagination infrastructure is a dead code path. Full-table fetches every 3 s are acceptable at <100 tasks but expensive at 1,000+.
+
+**[Medium] App.jsx is a 952-line god component** *(persists from W25)*
+
+- `apps/tasks/src/App.jsx` owns: board view state, backlog view state, filter dropdowns (status, priority, assignee, tag), confetti orchestration (Web Audio + canvas DOM), drag-and-drop scroll logic, column visibility, selected task, theme/view persistence, and all `useTasks`/`useTaskDrafts` call sites.
+- **Consequence (judgment):** Any new view or feature requires editing one 952-line file. The two child components (`TaskEditor.jsx`, `TaskCardSummary.jsx`) are crisp; the parent is the growing risk surface.
+
+---
+
+### Code Quality
+
+**[Medium] Assignee list drifts between API validation and frontend constants**
+
+- `services/tasks-api/src/routes/tasks.ts:10` — `validAssignees = new Set(['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy'])` — 5 values.
+- `apps/tasks/src/utils/constants.js:14` — `ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom']` — 4 values; `Ivy` is absent.
+- **Consequence (fact):** Ivy-assigned tasks created via the API (agent scripts, direct HTTP) appear in the board but cannot be assigned or re-assigned through the UI dropdown. The `?assignee=Ivy` filter works but is not surfaced.
+
+**[Medium] Stale `triage` status documented in client type comment**
+
+- `apps/tasks/src/tasksApi.ts:15` — `status: string; // open | triage | ready | doing | acceptance | done` lists `triage` as valid.
+- Prisma schema `TaskStatus` enum (`schema.prisma:14-22`) and `validStatuses` (`tasks.ts:9`) have no `triage` value.
+- **Consequence (fact):** Any code treating the TS type comment as a contract will attempt a value the API rejects with `INVALID_STATUS_VALUE`.
+
+**[Medium] tasks.ts route file at 517 lines mixes validation, query building, sorting, and mapping**
+
+- Validation helpers, cursor encode/decode, tag management, response mappers, and 6 route handlers share one file.
+- **Consequence (judgment):** Targeted unit testing of cursor/sort logic and tag management is harder than it needs to be; any structural change touches the same large file.
+
+**[Low] Inconsistent TypeScript/JavaScript in tasks app**
+
+- `apps/tasks/src/tasksApi.ts` is TypeScript; `App.jsx`, `useTasks.js`, `useTaskDrafts.js`, and all hooks are `.js`/`.jsx`.
+- **Consequence (judgment):** No strict-mode protection on the bulk of front-end code.
+
+---
+
+### Security
+
+**[High] Live API key in infra/plano/.env (gitignored but present on disk)**
+
+- `infra/plano/.env:1` — `PLANO_MINIMAX_API_KEY=sk-cp-f0BWFcEYSI2Z...` — a live Minimax API key.
+- **Fact:** `git check-ignore infra/plano/.env` confirms the file is gitignored; it is not in git history.
+- **Judgment:** Low git-leak risk, but if the repo directory is shared, snapshotted, or the file is accidentally staged in a future PR, the key is live. Recommend rotation and moving to a secrets manager.
+
+**[High] npm audit: 3 High advisories, 27 Moderate (31 total — up from 28 in W25)**
+
+- `npm audit` from repo root: `{ high: 3, moderate: 27, low: 1, total: 31 }`.
+- W25 reported 1 High (DOMPurify sanitizer-bypass affecting the markdown render path). Two new Highs appeared this week.
+- **Consequence (fact):** The DOMPurify bypass (`apps/tasks/src/components/MarkdownContent.jsx:15` renders task descriptions with `dangerouslySetInnerHTML`) represents the highest-priority live risk. The two new Highs require `npm audit --json` to identify affected packages before action.
+
+**[Low] CORS origin allowlist defaults to localhost-only**
+
+- `services/tasks-api/src/app.ts:5-20` — Correct posture for a local-only service currently; no production origin committed.
+
+---
+
+### Testing
+
+**[High] All 4 E2E specs fully mock the API — zero real integration coverage** *(persists from W25)*
+
+- `apps/tasks/test/e2e/happy-path.spec.js:9` — `page.route('**/api/v1/tasks**', ...)` intercepts every request and fulfills from an in-memory array.
+- All 4 specs (`happy-path`, `assignee-dropdown`, `assignee-filter`, `priority-filter`) follow this pattern.
+- **Consequence (fact):** The E2E CI job tests the React app against a hand-rolled mock, not the actual Express service. A breaking API change would not be detected. `CONTRIBUTING.md:69` states "Every AC covered by that PR needs at least one E2E test" — satisfied on paper but not in substance.
+
+**[Medium] Pagination logic has no unit tests that could catch the cursor/sort bug**
+
+- `services/tasks-api/test/read-endpoints.test.ts` mocks Prisma and tests filtering, status, and cursor decoding, but does not assert that page 2 returns the correct items for non-default sorts.
+- **Consequence (judgment):** The in-memory-sort + cursor mismatch described in Architecture would not be caught by the current suite even if exercised.
+
+---
+
+### Performance
+
+**[Medium] 3 s auto-refresh with limit=10000 is a polling tax that grows with data**
+
+- `apps/tasks/src/useTasks.js:7` — `DEFAULT_REFRESH_INTERVAL_MS = 3000`.
+- `apps/tasks/src/tasksApi.ts:96` — `limit=10000` on every poll.
+- **Consequence (fact):** Every 3 seconds the app issues a full-table Prisma query with tag includes. Acceptable at <100 tasks; expensive at 1,000+.
+
+---
+
+### Dependencies
+
+**[High] 3 High npm advisories (up from 1 in W25)**
+
+- Noted above under Security. The escalation from 1 → 3 High in a single week is worth an `npm audit --json` inspection to identify the two new packages.
+
+**[Low] Prisma at 5.20.0 — Prisma 6.x is available**
+
+- `services/tasks-api/package.json` pins `@prisma/client` and `prisma` at `^5.20.0`. Prisma 6 is a breaking-change release; migration is non-trivial but brings query performance improvements. Not urgent at this scale.
+
+---
+
+### DevEx & Operations
+
+**[Medium] No lint or format enforcement in CI**
+
+- `ci.yml` runs tests and build but no ESLint or Prettier step.
+- **Consequence (judgment):** Style inconsistencies and drift (TS/JS mixing, duplicate enum lists) accumulate without an automated gate.
+
+**[Low] make test does not include all CI lanes**
+
+- `Makefile` defines `test-api`, `test-app`, `test-e2e` but not website tests, otel-node tests, or Python agent tests. A developer passing `make test` locally can still break CI on other lanes.
+
+---
+
+### Documentation
+
+**[Medium] architecture.md states e2e tests use the real API — they do not**
+
+- `docs/architecture.md` describes "real app → API → Postgres flow" in the e2e section. The Playwright specs use `page.route()` mocks against all API calls. The doc is wrong.
+
+**[Low] tasksApi.ts type comment includes stale `triage` status**
+
+- Noted under Code Quality. The stale comment in the published client type will mislead consumers.
+
+---
+
+## Improvement Strategy
+
+### Theme 1 — Fix pagination or retire it
+
+**Current state:** Cursor-based pagination infrastructure doesn't function correctly for non-default sorts. The frontend sidesteps it with `limit=10000`.
+**Target state:** The sort parameter is pushed into the DB query (not applied in memory), the cursor encodes the correct sort key, and the frontend fetches in pages with a reasonable limit.
+**Trade-off:** Non-trivial to do correctly for multi-column sorts (priority has no natural DB index order). Quick path: add DB-level `orderBy` for each sort value, encode cursor against the sort key, and reduce `limit` to 200 or so in the client.
+**Done signal:** `tasksApi.ts` no longer hardcodes `limit=10000`; `nextCursor` is meaningful for every supported sort; CI passes.
+
+### Theme 2 — Make the E2E lane actually test the API
+
+**Current state:** All E2E specs mock the API. CI gives a green signal that means "the React app renders correctly against a hand-rolled stub."
+**Target state:** At least one E2E lane (new or converted) boots the real dev stack (Postgres + tasks-api) and drives the Playwright browser against it. The existing mocked specs can move to a `component-e2e` category.
+**Trade-off:** Slower CI job; requires seeding state in the test setup. Investment: M (the Postgres service container is already wired in CI).
+**Done signal:** `happy-path.spec.js` has no `page.route()` intercepts; it creates and archives a real task through the real API; passes in CI with the Postgres service container.
+
+### Theme 3 — Decompose App.jsx
+
+**Current state:** 952 lines; owns filters, view, confetti, audio, drag scroll, and all data bindings.
+**Target state:** Separate feature modules — `FilterBar`, `BoardView`, `BacklogView`, `TaskCelebration` — each with a focused responsibility. `App.jsx` becomes a shell that composes them.
+**Trade-off:** Risk of regressions during refactor; requires a coordinated PR. Recommended: add component-level tests first, then extract.
+**Done signal:** `App.jsx` < 250 lines; each extracted component has at least one unit test.
+
+### Theme 4 — Resolve npm vulnerabilities and consolidate assignee definition
+
+**Current state:** 31 advisories, 3 High; `validAssignees` in the API and `ASSIGNEE_OPTIONS` in the frontend have diverged.
+**Target state:** 0 High advisories; `ASSIGNEES` defined in a shared package constant consumed by both API validation and frontend dropdown.
+**Trade-off:** Dependency upgrades can break behavior; shared constant requires a new build step if put in a separate package (or simply a new shared module in `packages/ui` or a new `packages/contracts`).
+**Done signal:** `npm audit` exits 0 for High/Critical; adding a new assignee requires changing exactly one file.
+
+---
+
+## Task Plan
+
+### Milestone 0 — Safety net
+
+| # | Title | Effort | Risk |
+|---|-------|--------|------|
+| 0-A | Run `npm audit --json`, identify the 3 High packages, open a targeted upgrade PR | S | Low |
+| 0-B | Bump DOMPurify to `>=3.4.11` in `apps/tasks/package.json` | S | Low |
+| 0-C | Add a Vitest spec for cursor pagination semantics that asserts the current sort/cursor mismatch | S | Low |
+
+**Quick wins (do now, ≤ 15 min each):**
+- **Add Ivy to `ASSIGNEE_OPTIONS`** — `apps/tasks/src/utils/constants.js:14`. Zero risk; restores UI parity with API.
+- **Fix stale `triage` comment** — `apps/tasks/src/tasksApi.ts:15`. Remove `triage` from the status comment.
+- **Rotate the Minimax API key** — `infra/plano/.env:1`. Rotate in the Minimax dashboard, update the local `.env`.
+
+### Milestone 1 — Critical fixes
+
+| # | Title | Files | Acceptance criteria | Effort | Risk |
+|---|-------|-------|---------------------|--------|------|
+| 1-A | Fix pagination: push sort into DB, align cursor encoding | `tasks.ts`, `tasksApi.ts` | `?sort=dueAt&cursor=X` returns the correct next page; `limit=10000` removed from client | L | Medium |
+| 1-B | Make one E2E spec real: remove `page.route()` from `happy-path.spec.js`, hit the real API | `test/e2e/happy-path.spec.js`, `playwright.config.js`, `docs/architecture.md` | E2E spec creates/archives a real task; `docs/architecture.md` no longer contradicts the implementation | M | Medium |
+| 1-C | Address 3 High npm advisories | `package*.json` files | `npm audit` reports 0 High; CI passes | M | Medium |
+
+**Implementation sketch — 1-A (Fix pagination):**
+1. Map the `sort` param to a Prisma `orderBy` array inside `findMany` (e.g., `priority` → `[{ priority: 'asc' }, { createdAt: 'desc' }, { id: 'desc' }]`). Note: Postgres enum sort order is declaration order (`low/medium/high/urgent` in schema); invert or use a `CASE` expression to get the intuitive urgent-first order.
+2. Encode the cursor using the actual sort field value, not always `createdAt`. Switch `encodeCursor` to encode `(sortKeyValue, createdAt, id)` and update `decodeCursor` to match.
+3. Delete the JS `sortedTasks = ...` block (`tasks.ts:140-162`).
+4. In `tasksApi.ts`, replace `limit: '10000'` with a sensible default (e.g., `200`); expose `cursor` in `fetchTasks`; render a load-more when `hasNextPage` is true.
+5. Gotcha: Prisma cursor pagination requires cursor fields to be unique. The pattern is to include all sort fields + `id` in the cursor and build a compound `AND OR` where clause — the existing `createdAt + id` implementation is a good template.
+
+**Implementation sketch — 1-B (One real E2E):**
+1. Keep three mocked specs as "component-e2e" under `apps/tasks/test/component-e2e/` for speed.
+2. Rewrite `happy-path.spec.js` so it hits `http://127.0.0.1:4000/api/v1` directly (no `page.route()`). The CI job already brings up Postgres, applies migrations, and starts the API — just need to stop intercepting.
+3. Update `docs/architecture.md` and `CONTRIBUTING.md` to reflect the honest split between real and component-e2e.
+4. Gotcha: real E2E creates rows. Scope test titles with a `[e2e-<timestamp>]` prefix and `afterAll` clean-up via the archive endpoint, or use a transaction wrapper that rolls back.
+
+### Milestone 2 — High-leverage improvements
+
+| # | Title | Files | Acceptance criteria | Effort | Risk |
+|---|-------|-------|---------------------|--------|------|
+| 2-A | Shared assignee/status/priority constant | New `packages/contracts` or `packages/ui/src/constants.ts`; `tasks.ts`; `constants.js` | One file to change to add an assignee; Ivy in dropdown | M | Low |
+| 2-B | Decompose App.jsx into feature modules | `App.jsx`, new `FilterBar`, `BoardView`, `BacklogView`, `TaskCelebration` | `App.jsx` < 250 lines; each extracted component has ≥1 unit test; E2E still passes | L | Medium |
+| 2-C | Enable ESLint + Prettier in CI | `.eslintrc`, `ci.yml` | Lint job runs on PRs; no pre-existing violations block merge | M | Low |
+| 2-D | Enable strict TypeScript in tasks-api | `services/tasks-api/tsconfig.json`, route files | `tsc --noEmit` passes with `strict: true` | M | Medium |
+
+**Implementation sketch — 2-A (Shared constants):**
+1. Create `packages/ui/src/shared-constants.ts` (or a new `packages/contracts` workspace) exporting `ASSIGNEES`, `STATUSES`, `PRIORITIES`, `TASK_TYPES` as `readonly string[]`.
+2. In `tasks.ts`, import `ASSIGNEES` to populate `validAssignees`; same for statuses/priorities.
+3. In `constants.js`, import `ASSIGNEES` to replace `ASSIGNEE_OPTIONS`. Fixes the missing-Ivy bug as a side effect.
+4. Gotcha: `tasks.ts` has `strict: false`; an explicit type cast may be needed for the Set constructor until 2-D lands.
+
+### Milestone 3 — Quality & polish
+
+| # | Title | Effort |
+|---|-------|--------|
+| 3-A | Add pagination unit tests for cursor/sort alignment | M |
+| 3-B | Add `make test-website` and `make test-all` targets to Makefile | S |
+| 3-C | Wrap PATCH tag re-link in `prisma.$transaction` | S |
+| 3-D | Fix `marked.setOptions` → `marked.use()` (deprecated in marked v17) | S |
+| 3-E | Add `helmet` and `express.json({ limit: '64kb' })` to `app.ts` | S |
+| 3-F | Add structured logging with `trace_id` to tasks-api error middleware | M |
+| 3-G | Update `docs/specs/tasks-one-pager.md` status flow to match current schema | S |
+| 3-H | Evaluate Prisma 6 migration; document decision | M |
+
+---
+
+## Open Questions
+
+1. **E2E split architecture:** Should the new real E2E lane run on every PR (slower but gives feedback) or only on `main` post-merge (faster PRs but late detection)? And should the mocked specs stay in `test/e2e/` (renamed) or move to a vitest suite?
+
+2. **Pagination strategy:** Before fixing the sort/cursor mismatch, is the goal real server-side pagination with load-more UI, or just moving the sort to the DB while still fetching everything in one call (e.g., `limit=500`)? The latter removes the correctness bug with less UI work.
+
+3. **App.jsx decomposition timing:** A 952-line component refactor risks PR conflicts with active feature branches. Is there a quiet milestone coming where this can land cleanly?
+
+4. **Shared constants location:** Should `ASSIGNEES`, `STATUSES`, `PRIORITIES` live in a new `packages/contracts` package (semantically correct, slight more overhead) or in the existing `packages/ui` (simpler, slightly wrong semantically)?
+
+5. **Plano API key:** Confirm whether `PLANO_MINIMAX_API_KEY` in `infra/plano/.env` is still in active use. If not, delete it rather than rotate.
+
+6. **npm High advisory breakdown:** Until `npm audit --json` is run to identify the two new High packages (beyond DOMPurify), the severity of those advisories is unknown. Should this audit surface the package names before being published, or is the `npm audit` task enough as a milestone action?


### PR DESCRIPTION
## Executive Summary

**Health grade: B** (solid foundations persist; key structural defects from W25 remain unresolved and one new security escalation).

The sindustries monorepo is actively shipping: since the W25 audit (2026-06-15), content publishing, X ingest fixes, morning-brief enhancements, and website story updates all landed cleanly. The architecture, dual-mode dev/prodlike discipline, and CI pipeline remain strong. However, the three structural problems flagged in W25 are unchanged: (1) GET `/tasks` pages by cursor then sorts the result in memory, making `nextCursor` unreliable for any non-default sort; (2) `App.jsx` remains a 952-line god component; (3) all four E2E tests fully mock the API with `page.route()`, giving no real integration coverage despite CI docs claiming otherwise. New this week: npm advisories climbed from 28 to 31 with 3 High vulnerabilities (up from 1), and a frontend/API assignee drift was confirmed — `Ivy` is valid for the API but absent from the frontend `ASSIGNEE_OPTIONS` dropdown, making Ivy-assigned tasks unassignable through the UI. A live third-party API key sits in `infra/plano/.env` (gitignored, not in history, but present on disk).

**Top 3 risks:** (1) Mocked E2E tests produce false green CI — any real API regression is undetected; (2) Pagination/in-memory-sort bug silently corrupts large task lists when sort ≠ `priority`; (3) 3 High npm advisories (up from 1) on packages in the active dependency tree, including the DOMPurify sanitizer-bypass on the markdown render path.

**Top 3 opportunities:** (1) Fix the E2E lane to test the real API stack — it is already wired in CI, just needs the `page.route()` mocks removed; (2) Fix the pagination sort to run in the DB and drop the `limit=10000` hack in the client; (3) Decompose `App.jsx` into feature modules before it reaches 1,200 lines.

---

Full audit: [docs/repo-audits/2026-W26.md](docs/repo-audits/2026-W26.md)
