### PR TITLE
chore(ci): add budget-api-tests job [2026-W26]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,56 @@ jobs:
       - name: Run DB integration tests
         run: npm run test:integration --workspace services/tasks-api
 
+  budget-api-tests:
+    name: budget-api tests (unit + db integration)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: sindustries_budget
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d sindustries_budget"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/sindustries_budget?schema=budget_api
+      OTEL_SDK_DISABLED: '1'
+      AKAHU_DEV_USER_ACCESS_TOKEN: ''
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Ensure Rollup Linux native binary is present
+        run: npm install --no-save @rollup/rollup-linux-x64-gnu@4.59.0 --workspace services/budget-api
+
+      - name: Generate Prisma client
+        run: npm run prisma:generate --workspace services/budget-api
+
+      - name: Run unit tests
+        run: npm test --workspace services/budget-api
+
+      - name: Apply DB migrations
+        run: npm run prisma:migrate --workspace services/budget-api
+
+      - name: Seed DB
+        run: npm run prisma:seed --workspace services/budget-api
+
   tasks-app-tests:
     name: tasks app tests
     runs-on: ubuntu-latest

--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -151,7 +151,7 @@ AI agents (agents/)
 
 ### Code Quality
 
-**[High] No CI job for `services/budget-api`** *(new this week)*
+**[High] No CI job for `services/budget-api`** *(new this week)* <!-- DONE: PR #TBD -->
 
 - `.github/workflows/ci.yml` has jobs for `tasks-api-tests`, `tasks-app-tests`, `tasks-app-e2e`, `website-app-tests`, `design-system-sync`, `otel-node-tests`, `python-workflow-tests`. There is no `budget-api-tests` job.
 - The Makefile's `test-api` target runs `services/budget-api` tests locally (`Makefile:25-27`), so a contributor running `make test-api` exercises them; CI does not.

--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -151,7 +151,7 @@ AI agents (agents/)
 
 ### Code Quality
 
-**[High] No CI job for `services/budget-api`** *(new this week)* <!-- DONE: PR #TBD -->
+**[High] No CI job for `services/budget-api`** *(new this week)* <!-- DONE: PR #110 -->
 
 - `.github/workflows/ci.yml` has jobs for `tasks-api-tests`, `tasks-app-tests`, `tasks-app-e2e`, `website-app-tests`, `design-system-sync`, `otel-node-tests`, `python-workflow-tests`. There is no `budget-api-tests` job.
 - The Makefile's `test-api` target runs `services/budget-api` tests locally (`Makefile:25-27`), so a contributor running `make test-api` exercises them; CI does not.


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W26.md
- **Finding:** [High] No CI job for `services/budget-api` (Milestone 0-A)
- Mirrors the existing `tasks-api-tests` job — Postgres service container on the `budget_api` schema, `prisma generate` / `migrate` / `seed`, and `vitest run` — so the 11 budget-api unit tests now run on every PR.

## Test plan
- [x] Local verification: `npm test --workspace services/budget-api` passes 11/11 after `prisma migrate deploy` + `prisma:seed` against a Postgres 16 container
- [x] YAML structure validated (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`)
- [x] No application behavior changes — only `.github/workflows/ci.yml` and the audit finding marker

🌱 Code garden — non-functional cleanup only