### PR TITLE
chore(code-garden): document budget-api MVP auth posture in README

### DIFF
--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -244,7 +244,7 @@ AI agents (agents/)
 
 **[Medium] `docs/architecture.md` states e2e tests use the real API — they do not** *(persists)*
 
-**[Low] No README for `services/budget-api` covers the missing-auth contract** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**[Low] No README for `services/budget-api` covers the missing-auth contract** ✅ [PR #119](https://github.com/Stoffer-Industries/sindustries/pull/119)
 
 - `services/budget-api/README.md` exists (per directory listing) but does not flag that all routes are unauthenticated. A short "MVP scope: dev/Tailnet only — auth not yet enforced" callout would set expectations for the next contributor.
 

--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -244,7 +244,7 @@ AI agents (agents/)
 
 **[Medium] `docs/architecture.md` states e2e tests use the real API — they do not** *(persists)*
 
-**[Low] No README for `services/budget-api` covers the missing-auth contract**
+**[Low] No README for `services/budget-api` covers the missing-auth contract** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 
 - `services/budget-api/README.md` exists (per directory listing) but does not flag that all routes are unauthenticated. A short "MVP scope: dev/Tailnet only — auth not yet enforced" callout would set expectations for the next contributor.
 

--- a/services/budget-api/README.md
+++ b/services/budget-api/README.md
@@ -51,3 +51,14 @@ npm run dev
 - `GET /api/v1/categories/timeseries?userId=...&from=...&to=...`
 - `GET /api/v1/alerts?userId=...`
 
+## Security posture
+
+> **MVP scope: dev/Tailnet only — auth is not yet enforced.**
+>
+> Every route except `/api/v1/me` accepts a `userId` from the request body or
+> query and operates on that user without verifying a session token. Treat the
+> service as reachable only over a trusted Tailnet and never expose it on the
+> public internet until the `requireSession` middleware in
+> `services/budget-api/src/app.ts` lands (tracked in the repo audit under
+> "Theme 1 — Lock down `budget-api` before any non-Tailnet deployment").
+


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W26.md
- **Finding:** [Low] No README for `services/budget-api` covers the missing-auth contract
- Adds a "Security posture" section to `services/budget-api/README.md` flagging that the service is MVP-scope (dev/Tailnet only) and auth is not yet enforced. Pure documentation change; no code, no API surface, no behavior.

## Test plan
- [ ] No logic changes — diff is purely documentation
- [ ] `services/budget-api/README.md` renders the new section correctly

🌱 Code garden — non-functional cleanup only