### PR TITLE
docs(code-garden): document stale src/generated/ workaround [2026-W27]

### DIFF
--- a/docs/repo-audits/2026-W27.md
+++ b/docs/repo-audits/2026-W27.md
@@ -184,7 +184,7 @@ AI agents (agents/)
 
 - The W26 split moved pure helpers out, but the file still owns 6 handlers and the in-memory sort block (`tasks.ts:157-181`). Cleaning that up needs the pagination fix (1-C below) first.
 
-**[Low] `services/budget-api/src/generated/` still exists in older worktrees** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**[Low] `services/budget-api/src/generated/` still exists in older worktrees** ✅ [PR #136](https://github.com/Stoffer-Industries/sindustries/pull/136)
 
 - The schema now writes to `../generated/prisma`, but the old `services/budget-api/src/generated/prisma/` directory remains on my checkout (and would on anyone's pre-`c8dbac8` worktree until they `rm -rf` it). It's gitignored, so harmless; worth a one-line note in `services/budget-api/README.md`.
 

--- a/docs/repo-audits/2026-W27.md
+++ b/docs/repo-audits/2026-W27.md
@@ -184,7 +184,7 @@ AI agents (agents/)
 
 - The W26 split moved pure helpers out, but the file still owns 6 handlers and the in-memory sort block (`tasks.ts:157-181`). Cleaning that up needs the pagination fix (1-C below) first.
 
-**[Low] `services/budget-api/src/generated/` still exists in older worktrees**
+**[Low] `services/budget-api/src/generated/` still exists in older worktrees** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 
 - The schema now writes to `../generated/prisma`, but the old `services/budget-api/src/generated/prisma/` directory remains on my checkout (and would on anyone's pre-`c8dbac8` worktree until they `rm -rf` it). It's gitignored, so harmless; worth a one-line note in `services/budget-api/README.md`.
 

--- a/services/budget-api/README.md
+++ b/services/budget-api/README.md
@@ -39,6 +39,7 @@ npm run dev
 
 - `DATABASE_URL` must include `?schema=budget_api` (see `.env.example`).
 - If you see Prisma `P2021` errors like `The table budget_api.User does not exist`, it means migrations have not been applied yet.
+- The Prisma client writes to `services/budget-api/generated/prisma` (see `prisma/schema.prisma`). Worktrees branched before `c8dbac8` may still have a stale `services/budget-api/src/generated/` directory — it is gitignored but unused, and can be removed with `rm -rf services/budget-api/src/generated` to silence editor warnings.
 
 ## MVP endpoints
 


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W27.md
- **Finding:** [Low] `services/budget-api/src/generated/` still exists in older worktrees
- Added a one-line note to `services/budget-api/README.md` (Database notes) explaining that the Prisma client writes to `services/budget-api/generated/prisma`, and that pre-`c8dbac8` worktrees may carry a now-stale, gitignored `services/budget-api/src/generated/` directory that can be safely removed.

## Test plan
- [ ] No logic changes — diff is purely structural/cosmetic
- [ ] `git diff --name-only origin/main HEAD` shows only `services/budget-api/README.md` and `docs/repo-audits/2026-W27.md`

🌱 Code garden — non-functional cleanup only

🤖 Generated with Claude Code