### PR TITLE
chore(bookmarks): path fixes, cron rework, and otel API update

### DIFF
--- a/agents/crons/prompts/bookmark-review-lobster.md
+++ b/agents/crons/prompts/bookmark-review-lobster.md
@@ -1,4 +1,85 @@
-Run this exact command with the exec tool and base your reply only on its JSON output:
+## Pre-check — bail early if nothing to do
+
+Run this first:
+
+```
+python3 -c "
+import json, subprocess, sys
+
+def run(cmd):
+    r = subprocess.run(cmd, capture_output=True, text=True, cwd='/Users/quinnstoffer/.openclaw/workspace')
+    try:
+        return json.loads(r.stdout) if r.returncode == 0 else {}
+    except Exception:
+        return {}
+
+curate = run(['python3', 'codebases/sindustries/agents/workflows/bookmarks/scripts/list_curate_candidates.py', '--json']).get('count', -1)
+specs  = run(['python3', 'codebases/sindustries/agents/workflows/bookmarks/scripts/list_spec_requests.py', '--json']).get('count', -1)
+
+with open('/Users/quinnstoffer/.openclaw/workspace/brain/state/bookmark-review-state.json') as f:
+    state = json.load(f)
+lobster_ready = sum(
+    1 for v in state.get('items', {}).values()
+    if v.get('reviewStatus') == 'spec_created'
+    and v.get('approvalStatus') not in ('pending', 'approved', 'declined')
+)
+
+print(json.dumps({'curate': curate, 'specs': specs, 'lobster_ready': lobster_ready}))
+"
+```
+
+If all three values are 0, stop here and reply exactly: NO_REPLY
+
+Otherwise continue below.
+
+---
+
+Before the Lobster run, do the production bookmark review work in this order.
+
+1. Bookmark curation
+
+Read and follow:
+`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/bookmarks/curate/SKILL.md`
+
+Run the candidate list command:
+`python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/bookmarks/scripts/list_curate_candidates.py --json`
+
+If `count == 0`, skip scoring and still run the validate command below.
+
+If candidates exist, score the batch exactly as the skill describes:
+- Score each candidate 0-10 against every topic in the config.
+- Choose the highest scoring topic as the primary topic.
+- Write decisions to `brain/state/curate-output.json`.
+- Do not mutate state directly.
+
+Then validate/apply curation state:
+`python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/bookmarks/scripts/validate_curate_output.py --json`
+
+2. Spec writing and validation
+
+Read and follow:
+`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/product/spec-author/SKILL.md`
+
+Run the spec request list command:
+`python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/bookmarks/scripts/list_spec_requests.py --json`
+
+If `count == 0`, skip writing and still run the validate command below.
+
+If spec requests exist:
+- Process at most 2 requests in this cron run.
+- Read each requested bookmark file and review file.
+- Read `/Users/quinnstoffer/.openclaw/workspace/docs/state-of-the-nation.md`.
+- Read all existing specs under `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/docs/specs/`.
+- For `requestType == "new"`, write the spec markdown to `brain/bookmarks/specs/<slug>-<bookmarkKey>.md`.
+- For `requestType == "revision"`, read the existing specs named by `existingSpecDocs`, apply the requested revision, and overwrite the same spec path.
+- Append entries to `brain/state/spec-output.json`; merge with existing entries if the file already exists.
+- Do not call `update_spec_state.py`.
+- Do not trigger approval delivery from this phase.
+
+Then validate/apply spec state exactly once:
+`python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/bookmarks/scripts/validate_spec_output.py --json`
+
+After curation and spec validation, run this exact command with the exec tool and base your reply only on its JSON output:
 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/bookmarks/run.py
 
 Do not summarize from memory. Base your reply only on the JSON output.

--- a/agents/crons/prompts/morning-brief.md
+++ b/agents/crons/prompts/morning-brief.md
@@ -22,7 +22,7 @@ import json
 try:
     with open('/Users/quinnstoffer/.openclaw/workspace/brain/state/bookmark-review-state.json') as f:
         state = json.load(f)
-    pending = [(k, v['title']) for k, v in state.get('items', {}).items() if v.get('approvalStatus') == 'pending']
+    pending = [{'id': '#' + v['approvalId'], 'title': v.get('title','')[:60], 'topic': v.get('approvalTopic','')} for v in state.get('items', {}).values() if v.get('approvalStatus') == 'pending' and v.get('approvalId')]
     print(json.dumps(pending))
 except Exception as e:
     print('[]')
@@ -85,8 +85,8 @@ Output format:
 [What happened since yesterday — agent activity, things resolved, things that came up]
 
 ⚠️ PENDING APPROVALS
