### PR TITLE
fix: route code-garden PRs to Quinn

### DIFF
--- a/agents/skills/dev/code-garden/SKILL.md
+++ b/agents/skills/dev/code-garden/SKILL.md
@@ -96,6 +96,8 @@ Before opening the PR, edit the audit file to mark the finding done. Append `<!-
 
 Read and follow: `agents/skills/dev/pr-open/SKILL.md`
 
+Code-garden PRs use `--assignee rowanstoffer --reviewer quinnstoffer`.
+
 Use this PR body format:
 
 ```

--- a/agents/skills/dev/code-garden/SKILL.md
+++ b/agents/skills/dev/code-garden/SKILL.md
@@ -96,7 +96,7 @@ Before opening the PR, edit the audit file to mark the finding done. Append `<!-
 
 Read and follow: `agents/skills/dev/pr-open/SKILL.md`
 
-Code-garden PRs use `--assignee rowanstoffer --reviewer quinnstoffer`.
+Code-garden PRs use `--reviewer quinnstoffer`. Keep the assignee as the PR opener, following `agents/skills/dev/pr-open/SKILL.md`.
 
 Use this PR body format:
 


### PR DESCRIPTION
## Summary
- Explicitly documents that code-garden PRs should request `quinnstoffer` as reviewer.
- Keeps the PR assignee as the opener by deferring assignee ownership to `pr-open`.

## Test plan
- [x] `git diff --check`
- [x] No logic changes — skill documentation only