### PR TITLE
chore(code-garden): derive specimen kit/vars, consolidate CSS, sync vitest aliases

### DIFF
--- a/apps/tasks/src/styles/variables.css
+++ b/apps/tasks/src/styles/variables.css
@@ -1,12 +1,5 @@
 :root,
-[data-si-theme='dark'] {
-  --si-canvas-gradient: linear-gradient(
-    180deg,
-    var(--si-color-bg-section) 0%,
-    var(--si-color-bg-canvas) 100%
-  );
-}
-
+[data-si-theme='dark'],
 [data-si-theme='light'] {
   --si-canvas-gradient: linear-gradient(
     180deg,

--- a/apps/tasks/vitest.config.js
+++ b/apps/tasks/vitest.config.js
@@ -7,7 +7,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@sindustries/ui/react/styles.css': fileURLToPath(new URL('../../packages/ui/src/react/styles.css', import.meta.url)),
-      '@sindustries/ui/react': fileURLToPath(new URL('../../packages/ui/src/react/index.jsx', import.meta.url))
+      '@sindustries/ui/react': fileURLToPath(new URL('../../packages/ui/src/react/index.jsx', import.meta.url)),
+      '@sindustries/ui/specimen/styles.css': fileURLToPath(new URL('../../packages/ui/src/specimen/styles.css', import.meta.url)),
+      '@sindustries/ui/specimen': fileURLToPath(new URL('../../packages/ui/src/specimen/index.jsx', import.meta.url))
     }
   },
   test: {

--- a/docs/repo-audits/2026-W25.md
+++ b/docs/repo-audits/2026-W25.md
@@ -121,10 +121,10 @@ Findings are evidence-based. Each is flagged **Fact** (verifiable from the code 
 
 All five findings logged 2026-06-17 in the prior `docs/repo-audits/2026-W25.md` are still present in `HEAD` and re-tracked here so they don’t fall off the list when this audit replaces that file:
 
-- **F1 (Low)** — `KIT_TABS` hardcoded in `packages/ui/src/specimen/DesignSystemPage.jsx:7-11`; should derive from `SPECIMEN_PAGES`. ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
-- **F2 (Low)** — Initial theme defaults to `'dark'` in `DesignSystemPage.jsx:19`; should derive from `SPECIMEN_PAGES[0]?.theme`. ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
-- **F3 (Low)** — Redundant `[data-si-theme='light']` block at `apps/tasks/src/styles/variables.css:10-17`; same expression as the dark block. ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
-- **F4 (Medium)** — Alias drift: `apps/tasks/vitest.config.js:11` is a subset of `apps/tasks/vite.config.js:21-27` (missing the `specimen` aliases). Silent vitest failure waiting for the first specimen test. ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+- **F1 (Low)** — `KIT_TABS` hardcoded in `packages/ui/src/specimen/DesignSystemPage.jsx:7-11`; should derive from `SPECIMEN_PAGES`. ✅ [PR #125](https://github.com/Stoffer-Industries/sindustries/pull/125)
+- **F2 (Low)** — Initial theme defaults to `'dark'` in `DesignSystemPage.jsx:19`; should derive from `SPECIMEN_PAGES[0]?.theme`. ✅ [PR #125](https://github.com/Stoffer-Industries/sindustries/pull/125)
+- **F3 (Low)** — Redundant `[data-si-theme='light']` block at `apps/tasks/src/styles/variables.css:10-17`; same expression as the dark block. ✅ [PR #125](https://github.com/Stoffer-Industries/sindustries/pull/125)
+- **F4 (Medium)** — Alias drift: `apps/tasks/vitest.config.js:11` is a subset of `apps/tasks/vite.config.js:21-27` (missing the `specimen` aliases). Silent vitest failure waiting for the first specimen test. ✅ [PR #125](https://github.com/Stoffer-Industries/sindustries/pull/125)
 - **F5 (Low)** — `priorityVariant` in `apps/tasks/src/components/TaskCardSummary.jsx:5` hardcodes `['urgent','high','medium','low']` instead of importing `PRIORITIES`. Same root cause as C1. ✅ [PR #124](https://github.com/Stoffer-Industries/sindustries/pull/124)
 
 ### Strengths (what this repo does well)

--- a/docs/repo-audits/2026-W25.md
+++ b/docs/repo-audits/2026-W25.md
@@ -121,10 +121,10 @@ Findings are evidence-based. Each is flagged **Fact** (verifiable from the code 
 
 All five findings logged 2026-06-17 in the prior `docs/repo-audits/2026-W25.md` are still present in `HEAD` and re-tracked here so they don’t fall off the list when this audit replaces that file:
 
-- **F1 (Low)** — `KIT_TABS` hardcoded in `packages/ui/src/specimen/DesignSystemPage.jsx:7-11`; should derive from `SPECIMEN_PAGES`. *(Verified unchanged.)*
-- **F2 (Low)** — Initial theme defaults to `'dark'` in `DesignSystemPage.jsx:19`; should derive from `SPECIMEN_PAGES[0]?.theme`.
-- **F3 (Low)** — Redundant `[data-si-theme='light']` block at `apps/tasks/src/styles/variables.css:10-17`; same expression as the dark block.
-- **F4 (Medium)** — Alias drift: `apps/tasks/vitest.config.js:11` is a subset of `apps/tasks/vite.config.js:21-27` (missing the `specimen` aliases). Silent vitest failure waiting for the first specimen test.
+- **F1 (Low)** — `KIT_TABS` hardcoded in `packages/ui/src/specimen/DesignSystemPage.jsx:7-11`; should derive from `SPECIMEN_PAGES`. ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+- **F2 (Low)** — Initial theme defaults to `'dark'` in `DesignSystemPage.jsx:19`; should derive from `SPECIMEN_PAGES[0]?.theme`. ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+- **F3 (Low)** — Redundant `[data-si-theme='light']` block at `apps/tasks/src/styles/variables.css:10-17`; same expression as the dark block. ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+- **F4 (Medium)** — Alias drift: `apps/tasks/vitest.config.js:11` is a subset of `apps/tasks/vite.config.js:21-27` (missing the `specimen` aliases). Silent vitest failure waiting for the first specimen test. ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 - **F5 (Low)** — `priorityVariant` in `apps/tasks/src/components/TaskCardSummary.jsx:5` hardcodes `['urgent','high','medium','low']` instead of importing `PRIORITIES`. Same root cause as C1. ✅ [PR #124](https://github.com/Stoffer-Industries/sindustries/pull/124)
 
 ### Strengths (what this repo does well)

--- a/packages/ui/src/specimen/DesignSystemPage.jsx
+++ b/packages/ui/src/specimen/DesignSystemPage.jsx
@@ -4,11 +4,19 @@ import { SPECIMEN_PAGES } from './generated/pages.js';
 import { SpecimenSection } from './SpecimenSections.jsx';
 import './styles.css';
 
-const KIT_TABS = [
-  { id: 'tokens', label: 'Tokens' },
-  { id: 'pulse-react', label: 'Pulse' },
-  { id: 'brand-react', label: 'Brand' }
-];
+// Kit tabs are derived from SPECIMEN_PAGES so adding a page only requires
+// editing the generated manifest. The tabLabel mapping preserves the
+// short labels the existing tests assert against.
+const KIT_TAB_LABELS = {
+  tokens: 'Tokens',
+  'pulse-react': 'Pulse',
+  'brand-react': 'Brand'
+};
+
+const KIT_TABS = SPECIMEN_PAGES.map((page) => ({
+  id: page.id,
+  label: KIT_TAB_LABELS[page.id] ?? page.id
+}));
 
 function shellPackForPage(page) {
   return page?.pack ?? 'pulse';
@@ -16,7 +24,7 @@ function shellPackForPage(page) {
 
 export function DesignSystemPage({ backHref = '/', backLabel = '← Back' }) {
   const [activePageId, setActivePageId] = useState(SPECIMEN_PAGES[0]?.id ?? 'tokens');
-  const [theme, setTheme] = useState('dark');
+  const [theme, setTheme] = useState(SPECIMEN_PAGES[0]?.theme ?? 'dark');
   const activePage = SPECIMEN_PAGES.find((page) => page.id === activePageId) ?? SPECIMEN_PAGES[0];
   const nextTheme = theme === 'dark' ? 'light' : 'dark';
 


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W25.md (carried-over F1–F4)
- **Findings:**
  - **F1 (Low)** `KIT_TABS` now derived from `SPECIMEN_PAGES` with a short-label mapping that preserves today's `Tokens` / `Pulse` / `Brand` labels.
  - **F2 (Low)** Initial `theme` state now derives from `SPECIMEN_PAGES[0]?.theme ?? 'dark'`. No change for today's `tokens` page (no theme field); future pages with a `theme` property will be honored automatically.
  - **F3 (Low)** Consolidated the duplicate `[data-si-theme='light']` block in `apps/tasks/src/styles/variables.css` into the existing `:root, [data-si-theme='dark']` selector. The light-theme gradient value was identical to the dark-theme value, so the merged block produces the same rendered CSS.
  - **F4 (Medium)** Added the missing `@sindustries/ui/specimen` and `@sindustries/ui/specimen/styles.css` aliases to `apps/tasks/vitest.config.js` so it matches `apps/tasks/vite.config.js`. No behavior change for current tests (none import the specimen entrypoints today); future specimen tests will resolve consistently between vite and vitest.

No logic changes — diff is purely structural. Adding a new specimen page now requires editing only `SPECIMEN_PAGES`, not `DesignSystemPage.jsx`.

## Test plan
- [x] `@sindustries/ui` workspace: 10/10 tests pass (incl. `DesignSystemPage.test.jsx`).
- [x] `@sindustries/tasks-app` workspace: 111/111 tests pass.
- [x] Visual: F3 consolidation produces equivalent CSS — both themes get the same `--si-canvas-gradient` value.
- [x] `git diff origin/main HEAD --name-only` lists only application source (`packages/ui/`, `apps/tasks/`); no `agents/skills/`, `agents/crons/`, or workspace-context file leakage.

🌱 Code garden — non-functional cleanup only