-[Only if pending bookmark approvals exist. For each: topic | title ~50 chars | ID: approvalId]
-[Reply: approve [id] or decline [id]]
+[Only if pending bookmark approvals exist. For each: topic | title ~50 chars | #ap<id>]
+[Reply: approve #apXXXXXXXX or decline #apXXXXXXXX]
 [Skip this section entirely if none]
 
 🏗️ TEAM STATUS

--- a/agents/workflows/bookmarks/scripts/debug/request_single_spec_approval.py
+++ b/agents/workflows/bookmarks/scripts/debug/request_single_spec_approval.py
@@ -13,10 +13,9 @@ if str(BOOKMARKS_DIR) not in sys.path:
     sys.path.insert(0, str(BOOKMARKS_DIR))
 
 from common import SPECS_ROOT, STATE_PATH, load_state
-PREPARE_TOPIC_APPROVAL = BOOKMARKS_DIR / "prepare_topic_approval.py"
+PREPARE_TOPIC_APPROVAL = BOOKMARKS_DIR / "lobster_request_spec_approval.py"
 REQUEST_TOPIC_APPROVAL = BOOKMARKS_DIR / "request_topic_approval.py"
-GENERATE_SPECS = BOOKMARKS_DIR / "generate_specs.py"
-BUILD_TASK_PROPOSALS = BOOKMARKS_DIR / "build_task_proposals.py"
+GENERATE_SPECS = BOOKMARKS_DIR / "lobster_generate_specs.py"
 
 
 def run_json(args: list[str], stdin_payload: dict | None = None) -> dict:
@@ -43,7 +42,7 @@ def _spec_path(spec_doc: str) -> Path | None:
     spec_doc = (spec_doc or "").strip()
     if not spec_doc:
         return None
-    if spec_doc.startswith("brain/specs/"):
+    if spec_doc.startswith("brain/bookmarks/specs/") or spec_doc.startswith("brain/specs/"):
         return WORKSPACE / spec_doc
     return Path(SPECS_ROOT) / spec_doc
 
@@ -95,8 +94,7 @@ def reset_to_approval_ready(bookmark_key: str) -> dict:
         "monitoring": [],
         "reviewed": [],
     }
-    generated = run_json([sys.executable, str(GENERATE_SPECS), "--json"], payload)
-    proposed = run_json([sys.executable, str(BUILD_TASK_PROPOSALS), "--json"], generated)
+    run_json([sys.executable, str(GENERATE_SPECS), "--json"], payload)
     refreshed = load_state(state_path).get("items", {}).get(bookmark_key, {})
     return {
         "ok": True,
@@ -104,7 +102,6 @@ def reset_to_approval_ready(bookmark_key: str) -> dict:
         "reviewStatus": refreshed.get("reviewStatus"),
         "specDocs": refreshed.get("specDocs") or [],
         "specProposals": refreshed.get("specProposals") or [],
-        "taskProposalPayload": proposed,
     }
 
 

--- a/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py
+++ b/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from common import WORKSPACE, dump_json, now_iso
 
-SCRIPT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_ROOT = WORKSPACE / "codebases" / "sindustries" / "agents" / "skills" / "ops" / "tasks-api"
 if str(SCRIPT_ROOT) not in sys.path:
     sys.path.insert(0, str(SCRIPT_ROOT))
 

--- a/agents/workflows/bookmarks/scripts/request_topic_approval.py
+++ b/agents/workflows/bookmarks/scripts/request_topic_approval.py
@@ -272,6 +272,43 @@ def extract_delivery_ids(payload: dict | None) -> tuple[str | None, str | None]:
     return message_id, thread_id
 
 
+def _deliver_via_telegram_api(message: str, delivery: dict) -> dict | None:
+    """Fallback: send directly via Telegram Bot API when the gateway CLI times out."""
+    import urllib.request
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+    if not token or delivery.get("channel") != "telegram":
+        return None
+    target = delivery.get("target", "")
+    thread_id = delivery.get("threadId")
+    payload: dict[str, Any] = {
+        "chat_id": target,
+        "text": message,
+        "parse_mode": "Markdown",
+    }
+    if thread_id:
+        payload["message_thread_id"] = int(thread_id)
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"https://api.telegram.org/bot{token}/sendMessage",
+        data=data,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            result = json.loads(resp.read())
+            if result.get("ok"):
+                msg_id = str(result.get("result", {}).get("message_id", ""))
+                return {
+                    "ok": True,
+                    "messageId": msg_id,
+                    "threadId": thread_id,
+                    "deliveryMethod": "telegram-api-direct",
+                }
+    except Exception as exc:
+        return {"ok": False, "error": str(exc), "deliveryMethod": "telegram-api-direct"}
+    return None
+
+
 def deliver_approval_message(message: str, delivery: dict) -> dict:
     args = [
         "openclaw",
@@ -290,20 +327,34 @@ def deliver_approval_message(message: str, delivery: dict) -> dict:
     if delivery.get("threadId"):
         args.extend(["--thread-id", delivery["threadId"]])
 
-    completed = subprocess.run(
-        args,
-        capture_output=True,
-        text=True,
-    )
-    raw = (completed.stdout or "").strip()
-    stderr = (completed.stderr or "").strip()
+    cli_failed = False
     try:
-        payload = json.loads(raw or "{}")
-    except json.JSONDecodeError:
-        payload = {"raw": raw, "stderr": stderr}
-    if completed.returncode != 0 and isinstance(payload, dict) and not payload.get("error"):
-        payload["error"] = stderr or raw or f"openclaw message send failed with code {completed.returncode}"
-        payload["returncode"] = completed.returncode
+        completed = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=12,
+        )
+        raw = (completed.stdout or "").strip()
+        stderr = (completed.stderr or "").strip()
+        try:
+            payload = json.loads(raw or "{}")
+        except json.JSONDecodeError:
+            payload = {"raw": raw, "stderr": stderr}
+        if completed.returncode != 0 and isinstance(payload, dict) and not payload.get("error"):
+            payload["error"] = stderr or raw or f"openclaw message send failed with code {completed.returncode}"
+            payload["returncode"] = completed.returncode
+        cli_failed = completed.returncode != 0 or bool(payload.get("error"))
+    except subprocess.TimeoutExpired:
+        payload = {"error": "openclaw message send CLI timed out after 12s", "returncode": -1}
+        cli_failed = True
+
+    # If CLI delivery failed, fall back to direct Telegram API.
+    if cli_failed:
+        fallback = _deliver_via_telegram_api(message, delivery)
+        if fallback and fallback.get("ok"):
+            payload = fallback
+
     message_id, resolved_thread_id = extract_delivery_ids(payload)
     return {
         "channel": delivery["channel"],

--- a/packages/otel-node/src/register.cjs
+++ b/packages/otel-node/src/register.cjs
@@ -16,7 +16,7 @@ const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumenta
 const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
 const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-http');
 const { PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
-const { Resource } = require('@opentelemetry/resources');
+const { resourceFromAttributes } = require('@opentelemetry/resources');
 const { ATTR_SERVICE_NAME, ATTR_SERVICE_NAMESPACE } = require('@opentelemetry/semantic-conventions');
 
 const serviceName = process.env.OTEL_SERVICE_NAME || 'unknown-service';
@@ -24,7 +24,7 @@ const namespace = process.env.OTEL_SERVICE_NAMESPACE || 'sindustries';
 const environment = process.env.OTEL_ENVIRONMENT || process.env.NODE_ENV || 'development';
 
 const sdk = new NodeSDK({
-  resource: new Resource({
+  resource: resourceFromAttributes({
     [ATTR_SERVICE_NAME]: serviceName,
     [ATTR_SERVICE_NAMESPACE]: namespace,
     'deployment.environment': environment,

--- a/packages/otel-node/src/register.cjs
+++ b/packages/otel-node/src/register.cjs
@@ -16,7 +16,7 @@ const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumenta
 const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
 const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-http');
 const { PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
-const { resourceFromAttributes } = require('@opentelemetry/resources');
+const { Resource } = require('@opentelemetry/resources');
 const { ATTR_SERVICE_NAME, ATTR_SERVICE_NAMESPACE } = require('@opentelemetry/semantic-conventions');
 
 const serviceName = process.env.OTEL_SERVICE_NAME || 'unknown-service';
@@ -24,7 +24,7 @@ const namespace = process.env.OTEL_SERVICE_NAMESPACE || 'sindustries';
 const environment = process.env.OTEL_ENVIRONMENT || process.env.NODE_ENV || 'development';
 
 const sdk = new NodeSDK({
-  resource: resourceFromAttributes({
+  resource: new Resource({
     [ATTR_SERVICE_NAME]: serviceName,
     [ATTR_SERVICE_NAMESPACE]: namespace,
     'deployment.environment': environment,


### PR DESCRIPTION
## Summary
- **bookmark-review-lobster cron**: adds bail-early pre-check (skip if nothing to do) and folds curation + spec writing inline before the Lobster run
- **morning-brief**: approval ID format updated to `#ap<id>` style
- **Script path fixes**: `generate_specs.py` → `lobster_generate_specs.py`, `prepare_topic_approval.py` → `lobster_request_spec_approval.py` in debug script; `SCRIPT_ROOT` fixed in `lobster_create_tasks_from_proposals.py`
- **Telegram delivery fallback**: direct Bot API fallback in `request_topic_approval.py` when gateway CLI times out (12s timeout)
- **otel-node**: `resourceFromAttributes` → `new Resource()` for OTel API compatibility

These were local changes left uncommitted on the `move-stale-content-to-weekly-review` branch before it merged as PR #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)