### PR TITLE
chore(code-garden): drop .ts extensions from service imports [2026-W26]

### DIFF
--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -172,7 +172,7 @@ AI agents (agents/)
 
 - Targeted unit testing of cursor/sort logic and tag management is harder than it needs to be; any structural change touches the same large file.
 
-**[Low] `services/budget-api` and tasks-api use `.ts` route files in an ESM project** <!-- DONE: PR #TBD -->
+**[Low] `services/budget-api` and tasks-api use `.ts` route files in an ESM project** <!-- DONE: PR #114 -->
 
 - `services/budget-api/package.json:5` declares `"type": "module"`; imports use `'./routes/akahu.ts'` (with the `.ts` extension) and rely on `tsx` for both dev and "start". Once a real runtime build is needed, the `.ts` extension on import paths must change. Not urgent at MVP stage.
 

--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -172,7 +172,7 @@ AI agents (agents/)
 
 - Targeted unit testing of cursor/sort logic and tag management is harder than it needs to be; any structural change touches the same large file.
 
-**[Low] `services/budget-api` and tasks-api use `.ts` route files in an ESM project**
+**[Low] `services/budget-api` and tasks-api use `.ts` route files in an ESM project** <!-- DONE: PR #TBD -->
 
 - `services/budget-api/package.json:5` declares `"type": "module"`; imports use `'./routes/akahu.ts'` (with the `.ts` extension) and rely on `tsx` for both dev and "start". Once a real runtime build is needed, the `.ts` extension on import paths must change. Not urgent at MVP stage.
 

