### PR TITLE
chore(code-garden): use PRIORITIES constant in TaskCardSummary

### DIFF
--- a/apps/tasks/src/components/TaskCardSummary.jsx
+++ b/apps/tasks/src/components/TaskCardSummary.jsx
@@ -1,8 +1,9 @@
 import { Avatar, Badge } from '@sindustries/ui/react';
 import { assigneeInitial } from '../utils/helpers.js';
+import { PRIORITIES } from '../utils/constants.js';
 
 function priorityVariant(priority) {
-  return ['urgent', 'high', 'medium', 'low'].includes(priority) ? priority : 'neutral';
+  return PRIORITIES.includes(priority) ? priority : 'neutral';
 }
 
 function taskCardDate(task) {

--- a/docs/repo-audits/2026-W25.md
+++ b/docs/repo-audits/2026-W25.md
@@ -125,7 +125,7 @@ All five findings logged 2026-06-17 in the prior `docs/repo-audits/2026-W25.md` 
 - **F2 (Low)** — Initial theme defaults to `'dark'` in `DesignSystemPage.jsx:19`; should derive from `SPECIMEN_PAGES[0]?.theme`.
 - **F3 (Low)** — Redundant `[data-si-theme='light']` block at `apps/tasks/src/styles/variables.css:10-17`; same expression as the dark block.
 - **F4 (Medium)** — Alias drift: `apps/tasks/vitest.config.js:11` is a subset of `apps/tasks/vite.config.js:21-27` (missing the `specimen` aliases). Silent vitest failure waiting for the first specimen test.
-- **F5 (Low)** — `priorityVariant` in `apps/tasks/src/components/TaskCardSummary.jsx:5` hardcodes `['urgent','high','medium','low']` instead of importing `PRIORITIES`. Same root cause as C1.
+- **F5 (Low)** — `priorityVariant` in `apps/tasks/src/components/TaskCardSummary.jsx:5` hardcodes `['urgent','high','medium','low']` instead of importing `PRIORITIES`. Same root cause as C1. ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 
 ### Strengths (what this repo does well)
 

--- a/docs/repo-audits/2026-W25.md
+++ b/docs/repo-audits/2026-W25.md
@@ -125,7 +125,7 @@ All five findings logged 2026-06-17 in the prior `docs/repo-audits/2026-W25.md` 
 - **F2 (Low)** — Initial theme defaults to `'dark'` in `DesignSystemPage.jsx:19`; should derive from `SPECIMEN_PAGES[0]?.theme`.
 - **F3 (Low)** — Redundant `[data-si-theme='light']` block at `apps/tasks/src/styles/variables.css:10-17`; same expression as the dark block.
 - **F4 (Medium)** — Alias drift: `apps/tasks/vitest.config.js:11` is a subset of `apps/tasks/vite.config.js:21-27` (missing the `specimen` aliases). Silent vitest failure waiting for the first specimen test.
-- **F5 (Low)** — `priorityVariant` in `apps/tasks/src/components/TaskCardSummary.jsx:5` hardcodes `['urgent','high','medium','low']` instead of importing `PRIORITIES`. Same root cause as C1. ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+- **F5 (Low)** — `priorityVariant` in `apps/tasks/src/components/TaskCardSummary.jsx:5` hardcodes `['urgent','high','medium','low']` instead of importing `PRIORITIES`. Same root cause as C1. ✅ [PR #124](https://github.com/Stoffer-Industries/sindustries/pull/124)
 
 ### Strengths (what this repo does well)
 


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W25.md (carried into Theme 5 of 2026-W26)
- **Finding:** F5 (Low) — `priorityVariant` in `apps/tasks/src/components/TaskCardSummary.jsx:5` hardcoded `['urgent','high','medium','low']` instead of importing `PRIORITIES`. Same root cause as W25 C1 (priority constants drift).
- Replace inline array with the existing `PRIORITIES` constant from `apps/tasks/src/utils/constants.js`. All other priority consumers (`App.jsx`, `TaskEditor.jsx`) already use this constant.

## Test plan
- [ ] Relevant tests pass (`npm test --workspace apps/tasks` — 105/105 ✅)
- [ ] No logic changes — diff is purely structural (1-line array swap)

🌱 Code garden — non-functional cleanup only