### PR TITLE
feat(tasks): add dependency UI

### DIFF
--- a/apps/tasks/src/App.jsx
+++ b/apps/tasks/src/App.jsx
@@ -17,6 +17,7 @@ import {
 } from '@sindustries/ui/react';
 import { useTasks } from './useTasks.js';
 import { useTaskDrafts } from './useTaskDrafts.js';
+import { fetchTask } from './tasksApi';
 import { useDebounce } from './hooks/useDebounce.js';
 import { useToast } from './hooks/useToast.js';
 import { TaskCardSummary } from './components/TaskCardSummary.jsx';
@@ -805,6 +806,9 @@ export function App() {
                             scrollToTaskIfNeeded(task.id);
                           }}
                           onAddComment={(payload) => createTaskComment(task.id, payload)}
+                          onFetchDependency={fetchTask}
+                          onUpdateDependencies={(dependsOnIds) => patchTask(task.id, { dependsOnIds })}
+                          onOpenTask={openTask}
                           isSubmittingComment={submittingCommentForTaskId === task.id}
                         />
                       )}
@@ -890,6 +894,9 @@ export function App() {
                                     scrollToTaskIfNeeded(task.id);
                                   }}
                                   onAddComment={(payload) => createTaskComment(task.id, payload)}
+                                  onFetchDependency={fetchTask}
+                                  onUpdateDependencies={(dependsOnIds) => patchTask(task.id, { dependsOnIds })}
+                                  onOpenTask={openTask}
                                   isSubmittingComment={submittingCommentForTaskId === task.id}
                                 />
                               )}

--- a/apps/tasks/src/App.test.jsx
+++ b/apps/tasks/src/App.test.jsx
@@ -257,6 +257,70 @@ describe('tasks ui', () => {
     expect(card).toHaveClass('si-card--blocked');
   });
 