--- a/services/budget-api/prisma/seed.ts
+++ b/services/budget-api/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { prisma } from '../src/lib/prisma.ts';
+import { prisma } from '../src/lib/prisma';
 
 async function main() {
   const email = 'dev@example.com';

--- a/services/budget-api/src/app.ts
+++ b/services/budget-api/src/app.ts
@@ -1,12 +1,12 @@
 import express from 'express';
 
-import { alertsRouter } from './routes/alerts.ts';
-import { akahuRouter } from './routes/akahu.ts';
-import { cardsRouter } from './routes/cards.ts';
-import { categorizeRouter } from './routes/categorize.ts';
-import { categoriesRouter } from './routes/categories.ts';
-import { sessionRouter } from './routes/session.ts';
-import { transactionsRouter } from './routes/transactions.ts';
+import { alertsRouter } from './routes/alerts';
+import { akahuRouter } from './routes/akahu';
+import { cardsRouter } from './routes/cards';
+import { categorizeRouter } from './routes/categorize';
+import { categoriesRouter } from './routes/categories';
+import { sessionRouter } from './routes/session';
+import { transactionsRouter } from './routes/transactions';
 
 function getAllowedOrigins() {
   const configured = process.env.CORS_ALLOWED_ORIGINS?.split(',')

--- a/services/budget-api/src/repos/akahuRepo.ts
+++ b/services/budget-api/src/repos/akahuRepo.ts
@@ -1,4 +1,4 @@
-import { prisma } from '../lib/prisma.ts';
+import { prisma } from '../lib/prisma';
 
 export async function upsertAkahuConnection(params: {
   userId: string;

--- a/services/budget-api/src/repos/cardsRepo.ts
+++ b/services/budget-api/src/repos/cardsRepo.ts
@@ -1,4 +1,4 @@
-import { prisma } from '../lib/prisma.ts';
+import { prisma } from '../lib/prisma';
 
 export async function getCardById(cardId: string) {
   return prisma.linkedCard.findUnique({ where: { id: cardId } });

--- a/services/budget-api/src/repos/transactionsRepo.ts
+++ b/services/budget-api/src/repos/transactionsRepo.ts
@@ -1,4 +1,4 @@
-import { prisma } from '../lib/prisma.ts';
+import { prisma } from '../lib/prisma';
 
 export async function listTransactionsForUser(userId: string) {
   return prisma.transaction.findMany({

--- a/services/budget-api/src/routes/akahu.ts
+++ b/services/budget-api/src/routes/akahu.ts
@@ -1,21 +1,21 @@
 import { createHash } from 'node:crypto';
 import { Router } from 'express';
-import { prisma } from '../lib/prisma.ts';
-import { jsonError } from '../lib/http.ts';
-import { evaluateAlertsForUser } from '../services/alerts.ts';
+import { prisma } from '../lib/prisma';
+import { jsonError } from '../lib/http';
+import { evaluateAlertsForUser } from '../services/alerts';
 import {
   akahuGetAccounts,
   akahuGetPendingTransactions,
   akahuRefreshAllAccounts,
   akahuGetTransactions,
   exchangeAuthorizationCode
-} from '../services/akahuClient.ts';
+} from '../services/akahuClient';
 import {
   getAkahuConnectionForUser,
   markAkahuSyncComplete,
   upsertAkahuConnection
-} from '../repos/akahuRepo.ts';
-import { categorizeTransaction } from '../services/categorizer.ts';
+} from '../repos/akahuRepo';
+import { categorizeTransaction } from '../services/categorizer';
 
 export const akahuRouter = Router();
 

--- a/services/budget-api/src/routes/alerts.ts
+++ b/services/budget-api/src/routes/alerts.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
-import { prisma } from '../lib/prisma.ts';
-import { jsonError } from '../lib/http.ts';
-import { evaluateAlertsForUser } from '../services/alerts.ts';
+import { prisma } from '../lib/prisma';
+import { jsonError } from '../lib/http';
+import { evaluateAlertsForUser } from '../services/alerts';
 
 export const alertsRouter = Router();
 

--- a/services/budget-api/src/routes/cards.ts
+++ b/services/budget-api/src/routes/cards.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
-import { prisma } from '../lib/prisma.ts';
-import { jsonError } from '../lib/http.ts';
-import { getCardById, getMonthlyBudget, upsertMonthlyBudget } from '../repos/cardsRepo.ts';
+import { prisma } from '../lib/prisma';
+import { jsonError } from '../lib/http';
+import { getCardById, getMonthlyBudget, upsertMonthlyBudget } from '../repos/cardsRepo';
 
 export const cardsRouter = Router();
 

--- a/services/budget-api/src/routes/categories.ts
+++ b/services/budget-api/src/routes/categories.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import { prisma } from '../lib/prisma.ts';
-import { jsonError } from '../lib/http.ts';
+import { prisma } from '../lib/prisma';
+import { jsonError } from '../lib/http';
 
 export const categoriesRouter = Router();
 

--- a/services/budget-api/src/routes/categorize.ts
+++ b/services/budget-api/src/routes/categorize.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import { jsonError } from '../lib/http.ts';
-import { categorizeTransaction, categoryTaxonomy } from '../services/categorizer.ts';
+import { jsonError } from '../lib/http';
+import { categorizeTransaction, categoryTaxonomy } from '../services/categorizer';
 
 export const categorizeRouter = Router();
 

--- a/services/budget-api/src/routes/session.ts
+++ b/services/budget-api/src/routes/session.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import crypto from 'node:crypto';
-import { prisma } from '../lib/prisma.ts';
-import { jsonError } from '../lib/http.ts';
+import { prisma } from '../lib/prisma';
+import { jsonError } from '../lib/http';
 
 export const sessionRouter = Router();
 

--- a/services/budget-api/src/routes/transactions.ts
+++ b/services/budget-api/src/routes/transactions.ts
@@ -1,12 +1,12 @@
 import { Router } from 'express';
-import { jsonError } from '../lib/http.ts';
+import { jsonError } from '../lib/http';
 import { normalizeMerchantKey } from '@sindustries/budget-domain';
 import {
   getTransactionById,
   listTransactionsForUser,
   recordCategorizationFeedback,
   updateTransactionCategory
-} from '../repos/transactionsRepo.ts';
+} from '../repos/transactionsRepo';
 
 export const transactionsRouter = Router();
 

--- a/services/budget-api/src/server.ts
+++ b/services/budget-api/src/server.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { createApp } from './app.ts';
+import { createApp } from './app';
 
 const port = Number(process.env.PORT || 4002);
 

--- a/services/budget-api/src/services/alerts.ts
+++ b/services/budget-api/src/services/alerts.ts
@@ -1,5 +1,5 @@
 import { evaluateMonthlyCardBudget, type BudgetStage } from '@sindustries/budget-domain';
-import { prisma } from '../lib/prisma.ts';
+import { prisma } from '../lib/prisma';
 
 export async function evaluateAlertsForUser(params: { userId: string; month: string }) {
   const cards = await prisma.linkedCard.findMany({ where: { userId: params.userId } });

--- a/services/budget-api/src/services/categorizer.ts
+++ b/services/budget-api/src/services/categorizer.ts
@@ -1,5 +1,5 @@
 import { Categories, normalizeMerchantKey } from '@sindustries/budget-domain';
-import { prisma } from '../lib/prisma.ts';
+import { prisma } from '../lib/prisma';
 
 export type CategorizationResult = {
   category: string;

--- a/services/budget-api/test/akahuClient.test.ts
+++ b/services/budget-api/test/akahuClient.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   akahuGetPendingTransactions,
   akahuRefreshAllAccounts
-} from '../src/services/akahuClient.ts';
+} from '../src/services/akahuClient';
 
 function jsonResponse(status: number, body: unknown) {
   return {

--- a/services/budget-api/test/akahuSync.test.ts
+++ b/services/budget-api/test/akahuSync.test.ts
@@ -43,7 +43,7 @@ vi.mock('../src/services/categorizer.ts', () => ({
   categoryTaxonomy: []
 }));
 
-import { createApp } from '../src/app.ts';
+import { createApp } from '../src/app';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 

--- a/services/budget-api/test/alerts.test.ts
+++ b/services/budget-api/test/alerts.test.ts
@@ -17,8 +17,8 @@ vi.mock('../src/lib/prisma.ts', () => {
   };
 });
 
-import { prisma } from '../src/lib/prisma.ts';
-import { evaluateAlertsForUser } from '../src/services/alerts.ts';
+import { prisma } from '../src/lib/prisma';
+import { evaluateAlertsForUser } from '../src/services/alerts';
 
 describe('evaluateAlertsForUser', () => {
   it('creates deduped events per stage crossed', async () => {

--- a/services/budget-api/test/categorizer.test.ts
+++ b/services/budget-api/test/categorizer.test.ts
@@ -10,8 +10,8 @@ vi.mock('../src/lib/prisma.ts', () => {
   };
 });
 
-import { categorizeTransaction } from '../src/services/categorizer.ts';
-import { prisma } from '../src/lib/prisma.ts';
+import { categorizeTransaction } from '../src/services/categorizer';
+import { prisma } from '../src/lib/prisma';
 
 describe('categorizeTransaction', () => {
   it('uses feedback rule when available', async () => {

--- a/services/tasks-api/prisma/migrate-todo-to-ready.ts
+++ b/services/tasks-api/prisma/migrate-todo-to-ready.ts
@@ -1,7 +1,7 @@
 // Migration script to update existing tasks from todo -> open
 // Run this once to migrate existing data
 
-import { prisma } from '../src/lib/prisma.ts';
+import { prisma } from '../src/lib/prisma';
 
 async function migrate() {
   console.log('Starting migration: todo -> open');

--- a/services/tasks-api/src/app.ts
+++ b/services/tasks-api/src/app.ts
@@ -1,7 +1,7 @@
 import express from 'express';
-import { healthRouter } from './routes/health.ts';
-import { tasksRouter } from './routes/tasks.ts';
-import { tagsRouter } from './routes/tags.ts';
+import { healthRouter } from './routes/health';
+import { tasksRouter } from './routes/tasks';
+import { tagsRouter } from './routes/tags';
 
 function getAllowedOrigins() {
   const configured = process.env.CORS_ALLOWED_ORIGINS?.split(',')

--- a/services/tasks-api/src/routes/tags.ts
+++ b/services/tasks-api/src/routes/tags.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import { prisma } from '../lib/prisma.ts';
-import { badRequest } from '../lib/http.ts';
+import { prisma } from '../lib/prisma';
+import { badRequest } from '../lib/http';
 
 function normalizeString(value) {
   return typeof value === 'string' ? value.trim() : value;

--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import { prisma } from '../lib/prisma.ts';
-import { badRequest, notFound } from '../lib/http.ts';
+import { prisma } from '../lib/prisma';
+import { badRequest, notFound } from '../lib/http';
 
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 10000;

--- a/services/tasks-api/src/server.ts
+++ b/services/tasks-api/src/server.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { createApp } from './app.ts';
+import { createApp } from './app';
 
 const port = Number(process.env.PORT || 4000);
 const ALLOW_PORT_DB_MISMATCH = process.env.ALLOW_PORT_DB_MISMATCH === '1';

--- a/services/tasks-api/test/db-integration.test.ts
+++ b/services/tasks-api/test/db-integration.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import { describe, expect, it } from 'vitest';
-import { createApp } from '../src/app.ts';
+import { createApp } from '../src/app';
 
 describe('tasks api db integration', () => {
   it('reads seeded rows and persists create/update/archive through postgres', async () => {

--- a/services/tasks-api/test/health.test.ts
+++ b/services/tasks-api/test/health.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import { describe, expect, it } from 'vitest';
-import { createApp } from '../src/app.ts';
+import { createApp } from '../src/app';
 
 describe('health endpoint', () => {
   it('returns 200 and service status', async () => {


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W26.md
- **Finding:** [Low] `services/budget-api` and tasks-api use `.ts` route files in an ESM project
- Drop the `.ts` extension from every relative import path under `services/tasks-api/` and `services/budget-api/` (src, test, and prisma scripts). The audit identifies this as the right fix direction: once a real runtime build lands, the `.ts` extension on import paths must change. Normalising now means future build tooling (tsc / esbuild / swc) resolves imports with standard ESM rules without per-file patches.

## Test plan
- [x] `npm test --workspace services/tasks-api` — 19 tests pass across 4 files
- [x] `npm test --workspace services/budget-api` — 11 tests pass across 4 files
- [x] No logic changes — diff is purely cosmetic (every import resolves to the same file as before)
- [x] Scope guard verified: diff touches only `docs/repo-audits/2026-W26.md` and files under `services/{tasks-api,budget-api}/`; no `agents/skills/` or `agents/crons/` paths

🌱 Code garden — non-functional cleanup only