### PR TITLE
docs(agents): add feature factory v2 requirements to Quinn and Rowan docs

### DIFF
--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -54,6 +54,26 @@ Run:
 `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/content-tasks/run.py --json`
 Report only failures, blocked closed-unmerged PRs, or meaningful transitions.
 
+---
+
+OPENCLAW HANDOFFS (FEATURE FACTORY)
+
+Quinn is the only agent that can write to `~/.openclaw/`. When a feature task has an unresolved `[openclaw-needed]` comment from Rowan, Quinn applies the change.
+
+Each heartbeat:
+1. List active feature tasks (status: doing or acceptance):
+   `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/tasks_api_client.py list --status doing --status acceptance`
+2. For each task, scan comments for `[openclaw-needed]` entries that do not yet have a matching `[openclaw-done]`.
+3. For each unresolved `[openclaw-needed]`:
+   - Read the comment: it must include exact file paths, proposed diff summary, validation command, and rollback note.
+   - If the change affects product behaviour, ask Tom before applying.
+   - Apply the change to `~/.openclaw/`.
+   - Validate using the command in the comment.
+   - Post a task comment: `[openclaw-done] <changed paths> | validated: <command output summary> | <any follow-up notes>`
+4. If `[openclaw-needed]` comments exist but are unclear or unsafe, mark the task blocked and post a comment explaining what is missing.
+
+Do not apply `.openclaw` changes speculatively. Only act on explicit `[openclaw-needed]` comments from Rowan.
+
 PR REVIEW
 
 Process any PRs that need your attention.

--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -16,9 +16,40 @@ If no open PRs or no unresolved comments: skip the assignee part.
 
 ---
 
-## Step 2 — Code gardening
+## Step 2 — Feature task work
+
+Check for active feature tasks assigned to you:
+`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/tasks_api_client.py list --assignee Rowan --status ready --status doing --status acceptance`
+
+**Capacity:** 1 unblocked feature task per state at a time.
+
+### If a task is in `ready`:
+Write the tech design before touching any code.
+- Location: `docs/specs/<task-slug>-tech-design.md` in the primary implementation repo
+- Must cover: product spec link, task link, repos involved, branch names, worktree paths, any `.openclaw` changes needed, implementation plan, test plan, open questions for Quinn or Tom
+- When done: post a `[tech-design] <GitHub URL>` task comment with the branch URL
+- Quinn sets `tech_design_approved: true` after Tom signs off — do not start implementation until that is confirmed
+
+### If a task is in `doing`:
+Implement on your worktree branch. Work only in `~/workspaces/rowan/sindustries` (or the relevant worktree).
+- All changes come via PRs — no direct pushes to main
+- When `.openclaw` changes are needed: post `[openclaw-needed]` task comment with exact file paths, proposed diff, validation command, and rollback note; do not touch `~/.openclaw/` yourself
+- When implementation is complete: post `[rowan-prs] <url1>, <url2>` task comment listing all open PR URLs
+- PR body must include all parent task ACs checked off (`- [x]` done, `- [ ]` not yet)
+
+### If a task is in `acceptance`:
+Stay in acceptance while addressing PR review feedback — do not regress to doing.
+- Check open PRs for `CHANGES_REQUESTED` or unresolved review comments
+- Address valid feedback on the same branch and push; do not open new PRs for review iterations
+- Mark the task blocked when waiting on Tom to approve a PR
+
+---
+
+## Step 3 — Code gardening
 
 Read and follow:
 `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/dev/code-garden/SKILL.md`
 
-**Limit:** Open at most 1 code-garden PR at a time. Check for open PRs first — if one exists, skip to Step 1 (PR work) only.
+**Limit:** Open at most 1 code-garden PR at a time. Check for open PRs first — if one exists, skip this step.
+
+**Skip code gardening entirely** if you have an active unblocked feature task in `doing` or `acceptance`.

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -71,10 +71,39 @@ Rowan breaks large work into milestones that are:
 
 ---
 
+## Feature Factory v2 — Task Requirements
+
+### Tech design first
+Before writing any code on a feature task, write the tech design:
+- Location: `docs/specs/<task-slug>-tech-design.md` in the primary implementation repo
+- Must cover: product spec link, task link, repos involved, branch names, worktree paths, `.openclaw` changes needed, implementation plan, test plan, open questions
+- Post `[tech-design] <GitHub URL>` as a task comment when done
+- Wait for Quinn to set `tech_design_approved: true` before starting implementation
+
+### Implementation
+- Work on dedicated worktree branches; all changes come via PRs — no direct pushes to main
+- Capacity: 1 unblocked feature task per state at a time
+- When `.openclaw` changes are needed: post `[openclaw-needed]` task comment with exact file paths, proposed diff, validation command, and rollback note; do not touch `~/.openclaw/` yourself
+- When all implementation PRs are open: post `[rowan-prs] <url1>, <url2>` as a task comment
+
+### PR requirements
+- PR body must include all parent task ACs, with `- [x]` for done and `- [ ]` for not yet done
+- Each PR body must list which parent ACs its sub-ACs contribute to
+
+### Acceptance
+- Stay in `acceptance` while addressing PR review feedback — do not regress to `doing`
+- Address valid feedback on the same branch and push; do not open new PRs for review iterations
+- Mark task blocked when waiting on Tom to approve a PR
+
+### `.openclaw` boundary
+Rowan cannot write to `~/.openclaw/`. Post `[openclaw-needed]` and wait for Quinn's `[openclaw-done]` confirmation before considering that work complete.
+
+---
+
 ## PR Standards
 When Rowan opens a PR:
 - assign to **Tom** (`Stoff81`)
-- include clear description of changes
+- include clear description of changes and full AC checklist
 - include validation evidence
 - include screenshots/GIFs for UI work where useful
 - reference the task in the PR body


### PR DESCRIPTION
## Summary
- Quinn HEARTBEAT: .openclaw handoff section for feature factory (AC7.1, AC9.2)
- Rowan HEARTBEAT: feature task work step — tech design, implementation, PR feedback handling
- Rowan WORKFLOW: feature factory v2 requirements — tech design first, [rowan-prs] signal, .openclaw boundary, AC checklist in PRs, stay in acceptance while addressing feedback (AC7.1, AC9.3)

## Acceptance Criteria (from Feature Factory v2 task 2527ff9d)
- [x] AC7.1 openclaw: Rowan docs state permission boundary
- [x] AC9.2 openclaw: Rowan HEARTBEAT.md updated with task discovery and maintenance pass
- [x] AC9.3 openclaw: Rowan WORKFLOW.md updated with all v2 requirements

🤖 Generated with Claude Code