### PR TITLE
chore(tasks): migrate marked.setOptions to marked.use [2026-W26]

### DIFF
--- a/apps/tasks/src/utils/markdown.js
+++ b/apps/tasks/src/utils/markdown.js
@@ -1,8 +1,10 @@
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 
-// Configure marked for safe, sensible defaults
-marked.setOptions({
+// Configure marked for safe, sensible defaults.
+// marked.use accepts the same option keys as the deprecated setOptions,
+// so this is a behavior-equivalent migration from marked v17's deprecation.
+marked.use({
   gfm: true,
   breaks: true,
 });


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W26.md
- **Finding:** Milestone 3, task 3-D — Replace `marked.setOptions` with `marked.use()` (marked v17 deprecation)
- Mechanical one-line migration of `marked.setOptions({ gfm, breaks })` → `marked.use({ gfm, breaks })` in `apps/tasks/src/utils/markdown.js`. `marked.use` accepts the same option keys and produces identical parse output, so the migration is behavior-equivalent.

## Test plan
- [x] `apps/tasks` vitest suite (104 tests) passes locally; the 16 `markdown.test.js` cases all pass
- [ ] Confirm `git diff` touches only `apps/tasks/src/utils/markdown.js` (no agent/cron/doc leaks)
- [ ] Confirm rendered markdown in the task editor (GFM tables, task checkboxes, code blocks) still renders the same as before

🌱 Code garden — non-functional cleanup only