### PR TITLE
cod—audit: sindustries weekly review 2026-W26

### DIFF
--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -1,67 +1,76 @@
 # Repo Audit — sindustries — 2026-W26 (2026-06-22 → 2026-06-28)
 
-**Generated:** 2026-06-22 (Monday weekly cron)
-**Auditor:** Quinn (Chief of Staff)
+**Generated:** 2026-06-23 (Tuesday refresh)
+**Auditor:** Rowan (Staff Engineer)
 **Target:** `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`
-**Type:** Full four-phase audit
+**Type:** Full four-phase audit (refresh of Monday W26)
 
 ---
 
 ## Executive Summary
 
-**Health grade: B** (solid foundations persist; key structural defects from W25 remain unresolved and one new security escalation).
+**Health grade: B-** (downgraded from Monday's `B` — the new budget-api surface lands on main with no authorization checks and stores live banking tokens in plaintext).
 
-The sindustries monorepo is actively shipping: since the W25 audit (2026-06-15), content publishing, X ingest fixes, morning-brief enhancements, and website story updates all landed cleanly. The architecture, dual-mode dev/prodlike discipline, and CI pipeline remain strong. However, the three structural problems flagged in W25 are unchanged: (1) GET `/tasks` pages by cursor then sorts the result in memory, making `nextCursor` unreliable for any non-default sort; (2) `App.jsx` remains a 952-line god component; (3) all four E2E tests fully mock the API with `page.route()`, giving no real integration coverage despite CI docs claiming otherwise. New this week: npm advisories climbed from 28 to 31 with 3 High vulnerabilities (up from 1), and a frontend/API assignee drift was confirmed — `Ivy` is valid for the API but absent from the frontend `ASSIGNEE_OPTIONS` dropdown, making Ivy-assigned tasks unassignable through the UI. A live third-party API key sits in `infra/plano/.env` (gitignored, not in history, but present on disk).
+This refresh focuses on the `services/budget-api`, `apps/budget-mobile`, and `packages/budget-domain` surface that merged after Monday's audit ran. The findings are material: budget-api routes accept `userId` from the request body/query and operate on that user without any auth check (only `/me` validates a session token), and Akahu access tokens are persisted as a plaintext `String` in Postgres. The previously identified structural defects in the tasks surface all persist unchanged: GET `/tasks` pages by cursor then sorts in memory, `App.jsx` is still 952 lines, and all four Playwright specs still mock the API with `page.route()`. The npm advisory landscape shifted from `3 High / 27 Moderate / 31 total` (W26) to `1 Critical / 1 High / 50 Moderate / 52 total` — both new high-severity items are dev-tooling (vitest UI server, vite Windows `server.fs.deny` bypass) and not production-facing. The Minimax API key in `infra/plano/.env` flagged Monday is still on disk.
 
-**Top 3 risks:** (1) Mocked E2E tests produce false green CI — any real API regression is undetected; (2) Pagination/in-memory-sort bug silently corrupts large task lists when sort ≠ `priority`; (3) 3 High npm advisories (up from 1) on packages in the active dependency tree, including the DOMPurify sanitizer-bypass on the markdown render path.
+**Top 3 risks:** (1) `budget-api` has zero authorization on every route — any reachable client can read or mutate any user's transactions, balances, alerts, and Akahu connection by supplying a `userId` parameter; (2) Akahu bearer tokens are stored plaintext in `AkahuConnection.accessToken`, so a DB read compromises live banking-aggregation access; (3) tasks-api pagination sort-and-cursor mismatch and the fully-mocked E2E lane still ship green CI without exercising the real API.
 
-**Top 3 opportunities:** (1) Fix the E2E lane to test the real API stack — it is already wired in CI, just needs the `page.route()` mocks removed; (2) Fix the pagination sort to run in the DB and drop the `limit=10000` hack in the client; (3) Decompose `App.jsx` into feature modules before it reaches 1,200 lines.
+**Top 3 opportunities:** (1) Add a single `requireSession` middleware to `budget-api` and derive `userId` from `req.session` rather than the request body; (2) Encrypt the Akahu access token at rest (envelope encryption with `BUDGET_API_TOKEN_KEY`) or move it to a secret-manager-backed lookup; (3) Add a `budget-api-tests` job to `.github/workflows/ci.yml` — the Makefile already runs the suite locally, but CI does not exercise it.
 
 ---
 
 ## Repo Map
 
-**Purpose:** Mono-repo for Stoffer Industries product surfaces — a Tasks API and React app, a public-facing website, shared UI/design-token/OTel packages, and an AI agent operations layer (bookmark pipeline, content skills, cron definitions).
+**Purpose:** Mono-repo for Stoffer Industries product surfaces — Tasks API + React app, a budgeting product (mobile + API + shared domain), a public-facing website, shared UI/design-token/OTel packages, and an AI agent operations layer (bookmark pipeline, content skills, cron definitions).
 
 **Stack:**
-- Node 22, npm workspaces (`package.json:5-12`)
-- Apps: React 18 + Vite 8 (`apps/tasks`, `apps/website`)
-- Service: Express 4 + Prisma 5 + PostgreSQL 16 (`services/tasks-api`)
-- Shared packages: `@sindustries/ui` (component kit), `@sindustries/design-tokens` (token pipeline), `@sindustries/otel-node` (OTel auto-instrumentation)
-- Tests: Vitest everywhere; Playwright for e2e; Python `unittest` for agent workflows
-- Local runtime: Docker Compose (Postgres) + Tilt (host-run API/app); CI on GitHub Actions with a service-container Postgres
-- Agent ops: `agents/skills/` (bookmark curation, spec authoring, SIndustries copy, repo-audit); `agents/crons/prompts/` (cron definitions); `agents/workflows/bookmarks/` (lobster pipeline scripts)
+- Node 22, npm workspaces (`package.json:8-12`).
+- Web apps: React 18 + Vite (`apps/tasks`, `apps/website`).
+- Mobile app: React Native + Expo SDK 54 (`apps/budget-mobile`).
+- Services: Express 4 + Prisma 5 + PostgreSQL 16 (`services/tasks-api`, `services/budget-api`).
+- Shared packages: `@sindustries/ui` (component kit), `@sindustries/design-tokens` (token pipeline), `@sindustries/otel-node` (OTel auto-instrumentation), `@sindustries/budget-domain` (categorization + budget rules).
+- Tests: Vitest everywhere; Playwright for e2e; Python `unittest` for agent workflows.
+- Local runtime: Docker Compose (Postgres) + Tilt (host-run API/app); CI on GitHub Actions with service-container Postgres.
+- Agent ops: `agents/skills/` (now reorganized into `skills/bookmarks/`, `skills/content/`, `skills/dev/`, `skills/ops/`, `skills/product/`), `agents/crons/prompts/`, `agents/workflows/bookmarks/`.
 
 **Architecture sketch:**
 ```
 React (apps/tasks)
-  └─ tasksApi.ts ── fetch ──▶ Express (services/tasks-api)
+  └─ tasksApi.ts ── fetch ──▶ Express (services/tasks-api :4000)
                                    └─ Prisma ──▶ Postgres (schema: tasks_api)
                                    └─ OTel SDK ──▶ OTLP ──▶ Tempo/Prometheus
 
-React (apps/website) [static JSON-driven content; Vercel deploy]
+React (apps/website) [static JSON content; Vercel deploy]
+
+Expo / RN (apps/budget-mobile)  ── fetch (HTTP) ──▶ Express (services/budget-api :4002)
+                                                          └─ Prisma ──▶ Postgres (schema: budget_api)
+                                                          └─ fetch ──▶ Akahu OAuth + API (oauth.akahu.nz, api.akahu.io)
+                                                          └─ @sindustries/budget-domain (categorization, budget rules)
 
 AI agents (agents/)
-  └─ tasks-api skill ── HTTP ──▶ tasks-api
+  └─ tasks-api-ops skill ── HTTP ──▶ tasks-api
   └─ lobster bookmark pipeline ── state JSON + tasks-api
 ```
 
 **Key directories:**
-- `apps/tasks/` — Kanban + backlog task manager; main product surface
-- `apps/website/` — Public website; JSON-file CMS (stories, experiments, stacks, systems)
-- `services/tasks-api/` — Express API backed by Prisma/Postgres; Tasks CRUD + tags/comments
-- `packages/ui/` — Shared component library (React + Pencil specimen)
-- `packages/design-tokens/` — Token pipeline; syncs Pencil → CSS variables
-- `packages/otel-node/` — OTel SDK bootstrap; auto-instrumentation for Node services
-- `infra/` — Docker Compose (dev/prodlike), Tilt file, Prometheus/Grafana/Tempo config
-- `agents/` — AI skill definitions, cron prompts, bookmark pipeline orchestration
-- `docs/` — Architecture, specs, audit history
+- `apps/tasks/` — Kanban + backlog task manager (focus product).
+- `apps/website/` — Public website; JSON-file CMS.
+- `apps/budget-mobile/` — Expo React Native app; budgeting MVP screens.
+- `apps/mission-control/` — README-only placeholder for future aggregate shell.
+- `services/tasks-api/` — Express API; Tasks CRUD + tags + comments.
+- `services/budget-api/` — Express API; session + Akahu OAuth + accounts/transactions/alerts.
+- `packages/budget-domain/` — Pure functions: categorization, budget thresholds, merchant normalization.
+- `packages/ui/`, `packages/design-tokens/`, `packages/otel-node/` — shared libraries.
+- `infra/` — Docker Compose, Tilt, Prometheus/Grafana/Tempo; `infra/plano/.env` contains a Minimax API key.
+- `agents/` — AI skill definitions (reorganized this week by domain), cron prompts, bookmark pipeline orchestration.
+- `docs/` — Architecture, specs, audit history (`docs/repo-audits/`).
 
-**Surprises from discovery:**
-- `agents/` is a large, mature, autonomous operation system (bookmark review → spec → tasks pipeline) that now rivals the product surface in code volume.
-- `infra/plano/.env` contains a live Minimax API key — gitignored, not in history, but present on disk.
-- `tasksApi.ts:15` type comment lists `triage` as a valid status; the Prisma schema `TaskStatus` enum and API `validStatuses` do not include it.
-- `ASSIGNEE_OPTIONS` in the frontend lists 4 assignees; `validAssignees` in the API lists 5 (Ivy is missing from the UI).
+**Surprises from discovery (refresh):**
+- `services/budget-api` is the largest single new surface this week (~811 lines of route code, 5 migrations) and ships without auth checks on any route except `/me`.
+- `services/budget-api` is not exercised by CI — `.github/workflows/ci.yml` has no `budget-api-tests` job (`ci.yml` only references `tasks-api`, `tasks-app`, `website`, `otel-node`, `design-system-sync`).
+- The Akahu access token model uses a plain `String` field (`services/budget-api/prisma/schema.prisma:AkahuConnection.accessToken`). No encryption-at-rest layer.
+- The `AKAHU_DEV_USER_ACCESS_TOKEN` env var is consumed by the production code path in `routes/akahu.ts:79-83` as a "dev convenience" to auto-link any caller — the safeguard is "is the env var set?", which is brittle.
+- The mobile app talks to budget-api over plain HTTP on a Tailscale IP (`apps/budget-mobile/.env.local: EXPO_PUBLIC_API_BASE_URL=http://100.106.176.15:4002/api/v1`); acceptable for dev over Tailnet, worth flagging before any non-tailnet deployment.
 
 ---
 
@@ -69,176 +78,215 @@ AI agents (agents/)
 
 ### Strengths
 
-- **Monorepo boundaries are clean.** `apps/`, `services/`, `packages/`, `infra/`, `agents/` have clear semantics and the actual code respects them (`README.md:7-13`).
-- **Dual-mode dev/prodlike discipline is excellent.** Port–DB pairing guard (`server.ts:23-45`), prodlike seed guard, mode-env source-of-truth, and Makefile wrappers work coherently.
-- **API input validation is consistent.** All write routes validate enums before touching the DB, return structured `{ error: { code, message } }` errors, and pass exceptions to Express middleware.
-- **CI is comprehensive in scope.** `.github/workflows/ci.yml` covers Python agent tests, otel-node unit tests, tasks-api unit + DB integration tests, tasks-app unit/component tests, Playwright e2e, and website build.
-- **OTel instrumentation is well-integrated.** `packages/otel-node` cleanly wraps SDK bootstrap; `OTEL_SDK_DISABLED` flag prevents noise in CI and no-collector local setups.
-- **Spec-first workflow is documented and evidenced.** `docs/specs/` has 8 spec docs; `CONTRIBUTING.md` defines clear gates for non-trivial work.
-- **Draft persistence in localStorage** (`useTaskDrafts.js`) sanitizes stored state and handles version mismatches — a thoughtful correctness detail.
-- **DB integration tests hit a real Postgres.** `test/db-integration.test.ts` creates, updates, comments, and archives a task end-to-end through Express + Prisma + Postgres in CI.
+- **Monorepo boundaries remain clean.** `apps/`, `services/`, `packages/`, `infra/`, `agents/` semantics still hold; the new budgeting surfaces respect them.
+- **Shared domain package is the right call.** `packages/budget-domain` exports pure categorization/budget logic with co-located tests (`packages/budget-domain/src/budgets.test.ts`), giving the rules a unit-test home decoupled from Express.
+- **Akahu sync is idempotent.** `routes/akahu.ts` upserts by `(provider, providerCardId)` for cards and `providerTransactionId` for transactions; pending transactions are rebuilt each sync (`routes/akahu.ts:222-228`).
+- **Incremental Akahu sync window** uses `lastSyncedAt - 7d` overlap (`routes/akahu.ts:23, 91-99`), giving late-arriving bank entries a reasonable chance of landing.
+- **Categorization fallback chain is explicit.** Most-recent user correction wins; otherwise a heuristic stub returns `{source: 'rule' | 'model'}` (`services/categorizer.ts:11-44`), which makes future LLM swap-in straightforward.
+- **Session tokens stored as SHA-256 hash** in `Session.tokenHash` (`schema.prisma:Session`, `routes/session.ts:8-11`) — correct posture; the raw token never lands in the DB.
+- **Pending-transaction provider IDs are deterministic** (`routes/akahu.ts:303-318`), so reruns are idempotent even though Akahu doesn't expose stable IDs for pending entries.
+- All Monday-confirmed strengths still hold (dual-mode dev/prodlike, tasks-api validation, CI breadth, OTel integration, spec-first workflow, DB integration tests for tasks-api).
 
 ---
 
 ### Architecture & Design
 
-**[High] GET /tasks pages by cursor then sorts in memory — nextCursor is unreliable** *(persists from W25)*
+**[Critical] budget-api accepts userId from the request body/query with no auth check** *(new this week)*
 
-- `services/tasks-api/src/routes/tasks.ts:107-136` — `findMany` uses `orderBy: [{ createdAt: 'desc' }, { id: 'desc' }]` regardless of the `?sort=` parameter.
-- `tasks.ts:140-162` — After fetching `limit + 1` records keyed to the cursor window, the route re-sorts the result in JavaScript.
-- `tasks.ts:165` — `nextCursor` is then encoded from `lastTask` in the *sorted* slice, but the cursor encodes `(createdAt, id)` — the anchor for the *next* DB-level query. For `sort=dueAt` or `sort=statusChangedAt`, the cursor and sort order are misaligned, producing gaps or repeated items across pages.
-- **Consequence (fact):** Calling `/tasks?sort=dueAt&cursor=X` does not return the correct continuation. Currently masked because the client requests `limit=10000` and never paginates.
+- `services/budget-api/src/routes/akahu.ts:29, 56, 71` — `userId` comes from `req.query.userId` / `req.body.userId`; the only validation is `prisma.user.findUnique(...)`.
+- `services/budget-api/src/routes/transactions.ts:14, 36` — `GET /transactions` and `PATCH /transactions/:id/category` accept `userId` from the request and never verify a session.
+- `services/budget-api/src/routes/cards.ts:8`, `routes/categories.ts`, `routes/categorize.ts`, `routes/alerts.ts:9, 21, 35` — same pattern across every route except `GET /me`.
+- `services/budget-api/src/routes/session.ts:38-46` — the only place a Bearer token is validated. None of the other routers call this code or expose it as middleware.
+- **Consequence (fact):** Any client that can reach the budget-api can list/modify any user's transactions, balances, Akahu connection, and alert configuration by supplying the target `userId`. The mobile app currently sets `userId` client-side (`apps/budget-mobile/src/api/`); there is no server-side enforcement that a session token belongs to that user.
+- **Severity:** Critical — this is a horizontal-privilege escalation (IDOR) on every route, present in production-quality code that has migrations applied and CI builds passing.
 
-**[Medium] tasksApi.ts fetches limit=10000 on every auto-refresh, bypassing pagination** *(persists from W25)*
+**[High] GET /tasks pages by cursor then sorts in memory — nextCursor is unreliable for non-default sorts** *(persists from W25/W26)*
 
-- `apps/tasks/src/tasksApi.ts:96` — `query.set('limit', '10000')` is hardcoded.
-- `apps/tasks/src/useTasks.js:7` — `DEFAULT_REFRESH_INTERVAL_MS = 3000` triggers a full-table scan + JSON payload every 3 seconds.
-- **Consequence (fact):** The API's pagination infrastructure is a dead code path. Full-table fetches every 3 s are acceptable at <100 tasks but expensive at 1,000+.
+- `services/tasks-api/src/routes/tasks.ts:218-240` — `findMany` uses `orderBy: [{ createdAt: 'desc' }, { id: 'desc' }]` regardless of the `?sort=` parameter.
+- `services/tasks-api/src/routes/tasks.ts:243-289` — the result is re-sorted in JavaScript by `priority`/`dueAt`/`statusChangedAt`/etc.
+- `services/tasks-api/src/routes/tasks.ts:290+` — `nextCursor` is encoded from the in-memory-sorted slice, but the cursor anchor is `(createdAt, id)`, so the next DB page restarts at the wrong record for any sort except `createdAt`. Currently masked because the client requests `limit=10000`.
 
-**[Medium] App.jsx is a 952-line god component** *(persists from W25)*
+**[Medium] tasksApi.ts fetches `limit=10000` on every auto-refresh, bypassing pagination** *(persists)*
 
-- `apps/tasks/src/App.jsx` owns: board view state, backlog view state, filter dropdowns (status, priority, assignee, tag), confetti orchestration (Web Audio + canvas DOM), drag-and-drop scroll logic, column visibility, selected task, theme/view persistence, and all `useTasks`/`useTaskDrafts` call sites.
-- **Consequence (judgment):** Any new view or feature requires editing one 952-line file. The two child components (`TaskEditor.jsx`, `TaskCardSummary.jsx`) are crisp; the parent is the growing risk surface.
+- `apps/tasks/src/tasksApi.ts:96` — hardcoded; combined with `apps/tasks/src/useTasks.js:7` (`DEFAULT_REFRESH_INTERVAL_MS = 3000`) yields a 3 s full-table scan + tag include cycle. Acceptable at <100 tasks, expensive at 1,000+.
 
----
+**[Medium] App.jsx is a 952-line god component** *(persists)*
 
-### Code Quality
-
-**[Medium] Assignee list drifts between API validation and frontend constants**
-
-- `services/tasks-api/src/routes/tasks.ts:10` — `validAssignees = new Set(['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy'])` — 5 values.
-- `apps/tasks/src/utils/constants.js:14` — `ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom']` — 4 values; `Ivy` is absent.
-- **Consequence (fact):** Ivy-assigned tasks created via the API (agent scripts, direct HTTP) appear in the board but cannot be assigned or re-assigned through the UI dropdown. The `?assignee=Ivy` filter works but is not surfaced.
-
-**[Medium] Stale `triage` status documented in client type comment**
-
-- `apps/tasks/src/tasksApi.ts:15` — `status: string; // open | triage | ready | doing | acceptance | done` lists `triage` as valid.
-- Prisma schema `TaskStatus` enum (`schema.prisma:14-22`) and `validStatuses` (`tasks.ts:9`) have no `triage` value.
-- **Consequence (fact):** Any code treating the TS type comment as a contract will attempt a value the API rejects with `INVALID_STATUS_VALUE`.
-
-**[Medium] tasks.ts route file at 517 lines mixes validation, query building, sorting, and mapping**
-
-- Validation helpers, cursor encode/decode, tag management, response mappers, and 6 route handlers share one file.
-- **Consequence (judgment):** Targeted unit testing of cursor/sort logic and tag management is harder than it needs to be; any structural change touches the same large file.
-
-**[Low] Inconsistent TypeScript/JavaScript in tasks app**
-
-- `apps/tasks/src/tasksApi.ts` is TypeScript; `App.jsx`, `useTasks.js`, `useTaskDrafts.js`, and all hooks are `.js`/`.jsx`.
-- **Consequence (judgment):** No strict-mode protection on the bulk of front-end code.
+- `apps/tasks/src/App.jsx` owns board, backlog, filters, confetti orchestration, drag-scroll, theme/view persistence, and all data hooks. The two child components are crisp; the parent is the growing risk surface.
 
 ---
 
 ### Security
 
-**[High] Live API key in infra/plano/.env (gitignored but present on disk)**
+**[Critical] Live banking-aggregation tokens stored in plaintext** *(new this week)*
 
-- `infra/plano/.env:1` — `PLANO_MINIMAX_API_KEY=sk-cp-f0BWFcEYSI2Z...` — a live Minimax API key.
-- **Fact:** `git check-ignore infra/plano/.env` confirms the file is gitignored; it is not in git history.
-- **Judgment:** Low git-leak risk, but if the repo directory is shared, snapshotted, or the file is accidentally staged in a future PR, the key is live. Recommend rotation and moving to a secrets manager.
+- `services/budget-api/prisma/schema.prisma:AkahuConnection.accessToken String` — no encryption, no envelope wrapping, no separate KMS.
+- `services/budget-api/src/repos/akahuRepo.ts` reads and writes the token verbatim; sync paths read it on every call (`routes/akahu.ts:101`).
+- **Consequence (fact):** A read of the `budget_api.AkahuConnection` table yields a live bearer token that grants read access to a NZ banking aggregation feed (accounts, transactions, balances) for the linked user. Severity is Critical given the asset class.
+- **Judgment:** Encryption-at-rest via envelope encryption (`crypto.createCipheriv('aes-256-gcm', ...)` keyed off `BUDGET_API_TOKEN_KEY` from a secrets manager) is the minimum viable mitigation. A short-lived refresh-token pattern would be better but requires Akahu API changes.
 
-**[High] npm audit: 3 High advisories, 27 Moderate (31 total — up from 28 in W25)**
+**[High] `AKAHU_DEV_USER_ACCESS_TOKEN` is consumed by the production code path** *(new this week)*
 
-- `npm audit` from repo root: `{ high: 3, moderate: 27, low: 1, total: 31 }`.
-- W25 reported 1 High (DOMPurify sanitizer-bypass affecting the markdown render path). Two new Highs appeared this week.
-- **Consequence (fact):** The DOMPurify bypass (`apps/tasks/src/components/MarkdownContent.jsx:15` renders task descriptions with `dangerouslySetInnerHTML`) represents the highest-priority live risk. The two new Highs require `npm audit --json` to identify affected packages before action.
+- `services/budget-api/src/routes/akahu.ts:79-86` — if no `AkahuConnection` exists for a user, the route auto-creates one using `process.env.AKAHU_DEV_USER_ACCESS_TOKEN` and continues.
+- **Consequence (fact):** The "dev convenience" branch is only gated by the absence of an env var, not by a `NODE_ENV !== 'production'` check. If the env var ever leaks into a prod-shaped environment, any user without a connection silently inherits the dev token's bank linkage.
+- **Recommendation:** Gate the branch on `process.env.NODE_ENV !== 'production'` (or a dedicated `BUDGET_API_ALLOW_DEV_TOKEN=1` flag), or remove the branch and require explicit local seed.
 
-**[Low] CORS origin allowlist defaults to localhost-only**
+**[High] Live Minimax API key remains in `infra/plano/.env`** *(persists from W26)*
 
-- `services/tasks-api/src/app.ts:5-20` — Correct posture for a local-only service currently; no production origin committed.
+- `infra/plano/.env:1` — `PLANO_MINIMAX_API_KEY=sk-cp-…` is still present on disk.
+- Gitignored, not in history; risk surface is unchanged from Monday's report. **Still worth rotation** if the key is unused or current.
+
+**[Medium] budget-api has no body-size limit, no helmet, no rate limiting**
+
+- `services/budget-api/src/app.ts:42` — `app.use(express.json())` with no `{ limit }`. Default is `100kb`, but explicit is better; no helmet headers; no per-IP rate limit.
+- **Consequence (fact):** A misbehaving or malicious client can submit large JSON payloads without server-side guardrail; standard security headers are absent.
+
+**[Medium] vitest UI server has a critical advisory; vite has a high Windows-only advisory**
+
+- `npm audit` reports `vitest <3.2.6` GHSA-5xrq-8626-4rwp (CVSS 9.8) — arbitrary file read/exec when `vitest --ui` listens; not used in CI.
+- `vite <=6.4.2` GHSA-fx2h-pf6j-xcff — `server.fs.deny` bypass on Windows alternate paths; Windows-only.
+- **Consequence (judgment):** Both are dev-tool surfaces; production blast radius is low. Worth a `npm audit fix` pass next milestone but not urgent.
+
+---
+
+### Code Quality
+
+**[High] No CI job for `services/budget-api`** *(new this week)*
+
+- `.github/workflows/ci.yml` has jobs for `tasks-api-tests`, `tasks-app-tests`, `tasks-app-e2e`, `website-app-tests`, `design-system-sync`, `otel-node-tests`, `python-workflow-tests`. There is no `budget-api-tests` job.
+- The Makefile's `test-api` target runs `services/budget-api` tests locally (`Makefile:25-27`), so a contributor running `make test-api` exercises them; CI does not.
+- **Consequence (fact):** Tests in `services/budget-api/test/` (akahuClient, alerts, categorizer, akahuSync) can break on main without surfacing as a failing PR check.
+
+**[Medium] Assignee list drifts between API validation and frontend constants** *(persists)*
+
+- `services/tasks-api/src/routes/tasks.ts:10` — `validAssignees = new Set(['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy'])`.
+- `apps/tasks/src/utils/constants.js:15` — `ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom']` — Ivy still missing.
+
+**[Medium] Stale `triage` status documented in client type comment** *(persists)*
+
+- `apps/tasks/src/tasksApi.ts:8` — "use status='ready' or status='triage' instead" in the deprecation note.
+- `apps/tasks/src/tasksApi.ts:21` — `status: string;  // open | triage | ready | doing | acceptance | done` lists `triage` as valid.
+- No `triage` value exists in the API or Prisma schema.
+
+**[Medium] `routes/tasks.ts` is 517 lines mixing validation, query building, sorting, and mapping** *(persists)*
+
+- Targeted unit testing of cursor/sort logic and tag management is harder than it needs to be; any structural change touches the same large file.
+
+**[Low] `services/budget-api` and tasks-api use `.ts` route files in an ESM project**
+
+- `services/budget-api/package.json:5` declares `"type": "module"`; imports use `'./routes/akahu.ts'` (with the `.ts` extension) and rely on `tsx` for both dev and "start". Once a real runtime build is needed, the `.ts` extension on import paths must change. Not urgent at MVP stage.
 
 ---
 
 ### Testing
 
-**[High] All 4 E2E specs fully mock the API — zero real integration coverage** *(persists from W25)*
+**[High] All 4 E2E specs fully mock the API — zero real integration coverage** *(persists)*
 
-- `apps/tasks/test/e2e/happy-path.spec.js:9` — `page.route('**/api/v1/tasks**', ...)` intercepts every request and fulfills from an in-memory array.
-- All 4 specs (`happy-path`, `assignee-dropdown`, `assignee-filter`, `priority-filter`) follow this pattern.
-- **Consequence (fact):** The E2E CI job tests the React app against a hand-rolled mock, not the actual Express service. A breaking API change would not be detected. `CONTRIBUTING.md:69` states "Every AC covered by that PR needs at least one E2E test" — satisfied on paper but not in substance.
+- `apps/tasks/test/e2e/happy-path.spec.js:9` — `page.route('**/api/v1/tasks**', ...)` intercepts every request.
+- All 4 specs follow the same pattern. `CONTRIBUTING.md` lists E2E as a gate; in practice the gate validates the React app against a hand-rolled stub.
+- Note: `ci.yml:103-198` *does* boot the real `tasks-api` for the e2e job (Postgres service, prisma migrate, prisma seed, `npm run start`, wait-for-health). The infrastructure is already there — only `page.route()` is in the way.
 
-**[Medium] Pagination logic has no unit tests that could catch the cursor/sort bug**
+**[High] No tests in `packages/budget-domain` exercise the Categories taxonomy round-trip**
 
-- `services/tasks-api/test/read-endpoints.test.ts` mocks Prisma and tests filtering, status, and cursor decoding, but does not assert that page 2 returns the correct items for non-default sorts.
-- **Consequence (judgment):** The in-memory-sort + cursor mismatch described in Architecture would not be caught by the current suite even if exercised.
+- `packages/budget-domain/src/budgets.test.ts` exists and is the only test file; categorizer thresholds and merchant normalization are covered indirectly via budget-api unit tests. The `Categories` exported constant has no test that asserts the public list matches what the API surfaces.
+- **Consequence (judgment):** Safe today (single consumer), but a category rename will silently break the mobile picker UI without a failing test.
+
+**[Medium] Pagination logic has no unit tests that could catch the cursor/sort bug** *(persists)*
+
+- `services/tasks-api/test/read-endpoints.test.ts` mocks Prisma but does not assert page-2-correctness for non-default sorts.
 
 ---
 
 ### Performance
 
-**[Medium] 3 s auto-refresh with limit=10000 is a polling tax that grows with data**
+**[Medium] 3 s auto-refresh with `limit=10000` is a polling tax that grows with data** *(persists)*
 
-- `apps/tasks/src/useTasks.js:7` — `DEFAULT_REFRESH_INTERVAL_MS = 3000`.
-- `apps/tasks/src/tasksApi.ts:96` — `limit=10000` on every poll.
-- **Consequence (fact):** Every 3 seconds the app issues a full-table Prisma query with tag includes. Acceptable at <100 tasks; expensive at 1,000+.
+- Unchanged from Monday's report.
+
+**[Low] Akahu sync uses sequential `await prisma.linkedCard.upsert` inside a `for` loop**
+
+- `routes/akahu.ts:122-181` — per-account upsert + per-account `accountBalanceSnapshot.create` in a serial loop. Likely fine at <20 accounts per user; benchmark before optimizing.
 
 ---
 
 ### Dependencies
 
-**[High] 3 High npm advisories (up from 1 in W25)**
+**[Medium] npm advisory landscape: 52 total (50 moderate, 1 high, 1 critical)** *(changed)*
 
-- Noted above under Security. The escalation from 1 → 3 High in a single week is worth an `npm audit --json` inspection to identify the two new packages.
+- `npm audit` from repo root: `{ critical: 1, high: 1, moderate: 50, low: 0, total: 52 }`.
+- Critical = vitest UI server (dev tool). High = vite Windows path bypass (dev tool). 50 Moderate is largely esbuild/postcss/react-native/expo/OTel cascades introduced by the new `apps/budget-mobile` Expo SDK.
+- **Consequence (judgment):** No production-runtime advisory escalation this week; the previously reported "3 High" set has reshuffled. `npm audit fix` is worth running next milestone.
 
-**[Low] Prisma at 5.20.0 — Prisma 6.x is available**
+**[Low] Prisma at 5.20.0 — Prisma 6.x is available** *(persists)*
 
-- `services/tasks-api/package.json` pins `@prisma/client` and `prisma` at `^5.20.0`. Prisma 6 is a breaking-change release; migration is non-trivial but brings query performance improvements. Not urgent at this scale.
+- Unchanged.
 
 ---
 
 ### DevEx & Operations
 
-**[Medium] No lint or format enforcement in CI**
+**[Medium] No lint or format enforcement in CI** *(persists)*
 
 - `ci.yml` runs tests and build but no ESLint or Prettier step.
-- **Consequence (judgment):** Style inconsistencies and drift (TS/JS mixing, duplicate enum lists) accumulate without an automated gate.
 
-**[Low] make test does not include all CI lanes**
+**[Medium] `make test-api` runs both tasks-api and budget-api locally; CI runs only tasks-api**
 
-- `Makefile` defines `test-api`, `test-app`, `test-e2e` but not website tests, otel-node tests, or Python agent tests. A developer passing `make test` locally can still break CI on other lanes.
+- `Makefile:25-27` — both services tested by `make test-api`.
+- `.github/workflows/ci.yml` — only `tasks-api-tests` exists.
+
+**[Low] `apps/budget-mobile/.env.local` ships a Tailscale IP**
+
+- `apps/budget-mobile/.env.local:1` — `EXPO_PUBLIC_API_BASE_URL=http://100.106.176.15:4002/api/v1`. Acceptable for local dev over Tailscale; the file is gitignored. Worth a checklist note before the mobile app moves beyond local testing.
 
 ---
 
 ### Documentation
 
-**[Medium] architecture.md states e2e tests use the real API — they do not**
+**[Medium] `docs/architecture.md` states e2e tests use the real API — they do not** *(persists)*
 
-- `docs/architecture.md` describes "real app → API → Postgres flow" in the e2e section. The Playwright specs use `page.route()` mocks against all API calls. The doc is wrong.
+**[Low] No README for `services/budget-api` covers the missing-auth contract**
 
-**[Low] tasksApi.ts type comment includes stale `triage` status**
-
-- Noted under Code Quality. The stale comment in the published client type will mislead consumers.
+- `services/budget-api/README.md` exists (per directory listing) but does not flag that all routes are unauthenticated. A short "MVP scope: dev/Tailnet only — auth not yet enforced" callout would set expectations for the next contributor.
 
 ---
 
 ## Improvement Strategy
 
-### Theme 1 — Fix pagination or retire it
+### Theme 1 — Lock down `budget-api` before any non-Tailnet deployment *(new top priority)*
 
-**Current state:** Cursor-based pagination infrastructure doesn't function correctly for non-default sorts. The frontend sidesteps it with `limit=10000`.
-**Target state:** The sort parameter is pushed into the DB query (not applied in memory), the cursor encodes the correct sort key, and the frontend fetches in pages with a reasonable limit.
-**Trade-off:** Non-trivial to do correctly for multi-column sorts (priority has no natural DB index order). Quick path: add DB-level `orderBy` for each sort value, encode cursor against the sort key, and reduce `limit` to 200 or so in the client.
+**Current state:** Every route except `/me` accepts `userId` from the request and operates on that user without verifying a session. The Akahu access token is stored plaintext. The dev-token fallback runs unconditionally.
+
+**Target state:** A single `requireSession` Express middleware extracts the session token from `Authorization: Bearer …`, looks up `Session` by hash, attaches `req.userId`, and rejects everything else. All routers consume `req.userId`; no route reads `userId` from the body or query. Akahu tokens are encrypted at rest via envelope encryption keyed on a runtime secret. Dev-token fallback is gated by `NODE_ENV !== 'production'`.
+
+**Trade-off:** Touches every router file in `budget-api` and the mobile API client. The mobile client must be updated to send the Bearer token on every call (it already gets the token from `/session/dev-login`). Effort: M.
+
+**Done signal:** Hitting any `budget-api` route without a valid Bearer returns 401; the Akahu token field round-trips through encrypt/decrypt; `NODE_ENV=production` disables the dev fallback. CI exercises a route that hits 401 without a session.
+
+### Theme 2 — Make CI exercise the new surface
+
+**Current state:** `services/budget-api` ships migrations, route code, and a vitest suite, but no CI job validates them; the Akahu Postgres schema is never migrated in CI.
+
+**Target state:** A `budget-api-tests` job in `ci.yml` mirroring the `tasks-api-tests` job (Postgres service container, prisma generate/migrate/seed, vitest run). Optionally a second `budget-api-integration` job uses supertest.
+
+**Trade-off:** ~30-90 s of CI time; low risk. Effort: S.
+
+**Done signal:** `npm test --workspace services/budget-api` runs on every PR; failing tests block merge.
+
+### Theme 3 — Fix pagination or retire it *(carried forward from W26)*
+
+**Current state / target state / trade-off:** Unchanged from Monday. Push the sort into the DB, encode the cursor against the sort key, drop the `limit=10000` client hack.
+
 **Done signal:** `tasksApi.ts` no longer hardcodes `limit=10000`; `nextCursor` is meaningful for every supported sort; CI passes.
 
-### Theme 2 — Make the E2E lane actually test the API
+### Theme 4 — Make the E2E lane actually test the API *(carried forward)*
 
-**Current state:** All E2E specs mock the API. CI gives a green signal that means "the React app renders correctly against a hand-rolled stub."
-**Target state:** At least one E2E lane (new or converted) boots the real dev stack (Postgres + tasks-api) and drives the Playwright browser against it. The existing mocked specs can move to a `component-e2e` category.
-**Trade-off:** Slower CI job; requires seeding state in the test setup. Investment: M (the Postgres service container is already wired in CI).
-**Done signal:** `happy-path.spec.js` has no `page.route()` intercepts; it creates and archives a real task through the real API; passes in CI with the Postgres service container.
+**Current state / target state / trade-off:** Unchanged from Monday. CI already brings up the real stack; converting at least one spec to drop `page.route()` is the unblock.
 
-### Theme 3 — Decompose App.jsx
+**Done signal:** `happy-path.spec.js` has no `page.route()` intercepts; it creates and archives a real task end-to-end; passes in CI.
 
-**Current state:** 952 lines; owns filters, view, confetti, audio, drag scroll, and all data bindings.
-**Target state:** Separate feature modules — `FilterBar`, `BoardView`, `BacklogView`, `TaskCelebration` — each with a focused responsibility. `App.jsx` becomes a shell that composes them.
-**Trade-off:** Risk of regressions during refactor; requires a coordinated PR. Recommended: add component-level tests first, then extract.
-**Done signal:** `App.jsx` < 250 lines; each extracted component has at least one unit test.
+### Theme 5 — Consolidate constants and decompose App.jsx *(carried forward, lower priority than budgeting safety)*
 
-### Theme 4 — Resolve npm vulnerabilities and consolidate assignee definition
-
-**Current state:** 31 advisories, 3 High; `validAssignees` in the API and `ASSIGNEE_OPTIONS` in the frontend have diverged.
-**Target state:** 0 High advisories; `ASSIGNEES` defined in a shared package constant consumed by both API validation and frontend dropdown.
-**Trade-off:** Dependency upgrades can break behavior; shared constant requires a new build step if put in a separate package (or simply a new shared module in `packages/ui` or a new `packages/contracts`).
-**Done signal:** `npm audit` exits 0 for High/Critical; adding a new assignee requires changing exactly one file.
+**Current state / target state / trade-off:** Unchanged from Monday. Shared assignee/status/priority constants in `packages/ui` or new `packages/contracts`; phased `App.jsx` decomposition.
 
 ---
 
@@ -246,78 +294,87 @@ AI agents (agents/)
 
 ### Milestone 0 — Safety net
 
-| # | Title | Effort | Risk |
-|---|-------|--------|------|
-| 0-A | Run `npm audit --json`, identify the 3 High packages, open a targeted upgrade PR | S | Low |
-| 0-B | Bump DOMPurify to `>=3.4.11` in `apps/tasks/package.json` | S | Low |
-| 0-C | Add a Vitest spec for cursor pagination semantics that asserts the current sort/cursor mismatch | S | Low |
+| # | Title | Files | Acceptance criteria | Effort | Risk |
+|---|-------|-------|---------------------|--------|------|
+| 0-A | Add `budget-api-tests` CI job mirroring `tasks-api-tests` | `.github/workflows/ci.yml` | CI runs `npm test --workspace services/budget-api` against a Postgres service container; failing tests block merge | S | Low |
+| 0-B | Add a Vitest spec for tasks-api cursor pagination semantics asserting the current sort/cursor mismatch | `services/tasks-api/test/` | Test passes by documenting current behavior; future fix can flip it | S | Low |
+| 0-C | Add a vitest spec for `budget-api` that calls every route without a Bearer and expects 401 (currently passes by accident — adopt this as the contract) | `services/budget-api/test/` | After Milestone 1 lands, this spec turns from "documents the gap" into "enforces the rule" | S | Low |
 
 **Quick wins (do now, ≤ 15 min each):**
-- **Add Ivy to `ASSIGNEE_OPTIONS`** — `apps/tasks/src/utils/constants.js:14`. Zero risk; restores UI parity with API.
-- **Fix stale `triage` comment** — `apps/tasks/src/tasksApi.ts:15`. Remove `triage` from the status comment.
-- **Rotate the Minimax API key** — `infra/plano/.env:1`. Rotate in the Minimax dashboard, update the local `.env`.
+- **Add Ivy to `ASSIGNEE_OPTIONS`** — `apps/tasks/src/utils/constants.js:15`. Restores UI parity with API.
+- **Fix stale `triage` comment** — `apps/tasks/src/tasksApi.ts:8, 21`. Remove `triage` from the deprecation note and type comment.
+- **Gate `AKAHU_DEV_USER_ACCESS_TOKEN` on non-production** — `services/budget-api/src/routes/akahu.ts:79-86`. One-line guard: `if (process.env.NODE_ENV === 'production') return jsonError(res, 401, 'UNAUTHORIZED', 'Akahu not linked for this user');` before the dev branch.
+- **Rotate the Minimax API key** — `infra/plano/.env:1`. Rotate in the Minimax dashboard, update the local `.env`. (Still open from Monday.)
 
 ### Milestone 1 — Critical fixes
 
 | # | Title | Files | Acceptance criteria | Effort | Risk |
 |---|-------|-------|---------------------|--------|------|
-| 1-A | Fix pagination: push sort into DB, align cursor encoding | `tasks.ts`, `tasksApi.ts` | `?sort=dueAt&cursor=X` returns the correct next page; `limit=10000` removed from client | L | Medium |
-| 1-B | Make one E2E spec real: remove `page.route()` from `happy-path.spec.js`, hit the real API | `test/e2e/happy-path.spec.js`, `playwright.config.js`, `docs/architecture.md` | E2E spec creates/archives a real task; `docs/architecture.md` no longer contradicts the implementation | M | Medium |
-| 1-C | Address 3 High npm advisories | `package*.json` files | `npm audit` reports 0 High; CI passes | M | Medium |
+| 1-A | **Add `requireSession` middleware to `budget-api`** and use it on every router except `/session/dev-login` | `services/budget-api/src/app.ts`, all `routes/*.ts`, `apps/budget-mobile/src/api/*` | All endpoints reject calls without a valid `Authorization: Bearer` header; `userId` is read only from `req.userId`; mobile client always sends the bearer | M | Medium |
+| 1-B | **Encrypt Akahu access tokens at rest** | `services/budget-api/src/repos/akahuRepo.ts`, schema migration, `BUDGET_API_TOKEN_KEY` env doc | Tokens are written as AES-256-GCM ciphertext + IV; read path decrypts transparently; key rotation procedure documented in `services/budget-api/README.md` | M | Medium |
+| 1-C | Fix tasks-api pagination: push sort into DB, align cursor encoding | `services/tasks-api/src/routes/tasks.ts`, `apps/tasks/src/tasksApi.ts` | `?sort=dueAt&cursor=X` returns the correct next page; `limit=10000` removed from client | L | Medium |
+| 1-D | Make one E2E spec real: remove `page.route()` from `happy-path.spec.js` | `apps/tasks/test/e2e/happy-path.spec.js`, `playwright.config.js`, `docs/architecture.md` | E2E spec creates/archives a real task; `docs/architecture.md` no longer contradicts the implementation | M | Medium |
 
-**Implementation sketch — 1-A (Fix pagination):**
-1. Map the `sort` param to a Prisma `orderBy` array inside `findMany` (e.g., `priority` → `[{ priority: 'asc' }, { createdAt: 'desc' }, { id: 'desc' }]`). Note: Postgres enum sort order is declaration order (`low/medium/high/urgent` in schema); invert or use a `CASE` expression to get the intuitive urgent-first order.
-2. Encode the cursor using the actual sort field value, not always `createdAt`. Switch `encodeCursor` to encode `(sortKeyValue, createdAt, id)` and update `decodeCursor` to match.
-3. Delete the JS `sortedTasks = ...` block (`tasks.ts:140-162`).
+**Implementation sketch — 1-A (`requireSession` middleware):**
+1. Create `services/budget-api/src/middleware/requireSession.ts` that reads `Authorization: Bearer <token>`, computes `sha256(token)`, looks up `Session` by `tokenHash`, and either calls `next()` with `req.userId = session.userId` or returns `jsonError(res, 401, 'UNAUTHORIZED', 'Missing or invalid session')`.
+2. In `app.ts`, mount `sessionRouter` (login + `/me`) *before* the middleware. Then `app.use('/api/v1', requireSession); app.use('/api/v1', akahuRouter); …`.
+3. Walk every router and replace `req.query.userId`/`req.body.userId` reads with `req.userId`. Where the path includes a `:cardId` or `:transactionId`, add an ownership assertion: `if (record.userId !== req.userId) return jsonError(res, 404, …)`.
+4. Mobile client: store the bearer from `/session/dev-login`, attach it to every fetch.
+5. Gotcha: the alerts router currently uses `cardId` from the URL without an ownership check (`routes/alerts.ts:55-67`). The middleware fix is necessary but not sufficient; ownership lookups must land in the same change.
+
+**Implementation sketch — 1-B (Encrypt Akahu tokens):**
+1. Add `BUDGET_API_TOKEN_KEY` (32 bytes base64) to `.env.example`. Generate via `openssl rand -base64 32`. Fail-fast at boot if missing.
+2. Add `services/budget-api/src/lib/secrets.ts` exporting `encryptToken(plain) -> string` (returns `iv:ciphertext:authTag` base64-joined) and `decryptToken(ct) -> plain` using `aes-256-gcm`.
+3. Schema migration: `accessToken` stays `String`; semantics shift to "encrypted blob". Use `upsertAkahuConnection({ accessToken: encryptToken(plain) })` in `repos/akahuRepo.ts` and decrypt in `getAkahuConnectionForUser`.
+4. Backfill migration: a small `services/budget-api/scripts/rotate-akahu-tokens.ts` reads all rows, encrypts in place if not already.
+5. Gotcha: dev local `.env.dev.local` already has a token in it; the rotation script must run after the schema migration to avoid mis-decoding.
+
+**Implementation sketch — 1-C (Fix pagination):**
+1. Map the `sort` param to a Prisma `orderBy` array inside `findMany` (e.g., `priority` → `[{ priority: 'asc' }, { createdAt: 'desc' }, { id: 'desc' }]`).
+2. Encode the cursor using the actual sort field value, not always `createdAt`. Switch `encodeCursor` to encode `(sortKeyValue, createdAt, id)` and update `decodeCursor` accordingly.
+3. Delete the JS `sortedTasks = …` block in `routes/tasks.ts:242-289`.
 4. In `tasksApi.ts`, replace `limit: '10000'` with a sensible default (e.g., `200`); expose `cursor` in `fetchTasks`; render a load-more when `hasNextPage` is true.
-5. Gotcha: Prisma cursor pagination requires cursor fields to be unique. The pattern is to include all sort fields + `id` in the cursor and build a compound `AND OR` where clause — the existing `createdAt + id` implementation is a good template.
-
-**Implementation sketch — 1-B (One real E2E):**
-1. Keep three mocked specs as "component-e2e" under `apps/tasks/test/component-e2e/` for speed.
-2. Rewrite `happy-path.spec.js` so it hits `http://127.0.0.1:4000/api/v1` directly (no `page.route()`). The CI job already brings up Postgres, applies migrations, and starts the API — just need to stop intercepting.
-3. Update `docs/architecture.md` and `CONTRIBUTING.md` to reflect the honest split between real and component-e2e.
-4. Gotcha: real E2E creates rows. Scope test titles with a `[e2e-<timestamp>]` prefix and `afterAll` clean-up via the archive endpoint, or use a transaction wrapper that rolls back.
+5. Gotcha: Prisma enum sort order is declaration order (`low/medium/high/urgent`). For intuitive urgent-first, either reorder the enum (migration) or compute a `priorityScore` integer column and sort on that.
 
 ### Milestone 2 — High-leverage improvements
 
 | # | Title | Files | Acceptance criteria | Effort | Risk |
 |---|-------|-------|---------------------|--------|------|
-| 2-A | Shared assignee/status/priority constant | New `packages/contracts` or `packages/ui/src/constants.ts`; `tasks.ts`; `constants.js` | One file to change to add an assignee; Ivy in dropdown | M | Low |
-| 2-B | Decompose App.jsx into feature modules | `App.jsx`, new `FilterBar`, `BoardView`, `BacklogView`, `TaskCelebration` | `App.jsx` < 250 lines; each extracted component has ≥1 unit test; E2E still passes | L | Medium |
-| 2-C | Enable ESLint + Prettier in CI | `.eslintrc`, `ci.yml` | Lint job runs on PRs; no pre-existing violations block merge | M | Low |
-| 2-D | Enable strict TypeScript in tasks-api | `services/tasks-api/tsconfig.json`, route files | `tsc --noEmit` passes with `strict: true` | M | Medium |
-
-**Implementation sketch — 2-A (Shared constants):**
-1. Create `packages/ui/src/shared-constants.ts` (or a new `packages/contracts` workspace) exporting `ASSIGNEES`, `STATUSES`, `PRIORITIES`, `TASK_TYPES` as `readonly string[]`.
-2. In `tasks.ts`, import `ASSIGNEES` to populate `validAssignees`; same for statuses/priorities.
-3. In `constants.js`, import `ASSIGNEES` to replace `ASSIGNEE_OPTIONS`. Fixes the missing-Ivy bug as a side effect.
-4. Gotcha: `tasks.ts` has `strict: false`; an explicit type cast may be needed for the Set constructor until 2-D lands.
+| 2-A | Shared assignee/status/priority constants (was W26 2-A) | New `packages/ui/src/shared-constants.ts` or `packages/contracts`; `tasks.ts`; `constants.js` | One file to change to add an assignee; Ivy in dropdown | M | Low |
+| 2-B | Decompose `App.jsx` into feature modules | `App.jsx`, new `FilterBar`, `BoardView`, `BacklogView`, `TaskCelebration` | `App.jsx` < 250 lines; each extracted component has ≥1 unit test; E2E still passes | L | Medium |
+| 2-C | Add helmet + explicit body size limit to `budget-api` | `services/budget-api/src/app.ts` | `helmet()` mounted; `express.json({ limit: '64kb' })` | S | Low |
+| 2-D | Add ESLint + Prettier gate in CI | `.eslintrc`, `ci.yml` | Lint job runs on PRs; existing violations either fixed or `// eslint-disable-next-line` documented | M | Low |
+| 2-E | Enable strict TypeScript in `tasks-api` and `budget-api` | `tsconfig.json`, route files | `tsc --noEmit` passes with `strict: true` | M | Medium |
 
 ### Milestone 3 — Quality & polish
 
 | # | Title | Effort |
 |---|-------|--------|
-| 3-A | Add pagination unit tests for cursor/sort alignment | M |
+| 3-A | Pagination unit tests for cursor/sort alignment | M |
 | 3-B | Add `make test-website` and `make test-all` targets to Makefile | S |
 | 3-C | Wrap PATCH tag re-link in `prisma.$transaction` | S |
-| 3-D | Fix `marked.setOptions` → `marked.use()` (deprecated in marked v17) | S |
-| 3-E | Add `helmet` and `express.json({ limit: '64kb' })` to `app.ts` | S |
-| 3-F | Add structured logging with `trace_id` to tasks-api error middleware | M |
-| 3-G | Update `docs/specs/tasks-one-pager.md` status flow to match current schema | S |
-| 3-H | Evaluate Prisma 6 migration; document decision | M |
+| 3-D | Replace `marked.setOptions` with `marked.use()` (marked v17 deprecation) | S |
+| 3-E | Add structured logging with `trace_id` to both APIs' error middleware | M |
+| 3-F | Update `docs/specs/tasks-one-pager.md` status flow | S |
+| 3-G | Evaluate Prisma 6 migration; document decision | M |
+| 3-H | Add per-IP rate limit (express-rate-limit) on `/akahu/exchange` and `/session/dev-login` | S |
+| 3-I | Add a `packages/budget-domain` test that snapshots the public `Categories` taxonomy | S |
+| 3-J | Run `npm audit fix` and capture the resulting diff | S |
 
 ---
 
 ## Open Questions
 
-1. **E2E split architecture:** Should the new real E2E lane run on every PR (slower but gives feedback) or only on `main` post-merge (faster PRs but late detection)? And should the mocked specs stay in `test/e2e/` (renamed) or move to a vitest suite?
+1. **budget-api auth scope:** The dev-token + no-auth posture suggests the team accepted "Tailnet-only MVP" trade-offs. Is non-Tailnet deployment (TestFlight/internal prod) imminent? If yes, Milestone 1 must land before that; if a quarter away, the encryption work is still worth doing now but the middleware sequencing can move with the deployment plan.
 
-2. **Pagination strategy:** Before fixing the sort/cursor mismatch, is the goal real server-side pagination with load-more UI, or just moving the sort to the DB while still fetching everything in one call (e.g., `limit=500`)? The latter removes the correctness bug with less UI work.
+2. **Encryption key custody:** For Theme 1, where should `BUDGET_API_TOKEN_KEY` live? Options: `.env` (parity with current Akahu secrets, low ceremony), 1Password/secrets-manager (better), AWS KMS envelope (best, more setup). Recommend `.env` for the MVP cut and KMS-or-equivalent before any non-local deployment.
 
-3. **App.jsx decomposition timing:** A 952-line component refactor risks PR conflicts with active feature branches. Is there a quiet milestone coming where this can land cleanly?
+3. **Mobile session lifecycle:** `/session/dev-login` issues a token that lives forever (no expiry column on `Session`). Is rotating-on-expiry / a refresh-token model expected for the MVP, or can sessions stay infinite until the mobile app gets real auth?
 
-4. **Shared constants location:** Should `ASSIGNEES`, `STATUSES`, `PRIORITIES` live in a new `packages/contracts` package (semantically correct, slight more overhead) or in the existing `packages/ui` (simpler, slightly wrong semantically)?
+4. **CI budget for `budget-api`:** The Postgres service container adds ~30 s; do we want a single combined `apis-tests` job (one Postgres, two schemas) or two parallel jobs (faster wall-clock, more compute)?
 
-5. **Plano API key:** Confirm whether `PLANO_MINIMAX_API_KEY` in `infra/plano/.env` is still in active use. If not, delete it rather than rotate.
+5. **E2E split architecture (carried forward):** Should the new real E2E lane run on every PR or only on `main` post-merge? And should the mocked specs stay in `test/e2e/` (renamed) or move to a vitest suite?
 
-6. **npm High advisory breakdown:** Until `npm audit --json` is run to identify the two new High packages (beyond DOMPurify), the severity of those advisories is unknown. Should this audit surface the package names before being published, or is the `npm audit` task enough as a milestone action?
+6. **App.jsx decomposition timing (carried forward):** A 952-line component refactor risks PR conflicts with active feature branches. Is there a quiet milestone coming where this can land cleanly?
+
+7. **Plano Minimax API key (carried forward):** Confirm whether `PLANO_MINIMAX_API_KEY` in `infra/plano/.env` is still in active use. If not, delete it rather than rotate.


### PR DESCRIPTION
## Executive Summary

**Health grade: B-** (downgraded from Monday's `B` — the new budget-api surface lands on main with no authorization checks and stores live banking tokens in plaintext).

This refresh focuses on the `services/budget-api`, `apps/budget-mobile`, and `packages/budget-domain` surface that merged after Monday's audit ran. The findings are material: budget-api routes accept `userId` from the request body/query and operate on that user without any auth check (only `/me` validates a session token), and Akahu access tokens are persisted as a plaintext `String` in Postgres. The previously identified structural defects in the tasks surface all persist unchanged: GET `/tasks` pages by cursor then sorts in memory, `App.jsx` is still 952 lines, and all four Playwright specs still mock the API with `page.route()`. The npm advisory landscape shifted from `3 High / 27 Moderate / 31 total` (W26) to `1 Critical / 1 High / 50 Moderate / 52 total` — both new high-severity items are dev-tooling (vitest UI server, vite Windows `server.fs.deny` bypass) and not production-facing. The Minimax API key in `infra/plano/.env` flagged Monday is still on disk.

**Top 3 risks:** (1) `budget-api` has zero authorization on every route — any reachable client can read or mutate any user's transactions, balances, alerts, and Akahu connection by supplying a `userId` parameter; (2) Akahu bearer tokens are stored plaintext in `AkahuConnection.accessToken`, so a DB read compromises live banking-aggregation access; (3) tasks-api pagination sort-and-cursor mismatch and the fully-mocked E2E lane still ship green CI without exercising the real API.

**Top 3 opportunities:** (1) Add a single `requireSession` middleware to `budget-api` and derive `userId` from `req.session` rather than the request body; (2) Encrypt the Akahu access token at rest (envelope encryption with `BUDGET_API_TOKEN_KEY`) or move it to a secret-manager-backed lookup; (3) Add a `budget-api-tests` job to `.github/workflows/ci.yml` — the Makefile already runs the suite locally, but CI does not exercise it.

---

Full audit: [docs/repo-audits/2026-W26.md](docs/repo-audits/2026-W26.md)