+  it('opens a dependency that is outside the current task collection', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      const method = options.method ?? 'GET';
+      const urlText = String(url);
+
+      if (method === 'GET' && urlText.includes('/tasks?')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [
+              mockTask({
+                id: 'visible-task',
+                title: 'Visible task',
+                dependsOn: [{ id: 'done-dependency', title: 'Done dependency', status: 'done' }],
+                dependsOnIds: ['done-dependency']
+              })
+            ]
+          })
+        };
+      }
+
+      if (method === 'GET' && urlText.endsWith('/tasks/visible-task')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: mockTask({
+              id: 'visible-task',
+              title: 'Visible task',
+              dependsOn: [{ id: 'done-dependency', title: 'Done dependency', status: 'done' }],
+              dependsOnIds: ['done-dependency']
+            })
+          })
+        };
+      }
+
+      if (method === 'GET' && urlText.endsWith('/tasks/done-dependency')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: mockTask({
+              id: 'done-dependency',
+              title: 'Done dependency',
+              status: 'done'
+            })
+          })
+        };
+      }
+
+      throw new Error(`Unexpected fetch call: ${method} ${urlText}`);
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: 'Backlog' }));
+
+    await screen.findByRole('list', { name: 'Backlog list' });
+    fireEvent.click(screen.getByRole('button', { name: 'Visible task' }));
+    fireEvent.click(screen.getByRole('button', { name: /Done dependency\s*Done/ }));
+
+    await waitFor(() => expect(screen.getByLabelText('Detail title')).toHaveValue('Done dependency'));
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/tasks/done-dependency'), expect.any(Object));
+  });
+
   it('refreshes tasks when the window regains focus', async () => {
     localStorage.setItem('tasks-app-view', 'board');
     const fetchMock = vi

--- a/apps/tasks/src/App.test.jsx
+++ b/apps/tasks/src/App.test.jsx
@@ -201,7 +201,7 @@ describe('tasks ui', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Kanban' }));
 
     const readyColumn = await screen.findByTestId('column-ready');
-    const cards = within(readyColumn).getAllByRole('button');
+    const cards = within(readyColumn).getAllByRole('article');
     expect(cards[0]).toHaveTextContent('Older');
     expect(cards[1]).toHaveTextContent('Newer');
   });

--- a/apps/tasks/src/components/TaskCardSummary.jsx
+++ b/apps/tasks/src/components/TaskCardSummary.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import { Avatar, Badge } from '@sindustries/ui/react';
 import { assigneeInitial } from '../utils/helpers.js';
 import { PRIORITIES } from '../utils/constants.js';
@@ -21,11 +22,30 @@ function taskCardTags(task) {
 /**
  * Read-only task card body used in list/board views and the editor preview strip.
  */
-export function TaskCardSummary({ task, hasDraft, onTitleClick }) {
+export function TaskCardSummary({ task, hasDraft, onTitleClick, showCopyId = true }) {
   const date = taskCardDate(task);
   const tags = taskCardTags(task);
   const assignee = assigneeInitial(task.assignee);
   const TitleTag = onTitleClick ? 'button' : 'div';
+  const [didCopy, setDidCopy] = useState(false);
+  const copyTimeoutRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) window.clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
+
+  async function copyTaskId(event) {
+    event.stopPropagation();
+    const id = String(task.id ?? '');
+    if (!id || !navigator.clipboard?.writeText) return;
+
+    await navigator.clipboard.writeText(id);
+    setDidCopy(true);
+    if (copyTimeoutRef.current) window.clearTimeout(copyTimeoutRef.current);
+    copyTimeoutRef.current = window.setTimeout(() => setDidCopy(false), 1500);
+  }
 
   return (
     <>
@@ -49,6 +69,17 @@ export function TaskCardSummary({ task, hasDraft, onTitleClick }) {
           {hasDraft ? <Badge variant="draft" tone="pulse">Unsaved</Badge> : null}
         </div>
         <div className="task-card-footer-meta">
+          {showCopyId && task.id ? (
+            <button
+              type="button"
+              className="task-id-copy-btn"
+              aria-label={`Copy task ID ${task.id}`}
+              title={didCopy ? 'Copied' : 'Copy task ID'}
+              onClick={(event) => void copyTaskId(event)}
+            >
+              {didCopy ? 'Copied' : 'ID'}
+            </button>
+          ) : null}
           {assignee ? (
             <Avatar aria-label={`Assignee ${task.assignee}`}>
               {assignee}

--- a/apps/tasks/src/components/TaskCardSummary.test.jsx
+++ b/apps/tasks/src/components/TaskCardSummary.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TaskCardSummary } from './TaskCardSummary.jsx';
+
+describe('TaskCardSummary', () => {
+  it('copies the task ID without triggering the title click', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    });
+    const onTitleClick = vi.fn();
+
+    render(
+      <TaskCardSummary
+        task={{
+          id: 'task-123',
+          title: 'Copy target',
+          priority: 'medium',
+          status: 'ready',
+          tags: []
+        }}
+        onTitleClick={onTitleClick}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy task ID task-123' }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('task-123'));
+    expect(screen.getByRole('button', { name: 'Copy task ID task-123' })).toHaveTextContent('Copied');
+    expect(onTitleClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/tasks/src/components/TaskEditor.jsx
+++ b/apps/tasks/src/components/TaskEditor.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Button, Card, Divider, Field, Input, Select, Textarea } from '@sindustries/ui/react';
+import { Badge, Button, Card, Divider, Field, Input, Select, Textarea } from '@sindustries/ui/react';
 import { STATUSES, STATUS_LABELS, PRIORITIES, ASSIGNEE_OPTIONS } from '../utils/constants.js';
 import { normalizeComments, formatCommentTimestamp } from '../utils/helpers.js';
 import { MarkdownContent } from './MarkdownContent.jsx';
@@ -16,9 +16,25 @@ import { TaskCardSummary } from './TaskCardSummary.jsx';
  * @param {Function} props.onArchive - Callback to archive task
  * @param {Function} props.onClose - Callback to close editor
  * @param {Function} props.onAddComment - Callback to add comment
+ * @param {Function} props.onFetchDependency - Callback to validate and fetch dependency task
+ * @param {Function} props.onUpdateDependencies - Callback to replace dependsOnIds
+ * @param {Function} props.onOpenTask - Callback to navigate to a dependency task
  * @param {boolean} props.isSubmittingComment - Whether comment is being submitted
  */
-export function TaskEditor({ draft, task, isDirty, onDraftChange, onSave, onArchive, onClose, onAddComment, isSubmittingComment }) {
+export function TaskEditor({
+  draft,
+  task,
+  isDirty,
+  onDraftChange,
+  onSave,
+  onArchive,
+  onClose,
+  onAddComment,
+  onFetchDependency,
+  onUpdateDependencies,
+  onOpenTask,
+  isSubmittingComment
+}) {
   const descriptionRef = useRef(null);
   const titleRef = useRef(null);
   const statusRef = useRef(null);
@@ -30,6 +46,11 @@ export function TaskEditor({ draft, task, isDirty, onDraftChange, onSave, onArch
   const [commentDraft, setCommentDraft] = useState({ author: '', text: '' });
   const [isCommentComposerOpen, setIsCommentComposerOpen] = useState(false);
   const [isDescriptionEditing, setIsDescriptionEditing] = useState(false);
+  const [dependencyDraft, setDependencyDraft] = useState('');
+  const [dependencyCandidate, setDependencyCandidate] = useState(null);
+  const [dependencyError, setDependencyError] = useState('');
+  const [isCheckingDependency, setIsCheckingDependency] = useState(false);
+  const [isSavingDependency, setIsSavingDependency] = useState(false);
 
   useEffect(() => {
     const textarea = descriptionRef.current;
@@ -135,11 +156,87 @@ export function TaskEditor({ draft, task, isDirty, onDraftChange, onSave, onArch
     setIsCommentComposerOpen(false);
   }
 
+  function dependencyIds() {
+    if (Array.isArray(task.dependsOnIds)) return task.dependsOnIds.map((id) => String(id));
+    if (Array.isArray(task.dependsOn)) return task.dependsOn.map((dependency) => String(dependency.id));
+    return [];
+  }
+
+  async function handleValidateDependency() {
+    const candidateId = dependencyDraft.trim();
+    setDependencyCandidate(null);
+    setDependencyError('');
+
+    if (!candidateId) {
+      setDependencyError('Enter a task ID.');
+      return;
+    }
+
+    if (String(task.id) === candidateId) {
+      setDependencyError('A task cannot depend on itself.');
+      return;
+    }
+
+    if (dependencyIds().includes(candidateId)) {
+      setDependencyError('That dependency is already linked.');
+      return;
+    }
+
+    if (!onFetchDependency) {
+      setDependencyError('Task lookup is unavailable.');
+      return;
+    }
+
+    setIsCheckingDependency(true);
+    try {
+      const dependency = await onFetchDependency(candidateId);
+      if (!dependency || dependency.archivedAt) {
+        setDependencyError('Task not found.');
+        return;
+      }
+      setDependencyCandidate(dependency);
+    } catch (error) {
+      setDependencyError(error?.message || 'Task not found.');
+    } finally {
+      setIsCheckingDependency(false);
+    }
+  }
+
+  async function handleConfirmDependency() {
+    if (!dependencyCandidate || !onUpdateDependencies) return;
+    setIsSavingDependency(true);
+    setDependencyError('');
+    try {
+      const didUpdate = await onUpdateDependencies([...dependencyIds(), String(dependencyCandidate.id)]);
+      if (!didUpdate) return;
+      setDependencyDraft('');
+      setDependencyCandidate(null);
+    } catch (error) {
+      setDependencyError(error?.message || 'Failed to add dependency.');
+    } finally {
+      setIsSavingDependency(false);
+    }
+  }
+
+  async function handleRemoveDependency(dependencyId) {
+    if (!onUpdateDependencies) return;
+    setIsSavingDependency(true);
+    setDependencyError('');
+    try {
+      await onUpdateDependencies(dependencyIds().filter((id) => id !== String(dependencyId)));
+    } catch (error) {
+      setDependencyError(error?.message || 'Failed to remove dependency.');
+    } finally {
+      setIsSavingDependency(false);
+    }
+  }
+
   const comments = [...normalizeComments(task.comments)].sort((a, b) => {
     const timeDiff = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     if (timeDiff !== 0) return timeDiff;
     return String(b.id ?? '').localeCompare(String(a.id ?? ''));
   });
+  const dependencies = Array.isArray(task.dependsOn) ? task.dependsOn : [];
 
   return (
     <div className="task-card-editor" onClick={(e) => e.stopPropagation()}>
@@ -149,7 +246,7 @@ export function TaskEditor({ draft, task, isDirty, onDraftChange, onSave, onArch
         onClick={onClose}
         aria-label="Close task editor and show card view"
       >
-        <TaskCardSummary task={task} hasDraft={isDirty} />
+        <TaskCardSummary task={task} hasDraft={isDirty} showCopyId={false} />
       </button>
 
       <Divider variant="dashed" />
@@ -270,6 +367,108 @@ export function TaskEditor({ draft, task, isDirty, onDraftChange, onSave, onArch
             <span>Blocked</span>
           </label>
         </div>
+
+        <section className="dependencies-section" aria-label="Task dependencies">
+          <div className="dependencies-header">
+            <h4 className="si-font-display">Dependencies</h4>
+            <span className="small dependencies-count">
+              {dependencies.length === 0 ? 'No dependencies' : `${dependencies.length} linked`}
+            </span>
+          </div>
+
+          {dependencies.length > 0 ? (
+            <ol className="dependencies-list">
+              {dependencies.map((dependency) => (
+                <li key={dependency.id} className="dependency-row">
+                  <button
+                    type="button"
+                    className="dependency-link"
+                    onClick={() => onOpenTask?.(dependency.id)}
+                  >
+                    <span>{dependency.title}</span>
+                    <Badge variant="tag" tone="pulse">{STATUS_LABELS[dependency.status] ?? dependency.status}</Badge>
+                  </button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    tone="display"
+                    aria-label={`Remove dependency ${dependency.title}`}
+                    disabled={isSavingDependency}
+                    onClick={() => void handleRemoveDependency(dependency.id)}
+                  >
+                    Remove
+                  </Button>
+                </li>
+              ))}
+            </ol>
+          ) : null}
+
+          <div className="dependency-add">
+            <Field label="Add dependency by task ID">
+              <div className="dependency-add-row">
+                <Input
+                  aria-label="Dependency task ID"
+                  value={dependencyDraft}
+                  placeholder="Enter task ID"
+                  onChange={(event) => {
+                    setDependencyDraft(event.target.value);
+                    setDependencyCandidate(null);
+                    setDependencyError('');
+                  }}
+                  onMouseDown={stopPropagation}
+                  onTouchStart={stopPropagation}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.preventDefault();
+                      void handleValidateDependency();
+                    }
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  tone="display"
+                  disabled={isCheckingDependency || isSavingDependency || !dependencyDraft.trim()}
+                  onClick={() => void handleValidateDependency()}
+                >
+                  {isCheckingDependency ? 'Checking' : 'Check'}
+                </Button>
+              </div>
+            </Field>
+
+            {dependencyCandidate ? (
+              <div className="dependency-confirm" role="status">
+                <div>
+                  <span className="small">Link to</span>
+                  <strong>{dependencyCandidate.title}</strong>
+                  <Badge variant="tag" tone="pulse">{STATUS_LABELS[dependencyCandidate.status] ?? dependencyCandidate.status}</Badge>
+                </div>
+                <div className="dependency-confirm-actions">
+                  <Button
+                    type="button"
+                    variant="primary"
+                    tone="display"
+                    disabled={isSavingDependency}
+                    onClick={() => void handleConfirmDependency()}
+                  >
+                    Confirm
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    tone="display"
+                    disabled={isSavingDependency}
+                    onClick={() => setDependencyCandidate(null)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+
+            {dependencyError ? <p className="dependency-error" role="alert">{dependencyError}</p> : null}
+          </div>
+        </section>
       </div>
 
       <div className="editor-actions">

--- a/apps/tasks/src/components/TaskEditor.test.jsx
+++ b/apps/tasks/src/components/TaskEditor.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { TaskEditor } from '../components/TaskEditor.jsx';
 
 const defaultProps = {
@@ -24,6 +24,9 @@ const defaultProps = {
   onArchive: vi.fn(),
   onClose: vi.fn(),
   onAddComment: vi.fn(),
+  onFetchDependency: vi.fn(),
+  onUpdateDependencies: vi.fn(),
+  onOpenTask: vi.fn(),
   isSubmittingComment: false
 };
 
@@ -242,5 +245,94 @@ describe('TaskEditor', () => {
     render(<TaskEditor {...propsWithAssignee} />);
 
     expect(screen.getByLabelText('Detail assignee')).toHaveValue('Rowan');
+  });
+
+  it('renders dependency links with title and status', () => {
+    render(
+      <TaskEditor
+        {...defaultProps}
+        task={{
+          ...defaultProps.task,
+          dependsOn: [{ id: 'dep-1', title: 'Upstream API work', status: 'done' }],
+          dependsOnIds: ['dep-1']
+        }}
+      />
+    );
+
+    const dependencies = screen.getByRole('region', { name: 'Task dependencies' });
+    expect(within(dependencies).getByRole('button', { name: /Upstream API work\s*Done/ })).toBeInTheDocument();
+    expect(within(dependencies).getByText('Done')).toBeInTheDocument();
+  });
+
+  it('validates a dependency ID and confirms before adding it', async () => {
+    const onFetchDependency = vi.fn().mockResolvedValue({
+      id: 'dep-2',
+      title: 'Dependency task',
+      status: 'ready'
+    });
+    const onUpdateDependencies = vi.fn().mockResolvedValue(true);
+
+    render(
+      <TaskEditor
+        {...defaultProps}
+        task={{ ...defaultProps.task, id: 'task-1', dependsOn: [], dependsOnIds: [] }}
+        onFetchDependency={onFetchDependency}
+        onUpdateDependencies={onUpdateDependencies}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Dependency task ID'), { target: { value: 'dep-2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Check' }));
+
+    expect(await screen.findByText('Dependency task')).toBeInTheDocument();
+    expect(within(screen.getByRole('status')).getByText('Ready')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(onUpdateDependencies).toHaveBeenCalledWith(['dep-2']);
+    });
+  });
+
+  it('shows an inline error when dependency lookup fails', async () => {
+    const onFetchDependency = vi.fn().mockRejectedValue(new Error('Task not found'));
+
+    render(
+      <TaskEditor
+        {...defaultProps}
+        task={{ ...defaultProps.task, id: 'task-1', dependsOn: [], dependsOnIds: [] }}
+        onFetchDependency={onFetchDependency}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Dependency task ID'), { target: { value: 'missing-task' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Check' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Task not found');
+  });
+
+  it('removes one dependency without clearing the rest', async () => {
+    const onUpdateDependencies = vi.fn().mockResolvedValue(true);
+
+    render(
+      <TaskEditor
+        {...defaultProps}
+        task={{
+          ...defaultProps.task,
+          dependsOn: [
+            { id: 'dep-1', title: 'First dependency', status: 'ready' },
+            { id: 'dep-2', title: 'Second dependency', status: 'doing' }
+          ],
+          dependsOnIds: ['dep-1', 'dep-2']
+        }}
+        onUpdateDependencies={onUpdateDependencies}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove dependency First dependency' }));
+
+    await waitFor(() => {
+      expect(onUpdateDependencies).toHaveBeenCalledWith(['dep-2']);
+    });
   });
 });

--- a/apps/tasks/src/styles/editor.css
+++ b/apps/tasks/src/styles/editor.css
@@ -108,6 +108,115 @@
   width: 100%;
 }
 
+.dependencies-section {
+  background: var(--si-color-bg-field);
+  border: 2px solid var(--si-color-border-subtle);
+  border-radius: var(--si-radius-sm);
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+  width: 100%;
+}
+
+.dependencies-header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+}
+
+.dependencies-header h4 {
+  color: var(--si-color-text-muted);
+  font-size: 0.95rem;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.dependencies-count {
+  color: var(--si-color-text-muted);
+}
+
+.dependencies-list {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.dependency-row {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.dependency-link {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: var(--si-color-text-primary);
+  cursor: pointer;
+  display: flex;
+  flex: 1;
+  gap: 8px;
+  min-width: 0;
+  padding: 0;
+  text-align: left;
+}
+
+.dependency-link span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dependency-add {
+  display: grid;
+  gap: 8px;
+}
+
+.dependency-add-row {
+  display: flex;
+  gap: 8px;
+}
+
+.dependency-add-row .si-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.dependency-confirm {
+  align-items: center;
+  border: 1px solid var(--si-color-border-subtle);
+  border-radius: var(--si-radius-xs);
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  padding: 8px;
+}
+
+.dependency-confirm > div:first-child {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+.dependency-confirm-actions {
+  display: flex;
+  flex-shrink: 0;
+  gap: 8px;
+}
+
+.dependency-error {
+  color: var(--si-color-status-danger);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
 .comments-header {
   align-items: center;
   display: flex;

--- a/apps/tasks/src/styles/task.css
+++ b/apps/tasks/src/styles/task.css
@@ -79,6 +79,33 @@
   margin-left: auto;
 }
 
+.task-id-copy-btn {
+  align-items: center;
+  background: var(--si-color-bg-field);
+  border: 1px solid var(--si-color-border-subtle);
+  border-radius: var(--si-radius-xs);
+  color: var(--si-color-text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  font-family: var(--si-font-ui);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  height: 24px;
+  justify-content: center;
+  letter-spacing: 0;
+  min-width: 28px;
+  padding: 0 7px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.task-id-copy-btn:hover,
+.task-id-copy-btn:focus-visible {
+  border-color: var(--si-color-cta-primary);
+  color: var(--si-color-text-primary);
+  outline: none;
+}
+
 .task-card-date {
   color: var(--si-color-text-muted);
   font-family: var(--si-font-ui);

--- a/apps/tasks/src/tasksApi.ts
+++ b/apps/tasks/src/tasksApi.ts
@@ -91,7 +91,7 @@ const DEFAULT_API_BASE_BY_PORT: Record<string, string> = {
 const API_BASE =
   import.meta.env.VITE_TASKS_API_BASE_URL
   ?? DEFAULT_API_BASE_BY_PORT[window.location.port]
-  ?? 'http://localhost:4000/api/v1';
+  ?? 'http://localhost:4001/api/v1';
 
 async function api<T>(path: string, options?: RequestInit): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`, {

--- a/apps/tasks/src/tasksApi.ts
+++ b/apps/tasks/src/tasksApi.ts
@@ -66,6 +66,7 @@ export interface UpdateTaskPayload {
   tags?: string[];
   blocked?: boolean;
   taskType?: 'content' | 'code' | 'research' | null;
+  dependsOnIds?: Array<string | number>;
   // Note: 'ready' field removed — use status field instead
 }
 

--- a/apps/tasks/src/useTasks.js
+++ b/apps/tasks/src/useTasks.js
@@ -78,7 +78,11 @@ export function useTasks(filters, options = {}) {
     setError('');
     try {
       const task = await fetchTaskRequest(id);
-      setTasks((current) => current.map((entry) => (entry.id === id ? task : entry)));
+      setTasks((current) => {
+        const existingIndex = current.findIndex((entry) => String(entry.id) === String(id));
+        if (existingIndex === -1) return [...current, task];
+        return current.map((entry, index) => (index === existingIndex ? task : entry));
+      });
       return task;
     } catch (e) {
       setError(e.message);

--- a/apps/tasks/test/e2e/dependency-ui.spec.js
+++ b/apps/tasks/test/e2e/dependency-ui.spec.js
@@ -1,0 +1,121 @@
+import { expect, test } from '@playwright/test';
+
+test('task dependency UI: add, list, copy ID, and remove', async ({ page }) => {
+  const now = new Date().toISOString();
+  const tasks = [
+    {
+      id: 'task-a',
+      title: 'Task A',
+      description: 'Depends on another task',
+      status: 'ready',
+      statusChangedAt: now,
+      priority: 'medium',
+      archivedAt: null,
+      blocked: false,
+      tags: [],
+      comments: [],
+      dependsOnIds: []
+    },
+    {
+      id: 'task-b',
+      title: 'Task B',
+      description: 'Upstream dependency',
+      status: 'doing',
+      statusChangedAt: now,
+      priority: 'high',
+      archivedAt: null,
+      blocked: false,
+      tags: [],
+      comments: [],
+      dependsOnIds: []
+    }
+  ];
+
+  function withDependencies(task) {
+    return {
+      ...task,
+      dependsOn: (task.dependsOnIds ?? [])
+        .map((id) => tasks.find((candidate) => candidate.id === id))
+        .filter(Boolean)
+        .map((dependency) => ({
+          id: dependency.id,
+          title: dependency.title,
+          status: dependency.status,
+          completedAt: dependency.completedAt ?? null
+        })),
+      dependencyBlocked: (task.dependsOnIds ?? [])
+        .some((id) => tasks.find((candidate) => candidate.id === id)?.status !== 'done')
+    };
+  }
+
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async (text) => {
+          window.__copiedTaskId = text;
+        }
+      }
+    });
+  });
+
+  await page.route('**/api/v1/tasks**', async (route) => {
+    const request = route.request();
+    const method = request.method();
+    const url = new URL(request.url());
+    const isCollection = /\/tasks$/.test(url.pathname);
+    const detailMatch = url.pathname.match(/\/tasks\/([^/]+)$/);
+
+    if (method === 'GET' && isCollection) {
+      await route.fulfill({ json: { data: tasks.map(withDependencies) } });
+      return;
+    }
+
+    if (method === 'GET' && detailMatch) {
+      const [, taskId] = detailMatch;
+      const task = tasks.find((entry) => entry.id === taskId);
+      if (!task) {
+        await route.fulfill({ status: 404, json: { error: { message: 'Task not found' } } });
+        return;
+      }
+      await route.fulfill({ json: { data: withDependencies(task) } });
+      return;
+    }
+
+    if (method === 'PATCH' && detailMatch) {
+      const [, taskId] = detailMatch;
+      const body = request.postDataJSON();
+      const task = tasks.find((entry) => entry.id === taskId);
+      Object.assign(task, body);
+      await route.fulfill({ json: { data: withDependencies(task) } });
+      return;
+    }
+
+    await route.fulfill({ status: 404, json: { error: { message: 'Not found' } } });
+  });
+
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Backlog' }).click();
+  await page.getByRole('button', { name: 'Task A' }).click();
+
+  const dependencies = page.getByRole('region', { name: 'Task dependencies' });
+  await expect(dependencies.getByText('No dependencies')).toBeVisible();
+
+  await page.getByLabel('Dependency task ID').fill('task-b');
+  await page.getByRole('button', { name: 'Check' }).click();
+  await expect(dependencies.getByText('Link to')).toBeVisible();
+  await expect(dependencies.getByText('Task B')).toBeVisible();
+  await expect(dependencies.getByText('Doing')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Confirm' }).click();
+  await expect(dependencies.getByRole('button', { name: 'Task B Doing' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Close' }).last().click();
+  await page.getByRole('button', { name: 'Copy task ID task-a' }).click();
+  await expect.poll(() => page.evaluate(() => window.__copiedTaskId)).toBe('task-a');
+
+  await page.getByRole('button', { name: 'Task A' }).click();
+  await page.getByRole('button', { name: 'Remove dependency Task B' }).click();
+  await expect(dependencies.getByRole('button', { name: 'Task B Doing' })).toHaveCount(0);
+  await expect(dependencies.getByText('No dependencies')).toBeVisible();
+});

--- a/docs/specs/task-dependency-ui-tech-design.md
+++ b/docs/specs/task-dependency-ui-tech-design.md
@@ -1,0 +1,52 @@
+# Task Dependency UI Tech Design
+
+## Links
+
+- Source spec: `brain/bookmarks/specs/task-dependency-ui-2026-06-27.md`
+- Task: `8593d197-f3df-4486-aa50-dcaafd599264`
+- Upstream dependency: `456c92a8-835f-453e-a1ef-5ed5a31844f2` is done and merged to `main` in PR #120.
+- Branch: `task-8593d197-dependency-ui-rowan`
+
+## Scope
+
+This PR adds the UI layer for the task dependency data model now exposed by the Tasks API:
+
+- `apps/tasks/src/components/TaskEditor.jsx`
+  - Render dependency rows with title and status.
+  - Validate an entered dependency task ID via `GET /tasks/:id`.
+  - Confirm before saving the dependency.
+  - Remove individual dependencies through `PATCH /tasks/:id`.
+- `apps/tasks/src/components/TaskCardSummary.jsx`
+  - Add a small click-to-copy task ID affordance on normal cards.
+- `apps/tasks/src/tasksApi.ts`
+  - Type `dependsOnIds` on update payloads.
+- `apps/tasks/test/e2e/dependency-ui.spec.js`
+  - Cover add, list, copy ID, and remove in one browser-level flow.
+
+## Data Flow
+
+The editor treats dependencies as immediate server-side changes rather than draft form fields. This matches comments and archive behavior: dependency edits are independent actions from title, description, and status form edits.
+
+Adding a dependency:
+
+1. User enters a task ID in the detail editor.
+2. UI calls `fetchTask(id)` to validate the ID and display the candidate title/status.
+3. User confirms.
+4. UI patches `{ dependsOnIds: [...currentIds, id] }`.
+5. Existing task reload behavior refreshes the rendered dependency list.
+
+Removing a dependency:
+
+1. User clicks the dependency row's remove button.
+2. UI patches `{ dependsOnIds: currentIds.filter(id !== removedId) }`.
+3. Existing task reload behavior refreshes the rendered dependency list.
+
+## Test Plan
+
+- Unit: `TaskEditor` renders dependencies, validates before confirming, shows lookup errors, and removes one dependency without clearing the rest.
+- Unit: `TaskCardSummary` copies the task ID and stops the card/title click path.
+- E2E: `dependency-ui.spec.js` exercises the full add, list, copy, remove path against mocked API routes.
+
+## Notes
+
+The UI performs quick client-side checks for empty IDs, self-dependencies, and duplicate direct dependencies. Cycle detection and final validation remain server-owned.


### PR DESCRIPTION
## Summary
- Adds task-detail dependency management: linked dependencies show title/status, candidate IDs are validated before confirm, and individual dependencies can be removed.
- Adds a compact copy-ID affordance on task cards so users can grab IDs for dependency linking.
- Documents the UI design and adds unit plus Playwright coverage for the dependency workflow.

## Test plan
- [x] `npm --workspace apps/tasks test`
- [x] `npm --workspace apps/tasks run test:e2e`
- [x] `npm --workspace apps/tasks run build`

## Acceptance Criteria
- [x] AC1: Task detail view shows dependency links with title and status of each dependency
- [x] AC2: Dependencies can be added from task detail by entering a task ID; UI validates and shows title before confirming
- [x] AC3: Each dependency link can be removed individually from task detail
- [x] AC4: Each task card has a click-to-copy affordance for its task ID

## System spec
[no-system-spec-change] Pure UI work on `apps/tasks`; no durable system contract, persisted behaviour, or backend semantics change. Dependency data model and API surface are owned by PR #128 (Add task dependency references) — already merged — and this PR only consumes the read-only `dependsOn`/`dependsOnIds`/`dependencyBlocked` shape it exposes.

Depends on PR #128 (Add task dependency references) — merged.