### PR TITLE
chore(code-garden): add make test-website and test-all targets [2026-W26]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap up down reset-db migrate-db test test-api test-app test-e2e
+.PHONY: bootstrap up down reset-db migrate-db test test-api test-app test-website test-e2e test-all
 
 MODE ?= dev
 
@@ -21,12 +21,17 @@ migrate-db:
 
 test: test-api test-app test-e2e
 
+test-all: test-api test-website test-app test-e2e
+
 test-api:
 	cd services/tasks-api && npm test
 	cd services/budget-api && npm test
 
 test-app:
 	cd apps/tasks && npm test
+
+test-website:
+	cd apps/website && npm test
 
 test-e2e:
 	cd apps/tasks && npm run test:e2e

--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -351,7 +351,7 @@ AI agents (agents/)
 | # | Title | Effort |
 |---|-------|--------|
 | 3-A | Pagination unit tests for cursor/sort alignment | M |
-| 3-B | Add `make test-website` and `make test-all` targets to Makefile ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD) | S |
+| 3-B | Add `make test-website` and `make test-all` targets to Makefile ✅ [PR #131](https://github.com/Stoffer-Industries/sindustries/pull/131) | S |
 | 3-C | Wrap PATCH tag re-link in `prisma.$transaction` | S |
 | 3-D | Replace `marked.setOptions` with `marked.use()` (marked v17 deprecation) ✅ [PR #109](https://github.com/Stoffer-Industries/sindustries/pull/109) | S |
 | 3-E | Add structured logging with `trace_id` to both APIs' error middleware | M |

--- a/docs/repo-audits/2026-W26.md
+++ b/docs/repo-audits/2026-W26.md
@@ -351,7 +351,7 @@ AI agents (agents/)
 | # | Title | Effort |
 |---|-------|--------|
 | 3-A | Pagination unit tests for cursor/sort alignment | M |
-| 3-B | Add `make test-website` and `make test-all` targets to Makefile | S |
+| 3-B | Add `make test-website` and `make test-all` targets to Makefile ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD) | S |
 | 3-C | Wrap PATCH tag re-link in `prisma.$transaction` | S |
 | 3-D | Replace `marked.setOptions` with `marked.use()` (marked v17 deprecation) ✅ [PR #109](https://github.com/Stoffer-Industries/sindustries/pull/109) | S |
 | 3-E | Add structured logging with `trace_id` to both APIs' error middleware | M |


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W26.md
- **Finding:** [S] Add `make test-website` and `make test-all` targets to Makefile (Milestone 3, item 3-B)
- Adds two Makefile targets: `test-website` (runs `apps/website` vitest) and `test-all` (chains `test-api test-website test-app test-e2e`). The existing `test` target is unchanged so the default developer behaviour is preserved; `test-all` is the new everything-goes alias.

## Test plan
- [x] No logic changes — diff is purely additive Makefile targets
- [x] `make -n test-all` resolves to the expected command chain (tasks-api tests → budget-api tests → website tests → apps/tasks tests → apps/tasks e2e)
- [x] `make -n test` unchanged: tasks-api → budget-api → apps/tasks → apps/tasks e2e
- [x] `make -n test-website` resolves to `cd apps/website && npm test`

🌱 Code garden — non-functional cleanup only