### PR TITLE
cod—audit: sindustries weekly review 2026-W27

### DIFF
--- a/docs/repo-audits/2026-W27.md
+++ b/docs/repo-audits/2026-W27.md
@@ -1,0 +1,414 @@
+# Repo Audit — sindustries — 2026-W27 (2026-06-29 → 2026-07-05)
+
+**Generated:** 2026-06-29 (Monday cron)
+**Auditor:** Rowan (Staff Engineer)
+**Target:** `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`
+**Type:** Full four-phase audit
+
+---
+
+## Executive Summary
+
+**Health grade: B-** (held from W26 refresh — CI now exercises the new surfaces, but the W26 Critical findings in `budget-api` still ship on `main` unchanged, and three new structural issues landed with the feature-task workflow).
+
+This audit covers the work that merged after the W26 refresh: the new Rust+Python+Lobster `agents/workflows/feature-task` orchestrator, spec-checksum drift enforcement in `tasks-api`, the `tasks.ts` split into helper modules, the second attempt at the task-dependencies surface (server + DB in main, UI mid-delivery), per-service Prisma client isolation, and the new `budget-api-tests` and `feature-task-workflow-tests` CI jobs. The Critical W26 findings persist: every `budget-api` route except `/me` reads `userId` from the request and operates on that user without verifying a session, and the Akahu access token is still a plaintext `String` column. Worse, the `cards` and `alerts` routers expose IDOR on path parameters (`:cardId`, `:alertId`) — `POST /cards/:cardId/budget`, `GET /cards/:cardId/spend-summary`, and `DELETE /alerts/:alertId` resolve and mutate records purely from URL ids without an ownership lookup. Two new tasks-api migrations share the timestamp prefix `20260627000000`, leaving migration ordering at the mercy of filesystem sort. The new feature-task workflow hard-codes Quinn-specific absolute paths in `run.py` and the Lobster YAML.
+
+**Top 3 risks:** (1) `budget-api` ships every route except `/me` with no session check, and the `cards`/`alerts` routers compound this by trusting URL-supplied ids without ownership lookups — net IDOR on transactions, balances, budgets, alert configs, and Akahu connections; (2) Akahu bearer tokens are still stored plaintext (`AkahuConnection.accessToken String`), so a DB read yields live banking-aggregation access; (3) two tasks-api migrations share the prefix `20260627000000`, so the apply order depends on filesystem sort and the two could silently swap places between dev and CI.
+
+**Top 3 opportunities:** (1) Land the W26 Theme-1 `requireSession` middleware on `budget-api` and add ownership lookups on every path-parameter route; (2) Rename one of the two `20260627000000_*` migrations and add a precommit check that rejects duplicate prefixes; (3) Replace the hard-coded Quinn paths in `agents/workflows/feature-task/run.py:18` and `feature-task.lobster.yaml:9` with environment-driven defaults so feature-task runs anywhere CI can reach the binary.
+
+---
+
+## Repo Map
+
+**Purpose:** Mono-repo for Stoffer Industries product surfaces — Tasks API + React app, a budgeting product (mobile + API + shared domain), a public-facing website, shared UI/design-token/OTel packages, and an AI agent operations layer (bookmark pipeline, content skills, cron definitions, feature-factory workflow).
+
+**Stack:**
+- Node 22, npm workspaces (`package.json:8-12`).
+- Web apps: React 18 + Vite (`apps/tasks`, `apps/website`).
+- Mobile app: React Native + Expo SDK 54 (`apps/budget-mobile`).
+- Services: Express 4 + Prisma 5 + PostgreSQL 16 (`services/tasks-api`, `services/budget-api`).
+- Shared packages: `@sindustries/ui` (component kit), `@sindustries/design-tokens` (token pipeline), `@sindustries/otel-node` (OTel auto-instrumentation), `@sindustries/budget-domain` (categorization + budget rules).
+- Workflows: Rust binary + Lobster pipeline + Python launcher in `agents/workflows/feature-task` (new this week).
+- Tests: Vitest everywhere; Playwright for e2e; Python `unittest` for agent workflows; Rust `cargo test` for feature-task.
+- Local runtime: Docker Compose (Postgres) + Tilt (host-run API/app); CI on GitHub Actions with service-container Postgres.
+
+**Architecture sketch:**
+```
+React (apps/tasks)
+  └─ tasksApi.ts ── fetch ──▶ Express (services/tasks-api :4000)
+                                   └─ Prisma ──▶ Postgres (schema: tasks_api)
+                                   └─ OTel SDK ──▶ OTLP ──▶ Tempo/Prometheus
+
+React (apps/website) [static JSON content; Vercel deploy]
+
+Expo / RN (apps/budget-mobile) ── fetch ──▶ Express (services/budget-api :4002)
+                                                  └─ Prisma ──▶ Postgres (schema: budget_api)
+                                                  └─ fetch ──▶ Akahu OAuth + API
+                                                  └─ @sindustries/budget-domain
+
+AI agents (agents/)
+  └─ tasks-api-ops skill ── HTTP ──▶ tasks-api
+  └─ lobster bookmark pipeline ── state JSON + tasks-api
+  └─ feature-task workflow (Rust) ── HTTP ──▶ tasks-api + gh CLI for PR inspection
+```
+
+**Key directories:**
+- `apps/tasks/` — Kanban + backlog task manager (focus product).
+- `apps/website/` — Public website; JSON-file CMS.
+- `apps/budget-mobile/` — Expo React Native app; budgeting MVP screens.
+- `services/tasks-api/` — Express API; Tasks CRUD + tags + comments + dependencies + spec checksums.
+- `services/tasks-api/src/routes/tasks/` — new helper modules (`_constants.ts`, `_deps.ts`, `_mapper.ts`, `_pagination.ts`, `_spec.ts`, `_validation.ts`) extracted from `tasks.ts`.
+- `services/budget-api/` — Express API; session + Akahu OAuth + accounts/transactions/alerts.
+- `packages/budget-domain/` — Pure functions: categorization, budget thresholds, merchant normalization.
+- `packages/ui/`, `packages/design-tokens/`, `packages/otel-node/` — shared libraries.
+- `infra/` — Docker Compose, Tilt, Prometheus/Grafana/Tempo.
+- `agents/workflows/feature-task/` — new: Rust CLI (`src/main.rs`, 1625 lines) + Python launcher + Lobster pipeline + JSON fixtures + Cargo target dir (589 MB local).
+- `docs/` — Architecture, specs, system docs, audit history (`docs/repo-audits/`). New this week: `docs/systems/feature-task-workflow.md`, `docs/systems/task-dependencies.md`, `docs/specs/feature-factory-v2-tech-design.md`, `docs/designs/feature-factory-v2.md`.
+
+**Surprises from discovery:**
+- The `tasks.ts` split landed (`services/tasks-api/src/routes/tasks/_*.ts`), so the file is 479 lines (down from 517 at W26) and the dependency/spec-checksum logic now has dedicated helpers — but the in-memory sort + cursor mismatch (W26 carry-forward) is untouched.
+- `services/tasks-api/prisma/migrations/` has two directories with identical timestamp prefix `20260627000000` (`_add_task_dependencies` and `_add_task_spec_checksum`).
+- `apps/tasks/src/App.jsx` is still 952 lines — the task-dependency UI was reverted (`e27480d`, `70f687e`, `a4c5589`), but the underlying API/DB surface stayed.
+- `.gitignore` does not include `target/` or `**/target/`; the 589 MB `agents/workflows/feature-task/target/` directory is only ignored by my local `.git/info/exclude`. A fresh clone would not ignore it.
+- `agents/workflows/feature-task/run.py:18` hard-codes `/Users/quinnstoffer/.openclaw/workspace` and `feature-task.lobster.yaml:9` hard-codes `/Users/quinnstoffer/workspaces/rowan/sindustries` as defaults.
+- The `cards.ts` and `alerts.ts` budget-api routers extend the W26 IDOR pattern to URL path parameters — `POST /cards/:cardId/budget` (`routes/cards.ts:95-117`) and `DELETE /alerts/:alertId` (`routes/alerts.ts:39-45`) resolve records purely from path ids without ownership lookup.
+
+---
+
+## Audit Report
+
+### Strengths
+
+- **CI now exercises every shipping service.** `.github/workflows/ci.yml:111-159` adds the `budget-api-tests` job (resolves W26 0-A) and `ci.yml:98-109` adds `feature-task-workflow-tests`. Failing tests on the new surfaces now block PRs.
+- **`tasks.ts` split is a clean refactor.** The helper modules in `services/tasks-api/src/routes/tasks/` are short, pure, and named for intent (`_pagination.ts`, `_spec.ts`, `_deps.ts`, `_mapper.ts`, `_validation.ts`, `_constants.ts`). The split kept HTTP wiring in `tasks.ts` and pushed reusable logic out.
+- **Spec-checksum drift enforcement is well factored.** `_spec.ts:25-31` returns from the request on drift via a single `rejectSpecDrift(res, task, description)` call; `tasks.ts:383-385, 441` use it at the only two write surfaces (PATCH task, POST comment). The canonical form is a one-line `JSON.stringify(canonicalize(...))` that's easy to reproduce in the Rust worker.
+- **Feature-task workflow uses fixtures + 27 Rust unit tests.** `agents/workflows/feature-task/src/main.rs:1136-1450` includes 27 `#[test]` cases against the parse/transition helpers and `fixtures/*.json` files for the GitHub review-state branches. The CI job is `cargo test --manifest-path …/Cargo.toml`.
+- **Per-service Prisma generated output moved out of `src/`.** `services/tasks-api/prisma/schema.prisma:3` and `services/budget-api/prisma/schema.prisma:3` both write to `../generated/prisma`, keeping generated code out of the Vite/Vitest watch tree (`c8dbac8`).
+- **Quick wins from W26 are done.** `apps/tasks/src/utils/constants.js:15` now includes `'Ivy'`; `tasksApi.ts:8, 30` no longer mention the removed `triage` status (`32aca04` removed it).
+- All Monday W26 strengths still hold (dual-mode dev/prodlike, tasks-api validation, OTel integration, spec-first workflow, DB integration tests for tasks-api, Akahu sync idempotency).
+
+---
+
+### Architecture & Design
+
+**[Critical] budget-api accepts `userId` from the request body/query and operates on URL path ids with no ownership lookup** *(persists from W26 + new vectors this week)*
+
+- `services/budget-api/src/routes/akahu.ts:27, 52, 70` — `userId` from `req.query.userId` / `req.body.userId`; validated only via `prisma.user.findUnique`.
+- `services/budget-api/src/routes/transactions.ts:14, 36-46` — `GET /transactions` reads `userId` from the query; `PATCH /transactions/:transactionId/category` resolves the txn from the path and updates it without verifying the txn belongs to the caller.
+- `services/budget-api/src/routes/cards.ts:9, 95-117, 119-147` — `GET /cards/balance-history` reads `userId` from query; `POST /cards/:cardId/budget` and `GET /cards/:cardId/spend-summary` resolve `cardId` from the path and operate without any user check.
+- `services/budget-api/src/routes/alerts.ts:9, 19, 39-45, 47-61, 63-96, 98-104` — `POST /alerts/evaluate`/`GET /alerts` take `userId` from request; `GET /cards/:cardId/alert-config`, `POST /cards/:cardId/alert-config`, `DELETE /cards/:cardId/alert-config`, and `DELETE /alerts/:alertId` operate purely from path ids.
+- `services/budget-api/src/routes/session.ts:37-46` — `GET /me` is still the only route that validates a Bearer session.
+- **Consequence (fact):** Any client that can reach the budget-api can enumerate or modify any user's transactions, monthly budgets, balance history, alert configurations, and Akahu connection. The path-parameter routes don't even require knowing the target `userId` — a UUID for a card or alert id is sufficient.
+- **Severity:** Critical — a horizontal-privilege escalation surface that has widened, not narrowed, since W26. Documented as "MVP / Tailnet-only" in `services/budget-api/README.md` (per `48b840e`), but the gap is the same on day one of any non-Tailnet deployment.
+
+**[High] GET /tasks pages by cursor then sorts in memory — nextCursor is unreliable for non-default sorts** *(persists from W25/W26)*
+
+- `services/tasks-api/src/routes/tasks.ts:143-155` — `findMany` still uses `orderBy: [{ createdAt: 'desc' }, { id: 'desc' }]` regardless of the `?sort=` parameter.
+- `services/tasks-api/src/routes/tasks.ts:157-181` — the result is re-sorted in JavaScript by `priority`/`dueAt`/etc.
+- `services/tasks-api/src/routes/tasks.ts:183-194` — `nextCursor` is encoded from the in-memory-sorted slice's last task, but the cursor anchor is `(createdAt, id)` so the next DB page restarts at the wrong record for any sort except `createdAt`. The W26 refactor split out `_pagination.ts` but did not change the underlying logic; the cursor/sort mismatch test (`services/tasks-api/test/read-endpoints.test.ts`, per `03ba63e`) currently documents the gap rather than enforcing the fix.
+
+**[Medium] tasksApi.ts fetches `limit=10000` on every auto-refresh** *(persists)*
+
+- `apps/tasks/src/tasksApi.ts:110` — `new URLSearchParams({ sort: 'priority', limit: '10000' })`.
+- `apps/tasks/src/useTasks.js:4` — `const DEFAULT_REFRESH_INTERVAL_MS = 3000`.
+- `services/tasks-api/src/routes/tasks/_constants.ts:5` — `MAX_LIMIT = 10000`, so the client request is at the configured cap rather than being silently rejected. A 3s loop fetching all tasks + tag joins is acceptable at <100 tasks, expensive at 1,000+.
+
+**[Medium] App.jsx is a 952-line god component** *(persists)*
+
+- `apps/tasks/src/App.jsx` is unchanged in size — the task-dependency UI feature merge that would have grown it further was reverted (`70f687e`), so the file is the same shape as W26. The hooks count (`useState`/`useEffect`/`useMemo`/`useCallback`) is still 20.
+
+---
+
+### Security
+
+**[Critical] Live banking-aggregation tokens stored in plaintext** *(persists from W26, unchanged)*
+
+- `services/budget-api/prisma/schema.prisma:41` — `accessToken String` on `AkahuConnection`; no encryption, no envelope wrapping.
+- `services/budget-api/src/repos/akahuRepo.ts:3-13` reads and writes the token verbatim; `routes/akahu.ts:93` consumes it directly.
+- **Consequence (fact):** A read of `budget_api.AkahuConnection` yields a live Akahu bearer token that grants read access to a NZ banking aggregation feed for the linked user. No mitigation has been added since W26.
+
+**[High] `AKAHU_DEV_USER_ACCESS_TOKEN` is still consumed by the production code path** *(persists from W26, unchanged)*
+
+- `services/budget-api/src/routes/akahu.ts:79-89` — if no `AkahuConnection` exists for a user, the route auto-creates one using `process.env.AKAHU_DEV_USER_ACCESS_TOKEN` whenever the env var is set, regardless of `NODE_ENV`. The W26 quick-win fix (`NODE_ENV !== 'production'` guard) has not landed.
+
+**[High] Live Minimax API key remains in `infra/plano/.env`** *(persists from W26)*
+
+- `infra/plano/.env:1` — `PLANO_MINIMAX_API_KEY=sk-cp-…` still on disk.
+- Gitignored, not in history; risk surface unchanged. Worth rotating regardless.
+
+**[Medium] budget-api still has no body-size limit, no helmet, no rate limiting** *(persists)*
+
+- `services/budget-api/src/app.ts:42` — `app.use(express.json())` with no `{ limit }`. No `helmet()`; no per-IP rate limit. Same posture as W26.
+
+**[Medium] vitest UI critical advisory + vite high advisory remain in `npm audit`** *(persists)*
+
+- `npm audit` from repo root: `{ critical: 1, high: 1, moderate: 50, low: 0, total: 52 }` — bit-identical to W26. Both elevated entries are dev-tool surfaces (vitest UI / vite Windows `server.fs.deny` bypass).
+
+---
+
+### Code Quality
+
+**[High] Two tasks-api migrations share the timestamp prefix `20260627000000`** *(new this week)*
+
+- `services/tasks-api/prisma/migrations/20260627000000_add_task_dependencies/` (`feat(tasks): add task dependencies`, `207502b`).
+- `services/tasks-api/prisma/migrations/20260627000000_add_task_spec_checksum/` (`feat(feature-task): guard approved specs with checksums`, `1813322`).
+- **Consequence (fact):** Prisma applies migrations in lexical order of the directory name. With identical prefixes, the suffix decides the order (`d…` < `s…` here, so `_add_task_dependencies` runs first today). That ordering is implicit and would silently change if either directory were renamed. Replaying onto a fresh DB on a filesystem that returns directory entries in a different order is a footgun. Also, two distinct features sharing a timestamp makes `git bisect`-style rollbacks across just one of them awkward.
+- **Severity:** High — schema drift between environments would be silent until something fails.
+
+**[High] feature-task `run.py` and Lobster YAML hard-code Quinn-specific absolute paths** *(new this week)*
+
+- `agents/workflows/feature-task/run.py:18` — `WORKSPACE_ROOT = Path("/Users/quinnstoffer/.openclaw/workspace")` (with a `REPO.parents[1]` fallback only when that exact path is missing).
+- `agents/workflows/feature-task/feature-task.lobster.yaml:9` — `sindustriesRepo:\n    default: /Users/quinnstoffer/workspaces/rowan/sindustries` (a path that doesn't exist on Quinn's primary checkout, suggesting this default has never been validated).
+- `agents/workflows/feature-task/run.py:30-37` — `_load_dotenv_token` reads `~/.openclaw/.env` for `QUINN_GITHUB_TOKEN`, then exports it as `GH_TOKEN`, so feature-task always operates against GitHub as Quinn. Intentional per `6e4947f`, but worth a system-spec callout.
+- **Consequence (fact):** The workflow only runs end-to-end on a machine that matches Quinn's username layout. The `cargo test` CI job avoids the issue (it tests pure parse helpers), but `cargo run ...` invocations driven by Lobster will fail off-Quinn. The fallback chain in `run.py` rescues most cases inside Quinn's worktrees but doesn't recover the Lobster YAML default.
+- **Severity:** High for ops portability; not a runtime safety issue.
+
+**[High] `.gitignore` does not exclude `target/` — 589 MB build artifacts at risk of being committed** *(new this week)*
+
+- `.gitignore` (root) has no `target/` or `**/target/` pattern; my local clone only ignores `agents/workflows/feature-task/target/` via `.git/info/exclude` (`git check-ignore -v` confirms).
+- `du -sh agents/workflows/feature-task/target/` = 589 MB on my checkout.
+- **Consequence (fact):** A fresh clone that runs `cargo build` and then `git add -A` would stage hundreds of MB. The CI job avoids the issue because `actions/checkout` starts clean, but contributor workflows could trip on it.
+- **Severity:** High once anyone commits with `-A`; low if everyone uses surgical `git add path/to/file`.
+
+**[Medium] All 4 E2E specs still fully mock the API — zero real integration coverage** *(persists)*
+
+- `apps/tasks/test/e2e/happy-path.spec.js:19`, `priority-filter.spec.js:48, 162, 222`, `assignee-filter.spec.js:136-294`, `assignee-dropdown.spec.js` — all four specs intercept `**/api/v1/tasks**` via `page.route()`. The CI job at `ci.yml:184-260` already boots the real `tasks-api` with Postgres for these specs; only `page.route()` is in the way.
+
+**[Medium] feature-task workflow recompiles the Rust binary on every Lobster step** *(new this week)*
+
+- `agents/workflows/feature-task/feature-task.lobster.yaml:18-52` — each step shells `cargo run --manifest-path … -- <subcommand>`. After the first call cargo will short-circuit if nothing changed, but the cold path on every workflow start is six sequential `cargo run` invocations, each acquiring the cargo lock.
+- **Consequence (judgment):** Wasted wall-clock + IO on every pass. A `cargo build --release` once then six `target/release/feature-task <subcmd>` invocations would be straightforward.
+
+**[Medium] `routes/tasks.ts` is still 479 lines mixing HTTP wiring, validation orchestration, and pagination glue** *(partial: improved from 517)*
+
+- The W26 split moved pure helpers out, but the file still owns 6 handlers and the in-memory sort block (`tasks.ts:157-181`). Cleaning that up needs the pagination fix (1-C below) first.
+
+**[Low] `services/budget-api/src/generated/` still exists in older worktrees**
+
+- The schema now writes to `../generated/prisma`, but the old `services/budget-api/src/generated/prisma/` directory remains on my checkout (and would on anyone's pre-`c8dbac8` worktree until they `rm -rf` it). It's gitignored, so harmless; worth a one-line note in `services/budget-api/README.md`.
+
+---
+
+### Testing
+
+**[Medium] feature-task CI job runs `cargo test` against the binary crate but has no fixture coverage for the live HTTP path** *(new this week)*
+
+- `.github/workflows/ci.yml:98-109` — the job just runs `cargo test`. The 27 unit tests in `agents/workflows/feature-task/src/main.rs:1149-1450` cover parsing/transition helpers but do not exercise `api_get`/`api_patch` against a real or mocked tasks-api server.
+- **Consequence (judgment):** Regressions in the HTTP envelope, error mapping, or spec-checksum mismatch handshake won't be caught by CI; they'd only surface when the cron-triggered workflow runs against a live API.
+
+**[Medium] Pagination unit tests document the cursor/sort bug rather than enforcing the fix** *(persists from W26 0-B)*
+
+- `services/tasks-api/test/read-endpoints.test.ts` (per `03ba63e`) asserts current behavior so the future fix can flip it. Useful as a baseline, but no test fails when the bug is in place.
+
+**[Low] `services/budget-api` integration test does not exercise the missing-auth contract** *(persists from W26 0-C)*
+
+- The W26 plan included a spec that calls every route without a Bearer and expects 401 (currently passes by accident). That spec was not added.
+
+---
+
+### Performance
+
+**[Medium] 3 s auto-refresh with `limit=10000`** *(persists)*
+
+- Unchanged. Same posture as W26.
+
+**[Low] Akahu sync uses sequential `await prisma.linkedCard.upsert` inside a `for` loop** *(persists)*
+
+- `routes/akahu.ts:126-181` — fine at <20 accounts per user; benchmark before optimizing.
+
+---
+
+### Dependencies
+
+**[Medium] npm advisory landscape: 52 total (50 moderate, 1 high, 1 critical) — unchanged from W26**
+
+- Both elevated entries are dev-tool surfaces; production blast radius is low. `npm audit fix` still worth running next milestone.
+
+**[Low] feature-task uses `ureq = "2"` and `base64 = "0.22"`**
+
+- `agents/workflows/feature-task/Cargo.toml:11, 8` — `ureq 3.x` and `base64 0.23` are the current majors. No advisories; pure hygiene.
+
+**[Low] Prisma at 5.20.0 — Prisma 6.x is available** *(persists)*
+
+- Unchanged.
+
+---
+
+### DevEx & Operations
+
+**[Medium] No lint or format enforcement in CI** *(persists)*
+
+- `ci.yml` runs tests + build but no ESLint or Prettier step. New TypeScript files in `services/tasks-api/src/routes/tasks/` ship without lint gating.
+
+**[Medium] feature-task workflow assumes a long-lived Quinn-owned environment**
+
+- `agents/workflows/feature-task/run.py:23-26` prepends `~/.cargo/bin`, `/opt/homebrew/bin`, `/usr/local/bin` to PATH only if the directory exists; `agents/crons/prompts/feature-task-workflow.md` invokes `run.py` from the cron host. Acceptable while Quinn's Mac is the only runner; one note in the system spec would set expectations for moving it elsewhere.
+
+**[Low] `apps/budget-mobile/.env.local` ships a Tailscale IP** *(persists)*
+
+- Acceptable for local dev; flag before non-tailnet deployment.
+
+---
+
+### Documentation
+
+**[Medium] `docs/architecture.md` still states e2e tests use the real API — they do not** *(persists)*
+
+**[Medium] No system-spec callout for the spec-checksum drift handshake's interaction with PATCH writes**
+
+- `docs/systems/feature-task-workflow.md` describes the workflow but does not document that PATCH tasks with `description` changes will 409 `SPEC_CHECKSUM_MISMATCH` if the stored checksum no longer matches the AC text. Workers that edit task descriptions outside the feature-task path may hit this and need to know the contract.
+
+**[Low] `docs/systems/task-dependencies.md` describes a UI surface that is mid-delivery**
+
+- The system spec covers behavior delivered by PR #128 (per the spec's own note at L98). The DB and API are in `main`; the UI revert (`70f687e`) means the spec describes a contract whose UI half is still in flight. Not stale per se, but a reader needs to know that "dependency management UI is delivered separately" means "not yet on main."
+
+---
+
+## Improvement Strategy
+
+### Theme 1 — Close the budget-api auth gap before any non-Tailnet deployment *(carry-forward from W26 as still the top priority)*
+
+**Current state:** Same as W26, plus the IDOR has widened — `cards.ts` and `alerts.ts` now expose path-parameter routes that don't even require a `userId` to enumerate.
+
+**Target state:** Single `requireSession` middleware mounted before everything except `/session/dev-login`; every route reads `userId` from `req.userId`; every path-parameter route does an ownership lookup (e.g., `assertCardBelongsToUser(cardId, req.userId)`) before mutating.
+
+**Trade-off:** Touches every router file in budget-api and the mobile API client. Effort: M-L.
+
+**Done signal:** Hitting any `budget-api` route without a valid Bearer returns 401; the Akahu token field round-trips through encrypt/decrypt; `NODE_ENV=production` disables the dev fallback; a CI spec exercises a 401-without-bearer path.
+
+### Theme 2 — Eliminate the duplicate-timestamp migration footgun *(new top priority)*
+
+**Current state:** Two `20260627000000_*` directories ship to main.
+
+**Target state:** Rename one of them (e.g., `20260627000100_add_task_spec_checksum`), regenerate `migration.sql` if needed, and add a precommit script that fails on duplicate prefixes. Document in `services/tasks-api/README.md` that migration prefixes must be unique.
+
+**Trade-off:** A rename re-applies the migration on fresh DBs only; existing DBs already have the rows in `_prisma_migrations`. Coordinate the rename with a single `prisma migrate resolve` call on each environment, or accept that the rename only protects future contributors. Effort: S.
+
+**Done signal:** `services/tasks-api/prisma/migrations/` has no duplicate prefixes; a precommit hook rejects `git add` of new ones; a doc line tells future contributors why.
+
+### Theme 3 — Make feature-task portable and CI-runnable end-to-end *(new)*
+
+**Current state:** `run.py` and `feature-task.lobster.yaml` hard-code Quinn-specific paths; the workflow is only ever exercised through `cargo test` in CI.
+
+**Target state:** Replace the hard-coded `WORKSPACE_ROOT` and `sindustriesRepo` defaults with env-driven values resolved from `$GITHUB_WORKSPACE`/`$REPO_ROOT`/`PWD`. Add a smoke-test CI job that runs `cargo build --release` once, then invokes `target/release/feature-task spec-check` against a fixture envelope without hitting a live tasks-api.
+
+**Trade-off:** ~1 minute of CI time; one Python helper change. Effort: S.
+
+**Done signal:** A fresh contributor can `cargo run` the workflow from their own clone with no hard-coded Quinn paths; CI runs at least one stage end-to-end on the compiled binary.
+
+### Theme 4 — Fix pagination or retire it *(carry-forward from W25/W26)*
+
+**Current state / target state / trade-off:** Unchanged. Push sort into the DB, encode the cursor against the sort key, drop the `limit=10000` client hack.
+
+**Done signal:** `tasksApi.ts` no longer hardcodes `limit=10000`; `nextCursor` is meaningful for every supported sort; CI passes.
+
+### Theme 5 — Make the E2E lane actually test the API *(carry-forward)*
+
+**Current state / target state / trade-off:** Unchanged. CI already brings up the real stack; converting at least one spec to drop `page.route()` is the unblock.
+
+**Done signal:** `happy-path.spec.js` has no `page.route()` intercepts; it creates and archives a real task end-to-end; passes in CI.
+
+### Theme 6 — Decompose App.jsx *(carry-forward, lower priority than budgeting safety)*
+
+**Current state / target state / trade-off:** Unchanged from W26 — task-dependency UI revert kept this at the same shape, so the refactor remains a quiet-milestone candidate.
+
+---
+
+## Task Plan
+
+### Milestone 0 — Safety net
+
+| # | Title | Files | Acceptance criteria | Effort | Risk |
+|---|-------|-------|---------------------|--------|------|
+| 0-A | Rename one of the `20260627000000_*` migrations to a unique prefix | `services/tasks-api/prisma/migrations/20260627000000_add_task_spec_checksum/` | Directory renamed (e.g., `20260627000100_add_task_spec_checksum`), `_prisma_migrations` updated on all envs via `prisma migrate resolve --applied`; CI green | S | Medium (requires coordinated `migrate resolve` on existing envs) |
+| 0-B | Add precommit / CI check that rejects duplicate migration prefixes | `scripts/check-migration-prefixes.sh` (new), `Makefile`, `ci.yml` | Two migrations with identical 14-char prefix fail the check; doc in `services/tasks-api/README.md` | S | Low |
+| 0-C | Add `target/` and `**/target/` to root `.gitignore` | `.gitignore` | `git check-ignore agents/workflows/feature-task/target` returns `target/` from the tracked `.gitignore`, not `.git/info/exclude` | S | Low |
+| 0-D | Add a vitest spec for `budget-api` that calls every route without a Bearer and expects 401 *(was W26 0-C, still open)* | `services/budget-api/test/auth-contract.test.ts` (new) | Documents the gap today; after Theme 1 lands, the spec flips from "documents gap" to "enforces rule" | S | Low |
+
+**Quick wins (do now, ≤ 15 min each):**
+- **Gate `AKAHU_DEV_USER_ACCESS_TOKEN` on non-production** — `services/budget-api/src/routes/akahu.ts:79-89`. One-line guard before the dev branch.
+- **Rotate the Minimax API key** — `infra/plano/.env:1`. Carry-forward from W26.
+- **Add a `--release` cargo build prelude to the Lobster pipeline** — `agents/workflows/feature-task/feature-task.lobster.yaml`. One extra step at the top that builds once, then later steps invoke the binary directly.
+
+### Milestone 1 — Critical fixes
+
+| # | Title | Files | Acceptance criteria | Effort | Risk |
+|---|-------|-------|---------------------|--------|------|
+| 1-A | **Add `requireSession` middleware to `budget-api`** and ownership lookups on every path-parameter route | `services/budget-api/src/middleware/requireSession.ts` (new), `src/app.ts`, all `routes/*.ts`, `apps/budget-mobile/src/api/*` | All endpoints reject calls without a valid `Authorization: Bearer`; `userId` only ever read from `req.userId`; every `:cardId`/`:alertId`/`:transactionId` path verifies ownership before mutation | M | Medium |
+| 1-B | **Encrypt Akahu access tokens at rest** | `services/budget-api/src/repos/akahuRepo.ts`, schema migration, `BUDGET_API_TOKEN_KEY` env doc | Tokens written as AES-256-GCM ciphertext + IV; transparent decrypt in read path; key rotation procedure in `services/budget-api/README.md` | M | Medium |
+| 1-C | **Replace hard-coded Quinn paths in feature-task workflow** | `agents/workflows/feature-task/run.py`, `feature-task.lobster.yaml`, `agents/crons/prompts/feature-task-workflow.md` | `run.py` resolves workspace root from `WORKSPACE_ROOT` env or `REPO.parents[1]` only; Lobster YAML `sindustriesRepo` default reads from `${SINDUSTRIES_REPO}` env; cron prompt sets both vars explicitly | S | Low |
+| 1-D | Fix tasks-api pagination: push sort into DB, align cursor encoding | `services/tasks-api/src/routes/tasks.ts`, `services/tasks-api/src/routes/tasks/_pagination.ts`, `apps/tasks/src/tasksApi.ts` | `?sort=dueAt&cursor=X` returns the correct next page; `limit=10000` removed from client; carry-forward test in `read-endpoints.test.ts` flipped to assert the fix | L | Medium |
+| 1-E | Make one E2E spec real: remove `page.route()` from `happy-path.spec.js` | `apps/tasks/test/e2e/happy-path.spec.js`, `playwright.config.js`, `docs/architecture.md` | E2E spec creates/archives a real task; `docs/architecture.md` no longer contradicts the implementation | M | Medium |
+
+**Implementation sketch — 0-A (rename duplicate migration prefix):**
+1. Pick the safer rename: `20260627000000_add_task_spec_checksum` → `20260627000100_add_task_spec_checksum` (keeps dependencies migration as the "first" 06-27 entry, matching current dev/CI order).
+2. Rename the directory; the contents of `migration.sql` and `_prisma_migrations` references are file-name keyed.
+3. On every environment (`dev`, `prodlike`, CI cached DBs, prod when applicable), run:
+   ```bash
+   psql -c "UPDATE _prisma_migrations SET migration_name = '20260627000100_add_task_spec_checksum' WHERE migration_name = '20260627000000_add_task_spec_checksum';"
+   ```
+   Or, equivalently, `prisma migrate resolve --applied 20260627000100_add_task_spec_checksum` after manually marking the old name un-applied.
+4. Add `scripts/check-migration-prefixes.sh` that fails on duplicate 14-char prefixes; wire it into `Makefile` (`make check-migrations`) and `ci.yml` (`tasks-api-tests` job, before `prisma:migrate`).
+5. Gotcha: contributors who already have the old name applied locally will need the SQL update; ship a one-liner in `services/tasks-api/README.md`.
+
+**Implementation sketch — 1-A (`requireSession` middleware):**
+1. Create `services/budget-api/src/middleware/requireSession.ts` that reads `Authorization: Bearer <token>`, computes `sha256(token)`, looks up `Session` by `tokenHash`, and either calls `next()` with `req.userId = session.userId` or returns `jsonError(res, 401, 'UNAUTHORIZED', 'Missing or invalid session')`.
+2. In `app.ts`, mount `sessionRouter` (login + `/me`) *before* the middleware. Then `app.use('/api/v1', requireSession); app.use('/api/v1', akahuRouter); …`.
+3. Walk every router and replace `req.query.userId`/`req.body.userId` reads with `req.userId`. For every path with `:cardId`/`:transactionId`/`:alertId`, add ownership assertion: `if (record.userId !== req.userId) return jsonError(res, 404, …)`.
+4. Mobile client: store the bearer from `/session/dev-login`, attach to every fetch.
+5. Gotcha — `alerts.ts:39-45` (`DELETE /alerts/:alertId`) currently uses `prisma.notificationEvent.findUnique({ where: { id } })` and then deletes; you need to add a `where: { id, userId: req.userId }` filter and return 404 on miss.
+6. Gotcha — `cards.ts:95-117` and `cards.ts:119-147` resolve cards from path id; `getCardById(cardId)` does not currently scope by user. Either change the repo to require `userId` or add the check in the route.
+
+**Implementation sketch — 1-C (portable feature-task paths):**
+1. In `run.py:15-26`, replace the hard-coded `WORKSPACE_ROOT` with `Path(os.environ.get("WORKSPACE_ROOT", REPO.parents[1] if len(REPO.parents) > 1 else REPO.parent))`.
+2. In `feature-task.lobster.yaml:8-11`, change the `sindustriesRepo:\n    default: /Users/quinnstoffer/workspaces/rowan/sindustries` to use a `${SINDUSTRIES_REPO}` placeholder, and document the required env var in `docs/systems/feature-task-workflow.md`.
+3. In `agents/crons/prompts/feature-task-workflow.md`, export `WORKSPACE_ROOT` and `SINDUSTRIES_REPO` explicitly (or call `run.py` with `--workspace-root` if you add the CLI flag).
+4. Add a CI smoke step that runs `WORKSPACE_ROOT=$(pwd)/.. SINDUSTRIES_REPO=$(pwd) cargo run --manifest-path agents/workflows/feature-task/Cargo.toml -- spec-check --dry-run true` against the existing `fixtures/task_full.md`.
+5. Gotcha — `_load_dotenv_token('QUINN_GITHUB_TOKEN')` is Quinn-specific by design. Leave the env-var lookup as a fallback path, but document the requirement so non-Quinn contributors know what GH_TOKEN to set.
+
+### Milestone 2 — High-leverage improvements
+
+| # | Title | Files | Acceptance criteria | Effort | Risk |
+|---|-------|-------|---------------------|--------|------|
+| 2-A | Shared assignee/status/priority constants between `tasks-api` and `apps/tasks` | `packages/contracts` (new) or `packages/ui/src/shared-constants.ts`; `services/tasks-api/src/routes/tasks/_constants.ts`; `apps/tasks/src/utils/constants.js` | One file to change to add an assignee; both halves consume it | M | Low |
+| 2-B | Decompose `App.jsx` into feature modules | `App.jsx`, new `FilterBar`, `BoardView`, `BacklogView`, `TaskCelebration` | `App.jsx` < 250 lines; each extracted component has ≥1 unit test; E2E still passes | L | Medium |
+| 2-C | Add helmet + explicit body size limit to `budget-api` | `services/budget-api/src/app.ts` | `helmet()` mounted; `express.json({ limit: '64kb' })` | S | Low |
+| 2-D | Add ESLint + Prettier gate in CI | `.eslintrc`, `ci.yml` | Lint job runs on PRs; existing violations either fixed or `// eslint-disable-next-line` documented | M | Low |
+| 2-E | Enable strict TypeScript in `tasks-api` and `budget-api` | `tsconfig.json`, route files | `tsc --noEmit` passes with `strict: true` | M | Medium |
+| 2-F | Add a feature-task HTTP-path smoke test in CI | `agents/workflows/feature-task/tests/` (new), `.github/workflows/ci.yml` | A test boots a mock tasks-api and exercises `load-task` end-to-end | S | Low |
+
+### Milestone 3 — Quality & polish
+
+| # | Title | Effort |
+|---|-------|--------|
+| 3-A | Pagination unit tests assert post-fix correctness | M |
+| 3-B | Wrap budget-api Akahu sync card/balance loop in `prisma.$transaction` | S |
+| 3-C | Add structured logging with `trace_id` to both APIs' error middleware | M |
+| 3-D | Update `docs/specs/tasks-one-pager.md` and `docs/architecture.md` to match current behavior | S |
+| 3-E | Evaluate Prisma 6 migration; document decision | M |
+| 3-F | Add per-IP rate limit (`express-rate-limit`) on `/akahu/exchange` and `/session/dev-login` | S |
+| 3-G | Bump feature-task `ureq` and `base64` to current majors | S |
+| 3-H | Run `npm audit fix` and capture the resulting diff | S |
+| 3-I | Remove stale `services/budget-api/src/generated/` checkouts via a `make clean-generated` target | S |
+| 3-J | Document the spec-checksum mismatch contract in `docs/systems/feature-task-workflow.md` | S |
+
+---
+
+## Open Questions
+
+1. **Migration rename rollout:** Task 0-A requires updating `_prisma_migrations` on every environment that already applied the old name. Prod budget-api isn't in scope yet, but tasks-api is deployed. What's the migration-rollout sequence for renaming a migration that's already been applied to a live DB?
+
+2. **budget-api auth scope:** The dev-token + no-auth posture says "MVP / Tailnet-only." Is non-Tailnet deployment (TestFlight/internal prod) imminent? If yes, Milestone 1 must land before that.
+
+3. **Encryption key custody:** For Theme 1, where should `BUDGET_API_TOKEN_KEY` live? `.env` parity with current Akahu secrets vs. 1Password vs. AWS KMS. Recommend `.env` for the MVP cut and KMS-or-equivalent before any non-local deployment.
+
+4. **feature-task ownership of GitHub identity:** `run.py` always exports Quinn's PAT as `GH_TOKEN`. Should the cron host become a separate bot identity, or do we accept "Quinn = the system" until production? Calling this out so the answer is captured in `docs/systems/feature-task-workflow.md`.
+
+5. **Mobile session lifecycle:** `/session/dev-login` issues a token that lives forever (no expiry column on `Session`). Is rotating-on-expiry / a refresh-token model expected for the MVP, or can sessions stay infinite until the mobile app gets real auth?
+
+6. **E2E split architecture (carry-forward):** Should the new real E2E lane run on every PR or only on `main` post-merge? And should the mocked specs stay in `test/e2e/` (renamed) or move to a vitest suite?
+
+7. **App.jsx decomposition timing (carry-forward):** A 952-line component refactor risks PR conflicts with active feature branches. Is there a quiet milestone coming where this can land cleanly?
+
+8. **Plano Minimax API key (carry-forward):** Confirm whether `PLANO_MINIMAX_API_KEY` in `infra/plano/.env` is still in active use. If not, delete it rather than rotate.


### PR DESCRIPTION
## Executive Summary

**Health grade: B-** (held from W26 refresh — CI now exercises the new surfaces, but the W26 Critical findings in `budget-api` still ship on `main` unchanged, and three new structural issues landed with the feature-task workflow).

This audit covers the work that merged after the W26 refresh: the new Rust+Python+Lobster `agents/workflows/feature-task` orchestrator, spec-checksum drift enforcement in `tasks-api`, the `tasks.ts` split into helper modules, the second attempt at the task-dependencies surface (server + DB in main, UI mid-delivery), per-service Prisma client isolation, and the new `budget-api-tests` and `feature-task-workflow-tests` CI jobs. The Critical W26 findings persist: every `budget-api` route except `/me` reads `userId` from the request and operates on that user without verifying a session, and the Akahu access token is still a plaintext `String` column. Worse, the `cards` and `alerts` routers expose IDOR on path parameters (`:cardId`, `:alertId`) — `POST /cards/:cardId/budget`, `GET /cards/:cardId/spend-summary`, and `DELETE /alerts/:alertId` resolve and mutate records purely from URL ids without an ownership lookup. Two new tasks-api migrations share the timestamp prefix `20260627000000`, leaving migration ordering at the mercy of filesystem sort. The new feature-task workflow hard-codes Quinn-specific absolute paths in `run.py` and the Lobster YAML.

**Top 3 risks:** (1) `budget-api` ships every route except `/me` with no session check, and the `cards`/`alerts` routers compound this by trusting URL-supplied ids without ownership lookups — net IDOR on transactions, balances, budgets, alert configs, and Akahu connections; (2) Akahu bearer tokens are still stored plaintext (`AkahuConnection.accessToken String`), so a DB read yields live banking-aggregation access; (3) two tasks-api migrations share the prefix `20260627000000`, so the apply order depends on filesystem sort and the two could silently swap places between dev and CI.

**Top 3 opportunities:** (1) Land the W26 Theme-1 `requireSession` middleware on `budget-api` and add ownership lookups on every path-parameter route; (2) Rename one of the two `20260627000000_*` migrations and add a precommit check that rejects duplicate prefixes; (3) Replace the hard-coded Quinn paths in `agents/workflows/feature-task/run.py:18` and `feature-task.lobster.yaml:9` with environment-driven defaults so feature-task runs anywhere CI can reach the binary.

---

Full audit: [`docs/repo-audits/2026-W27.md`](docs/repo-audits/2026-W27.md)

🤖 Generated with Claude Code