### PR TITLE
test(budget-domain): snapshot Categories taxonomy and isCategory round-trip [2026-W26]

### DIFF
--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -186,7 +186,7 @@ AI agents (agents/)
 - All 4 specs follow the same pattern. `CONTRIBUTING.md` lists E2E as a gate; in practice the gate validates the React app against a hand-rolled stub.
 - Note: `ci.yml:103-198` *does* boot the real `tasks-api` for the e2e job (Postgres service, prisma migrate, prisma seed, `npm run start`, wait-for-health). The infrastructure is already there — only `page.route()` is in the way.
 
-**[High] No tests in `packages/budget-domain` exercise the Categories taxonomy round-trip** <!-- DONE: PR #TBD -->
+**[High] No tests in `packages/budget-domain` exercise the Categories taxonomy round-trip** <!-- DONE: PR #103 -->
 
 - `packages/budget-domain/src/budgets.test.ts` exists and is the only test file; categorizer thresholds and merchant normalization are covered indirectly via budget-api unit tests. The `Categories` exported constant has no test that asserts the public list matches what the API surfaces.
 - **Consequence (judgment):** Safe today (single consumer), but a category rename will silently break the mobile picker UI without a failing test.

--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -186,7 +186,7 @@ AI agents (agents/)
 - All 4 specs follow the same pattern. `CONTRIBUTING.md` lists E2E as a gate; in practice the gate validates the React app against a hand-rolled stub.
 - Note: `ci.yml:103-198` *does* boot the real `tasks-api` for the e2e job (Postgres service, prisma migrate, prisma seed, `npm run start`, wait-for-health). The infrastructure is already there — only `page.route()` is in the way.
 
-**[High] No tests in `packages/budget-domain` exercise the Categories taxonomy round-trip**
+**[High] No tests in `packages/budget-domain` exercise the Categories taxonomy round-trip** <!-- DONE: PR #TBD -->
 
 - `packages/budget-domain/src/budgets.test.ts` exists and is the only test file; categorizer thresholds and merchant normalization are covered indirectly via budget-api unit tests. The `Categories` exported constant has no test that asserts the public list matches what the API surfaces.
 - **Consequence (judgment):** Safe today (single consumer), but a category rename will silently break the mobile picker UI without a failing test.

--- a/packages/budget-domain/src/categories.test.ts
+++ b/packages/budget-domain/src/categories.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { Categories, isCategory } from './categories';
+
+describe('Categories taxonomy', () => {
+  it('exposes the documented public list', () => {
+    // Snapshot of the public taxonomy exported from @sindustries/budget-domain.
+    // Consumed by services/budget-api (categories router + categorization) and
+    // apps/budget-mobile (picker UI). Any change here is a contract change
+    // visible to both consumers.
+    expect(Categories).toEqual([
+      'groceries',
+      'dining',
+      'transport',
+      'shopping',
+      'utilities',
+      'entertainment',
+      'health',
+      'travel',
+      'subscriptions',
+      'fees',
+      'transfers',
+      'other'
+    ]);
+  });
+
+  it('round-trips every value through isCategory', () => {
+    for (const value of Categories) {
+      expect(isCategory(value)).toBe(true);
+    }
+  });
+
+  it('rejects non-Category strings', () => {
+    expect(isCategory('not-a-category')).toBe(false);
+    expect(isCategory('')).toBe(false);
+    expect(isCategory('GROCERIES')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W26.md
- **Finding:** [High] No tests in `packages/budget-domain` exercise the Categories taxonomy round-trip
- Adds `packages/budget-domain/src/categories.test.ts` that snapshots the public `Categories` taxonomy and asserts `isCategory` round-trips every value. Pure test addition — no source changes, no behavior changes.

## Test plan
- [ ] `npm test --workspace packages/budget-domain` passes (6 tests across 2 files)
- [ ] No logic changes — diff is purely a new test file plus an audit-marking comment

🌱 Code garden — non-functional cleanup only