### PR TITLE
chore(code-garden): sync ivy in e2e assignee-filter spec [2026-W26]

### DIFF
--- a/apps/tasks/test/e2e/assignee-filter.spec.js
+++ b/apps/tasks/test/e2e/assignee-filter.spec.js
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-const ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom'];
+const ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom', 'Ivy'];
 
 function mockTasks(tasks) {
   return async (route) => {

--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -157,7 +157,7 @@ AI agents (agents/)
 - The Makefile's `test-api` target runs `services/budget-api` tests locally (`Makefile:25-27`), so a contributor running `make test-api` exercises them; CI does not.
 - **Consequence (fact):** Tests in `services/budget-api/test/` (akahuClient, alerts, categorizer, akahuSync) can break on main without surfacing as a failing PR check.
 
-**[Medium] Assignee list drifts between API validation and frontend constants** *(persists)* <!-- DONE: PR #101 --> <!-- DONE: PR #TBD -->
+**[Medium] Assignee list drifts between API validation and frontend constants** *(persists)* <!-- DONE: PR #101 --> <!-- DONE: PR #113 -->
 
 - `services/tasks-api/src/routes/tasks.ts:10` — `validAssignees = new Set(['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy'])`.
 - `apps/tasks/src/utils/constants.js:15` — `ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom']` — Ivy still missing. PR #101 fixed this copy but missed `apps/tasks/test/e2e/assignee-filter.spec.js:3` which had its own local `['Quinn', 'Rowan', 'Lox', 'Tom']` literal (no Ivy); sibling `assignee-dropdown.spec.js:3` correctly uses `['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy']`.

--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -157,10 +157,10 @@ AI agents (agents/)
 - The Makefile's `test-api` target runs `services/budget-api` tests locally (`Makefile:25-27`), so a contributor running `make test-api` exercises them; CI does not.
 - **Consequence (fact):** Tests in `services/budget-api/test/` (akahuClient, alerts, categorizer, akahuSync) can break on main without surfacing as a failing PR check.
 
-**[Medium] Assignee list drifts between API validation and frontend constants** *(persists)* <!-- DONE: PR #101 -->
+**[Medium] Assignee list drifts between API validation and frontend constants** *(persists)* <!-- DONE: PR #101 --> <!-- DONE: PR #TBD -->
 
 - `services/tasks-api/src/routes/tasks.ts:10` — `validAssignees = new Set(['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy'])`.
-- `apps/tasks/src/utils/constants.js:15` — `ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom']` — Ivy still missing.
+- `apps/tasks/src/utils/constants.js:15` — `ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom']` — Ivy still missing. PR #101 fixed this copy but missed `apps/tasks/test/e2e/assignee-filter.spec.js:3` which had its own local `['Quinn', 'Rowan', 'Lox', 'Tom']` literal (no Ivy); sibling `assignee-dropdown.spec.js:3` correctly uses `['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy']`.
 
 **[Medium] Stale `triage` status documented in client type comment** *(persists)* <!-- DONE: PR #100 -->
 


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W26.md
- **Finding:** [Medium] Assignee list drifts between API validation and frontend constants (extension of PR #101)
- Add `Ivy` to the local `ASSIGNEE_OPTIONS` literal in `apps/tasks/test/e2e/assignee-filter.spec.js:3`, bringing it in line with the canonical list in `apps/tasks/src/utils/constants.js` (already updated by PR #101) and the sibling spec `apps/tasks/test/e2e/assignee-dropdown.spec.js:3` (which already included Ivy). Pure data-literal change; the spec still mocks the API and just iterates one more assignee.

## Test plan
- [x] `npm test --workspace apps/tasks` — 104 vitest tests pass (Playwright spec is not exercised by the vitest lane)
- [ ] `npm run test:e2e --workspace apps/tasks` exercises the iteration — `assignee-filter.spec.js` now asserts the menu contains `IVY` alongside the existing four
- [x] No logic changes — diff is a one-item literal addition

🌱 Code garden — non-functional cleanup only