### PR TITLE
chore(code-garden): sync task assignee options

### DIFF
--- a/apps/tasks/src/utils/constants.js
+++ b/apps/tasks/src/utils/constants.js
@@ -12,6 +12,6 @@ export const PRIORITIES = ['urgent', 'high', 'medium', 'low'];
 
 export const PRIORITY_SCORE = { urgent: 0, high: 1, medium: 2, low: 3 };
 
-export const ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom'];
+export const ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom', 'Ivy'];
 
 export const CONFETTI_COLORS = ['#ffc935', '#00d4ff', '#ff3e8a', '#31c76a', '#f3f1ec', '#7d5dff'];

--- a/apps/tasks/test/e2e/assignee-dropdown.spec.js
+++ b/apps/tasks/test/e2e/assignee-dropdown.spec.js
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-const RESERVED_ASSIGNEES = ['Tom', 'Quinn', 'Rowan', 'Lox'];
+const RESERVED_ASSIGNEES = ['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy'];
 
 test('AC2: assignee dropdown shows reserved options', async ({ page }) => {
   const tasks = [
@@ -38,17 +38,16 @@ test('AC2: assignee dropdown shows reserved options', async ({ page }) => {
   const assigneeSelect = page.locator('select[aria-label="Detail assignee"]');
   await expect(assigneeSelect).toBeVisible();
   
-  // Check all options are present (4 reserved + 1 Unassigned = 5)
+  // Check all options are present (reserved assignees + Unassigned)
   const options = assigneeSelect.locator('option');
-  await expect(options).toHaveCount(5);
+  await expect(options).toHaveCount(RESERVED_ASSIGNEES.length + 1);
   
   // Verify options contain expected values by getting all text
   const allOptionsText = await options.allTextContents();
   expect(allOptionsText).toContain('Unassigned');
-  expect(allOptionsText).toContain('Tom');
-  expect(allOptionsText).toContain('Quinn');
-  expect(allOptionsText).toContain('Rowan');
-  expect(allOptionsText).toContain('Lox');
+  for (const assignee of RESERVED_ASSIGNEES) {
+    expect(allOptionsText).toContain(assignee);
+  }
 });
 
 test('AC3: can select assignee from dropdown', async ({ page }) => {

--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -157,7 +157,7 @@ AI agents (agents/)
 - The Makefile's `test-api` target runs `services/budget-api` tests locally (`Makefile:25-27`), so a contributor running `make test-api` exercises them; CI does not.
 - **Consequence (fact):** Tests in `services/budget-api/test/` (akahuClient, alerts, categorizer, akahuSync) can break on main without surfacing as a failing PR check.
 
-**[Medium] Assignee list drifts between API validation and frontend constants** *(persists)*
+**[Medium] Assignee list drifts between API validation and frontend constants** *(persists)* <!-- DONE: PR #101 -->
 
 - `services/tasks-api/src/routes/tasks.ts:10` — `validAssignees = new Set(['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy'])`.
 - `apps/tasks/src/utils/constants.js:15` — `ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom']` — Ivy still missing.


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W26.md
- **Finding:** [Medium] Assignee list drifts between API validation and frontend constants
- **Tier:** T2
- Adds Ivy to the tasks app assignee picker so it matches the API validation set.

## Test plan
- [x] `npm test --workspace @sindustries/tasks-app`
- [x] No logic changes — diff is constant sync plus audit marker

🌱 Code garden — non-functional cleanup only