### PR TITLE
chore(content): move stale check into weekly review

### DIFF
--- a/agents/skills/content-notes/SKILL.md
+++ b/agents/skills/content-notes/SKILL.md
@@ -5,7 +5,7 @@ description: "Append SIndustries-relevant daily ops notes for the weekly content
 
 # Content Notes
 
-Track SIndustries-relevant signals during heartbeat by appending structured daily notes. The weekly cron reads them and creates content tasks.
+Track SIndustries-relevant signals during heartbeat by appending structured daily notes. The weekly cron reads them into Tom's review file.
 
 ---
 
@@ -77,20 +77,4 @@ notes_path.write_text(content.replace(
     f"<!-- heartbeat appends here -->\n{note_text}"
 ))
 print(f"Appended note to {notes_path}")
-```
-
----
-
-## Stale content check (heartbeat, once per day)
-
-Run:
-
-```
-python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/content/sindustries-stale-content/check_stale_content.py
-```
-
-For each `STALE:` line in the output, append a daily note with the format:
-
-```
-- [YYYY-MM-DD] **<slug>** — listed as <status> but updatedAt is <date> (>30 days) | why: website content may need a status update | ref: codebases/sindustries/apps/website/src/content/<file>
 ```

--- a/agents/skills/content/sindustries-stale-content/SKILL.md
+++ b/agents/skills/content/sindustries-stale-content/SKILL.md
@@ -11,6 +11,5 @@ Run from this skill directory:
 python3 check_stale_content.py
 ```
 
-For each `STALE:` line in the output, append a daily content note using the
-`content-notes` skill. The note should identify the slug, stale status/date, why
-it may need a website update, and the source content file.
+The weekly content review cron consumes the output directly. Do not append
+heartbeat content notes for stale items.

--- a/agents/skills/content/sindustries-stale-content/check_stale_content.py
+++ b/agents/skills/content/sindustries-stale-content/check_stale_content.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """
-Heartbeat stale-content check.
+Weekly content review stale-content check.
 
 Flags experiments and systems in the sindustries content files where
 updatedAt is more than 30 days ago and status is active/building/operating.
 
-Called from heartbeat. Prints stale items to stdout; exits 0 either way.
+Called from the weekly content review cron. Prints stale items to stdout; exits
+0 either way.
 """
 from __future__ import annotations
 

--- a/agents/skills/content/sindustries-weekly-content-review/SKILL.md
+++ b/agents/skills/content/sindustries-weekly-content-review/SKILL.md
@@ -62,6 +62,16 @@ Read each of these files in full:
 
 Build a mental model of: what is currently published, what statuses exist, when each item was last updated.
 
+Then run the stale-content checker:
+
+```bash
+python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/content/sindustries-stale-content/check_stale_content.py
+```
+
+Treat each stale item as an additional weekly-review signal. Do not append stale
+items to `brain/ops/notes/`; the weekly review is the place where stale content
+is triaged.
+
 ---
 
 ## Step 4 — Compare and generate change items
@@ -71,6 +81,15 @@ For each daily note bullet, ask:
 - Which content item does it relate to? (experiment, system, stack, release, story)
 - What specifically needs to change: **add**, **edit**, or **remove**?
 - Is the change factual/technical (Quinn can execute) or strategic/narrative/first-person (needs Tom)?
+
+For each stale-content checker item, add one of:
+- `EDIT experiment/<slug> — review stale status/update date (<N> days old)`
+- `EDIT system/<slug> — review stale status/update date (<N> days old)`
+
+Classify these as **Quinn can execute** when the only likely change is a factual
+`updatedAt`, status, or `currentLearning` refresh with evidence. Classify as
+**Needs Tom approval** when the stale item needs narrative repositioning,
+summary rewrites, or strategic context.
 
 Produce a flat list of proposed change items. Each item should be:
 - One line, starting with the action: `ADD`, `EDIT`, or `REMOVE`
