### PR TITLE
chore(repo): gitignore per-service Prisma generated output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,11 @@ dist/
 **/.env
 services/tasks-api/.env.dev
 services/tasks-api/.env.prodlike
+services/tasks-api/src/generated/
 services/budget-api/.env.dev
 services/budget-api/.env.dev.local
 services/budget-api/.env.prodlike.local
+services/budget-api/src/generated/
 apps/tasks/test-results/.last-run.json
 .db-backups/
 .vercel


### PR DESCRIPTION
The 2026-06-26 prodlike recovery split Prisma's runtime client into a per-service output directory (services/{tasks-api,budget-api}/src/generated/) so each service generates to a known path instead of relying on a hoisted node_modules client. The directories are recreated on every 'npm run prisma:generate' and should never be committed.

Without these .gitignore entries, 'git add .' would happily stage the generated Prisma client.