### PR TITLE
chore(code-garden): add make clean-generated target [2026-W27]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap up down reset-db migrate-db test test-api test-app test-website test-e2e test-all
+.PHONY: bootstrap up down reset-db migrate-db test test-api test-app test-website test-e2e test-all clean-generated
 
 MODE ?= dev
 
@@ -35,3 +35,11 @@ test-website:
 
 test-e2e:
 	cd apps/tasks && npm run test:e2e
+
+# Removes the stale pre-c8dbac8 src/generated/ directories on older worktrees.
+# The Prisma schema now writes to services/*/generated/prisma; the older
+# src/generated/ path is gitignored and only present on checkouts created
+# before c8dbac8. Safe to run; re-running `prisma generate` will repopulate
+# the canonical services/*/generated/prisma directory.
+clean-generated:
+	rm -rf services/budget-api/src/generated services/tasks-api/src/generated

--- a/docs/repo-audits/2026-W27.md
+++ b/docs/repo-audits/2026-W27.md
@@ -390,7 +390,7 @@ AI agents (agents/)
 | 3-F | Add per-IP rate limit (`express-rate-limit`) on `/akahu/exchange` and `/session/dev-login` | S |
 | 3-G | Bump feature-task `ureq` and `base64` to current majors | S |
 | 3-H | Run `npm audit fix` and capture the resulting diff | S |
-| 3-I | Remove stale `services/budget-api/src/generated/` checkouts via a `make clean-generated` target | S |
+| 3-I | Remove stale `services/budget-api/src/generated/` checkouts via a `make clean-generated` target ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD) | S |
 | 3-J | Document the spec-checksum mismatch contract in `docs/systems/feature-task-workflow.md` ✅ [PR #135](https://github.com/Stoffer-Industries/sindustries/pull/TBD) | S |
 
 ---

--- a/docs/repo-audits/2026-W27.md
+++ b/docs/repo-audits/2026-W27.md
@@ -390,7 +390,7 @@ AI agents (agents/)
 | 3-F | Add per-IP rate limit (`express-rate-limit`) on `/akahu/exchange` and `/session/dev-login` | S |
 | 3-G | Bump feature-task `ureq` and `base64` to current majors | S |
 | 3-H | Run `npm audit fix` and capture the resulting diff | S |
-| 3-I | Remove stale `services/budget-api/src/generated/` checkouts via a `make clean-generated` target ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD) | S |
+| 3-I | Remove stale `services/budget-api/src/generated/` checkouts via a `make clean-generated` target ✅ [PR #137](https://github.com/Stoffer-Industries/sindustries/pull/137) | S |
 | 3-J | Document the spec-checksum mismatch contract in `docs/systems/feature-task-workflow.md` ✅ [PR #135](https://github.com/Stoffer-Industries/sindustries/pull/TBD) | S |
 
 ---


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W27.md
- **Finding:** [S] Milestone 3 item 3-I — Remove stale `services/budget-api/src/generated/` checkouts via a `make clean-generated` target
- Adds an opt-in `make clean-generated` target that removes the now-stale pre-`c8dbac8` `services/budget-api/src/generated` and `services/tasks-api/src/generated` directories. The Prisma schema writes to `services/*/generated/prisma`; the older `src/generated/` path is gitignored and only present on older worktrees. After running the target, `prisma generate` repopulates the canonical directory. No app code or behaviour changed.

## Test plan
- [x] `make -n clean-generated` resolves to `rm -rf services/budget-api/src/generated services/tasks-api/src/generated`
- [x] No logic changes — diff is purely an additive Makefile target plus the audit mark-done line
- [x] `git diff --name-only origin/main HEAD` shows only `Makefile` and `docs/repo-audits/2026-W27.md`

🌱 Code garden — non-functional cleanup only