@@ -134,6 +153,10 @@ _Signals noted but insufficient detail to act on._
 <!-- Raw notes appended for context. Do not re-ingest these in subsequent runs. -->
 
 [paste raw note bullets here, grouped by date]
+
+## Reference — Stale content check
+
+[paste stale-content checker output here, or `STALE_CHECK_OK: ...` if nothing is stale]
 ```
 
 **Rules:**

--- a/agents/workflows/bookmarks/scripts/debug/request_single_spec_approval.py
+++ b/agents/workflows/bookmarks/scripts/debug/request_single_spec_approval.py
@@ -7,16 +7,16 @@ import subprocess
 import sys
 from pathlib import Path
 
-WORKSPACE = Path(__file__).resolve().parents[3]
-BOOKMARKS_DIR = WORKSPACE / "scripts" / "bookmarks"
+WORKSPACE = Path(__file__).resolve().parents[7]
+BOOKMARKS_DIR = Path(__file__).resolve().parent.parent
 if str(BOOKMARKS_DIR) not in sys.path:
     sys.path.insert(0, str(BOOKMARKS_DIR))
 
 from common import SPECS_ROOT, STATE_PATH, load_state
-PREPARE_TOPIC_APPROVAL = WORKSPACE / "scripts" / "bookmarks" / "prepare_topic_approval.py"
-REQUEST_TOPIC_APPROVAL = WORKSPACE / "scripts" / "bookmarks" / "request_topic_approval.py"
-GENERATE_SPECS = WORKSPACE / "scripts" / "bookmarks" / "generate_specs.py"
-BUILD_TASK_PROPOSALS = WORKSPACE / "scripts" / "bookmarks" / "build_task_proposals.py"
+PREPARE_TOPIC_APPROVAL = BOOKMARKS_DIR / "prepare_topic_approval.py"
+REQUEST_TOPIC_APPROVAL = BOOKMARKS_DIR / "request_topic_approval.py"
+GENERATE_SPECS = BOOKMARKS_DIR / "generate_specs.py"
+BUILD_TASK_PROPOSALS = BOOKMARKS_DIR / "build_task_proposals.py"
 
 
 def run_json(args: list[str], stdin_payload: dict | None = None) -> dict:

--- a/agents/workflows/bookmarks/scripts/handle_approval_reply.py
+++ b/agents/workflows/bookmarks/scripts/handle_approval_reply.py
@@ -18,8 +18,8 @@ from pathlib import Path
 
 # Resolve the bookmark workflow dir so `common` can be imported from here.
 _env_ws = os.environ.get("OPENCLAW_WORKSPACE", "").strip()
-_ws = Path(_env_ws).resolve() if _env_ws else Path(__file__).resolve().parents[2] / "workspace"
-_bookmark_wf = _ws / "codebases" / "sindustries" / "agents" / "workflows" / "bookmarks" / "scripts"
+_ws = Path(_env_ws).resolve() if _env_ws else Path(__file__).resolve().parents[6]
+_bookmark_wf = Path(__file__).resolve().parent
 if str(_bookmark_wf) not in sys.path:
     sys.path.insert(0, str(_bookmark_wf))
 

--- a/agents/workflows/bookmarks/scripts/rebuild_revised_approval.py
+++ b/agents/workflows/bookmarks/scripts/rebuild_revised_approval.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 _env_ws = os.environ.get("OPENCLAW_WORKSPACE", "").strip()
 WORKSPACE = Path(_env_ws).resolve() if _env_ws else Path(__file__).resolve().parents[6]
-_BOOKMARK_WF = WORKSPACE / 'codebases' / 'sindustries' / 'agents' / 'workflows' / 'bookmark'
+_BOOKMARK_WF = WORKSPACE / 'codebases' / 'sindustries' / 'agents' / 'workflows' / 'bookmarks' / 'scripts'
 STATE_PATH = WORKSPACE / 'brain' / 'state' / 'bookmark-review-state.json'
 GENERATE_SPECS = _BOOKMARK_WF / 'lobster_generate_specs.py'
 REQUEST_SPEC_APPROVAL = _BOOKMARK_WF / 'lobster_request_spec_approval.py'

--- a/agents/workflows/bookmarks/scripts/rebuild_revised_approval.py
+++ b/agents/workflows/bookmarks/scripts/rebuild_revised_approval.py
@@ -10,7 +10,7 @@ import sys
 from pathlib import Path
 
 _env_ws = os.environ.get("OPENCLAW_WORKSPACE", "").strip()
-WORKSPACE = Path(_env_ws).resolve() if _env_ws else Path(__file__).resolve().parents[5]
+WORKSPACE = Path(_env_ws).resolve() if _env_ws else Path(__file__).resolve().parents[6]
 _BOOKMARK_WF = WORKSPACE / 'codebases' / 'sindustries' / 'agents' / 'workflows' / 'bookmark'
 STATE_PATH = WORKSPACE / 'brain' / 'state' / 'bookmark-review-state.json'
 GENERATE_SPECS = _BOOKMARK_WF / 'lobster_generate_specs.py'

--- a/docs/specs/content-factory.md
+++ b/docs/specs/content-factory.md
@@ -382,7 +382,7 @@ Before any content moves to review:
 
 ## Stale Content
 
-Quinn's heartbeat flags experiments and systems with `updatedAt` older than 30 days as potentially stale. These appear in the weekly review as candidate updates, not automatic changes.
+The weekly content review cron flags experiments and systems with `updatedAt` older than 30 days as potentially stale. These appear in the weekly review as candidate updates, not automatic changes.
 
 ---
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,387 @@
+# Workflows — Master Reference
+
+> The high-level map of how work flows through our setup. If something looks weird, start here, then drill into the linked doc.
+
+**Last reviewed:** 2026-06-23
+**Owner:** Quinn (chief of staff)
+**Audience:** Tom — when you need to remember what runs where
+
+---
+
+## Master View
+
+```mermaid
+flowchart TB
+  tom[Tom]
+
+  subgraph inputs[Inputs]
+    xb[X Bookmarks]
+    web[Web research]
+    tick[Heartbeat tick every 30min]
+  end
+
+  subgraph core[Core processing]
+    bm[brain/bookmarks/]
+    hb[Heartbeat]
+    notes[brain/ops/notes/]
+    tasks_api[Tasks API]
+    content[Content pipeline]
+  end
+
+  subgraph agents[Agents]
+    quinn[Quinn]
+    rowan[Rowan]
+    ivy[Ivy]
+    lox[Lox]
+  end
+
+  subgraph surfaces[Surfaces to Tom]
+    prs[Pull requests]
+    brief[Morning brief]
+    alerts[Telegram alerts]
+    main[main branch]
+  end
+
+  xb --> bm
+  web --> bm
+  tick --> hb
+  bm --> hb
+  hb --> tasks_api
+  hb --> content
+  hb --> notes
+  notes --> content
+
+  tom --> quinn
+  quinn --> rowan
+  quinn --> ivy
+  quinn --> lox
+  tasks_api --> rowan
+  content --> ivy
+
+  rowan --> prs
+  ivy --> prs
+  prs --> main
+  prs --> tom
+  hb --> brief
+  brief --> tom
+  lox --> alerts
+  alerts --> tom
+```
+
+**Three read paths for Tom:**
+1. You ask Quinn → Quinn orchestrates → Rowan / Ivy / Lox → PR → you merge
+2. Heartbeat ticks → finds actionable work → advances state → reports in morning brief
+3. X bookmark or web link → ingest → curate → spec → task → Rowan → PR
+
+---
+
+## 1. Bookmark Pipeline
+
+Inbound links (X bookmarks, web research) become actionable tasks.
+
+```mermaid
+flowchart LR
+  src[X / web source] --> ing[x-bookmark-ingest]
+  ing --> bm[brain/bookmarks/]
+  bm -->|lobster summarize| summarized
+  summarized -->|heartbeat curate| curated
+  curated -->|score above threshold| spec_req[spec_requested]
+  curated -->|score below threshold| declined
+  spec_req -->|heartbeat writes spec| spec_created[spec_created]
+  spec_created -->|lobster creates task| tasked
+  tasked -->|Rowan implements| pr_opened[PR opened]
+  pr_opened -->|merged| done
+```
+
+**State machine**
+
+| State | Owner | Trigger to next |
+|---|---|---|
+| ingest | x-bookmark-ingest | lobster summarize step |
+| summarized | lobster | heartbeat curate step |
+| curated | heartbeat | score above threshold → spec_requested |
+| spec_requested | heartbeat | spec markdown written + validated |
+| spec_created | validate | lobster generate_tasks → task created |
+| tasked | Rowan / agent | PR opened |
+| done | — | PR merged |
+| declined | — | score below threshold, no follow-up |
+
+**Key files**
+- State: `brain/state/bookmark-review-state.json`
+- Spec output: `brain/state/spec-output.json`
+- Specs land in: `brain/bookmarks/specs/`
+- Curation skill: `agents/skills/bookmarks/curate/`
+- Spec skill: `agents/skills/product/spec-author/`
+- Lobster scripts: `agents/workflows/bookmarks/scripts/`
+
+**Guardrails (from MEMORY.md)**
+- State transitions only via the state machine — no leaking logic into list functions (learned the hard way during the spec_requested drift bug)
+- Once `tasked`, secondary curations do not generate new specs — by design
+
+---
+
+## 2. Content Pipeline
+
+Public content flows from two streams that converge on the website:
+
+1. **Ad hoc signals** (event-driven) — Lox incidents + Quinn ops notes + heartbeat observations land in daily notes
+2. **Weekly review** (cron-driven) — Quinn compares last 7 days of notes against live website content, proposes edits
+3. **Tom triage** — Quinn can execute items ship directly; Tom approval items move to a task
+4. **Task → Ivy** — content-tasks dispatcher spawns Ivy, who drafts two PRs
+
+```mermaid
+flowchart LR
+  subgraph capture[Daily capture]
+    lox_daily[Lox daily checks]
+    chat[Chat session]
+    hb_tick[Heartbeat tick]
+  end
+
+  lox_daily -->|signal| notes[brain/ops/notes/YYYY-MM-DD.md]
+  chat -->|signal| notes
+  hb_tick -->|content signal| notes
+  stale_check[Stale content check] -->|weekly cron| review
+
+  notes -->|weekly cron| review[sindustries-weekly-content-review skill]
+  website[apps/website/src/content/] --> review
+  review --> review_file[brain/content/sindustries-weekly-content/YYYY-MM-DD.md]
+
+  review_file --> tom{Tom triage}
+  tom -->|Quinn executes| quinn_changes[Apply factual edits]
+  tom -->|Needs Tom| tom_changes[Strategic / narrative edits]
+  quinn_changes --> merged[Website updated]
+  tom_changes --> task[Tasks API task]
+  task --> ivy[Ivy]
+  ivy --> prs[Two PRs]
+  prs --> tom_review{Tom reviews}
+  tom_review --> merged
+```
+
+**Cadence**
+
+| Step | Cadence | Trigger |
+|---|---|---|
+| Daily ops notes | Continuous | Reflexive — write when something happens (per `memory/feedback_ops_notes_bar.md`) |
+| Stale content check | Weekly | Weekly content review runs `sindustries-stale-content` |
+| Weekly review | Weekly | Cron `sindustries-weekly-content` triggers `sindustries-weekly-content-review` skill |
+| Tom triage | Weekly | Quinn notifies when review file ready |
+| Content task dispatch | Every heartbeat tick | Heartbeat runs `content-tasks/run.py`; script discovers all active content tasks and runs the lobster pipeline once per task |
+
+**How the content-tasks dispatcher works (heartbeat-driven, every tick):**
+
+1. Heartbeat invokes `content-tasks/run.py` once per tick.
+2. Script's `discover_tasks()` queries Tasks API for tasks in states `[open, ready, doing, acceptance]` where `taskType == "content"`. Dedupes by id.
+3. For each found task, `run_workflow(task_id, capacity_limit)` spawns one `lobster run --mode tool` against `content-tasks/content-task.lobster.yaml` with `{taskId, ivyCapacityLimit}` as args.
+4. The lobster pipeline is what actually orchestrates Ivy and owns all status transitions. Quinn just dispatches and reports failures / blocked PRs / meaningful transitions.
+
+So: **1 heartbeat tick = 1 invocation of `content-tasks/run.py` = N lobster runs (one per active content task).** The script's CLI docstring says it explicitly: "Run one content-task workflow pass for every active content task."
+
+**Why two streams:** Tom's bar for public content is high. Ops notes are cheap to capture; the weekly review applies judgment; Tom only sees a short triage list, not the raw notes.
+
+**Key files**
+- Notes: `brain/ops/notes/YYYY-MM-DD.md`
+- Reviews: `brain/content/sindustries-weekly-content/YYYY-MM-DD.md`
+- Content source: `codebases/sindustries/apps/website/src/content/`
+- Skills: `agents/skills/content-notes/`, `agents/skills/content/sindustries-weekly-content-review/`, `agents/skills/content/sindustries-stale-content/`
+- Dispatcher: `agents/workflows/content-tasks/run.py`
+- Cron: `agents/crons/prompts/sindustries-weekly-content.md`
+
+**Rules baked in from MEMORY.md**
+- Ivy must not include internal technical refs (PR numbers, code module names, internal tool names like "Tasks API") in public content
+- Quinn dispatches; Lobster owns status transitions
+- Each weekly review **must** include both "Quinn can execute" and "Needs Tom approval" sections — never mirror a prior week whose Tom section was empty
+
+---
+
+## 3. Task Lifecycle
+
+Cross-cutting workflow for everything in the Tasks API. Single source of truth: `TASK_PROCESS.md`.
+
+```mermaid
+stateDiagram-v2
+  [*] --> created
+  created --> doing
+  doing --> in_review
+  in_review --> in_acceptance
+  in_acceptance --> done
+  doing --> declined
+  doing --> cancelled
+  in_review --> doing
+```
+
+**Who can do what**
+- **Agents (Rowan, Ivy):** open PRs, write code/copy, comment progress. **Cannot** change task state.
+- **Quinn:** advances state via the Tasks API during heartbeat, after `task_transition_check.py` validates the move.
+- **Tom:** reviews PRs, merges, approves in-acceptance items.
+
+**Key files**
+- Source of truth: `TASK_PROCESS.md`
+- Transition validator: `scripts/task_transition_check.py`
+- API client: `agents/skills/ops/tasks-api/tasks_api_client.py`
+- Prodlike API: `http://localhost:4001/api/v1`
+
+---
+
+## 4. Heartbeat
+
+Runs every 30 min. Inspects state, advances what is actionable, reports.
+
+```mermaid
+flowchart TB
+  tick[Every 30 min] --> sections
+  sections --> s1[1. Bookmark curation]
+  sections --> s2[2. Spec dispatch]
+  sections --> s3[3. Content task lobster check]
+  sections --> s4[4. Quinn PR review]
+  sections --> s5[5. Task inspection]
+  
+  s1 --> report[Heartbeat summary]
+  s2 --> report
+  s3 --> report
+  s4 --> report
+  s5 --> report
+```
+
+**Sections in detail**
+
+| # | Section | What it does | State it touches |
+|---|---|---|---|
+| 1 | Bookmark curation | Scores curated bookmarks against topics, refreshes stale curations | `bookmark-review-state.json` |
+| 2 | Spec dispatch | Writes spec markdown for `spec_requested` items, max 2 per heartbeat | `bookmark-review-state.json` |
+| 3 | Content task lobster | Reports only failures / blocked / meaningful transitions | none (read-only) |
+| 4 | PR review | Lists open PRs assigned to Quinn, reviews for blockers | none (read-only) |
+| 5 | Task inspection | Runs `task_transition_check` on heartbeat task set, advances valid tasks | Tasks API |
+
+**Heartbeat never:**
+- Modifies code
+- Sends Tom approval requests for specs (that is the lobster's job)
+- Skips the validate step (idempotent, safe to re-run)
+
+**Key files**
+- Config: `HEARTBEAT.md`
+- Heartbeat state: `memory/heartbeat-state.json`
+- Task list view: `tasks_api_client.py list --heartbeat`
+
+---
+
+## 5. Incidents and Ops Notes
+
+How things go wrong, get noticed, and reach Tom.
+
+**Two surfaces, one shared language:**
+
+- **Lox (infra)** — runs health checks, catches infra incidents, writes runbooks and incident reviews, escalates via Telegram
+- **Quinn (ops)** — notices workflow / process / agent anomalies during chat or heartbeat, writes ops notes, escalates via ops state and morning brief
+
+Both can produce **content signals** that flow into the Content Pipeline.
+
+```mermaid
+flowchart LR
+  subgraph lox_side[Lox side]
+    lox_check[Daily health check] -->|anomaly| lox_runbook[infra/runbooks/]
+    lox_check -->|incident| lox_ir[workspace docs/infra/incident-reviews/]
+    lox_ir -->|severity high| lox_alert[Telegram alert]
+  end
+
+  subgraph quinn_side[Quinn side]
+    chat[Chat session] -->|anomaly| op_note[ops note]
+    hb[Heartbeat] -->|anomaly| op_note
+    op_note -->|escalate| op_state[quinn-ops-state.json]
+  end
+
+  lox_alert --> tom[Tom]
+  op_state --> brief[Heartbeat morning brief]
+  brief --> tom
+
+  lox_ir -.->|content signal| daily_notes[brain/ops/notes/]
+  op_note -.->|content signal| daily_notes
+```
+
+**Lox → Tom**
+- Cron failures → `notify-soft-fail` skill → sessions_send to Lox → Lox investigates → `openclaw message send --channel telegram --account lox` to Tom
+- Hard failures: cron `failureAlert` (infrastructure level safety net)
+- Soft failures: agent-level via `notify-soft-fail`
+- Crons **never** message Tom directly — they go through Lox
+
+**Quinn → Tom**
+- Ops notes written reflexively in chat or heartbeat (per `memory/feedback_ops_notes_bar.md`)
+- Escalations tracked in `quinn-ops-state.json` with severity, attempts, status
+- Surface paths: heartbeat morning brief (most), direct Telegram (rare, only when urgent)
+- Bar is LOW for notes; bar is HIGH for escalation
+
+**Shared language:** Anything either side produces that could be public content becomes a row in `brain/ops/notes/YYYY-MM-DD.md` and feeds the Content Pipeline (see section 2).
+
+**Key files**
+- Lox logs: workspace `docs/infra/lox-daily-YYYY-MM-DD.md`
+- Lox runbooks: `infra/runbooks/`
+- Lox incident reviews: workspace `docs/infra/incident-reviews/`
+- Lox notify: `agents/skills/ops/notify-soft-fail/`
+- Quinn ops state: `quinn-ops-state.json` (in workspace root)
+- Quinn ops notes: `memory/YYYY-MM-DD.md` (narrative) + `brain/ops/notes/YYYY-MM-DD.md` (content signals)
+
+---
+
+## Doc Tree — Where Things Live
+
+| Location | Purpose | Owner |
+|---|---|---|
+| `brain/bookmarks/` | Inbound material (X, links, research) | x-bookmark-ingest |
+| `brain/reviews/` | Our opinions / analysis on bookmarks | Quinn |
+| `brain/specs/` | Implementation plans derived from reviews | spec-author skill |
+| `brain/posts/` | Public content (blog, social) | Ivy |
+| `brain/ops/notes/` | Daily content signals (feeds weekly review) | Quinn / Lox |
+| `brain/content/sindustries-weekly-content/` | Weekly review files for Tom triage | Quinn |
+| workspace `docs/infra/` | Runbooks and setup docs | Quinn / Lox |
+| `docs/specs/` (in sindustries repo) | System specs — ground truth | Quinn |
+
+**Rule of thumb (from AGENTS.md):**
+- raw / inbound idea → `brain/bookmarks/`
+- interpretation / opinion → `brain/reviews/`
+- build-against plan → `brain/specs/`
+- publishable content → `brain/posts/`
+- daily content signal → `brain/ops/notes/`
+- weekly review for triage → `brain/content/sindustries-weekly-content/`
+- workflow reference → `workflows/`
+- current system / runbook → workspace `docs/infra/`
+
+---
+
+## Agent Roster
+
+| Agent | Role | Writes | State it owns |
+|---|---|---|---|
+| **Quinn** | Orchestrator + front door | `MEMORY.md`, `AGENTS.md`, daily logs, workflow docs, ops notes | All task state transitions |
+| **Rowan** | Developer | Code, PRs | Nothing (reads state, writes code) |
+| **Ivy** | Content | Blog posts, public copy, website content edits | Nothing (read-only) |
+| **Lox** | Infra + incidents | Runbooks, daily health logs, incident reviews | Incident state, ops alerts |
+
+**Critical rule:** Agents (Rowan, Ivy, Lox) **never** change task status, blocked, or completedAt. Only Quinn during heartbeat.
+
+---
+
+## When Something Looks Weird
+
+Quick troubleshooting pointer — find the symptom and check the file.
+
+| Symptom | First place to look |
+|---|---|
+| Bookmark stuck in a state | `brain/state/bookmark-review-state.json` |
+| Spec never written | `brain/state/spec-output.json` last entry + validate step output |
+| Task not advancing | `task_transition_check.py <task-id>` for failed criteria |
+| Heartbeat silently broken | `HEARTBEAT.md` + `cron list` |
+| PR not appearing | `gh pr list --repo Stoffer-Industries/sindustries` |
+| Curation scores stale | `brain/state/bookmark-review-state.json` → check `curation.createdAt` |
+| Weekly content review missing | `agents/crons/prompts/sindustries-weekly-content.md` + last entry in `brain/content/sindustries-weekly-content/` |
+| Infra incident | workspace `docs/infra/incident-reviews/` + Lox daily log |
+| Lox did not escalate | `agents/skills/ops/notify-soft-fail/SKILL.md` delivery chain |
+| Quinn escalation stuck | `quinn-ops-state.json` → check `attempts` and `severity` |
+
+---
+
+## See Also
+
+- `TASK_PROCESS.md` — single source of truth for task workflow
+- `AGENTS.md` — workspace conventions
+- `MEMORY.md` — long-term memory (includes guardrails and lessons learned)
+- `agents/rowan/SOUL.md` — Rowan's operating contract
+- `agents/skills/` — individual skill docs (bookmarks/curate, product/spec-author, ops/tasks-api, content-notes, sindustries-weekly-content-review, ops/notify-soft-fail)


### PR DESCRIPTION
Moves stale-content triage out of Quinn's heartbeat/content-notes flow and into the weekly content review skill. Also relocates the workflows master reference into the SIndustries repo under workflows/README.md.\n\nValidation:\n- python3 agents/skills/content/sindustries-stale-content/check_stale_content.py\n- skill frontmatter validation