### PR TITLE
fix(otel-node): use Resource class constructor for @opentelemetry/resources v2.x

### DIFF
--- a/packages/otel-node/src/index.ts
+++ b/packages/otel-node/src/index.ts
@@ -1,7 +1,7 @@
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { resourceFromAttributes } from '@opentelemetry/resources';
+import { Resource } from '@opentelemetry/resources';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import {
@@ -37,7 +37,7 @@ export function startOtel(options?: StartOtelOptions): void {
   const environment =
     process.env.OTEL_ENVIRONMENT ?? process.env.NODE_ENV ?? 'development';
 
-  const resource = resourceFromAttributes({
+  const resource = new Resource({
     [ATTR_SERVICE_NAME]: serviceName,
     [ATTR_SERVICE_NAMESPACE]: namespace,
     'deployment.environment': environment,

--- a/packages/otel-node/src/register.cjs
+++ b/packages/otel-node/src/register.cjs
@@ -16,7 +16,7 @@ const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumenta
 const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
 const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-http');
 const { PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
-const { resourceFromAttributes } = require('@opentelemetry/resources');
+const { Resource } = require('@opentelemetry/resources');
 const { ATTR_SERVICE_NAME, ATTR_SERVICE_NAMESPACE } = require('@opentelemetry/semantic-conventions');
 
 const serviceName = process.env.OTEL_SERVICE_NAME || 'unknown-service';
@@ -24,7 +24,7 @@ const namespace = process.env.OTEL_SERVICE_NAMESPACE || 'sindustries';
 const environment = process.env.OTEL_ENVIRONMENT || process.env.NODE_ENV || 'development';
 
 const sdk = new NodeSDK({
-  resource: resourceFromAttributes({
+  resource: new Resource({
     [ATTR_SERVICE_NAME]: serviceName,
     [ATTR_SERVICE_NAMESPACE]: namespace,
     'deployment.environment': environment,


### PR DESCRIPTION
## Summary

Fixes the regression introduced by d4e25ab ("fix(otel-node): revert to resourceFromAttributes for @opentelemetry/resources v2.x"). d4e25ab's claim was wrong: `@opentelemetry/resources@2.7.1` only exports the `Resource` class, NOT a `resourceFromAttributes` factory. The v1-style call crashed the NodeSDK init in both `register.cjs` and `index.ts` with:

```
TypeError: resourceFromAttributes is not a function
    at packages/otel-node/src/register.cjs:27
    at packages/otel-node/src/index.ts:40
```

This PR switches both files to the actual v2 API:

```diff
- import { resourceFromAttributes } from '@opentelemetry/resources';
+ import { Resource } from '@opentelemetry/resources';
- resource: resourceFromAttributes({ ...attrs });
+ resource: new Resource({ ...attrs });
```

The `Resource` class exposes an `.attributes` getter, so the existing assertions in `startOtel.sdk.test.ts` (`resource.attributes[ATTR_SERVICE_NAME]`, etc.) continue to pass without modification.

## Why d4e25ab was wrong

The 2026-06-11 Lox memory note (which d4e25ab's author referenced) was itself incorrect: it claimed the v2.x release removed the `Resource` class and replaced it with a `resourceFromAttributes()` factory. That is not what shipped. Direct check of the installed package:

```
$ grep exports node_modules/@opentelemetry/resources/build/src/index.js
exports.Resource = void 0;     // the class IS still exported
                               // no resourceFromAttributes anywhere
```

The Lox memory note has been corrected as part of this incident.

## Verification

- `cd packages/otel-node && npx vitest run`: **10/10 pass** (was 7 fail / 3 pass with the broken d4e25ab code)
- Prodlike tasks-api (`http://localhost:4001/health`): HTTP 200, listener up via `tsx watch` auto-reload of the `register.cjs` preload
- `new Resource({...})` is the documented v2 API per the package's own type definitions in `@opentelemetry/resources@2.7.1/build/src/Resource.d.ts`

## Files changed

- `packages/otel-node/src/index.ts` — import + line 40
- `packages/otel-node/src/register.cjs` — import + line 27

No test changes were required; the tests' shape (`resource.attributes[<key>]`) is preserved by the `Resource` class's `.attributes` getter.

## Suggested action on d4e25ab

Either **amend** d4e25ab with this content (cleaner history), or **revert** d4e25ab and merge this PR. Either is fine; the d4e25ab commit message and code are both wrong and should not land in `main` as-is.