### PR TITLE
Add task dependency references

### DIFF
--- a/agents/skills/ops/tasks-api/tasks_api_client.py
+++ b/agents/skills/ops/tasks-api/tasks_api_client.py
@@ -5,6 +5,7 @@ Usage examples:
   TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 scripts/tasks_api_client.py list --limit 50
   TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 scripts/tasks_api_client.py create --title "Test" --priority high
   TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 scripts/tasks_api_client.py patch --id <task-id> --status doing
+  TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 scripts/tasks_api_client.py patch --id <task-id> --depends-on <dependency-id>
   TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 scripts/tasks_api_client.py archive --id <task-id>
 """
 
@@ -132,6 +133,8 @@ def cmd_create(args):
 def cmd_patch(args):
     base = get_base_url()
     payload = {}
+    if args.depends_on is not None and args.clear_dependencies:
+        raise SystemExit("--depends-on and --clear-dependencies are mutually exclusive")
 
     # Support --field as a shortcut for picking field + value in one go
     # This enables telegram button flows like: /tasks patch --id <id> --field status
@@ -158,6 +161,10 @@ def cmd_patch(args):
                 payload[key] = value == "true"
     if args.tags is not None:
         payload["tags"] = args.tags
+    if args.depends_on is not None:
+        payload["dependsOnIds"] = args.depends_on
+    if args.clear_dependencies:
+        payload["dependsOnIds"] = []
 
     # Handle description: append to existing instead of replacing
     if args.description is not None:
@@ -222,6 +229,8 @@ def build_parser():
     u.add_argument("--priority")
     u.add_argument("--assignee")
     u.add_argument("--tags", nargs="*")
+    u.add_argument("--depends-on", nargs="+", dest="depends_on", help="Replace task dependencies with these task IDs")
+    u.add_argument("--clear-dependencies", action="store_true", help="Clear all task dependencies")
     u.add_argument("--blocked", choices=["true", "false"])
     u.add_argument("--ready", choices=["true", "false"])
     u.set_defaults(func=cmd_patch)

--- a/agents/skills/ops/tasks-api/tests/test_tasks_api_client.py
+++ b/agents/skills/ops/tasks-api/tests/test_tasks_api_client.py
@@ -1,0 +1,68 @@
+import importlib.util
+import pathlib
+import unittest
+from unittest.mock import patch
+
+
+MODULE_PATH = pathlib.Path(__file__).parents[1] / "tasks_api_client.py"
+SPEC = importlib.util.spec_from_file_location("tasks_api_client", MODULE_PATH)
+tasks_api_client = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(tasks_api_client)
+
+
+class TasksApiClientPatchTest(unittest.TestCase):
+    def test_patch_depends_on_maps_to_depends_on_ids(self):
+        parser = tasks_api_client.build_parser()
+        args = parser.parse_args(
+            [
+                "patch",
+                "--id",
+                "task-1",
+                "--depends-on",
+                "dep-1",
+                "dep-2",
+            ]
+        )
+
+        with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"), patch.object(
+            tasks_api_client, "api_request", return_value={"data": {"id": "task-1"}}
+        ) as api_request, patch("builtins.print"):
+            args.func(args)
+
+        api_request.assert_called_once_with(
+            "PATCH",
+            "http://tasks.test/api/v1",
+            "/tasks/task-1",
+            {"dependsOnIds": ["dep-1", "dep-2"]},
+        )
+
+    def test_patch_clear_dependencies_maps_to_empty_depends_on_ids(self):
+        parser = tasks_api_client.build_parser()
+        args = parser.parse_args(["patch", "--id", "task-1", "--clear-dependencies"])
+
+        with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"), patch.object(
+            tasks_api_client, "api_request", return_value={"data": {"id": "task-1"}}
+        ) as api_request, patch("builtins.print"):
+            args.func(args)
+
+        api_request.assert_called_once_with(
+            "PATCH",
+            "http://tasks.test/api/v1",
+            "/tasks/task-1",
+            {"dependsOnIds": []},
+        )
+
+    def test_patch_rejects_depends_on_with_clear_dependencies(self):
+        parser = tasks_api_client.build_parser()
+        args = parser.parse_args(
+            ["patch", "--id", "task-1", "--depends-on", "dep-1", "--clear-dependencies"]
+        )
+
+        with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"):
+            with self.assertRaises(SystemExit):
+                args.func(args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/tasks/src/App.jsx
+++ b/apps/tasks/src/App.jsx
@@ -32,7 +32,7 @@ function isReadyTask(task) {
 function cardState(task, isSelected) {
   if (task.archivedAt) return 'archived';
   if (isSelected) return 'editing';
-  if (task.blocked) return 'blocked';
+  if (task.blocked || task.dependencyBlocked) return 'blocked';
   if (isReadyTask(task)) return 'ready';
   return undefined;
 }

--- a/apps/tasks/src/App.test.jsx
+++ b/apps/tasks/src/App.test.jsx
@@ -235,6 +235,28 @@ describe('tasks ui', () => {
     expect(within(card).getByText('2026-03-07')).toBeInTheDocument();
   });
 
+  it('marks dependency-blocked tasks with the blocked card state', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [mockTask({
+            id: 'dependency-blocked',
+            title: 'Dependency blocked',
+            dependencyBlocked: true,
+            blocked: false
+          })]
+        })
+      })
+    );
+
+    render(<App />);
+
+    const card = await screen.findByTestId('card-dependency-blocked');
+    expect(card).toHaveClass('si-card--blocked');
+  });
+
   it('refreshes tasks when the window regains focus', async () => {
     localStorage.setItem('tasks-app-view', 'board');
     const fetchMock = vi

--- a/apps/tasks/src/tasksApi.test.ts
+++ b/apps/tasks/src/tasksApi.test.ts
@@ -137,13 +137,13 @@ describe('tasksApi', () => {
       const task = { id: 1, title: 'Updated' };
       mockFetch.mockResolvedValueOnce(mockResponse(task));
 
-      const result = await updateTask(1, { title: 'Updated', status: 'done' });
+      const result = await updateTask(1, { title: 'Updated', status: 'done', dependsOnIds: ['dep-1'] });
 
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:4000/api/v1/tasks/1',
         expect.objectContaining({
           method: 'PATCH',
-          body: JSON.stringify({ title: 'Updated', status: 'done' })
+          body: JSON.stringify({ title: 'Updated', status: 'done', dependsOnIds: ['dep-1'] })
         })
       );
       expect(result).toEqual(task);

--- a/apps/tasks/src/tasksApi.ts
+++ b/apps/tasks/src/tasksApi.ts
@@ -16,6 +16,13 @@ export interface Comment {
   createdAt?: string;
 }
 
+export interface DependencyReference {
+  id: string | number;
+  title: string;
+  status: string;
+  completedAt?: string | null;
+}
+
 export interface Task {
   id: string | number;
   title: string;
@@ -31,6 +38,9 @@ export interface Task {
   createdAt?: string | null;
   statusChangedAt?: string | null;
   comments?: Comment[];
+  dependsOn?: DependencyReference[];
+  dependsOnIds?: Array<string | number>;
+  dependencyBlocked?: boolean;
 }
 
 export interface CreateTaskPayload {
@@ -41,6 +51,7 @@ export interface CreateTaskPayload {
   assignee?: string | null;
   tags?: string[];
   blocked?: boolean;
+  dependsOnIds?: Array<string | number>;
   taskType?: 'content' | 'code' | 'research' | null;
   // Note: 'ready' field removed; use status='ready' instead
 }

--- a/docs/specs/add-blocked-by-reference-tech-design.md
+++ b/docs/specs/add-blocked-by-reference-tech-design.md
@@ -1,0 +1,170 @@
+# Add Blocked by Reference Tech Design
+
+## Links
+
+- Product spec: `brain/bookmarks/specs/blocked-by-reference-2026-06-27.md`
+- Task: `456c92a8-835f-453e-a1ef-5ed5a31844f2` (`Add Blocked by reference`)
+- Task API detail: `http://localhost:4001/api/v1/tasks/456c92a8-835f-453e-a1ef-5ed5a31844f2`
+
+## Scope
+
+- Repository: `Stoffer-Industries/sindustries`
+- Branch: `task-456c92a8-depends-on`
+- Worktree: `~/workspaces/rowan/sindustries`
+- Primary code surfaces:
+  - `services/tasks-api/prisma/schema.prisma`
+  - `services/tasks-api/src/routes/tasks.ts`
+  - `services/tasks-api/test/read-endpoints.test.ts`
+  - `services/tasks-api/test/pagination-cursor.test.ts` if list mapping needs integration-style coverage
+  - `apps/tasks/src/tasksApi.ts`
+  - `apps/tasks/src/App.jsx`
+  - `apps/tasks/src/utils/helpers.js`
+  - `apps/tasks/src/**/*.test.*` for visible blocked behavior
+  - `agents/skills/ops/tasks-api/tasks_api_client.py`
+  - `agents/skills/ops/tasks-api/tests/test_task_transition_check.py` or a new focused client test if the current suite is not the right fit
+
+## Product Summary
+
+The existing `blocked` field is a manual override and must keep that meaning. This feature adds explicit task dependencies so a task can say "I depend on these other tasks" as first-class data. The API returns `dependencyBlocked: true` when at least one dependency is not `done`. Consumers treat a task as visibly blocked when `blocked || dependencyBlocked`.
+
+The first version is data/API/client only except for keeping current UI blocked styling correct when `dependencyBlocked` appears. There is no dependency graph UI, no cascading status transition, no notification on dependency resolution, and no deep cycle detection beyond rejecting self references and direct A/B circular dependencies.
+
+## Data Model
+
+Add a self-referential join model rather than a JSON array on `Task`. A join table keeps referential integrity, makes dependency status joins straightforward, and avoids ad hoc UUID parsing from a text field.
+
+Proposed Prisma shape:
+
+```prisma
+model Task {
+  id                  String           @id @default(uuid()) @db.Uuid
+  // existing fields...
+  dependencies        TaskDependency[] @relation("TaskDependsOn")
+  dependedOnBy        TaskDependency[] @relation("TaskDependedOnBy")
+}
+
+model TaskDependency {
+  taskId       String   @db.Uuid
+  dependsOnId  String   @db.Uuid
+  createdAt    DateTime @default(now())
+
+  task          Task     @relation("TaskDependsOn", fields: [taskId], references: [id], onDelete: Cascade)
+  dependsOn     Task     @relation("TaskDependedOnBy", fields: [dependsOnId], references: [id], onDelete: Cascade)
+
+  @@id([taskId, dependsOnId])
+  @@index([dependsOnId])
+}
+```
+
+Run a Prisma migration under `services/tasks-api/prisma/migrations/`. No data backfill is required because existing tasks start with no dependencies.
+
+## API Contract
+
+Extend task response mapping with:
+
+```json
+{
+  "dependsOn": [
+    {
+      "id": "uuid",
+      "title": "Dependency title",
+      "status": "doing",
+      "completedAt": null
+    }
+  ],
+  "dependsOnIds": ["uuid"],
+  "dependencyBlocked": true
+}
+```
+
+`dependsOnIds` gives automation a compact stable field. `dependsOn` gives humans and clients enough detail to explain why a task is blocked without a second round trip. `dependencyBlocked` is derived in the service layer on read from included dependency task statuses, not materialized in the database. That keeps completion of a dependency immediately reflected on the next read and avoids write-time synchronization.
+
+For `GET /tasks`, include dependency records with only the fields needed to compute and display dependency state. Keep comments out of list responses as they are today. For `GET /tasks/:id`, include dependency details alongside existing tags and comments.
+
+For `PATCH /tasks/:id`, accept a full replacement field:
+
+```json
+{
+  "dependsOnIds": ["uuid-a", "uuid-b"]
+}
+```
+
+Full replacement matches current `tags` behavior and makes add/remove idempotent for agents. Omitted `dependsOnIds` means no dependency change. An empty array clears dependencies.
+
+Validation rules:
+
+- `dependsOnIds` must be an array of UUID strings.
+- Unknown dependency task IDs return `400` with a clear code such as `DEPENDENCY_TASK_NOT_FOUND`.
+- Self reference returns `400 SELF_DEPENDENCY_NOT_ALLOWED`.
+- Direct circular reference returns `400 CIRCULAR_DEPENDENCY_NOT_ALLOWED` when task A would depend on B while B already depends on A.
+- Duplicate IDs are normalized away before writes.
+- Archived dependency tasks are rejected for new dependency writes unless product approval explicitly allows historical dependencies. This keeps "blocked by completed/unfinished work" tied to active tasks.
+
+Use a Prisma transaction for the dependency update path so deleting old dependency rows and inserting new rows is atomic. Keep general task field updates and dependency replacement in the same request flow, but avoid partial success when dependency validation fails.
+
+## UI Behavior
+
+Although graph editing is out of scope, the existing tasks UI already computes card visual state from `task.blocked`. Update that logic to use `task.blocked || task.dependencyBlocked` so dependent tasks look blocked in current board/backlog views.
+
+Update TypeScript task shapes in `apps/tasks/src/tasksApi.ts` to include:
+
+- `dependsOn?: DependencyReference[]`
+- `dependsOnIds?: Array<string | number>`
+- `dependencyBlocked?: boolean`
+
+Do not add dependency editing controls in this task unless Tom/Quinn explicitly expand scope. The spec only requires dependencies addable/removable through the existing API update endpoint, not through the current UI.
+
+## Tasks API Client
+
+Update `agents/skills/ops/tasks-api/tasks_api_client.py` so `get` and `list` print the new fields unchanged from the API response. Add patch support for dependency replacement, preferably:
+
+```bash
+python3 tasks_api_client.py patch --id <task-id> --depends-on <uuid-a> <uuid-b>
+```
+
+Implementation detail: map `--depends-on` to `dependsOnIds`. Passing no values should not be ambiguous with "clear all"; use an explicit `--clear-dependencies` flag if clearing from the CLI is needed. Programmatic callers can still use raw `api_request` or helper extension if they need exact control.
+
+## [openclaw-needed]
+
+No out-of-repo OpenClaw runtime change is required if the implementation branch updates the versioned `agents/skills/ops/tasks-api/tasks_api_client.py` in this repository. After merge, confirm the runtime copy at `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/tasks_api_client.py` is refreshed from the repository checkout before relying on the new CLI flags in heartbeats.
+
+## Implementation Plan
+
+1. Add the Prisma self-referential dependency model and migration.
+2. Extend route-level include helpers for list/detail reads so dependencies are available to `mapTask`.
+3. Update `mapTask` to return `dependsOn`, `dependsOnIds`, and `dependencyBlocked`.
+4. Add `dependsOnIds` parsing and validation in `PATCH /tasks/:id`.
+5. Implement dependency replacement in a Prisma transaction after validating self references, missing tasks, archived tasks, and direct cycles.
+6. Update frontend task types and card state to treat `dependencyBlocked` as blocked for existing visual state.
+7. Update `tasks_api_client.py` to expose returned dependency fields and support setting dependency IDs through `patch`.
+8. Add focused tests across API mapping, validation, CLI argument payload creation, and existing UI blocked state.
+
+## Test Plan
+
+- `npm test --workspace services/tasks-api`
+  - list response includes `dependencyBlocked: false` and empty dependency arrays when no dependencies exist
+  - detail response includes dependency references and computes `dependencyBlocked: true` when a dependency is `open`, `ready`, `doing`, or `acceptance`
+  - detail/list response computes `dependencyBlocked: false` when all dependencies are `done`
+  - patch can add, replace, and clear dependencies through `dependsOnIds`
+  - patch rejects self dependency
+  - patch rejects direct circular dependency
+  - patch rejects unknown or archived dependency IDs with clear errors
+- `npm test --workspace apps/tasks`
+  - `Task` API typing/normalization keeps dependency fields
+  - card state uses `blocked || dependencyBlocked`
+- `python3 -m pytest agents/skills/ops/tasks-api/tests`
+  - CLI patch args produce `dependsOnIds`
+  - list/get output preserves dependency fields
+- Manual smoke:
+  - create two tasks through API
+  - set task B to depend on task A
+  - confirm task B returns `dependencyBlocked: true`
+  - mark task A `done`
+  - confirm task B returns `dependencyBlocked: false` while `blocked` remains unchanged
+
+## Open Questions and Risks
+
+- Should dependencies on archived tasks be allowed for historical accuracy? This design rejects them for new writes to keep active workflow semantics simple.
+- Should the response field be only `dependsOn`, only `dependsOnIds`, or both? This design returns both because humans and agents have different needs and the payload size is small.
+- The current `GET /tasks` route already has known pagination/sort limitations. Adding dependency includes should not expand that refactor; keep the dependency change focused and leave pagination semantics unchanged.
+- Direct cycle detection is intentionally shallow per spec. A later graph feature may need recursive cycle checks before dependencies become heavily nested.

--- a/services/tasks-api/prisma/migrations/20260627000000_add_task_dependencies/migration.sql
+++ b/services/tasks-api/prisma/migrations/20260627000000_add_task_dependencies/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "TaskDependency" (
+    "taskId" UUID NOT NULL,
+    "dependsOnId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TaskDependency_pkey" PRIMARY KEY ("taskId","dependsOnId")
+);
+
+-- CreateIndex
+CREATE INDEX "TaskDependency_dependsOnId_idx" ON "TaskDependency"("dependsOnId");
+
+-- AddForeignKey
+ALTER TABLE "TaskDependency" ADD CONSTRAINT "TaskDependency_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskDependency" ADD CONSTRAINT "TaskDependency_dependsOnId_fkey" FOREIGN KEY ("dependsOnId") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/services/tasks-api/prisma/schema.prisma
+++ b/services/tasks-api/prisma/schema.prisma
@@ -41,10 +41,24 @@ model Task {
 
   tags            TaskTag[]
   comments        TaskComment[]
+  dependencies    TaskDependency[] @relation("TaskDependsOn")
+  dependedOnBy    TaskDependency[] @relation("TaskDependedOnBy")
 
   @@index([archivedAt, priority])
   @@index([status, statusChangedAt])
   @@index([dueAt])
+}
+
+model TaskDependency {
+  taskId      String   @db.Uuid
+  dependsOnId String   @db.Uuid
+  createdAt   DateTime @default(now())
+
+  task      Task @relation("TaskDependsOn", fields: [taskId], references: [id], onDelete: Cascade)
+  dependsOn Task @relation("TaskDependedOnBy", fields: [dependsOnId], references: [id], onDelete: Cascade)
+
+  @@id([taskId, dependsOnId])
+  @@index([dependsOnId])
 }
 
 model TaskComment {

--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -9,6 +9,22 @@ const validStatuses = new Set(['open', 'ready', 'doing', 'acceptance', 'done']);
 const validPriorities = new Set(['low', 'medium', 'high', 'urgent']);
 const validAssignees = new Set(['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy']);
 const validSorts = new Set(['priority', 'createdAt', 'updatedAt', 'dueAt', 'statusChangedAt']);
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const dependencyInclude = {
+  dependencies: {
+    include: {
+      dependsOn: {
+        select: {
+          id: true,
+          title: true,
+          status: true,
+          completedAt: true
+        }
+      }
+    }
+  }
+};
 
 const priorityOrder = {
   urgent: 0,
@@ -62,6 +78,16 @@ function mapComment(comment) {
 }
 
 function mapTask(task) {
+  const dependsOn = task.dependencies
+    ?.map((dependency) => dependency.dependsOn)
+    .filter(Boolean)
+    .map((dependency) => ({
+      id: dependency.id,
+      title: dependency.title,
+      status: dependency.status,
+      completedAt: dependency.completedAt
+    })) ?? [];
+
   return {
     id: task.id,
     title: task.title,
@@ -78,7 +104,10 @@ function mapTask(task) {
     updatedAt: task.updatedAt,
     taskType: task.taskType ?? null,
     tags: task.tags?.map((taskTag) => taskTag.tag?.name).filter(Boolean) ?? [],
-    comments: task.comments?.map(mapComment) ?? []
+    comments: task.comments?.map(mapComment) ?? [],
+    dependsOn,
+    dependsOnIds: dependsOn.map((dependency) => dependency.id),
+    dependencyBlocked: dependsOn.some((dependency) => dependency.status !== 'done')
   };
 }
 
@@ -100,6 +129,22 @@ function normalizeTags(tags) {
   return [...new Set(normalized)];
 }
 
+function normalizeDependsOnIds(value) {
+  if (!Array.isArray(value)) return null;
+  const normalized = [];
+  const seen = new Set();
+
+  for (const id of value) {
+    if (typeof id !== 'string' || !uuidPattern.test(id)) return null;
+    if (!seen.has(id)) {
+      seen.add(id);
+      normalized.push(id);
+    }
+  }
+
+  return normalized;
+}
+
 async function connectTags(tagNames) {
   if (!tagNames?.length) return [];
 
@@ -112,6 +157,46 @@ async function connectTags(tagNames) {
       })
     )
   );
+}
+
+async function validateDependsOnIds(res, taskId, dependsOnIds) {
+  if (dependsOnIds.includes(taskId)) {
+    badRequest(res, 'SELF_DEPENDENCY_NOT_ALLOWED', 'Task cannot depend on itself');
+    return false;
+  }
+
+  if (dependsOnIds.length === 0) return true;
+
+  const dependencyTasks = await prisma.task.findMany({
+    where: { id: { in: dependsOnIds } },
+    select: { id: true, archivedAt: true }
+  });
+  const foundIds = new Set(dependencyTasks.map((task) => task.id));
+  const missingId = dependsOnIds.find((id) => !foundIds.has(id));
+  if (missingId) {
+    badRequest(res, 'DEPENDENCY_TASK_NOT_FOUND', `Dependency task not found: ${missingId}`);
+    return false;
+  }
+
+  const archivedTask = dependencyTasks.find((task) => task.archivedAt);
+  if (archivedTask) {
+    badRequest(res, 'ARCHIVED_DEPENDENCY_NOT_ALLOWED', `Dependency task is archived: ${archivedTask.id}`);
+    return false;
+  }
+
+  const directCycle = await prisma.taskDependency.findFirst({
+    where: {
+      taskId: { in: dependsOnIds },
+      dependsOnId: taskId
+    },
+    select: { taskId: true }
+  });
+  if (directCycle) {
+    badRequest(res, 'CIRCULAR_DEPENDENCY_NOT_ALLOWED', 'Direct circular dependencies are not allowed');
+    return false;
+  }
+
+  return true;
 }
 
 export const tasksRouter = Router();
@@ -239,7 +324,8 @@ tasksRouter.get('/tasks', async (req, res, next) => {
           include: {
             tag: true
           }
-        }
+        },
+        ...dependencyInclude
       },
       take: limit + 1
     });
@@ -301,7 +387,8 @@ tasksRouter.get('/tasks/:id', async (req, res, next) => {
         },
         comments: {
           orderBy: [{ createdAt: 'asc' }, { id: 'asc' }]
-        }
+        },
+        ...dependencyInclude
       }
     });
 
@@ -364,7 +451,8 @@ tasksRouter.post('/tasks', async (req, res, next) => {
           include: {
             tag: true
           }
-        }
+        },
+        ...dependencyInclude
       }
     });
 
@@ -381,6 +469,8 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
     if (!existing) return notFound(res, 'TASK_NOT_FOUND', 'Task not found');
 
     const updates = {};
+    const hasDependencyUpdate = req.body?.dependsOnIds !== undefined;
+    const dependsOnIds = hasDependencyUpdate ? normalizeDependsOnIds(req.body.dependsOnIds) : undefined;
     const title = normalizeString(req.body?.title);
     const description = req.body?.description === undefined ? undefined : normalizeString(req.body.description);
     const assignee = req.body?.assignee === undefined ? undefined : normalizeString(req.body.assignee);
@@ -388,6 +478,10 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
     if (req.body?.title !== undefined) {
       if (!title) return badRequest(res, 'TITLE_EMPTY', 'title cannot be empty');
       updates.title = title;
+    }
+
+    if (hasDependencyUpdate && !dependsOnIds) {
+      return badRequest(res, 'INVALID_DEPENDS_ON_IDS', 'dependsOnIds must be an array of UUID strings');
     }
 
     if (description !== undefined) updates.description = description || null;
@@ -436,37 +530,55 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
       updates.taskType = req.body.taskType || null;
     }
 
-    const updated = await prisma.task.update({
-      where: { id },
-      data: updates,
-      include: {
-        tags: {
-          include: {
-            tag: true
-          }
-        }
-      }
-    });
+    if (hasDependencyUpdate) {
+      const validDependencies = await validateDependsOnIds(res, id, dependsOnIds);
+      if (!validDependencies) return;
+    }
 
+    const hasTagUpdate = req.body?.tags !== undefined;
+    let tagRecords = null;
     if (req.body?.tags !== undefined) {
       const tags = normalizeTags(req.body.tags);
       if (!tags) return badRequest(res, 'INVALID_TAGS', 'tags must be an array of strings');
-      const tagRecords = await connectTags(tags);
-      await prisma.taskTag.deleteMany({ where: { taskId: id } });
-      if (tagRecords.length > 0) {
-        await prisma.taskTag.createMany({
-          data: tagRecords.map((tag) => ({ taskId: id, tagId: tag.id })),
-          skipDuplicates: true
-        });
-      }
+      tagRecords = await connectTags(tags);
     }
 
-    const task = await prisma.task.findFirst({
-      where: { id },
-      include: { tags: { include: { tag: true } } }
+    const task = await prisma.$transaction(async (tx) => {
+      await tx.task.update({
+        where: { id },
+        data: updates
+      });
+
+      if (hasTagUpdate) {
+        await tx.taskTag.deleteMany({ where: { taskId: id } });
+        if (tagRecords.length > 0) {
+          await tx.taskTag.createMany({
+            data: tagRecords.map((tag) => ({ taskId: id, tagId: tag.id })),
+            skipDuplicates: true
+          });
+        }
+      }
+
+      if (hasDependencyUpdate) {
+        await tx.taskDependency.deleteMany({ where: { taskId: id } });
+        if (dependsOnIds.length > 0) {
+          await tx.taskDependency.createMany({
+            data: dependsOnIds.map((dependsOnId) => ({ taskId: id, dependsOnId })),
+            skipDuplicates: true
+          });
+        }
+      }
+
+      return tx.task.findFirst({
+        where: { id },
+        include: {
+          tags: { include: { tag: true } },
+          ...dependencyInclude
+        }
+      });
     });
 
-    return res.status(200).json({ data: mapTask(task ?? updated) });
+    return res.status(200).json({ data: mapTask(task) });
   } catch (error) {
     return next(error);
   }

--- a/services/tasks-api/test/read-endpoints.test.ts
+++ b/services/tasks-api/test/read-endpoints.test.ts
@@ -8,6 +8,11 @@ const prismaMock = {
     create: vi.fn(),
     update: vi.fn()
   },
+  taskDependency: {
+    findFirst: vi.fn(),
+    deleteMany: vi.fn(),
+    createMany: vi.fn()
+  },
   taskComment: {
     create: vi.fn()
   },
@@ -18,7 +23,8 @@ const prismaMock = {
   tag: {
     findMany: vi.fn(),
     upsert: vi.fn()
-  }
+  },
+  $transaction: vi.fn()
 };
 
 vi.mock('../src/lib/prisma.ts', () => ({
@@ -43,6 +49,7 @@ function task(overrides = {}) {
     createdAt: new Date('2026-03-01T00:00:00.000Z'),
     updatedAt: new Date('2026-03-01T00:00:00.000Z'),
     tags: [],
+    dependencies: [],
     ...overrides
   };
 }
@@ -50,6 +57,7 @@ function task(overrides = {}) {
 describe('tasks api endpoints', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (callback) => callback(prismaMock));
   });
 
   it('GET /api/v1/tasks returns paginated task list', async () => {
@@ -65,12 +73,51 @@ describe('tasks api endpoints', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.data).toHaveLength(2);
+    expect(response.body.data[0]).toMatchObject({
+      dependsOn: [],
+      dependsOnIds: [],
+      dependencyBlocked: false
+    });
     expect(response.body.page).toEqual({
       limit: 2,
       nextCursor: null,
       hasNextPage: false
     });
     expect(prismaMock.task.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('GET /api/v1/tasks maps dependency references and blocked state', async () => {
+    prismaMock.task.findMany.mockResolvedValue([
+      task({
+        id: '11111111-1111-1111-1111-111111111111',
+        dependencies: [
+          {
+            dependsOn: {
+              id: '22222222-2222-2222-2222-222222222222',
+              title: 'Dependency',
+              status: 'doing',
+              completedAt: null
+            }
+          }
+        ]
+      })
+    ]);
+
+    const app = createApp();
+    const response = await request(app).get('/api/v1/tasks');
+
+    expect(response.status).toBe(200);
+    expect(response.body.data[0].dependsOn).toEqual([
+      {
+        id: '22222222-2222-2222-2222-222222222222',
+        title: 'Dependency',
+        status: 'doing',
+        completedAt: null
+      }
+    ]);
+    expect(response.body.data[0].dependsOnIds).toEqual(['22222222-2222-2222-2222-222222222222']);
+    expect(response.body.data[0].dependencyBlocked).toBe(true);
+    expect(prismaMock.task.findMany.mock.calls[0][0].include.dependencies).toBeDefined();
   });
 
   it('GET /api/v1/tasks includes archived tasks when requested', async () => {
@@ -107,6 +154,16 @@ describe('tasks api endpoints', () => {
         id: '22222222-2222-2222-2222-222222222222',
         title: 'Task detail',
         tags: [{ tag: { name: 'backend' } }],
+        dependencies: [
+          {
+            dependsOn: {
+              id: '33333333-3333-3333-3333-333333333333',
+              title: 'Done dependency',
+              status: 'done',
+              completedAt: new Date('2026-03-10T00:00:00.000Z')
+            }
+          }
+        ],
         comments: [
           {
             id: 'comment-1',
@@ -132,6 +189,8 @@ describe('tasks api endpoints', () => {
     expect(response.status).toBe(200);
     expect(response.body.data.id).toBe('22222222-2222-2222-2222-222222222222');
     expect(response.body.data.tags).toEqual(['backend']);
+    expect(response.body.data.dependsOnIds).toEqual(['33333333-3333-3333-3333-333333333333']);
+    expect(response.body.data.dependencyBlocked).toBe(false);
     expect(response.body.data.comments).toEqual([
       {
         id: 'comment-1',
@@ -249,6 +308,135 @@ describe('tasks api endpoints', () => {
     expect(response.body.data.title).toBe('Updated title');
     expect(response.body.data.status).toBe('doing');
     expect(prismaMock.task.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('PATCH /api/v1/tasks/:id replaces dependencies', async () => {
+    const dependencyId = '22222222-2222-2222-2222-222222222222';
+    prismaMock.task.findFirst
+      .mockResolvedValueOnce(task())
+      .mockResolvedValueOnce(task({
+        dependencies: [
+          {
+            dependsOn: {
+              id: dependencyId,
+              title: 'Dependency',
+              status: 'ready',
+              completedAt: null
+            }
+          }
+        ]
+      }));
+    prismaMock.task.findMany.mockResolvedValue([{ id: dependencyId, archivedAt: null }]);
+    prismaMock.taskDependency.findFirst.mockResolvedValue(null);
+    prismaMock.task.update.mockResolvedValue(task());
+
+    const app = createApp();
+    const response = await request(app)
+      .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
+      .send({ dependsOnIds: [dependencyId, dependencyId] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.dependsOnIds).toEqual([dependencyId]);
+    expect(response.body.data.dependencyBlocked).toBe(true);
+    expect(prismaMock.taskDependency.deleteMany).toHaveBeenCalledWith({
+      where: { taskId: '11111111-1111-1111-1111-111111111111' }
+    });
+    expect(prismaMock.taskDependency.createMany).toHaveBeenCalledWith({
+      data: [{ taskId: '11111111-1111-1111-1111-111111111111', dependsOnId: dependencyId }],
+      skipDuplicates: true
+    });
+  });
+
+  it('PATCH /api/v1/tasks/:id clears dependencies', async () => {
+    prismaMock.task.findFirst
+      .mockResolvedValueOnce(task())
+      .mockResolvedValueOnce(task());
+    prismaMock.task.update.mockResolvedValue(task());
+
+    const app = createApp();
+    const response = await request(app)
+      .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
+      .send({ dependsOnIds: [] });
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.taskDependency.deleteMany).toHaveBeenCalledWith({
+      where: { taskId: '11111111-1111-1111-1111-111111111111' }
+    });
+    expect(prismaMock.taskDependency.createMany).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /api/v1/tasks/:id rejects invalid dependency payloads', async () => {
+    prismaMock.task.findFirst.mockResolvedValue(task());
+
+    const app = createApp();
+    const response = await request(app)
+      .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
+      .send({ dependsOnIds: ['not-a-uuid'] });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: { code: 'INVALID_DEPENDS_ON_IDS', message: 'dependsOnIds must be an array of UUID strings' }
+    });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /api/v1/tasks/:id rejects self dependencies', async () => {
+    prismaMock.task.findFirst.mockResolvedValue(task());
+
+    const app = createApp();
+    const response = await request(app)
+      .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
+      .send({ dependsOnIds: ['11111111-1111-1111-1111-111111111111'] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('SELF_DEPENDENCY_NOT_ALLOWED');
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /api/v1/tasks/:id rejects unknown dependencies', async () => {
+    const dependencyId = '22222222-2222-2222-2222-222222222222';
+    prismaMock.task.findFirst.mockResolvedValue(task());
+    prismaMock.task.findMany.mockResolvedValue([]);
+
+    const app = createApp();
+    const response = await request(app)
+      .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
+      .send({ dependsOnIds: [dependencyId] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('DEPENDENCY_TASK_NOT_FOUND');
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /api/v1/tasks/:id rejects archived dependencies', async () => {
+    const dependencyId = '22222222-2222-2222-2222-222222222222';
+    prismaMock.task.findFirst.mockResolvedValue(task());
+    prismaMock.task.findMany.mockResolvedValue([{ id: dependencyId, archivedAt: new Date('2026-03-01T00:00:00.000Z') }]);
+
+    const app = createApp();
+    const response = await request(app)
+      .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
+      .send({ dependsOnIds: [dependencyId] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('ARCHIVED_DEPENDENCY_NOT_ALLOWED');
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /api/v1/tasks/:id rejects direct circular dependencies', async () => {
+    const dependencyId = '22222222-2222-2222-2222-222222222222';
+    prismaMock.task.findFirst.mockResolvedValue(task());
+    prismaMock.task.findMany.mockResolvedValue([{ id: dependencyId, archivedAt: null }]);
+    prismaMock.taskDependency.findFirst.mockResolvedValue({ taskId: dependencyId });
+
+    const app = createApp();
+    const response = await request(app)
+      .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
+      .send({ dependsOnIds: [dependencyId] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('CIRCULAR_DEPENDENCY_NOT_ALLOWED');
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
   });
 
   it('DELETE /api/v1/tasks/:id archives task', async () => {


### PR DESCRIPTION
## Summary
- Add first-class task dependency storage with a Prisma join table and migration.
- Expose `dependsOn`, `dependsOnIds`, and computed `dependencyBlocked` on task list/detail/update responses.
- Support dependency replacement through `PATCH /tasks/:id` with validation for invalid IDs, missing/archived tasks, self references, and direct circular dependencies.
- Treat `blocked || dependencyBlocked` as blocked in the tasks UI and expose dependency patch flags in `tasks_api_client.py`.

## Tests
- `DATABASE_URL=postgresql://user:pass@localhost:5432/tasks npm --workspace services/tasks-api run prisma:validate`
- `npm --workspace services/tasks-api test`
- `npm --workspace apps/tasks test`
- `python3 -m pytest agents/skills/ops/tasks-api/tests`
- `git diff --check`

## Acceptance Criteria
- [x] AC1: A task can store references to one or more other tasks it depends on (first-class data, not a description convention)
- [x] AC2: API exposes computed dependencyBlocked property — true when any dependency is not yet done; blocked field is unchanged
- [x] AC3: A task is visibly blocked when blocked: true OR dependencyBlocked: true
- [x] AC4: Dependency references readable via existing task detail endpoint
- [x] AC5: Dependencies addable/removable via existing task update endpoint
- [x] AC6: Self-references and direct circular dependencies rejected with clear error
- [x] AC7: tasks_api_client.py exposes dependency references and dependencyBlocked in list/get output