### PR TITLE
chore(code-garden): remove stale triage comments

### DIFF
--- a/apps/tasks/src/tasksApi.ts
+++ b/apps/tasks/src/tasksApi.ts
@@ -6,7 +6,7 @@ export interface TaskFilters {
   tag?: string;
   assignee?: string;
   includeArchived?: boolean;
-  // Note: 'ready' boolean filter is deprecated — use status='ready' or status='triage' instead
+  // Note: 'ready' boolean filter is deprecated; use status='ready' instead
 }
 
 export interface Comment {
@@ -20,7 +20,7 @@ export interface Task {
   id: string | number;
   title: string;
   description?: string | null;
-  status: string;  // open | triage | ready | doing | acceptance | done
+  status: string;  // open | ready | doing | acceptance | done
   priority: string;
   assignee?: string | null;
   dueAt?: string | null;
@@ -42,7 +42,7 @@ export interface CreateTaskPayload {
   tags?: string[];
   blocked?: boolean;
   taskType?: 'content' | 'code' | 'research' | null;
-  // Note: 'ready' field removed — use status='triage' or status='ready' instead
+  // Note: 'ready' field removed; use status='ready' instead
 }
 
 export interface UpdateTaskPayload {
@@ -103,7 +103,7 @@ export async function fetchTasks(filters: TaskFilters): Promise<Task[]> {
   if (filters.tag) query.set('tag', filters.tag);
   if (filters.assignee) query.set('assignee', filters.assignee);
   if (filters.includeArchived) query.set('includeArchived', 'true');
-  // Note: 'ready' boolean filter is deprecated — use status='ready' or status='triage' instead
+  // Note: 'ready' boolean filter is deprecated; use status='ready' instead
   return api<Task[]>('/tasks?' + query.toString());
 }
 

--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -162,7 +162,7 @@ AI agents (agents/)
 - `services/tasks-api/src/routes/tasks.ts:10` — `validAssignees = new Set(['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy'])`.
 - `apps/tasks/src/utils/constants.js:15` — `ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom']` — Ivy still missing.
 
-**[Medium] Stale `triage` status documented in client type comment** *(persists)*
+**[Medium] Stale `triage` status documented in client type comment** *(persists)* <!-- DONE: PR #100 -->
 
 - `apps/tasks/src/tasksApi.ts:8` — "use status='ready' or status='triage' instead" in the deprecation note.
 - `apps/tasks/src/tasksApi.ts:21` — `status: string;  // open | triage | ready | doing | acceptance | done` lists `triage` as valid.


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W26.md
- **Finding:** [Medium] Stale `triage` status documented in client type comment
- **Tier:** T1
- Removed obsolete `triage` references from client-side comments so the documented status set matches the app/API contract.

## Test plan
- [x] Relevant tests pass: `npm test --workspace apps/tasks`
- [x] No logic changes — diff is purely structural/cosmetic

🌱 Code garden — non-functional cleanup only