### PR TITLE
fix(bookmarks): route x-ingest tagger through OpenClaw gateway

### DIFF
--- a/agents/skills/bookmarks/x-ingest/scripts/x/process.cjs
+++ b/agents/skills/bookmarks/x-ingest/scripts/x/process.cjs
@@ -239,6 +239,20 @@ function getAcpxCommand() {
   return (process.env.BOOKMARK_LLM_ACPX_COMMAND || '/opt/homebrew/bin/acpx').trim();
 }
 
+// acpx supports multiple ACP agent backends. We default to `openclaw` so the
+// tagger routes through the OpenClaw gateway provider pool (`minimax-portal/*`),
+// which is the billing pool that's currently healthy in this workspace. The
+// previous default (`codex`) routed through `@zed-industries/codex-acp` to
+// OpenAI's `/v1/responses` endpoint, which requires an `api.responses.write`
+// scope our key doesn't have — see
+// `infra/runbooks/bookmark-acpx-openai-401-no-scopes.md`. The OpenClaw
+// gateway is a separate billing pool from `MINIMAX_API_KEY` (direct), so
+// flipping the subcommand does not affect the direct-pool path documented in
+// `infra/runbooks/minimax-direct-key-out-of-balance.md`.
+function getAcpxSubcommand() {
+  return (process.env.BOOKMARK_LLM_ACPX_SUBCOMMAND || 'openclaw').trim();
+}
+
 function truncateForLlm(value, maxChars) {
   const text = String(value || '');
   if (text.length <= maxChars) return text;
@@ -270,7 +284,10 @@ async function generateMetadata(url, tweetText, isTweetLink = false, linkedArtic
 
   function callViaAcpx() {
     const acpxCommand = getAcpxCommand();
-    const model = (process.env.BOOKMARK_LLM_MODEL || 'minimax').trim();
+    const acpxSubcommand = getAcpxSubcommand();
+    // Default to an OpenClaw gateway model — see getAcpxSubcommand() comment
+    // for why this is no longer `codex`. Operators can still override via env.
+    const model = (process.env.BOOKMARK_LLM_MODEL || 'minimax-portal/MiniMax-M3').trim();
     const timeoutMs = parseInt(process.env.BOOKMARK_LLM_TIMEOUT_SECONDS || '120', 10) * 1000;
     const prompt = [
       'You are tagging X bookmarks for a second brain.',
@@ -285,7 +302,15 @@ async function generateMetadata(url, tweetText, isTweetLink = false, linkedArtic
 
     const result = spawnSync(
       acpxCommand,
-      ['--approve-all', '--format', 'quiet', '--model', model, 'codex', 'exec', '-f', '-'],
+      [
+        '--approve-all',
+        '--format', 'quiet',
+        '--allowed-tools', '',
+        '--model', model,
+        acpxSubcommand,
+        'exec',
+        '-f', '-'
+      ],
       {
         input: prompt,
         encoding: 'utf8',


### PR DESCRIPTION
## Summary
- Switch the x-ingest tagger's acpx subcommand default from `codex` to `openclaw` and the model default from `minimax` (not a real model) to `minimax-portal/MiniMax-M3` (real OpenClaw gateway model).
- Add `--allowed-tools ""` so tag generation stays a pure text-in/JSON-out task — no MCP server / tool round-trips per bookmark.
- Operators retain full override via `BOOKMARK_LLM_ACPX_SUBCOMMAND` and `BOOKMARK_LLM_MODEL` env vars.

## Why
The previous default routed through `@zed-industries/codex-acp` → OpenAI `/v1/responses`. That endpoint requires the `api.responses.write` scope, which the workspace's `OPENAI_API_KEY` does not have — so every enrichment call has returned 401 since 2026-06-19. The bookmark cron still exits 0 and archives fine (graceful-degradation is by design — see `infra/runbooks/bookmark-acpx-openai-401-no-scopes.md`), but ~4 bookmarks landed in `brain/bookmarks/x/` with `needs-review` fallback tags instead of real content tags.

The OpenClaw gateway provider pool is a **separate billing pool** from `MINIMAX_API_KEY` (direct), and is currently healthy. Routing through `acpx openclaw` bypasses both the OpenAI scope issue and the (currently out-of-balance) direct pool.

## Test plan
- [ ] Local smoke test against two of the four affected bookmarks — both returned 7 real content tags instead of `needs-review`. See commit message for example output.
- [ ] Verify graceful-degradation still works: set `BOOKMARK_LLM_MODEL=this-model-does-not-exist` and confirm the cron still archives the bookmark with the fallback tag.
- [ ] Verify env-var override still works: set `BOOKMARK_LLM_ACPX_SUBCOMMAND=codex BOOKMARK_LLM_MODEL=gpt-4o-mini` (once OpenAI scope is granted) and confirm the original path is reachable.
- [ ] After merge: trigger a one-off re-tag of the 4 affected bookmarks (cron entry point exists for this) to clean up the `needs-review` rows in `brain/state/x-bookmark-tags-log.csv`.

## Out of scope
- Granting `api.responses.write` on the OpenAI key — Tom's call. The OpenClaw path is preferred because it uses a billing pool we already have and removes the OpenAI dependency entirely.
- Topping up the `MINIMAX_API_KEY` direct pool (out of balance per `infra/runbooks/minimax-direct-key-out-of-balance.md`) — also Tom's call. The direct pool is unused by this code path even when healthy, so this fix does not depend on that top-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)