### PR TITLE
docs(code-garden): mark marked migration done [2026-W26]

### DIFF
--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -353,7 +353,7 @@ AI agents (agents/)
 | 3-A | Pagination unit tests for cursor/sort alignment | M |
 | 3-B | Add `make test-website` and `make test-all` targets to Makefile | S |
 | 3-C | Wrap PATCH tag re-link in `prisma.$transaction` | S |
-| 3-D | Replace `marked.setOptions` with `marked.use()` (marked v17 deprecation) | S |
+| 3-D | Replace `marked.setOptions` with `marked.use()` (marked v17 deprecation) ✅ [PR #109](https://github.com/Stoffer-Industries/sindustries/pull/109) | S |
 | 3-E | Add structured logging with `trace_id` to both APIs' error middleware | M |
 | 3-F | Update `docs/specs/tasks-one-pager.md` status flow | S |
 | 3-G | Evaluate Prisma 6 migration; document decision | M |


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W26.md
- **Finding:** [Low] Replace `marked.setOptions` with `marked.use()` (marked v17 deprecation)
- Records that the behavior-equivalent marked migration already landed in PR #109.

## Test plan
- [x] No code changes — audit bookkeeping only
- [x] No logic changes — diff is purely documentation metadata

🌱 Code garden — non-functional cleanup only