### PR TITLE
chore(brain): rename brain/specs/ to brain/tasks/specs/

### DIFF
--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -4,7 +4,7 @@
 Heartbeat discovers and advances content tasks assigned to Ivy.
 
 Workflow semantics for the content task workflow Lobster are defined in:
-- /Users/quinnstoffer/.openclaw/workspace/brain/tasks/specs/app-tasks/content-task-workflow-lobster.md
+- agents/workflows/content-tasks/content-task.lobster.yaml
 
 Ivy must NEVER change task status. The Lobster does that.
 

--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -4,7 +4,7 @@
 Heartbeat discovers and advances content tasks assigned to Ivy.
 
 Workflow semantics for the content task workflow Lobster are defined in:
-- /Users/quinnstoffer/.openclaw/workspace/brain/specs/app-tasks/content-task-workflow-lobster.md
+- /Users/quinnstoffer/.openclaw/workspace/brain/tasks/specs/app-tasks/content-task-workflow-lobster.md
 
 Ivy must NEVER change task status. The Lobster does that.
 

--- a/agents/definitions/quinn/AGENTS.md
+++ b/agents/definitions/quinn/AGENTS.md
@@ -123,7 +123,7 @@ When creating, moving, or restoring documentation, use these directories consist
 
 - `brain/bookmarks/` — inbound material to review later. This is the staging area for information we care about (from X, podcasts, links, or our own research) that may lead to action later.
 - `brain/reviews/` — our opinions, analysis, and synthesis about bookmarks as they relate to our world.
-- `brain/specs/` — implementation-target documents, usually derived from reviews and may include delivery planning or scheduling.
+- `brain/tasks/specs/` — implementation-target documents for feature tasks, usually derived from reviews and may include delivery planning or scheduling.
 - `brain/posts/` — content we create for the outside world.
 - `docs/infra/` — documentation about the current OpenClaw setup, runtime, incidents, baselines, and operational setup.
 
@@ -131,7 +131,7 @@ When creating, moving, or restoring documentation, use these directories consist
 If unsure where something belongs:
 - raw/inbound idea → `brain/bookmarks/`
 - interpretation/opinion → `brain/reviews/`
-- build-against plan/spec → `brain/specs/`
+- build-against plan/spec → `brain/tasks/specs/`
 - publishable outward content → `brain/posts/`
 - current system/runbook/setup docs → `docs/infra/`
 

--- a/agents/skills/product/feature-task-create/SKILL.md
+++ b/agents/skills/product/feature-task-create/SKILL.md
@@ -15,13 +15,13 @@ Use when turning a request into a tracked feature task. Covers the factory vs di
 - Is a new capability, not a removal or rename
 - Will take Rowan more than a few hours of focused work
 
-**Assign directly** (no factory, no spec) when the work is:
+**Assign directly** (no task needed) when the work is:
 - Removing or renaming an old artifact
 - A typo / cosmetic fix
 - A config or path correction
 - Something Tom has already verbally approved and scoped
 
-Direct tasks still go through the Tasks API but do not need `taskType: feature` or a spec line. Use a `taskType: chore` and skip the spec and workstream block.
+For direct work: hand it to Rowan with a clear instruction and let him open a PR. No Tasks API call needed.
 
 ---
 
@@ -117,7 +117,7 @@ base = 'http://localhost:4001/api/v1'
 
 # Create new task
 payload = json.dumps({
-    'title': '🔧 <Title>',
+    'title': '<Title>',
     'description': '<formatted description from Step 3>',
     'taskType': 'feature',
     'assignee': 'Rowan',

--- a/agents/skills/product/feature-task-create/SKILL.md
+++ b/agents/skills/product/feature-task-create/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: feature-task-create
+description: "Create or clean up a feature task: decide whether to use the feature factory, write the spec, format the task description, and call the Tasks API."
+---
+
+# Feature Task Create
+
+Use when turning a request into a tracked feature task. Covers the factory vs direct decision, spec placement, and task format.
+
+## Step 1 — Feature Factory or Direct?
+
+**Use the feature factory** when the work:
+- Has more than one non-trivial acceptance criterion
+- Requires spec approval from Tom before implementation starts
+- Is a new capability, not a removal or rename
+- Will take Rowan more than a few hours of focused work
+
+**Assign directly** (no factory, no spec) when the work is:
+- Removing or renaming an old artifact
+- A typo / cosmetic fix
+- A config or path correction
+- Something Tom has already verbally approved and scoped
+
+Direct tasks still go through the Tasks API but do not need `taskType: feature` or a spec line. Use a `taskType: chore` and skip the spec and workstream block.
+
+---
+
+## Step 2 — Write or Identify the Spec
+
+**Feature tasks need a spec.** Choose the right location:
+
+| Situation | Spec location |
+|---|---|
+| New spec for this feature | `brain/tasks/specs/<slug>-YYYY-MM-DD.md` |
+| Bookmark pipeline produced a spec | `brain/bookmarks/specs/<slug>-<key>.md` |
+| An existing sindustries spec covers this | `docs/specs/<filename>.md` |
+
+Do **not** amend an existing approved spec unless the task is explicitly an amendment. Do **not** create a new spec inside `docs/specs/` — that dir is for committed, reviewed specs only.
+
+### Spec format (brain/tasks/specs/)
+
+```markdown
+# Spec — <Title>
+
+**Status:** Draft
+- [ ] Approved by Tom
+
+## Outcome
+
+One paragraph: what is demonstrably different after this ships?
+
+## Acceptance Criteria
+
+- [ ] AC1: observable outcome
+- [ ] AC2: observable outcome
+
+Rules: max 8 ACs, implementation-agnostic, no script names or file paths.
+
+## Non-Goals
+
+What this deliberately does not cover.
+
+## Notes
+
+Key constraints or non-obvious integration points. One paragraph max.
+```
+
+---
+
+## Step 3 — Format the Task Description
+
+```
+**Type:** feature
+**Spec:** <relative path from workspace root, e.g. brain/tasks/specs/my-spec-2026-06-29.md>
+
+<One paragraph describing what the feature does and why it matters>
+
+---
+
+**Acceptance Criteria**
+
+- [ ] AC1: ...
+- [ ] AC2: ...
+
+---
+
+**Workstreams**
+
+- Owner: Rowan
+  Repo: Stoffer-Industries/sindustries
+  Branch: task-<first 8 chars of task ID>-<short-slug>
+  Worktree: ~/workspaces/rowan/sindustries
+  PR: (pending)
+  Scope: <what Rowan builds>
+  ACs: AC1, AC2, ...
+  Status: open
+
+- Owner: Quinn          ← only if Quinn has ACs
+  Scope: <what Quinn does>
+  ACs: AC3, ...
+  Status: open
+```
+
+**Spec line rules:**
+- Must be exactly `**Spec:** <path>` — no parentheticals after the path
+- Lobster parses this with a strict regex; any suffix breaks it
+- Path is relative to workspace root (not an absolute path)
+
+---
+
+## Step 4 — Call the Tasks API
+
+```python
+import urllib.request, json
+
+base = 'http://localhost:4001/api/v1'
+
+# Create new task
+payload = json.dumps({
+    'title': '🔧 <Title>',
+    'description': '<formatted description from Step 3>',
+    'taskType': 'feature',
+    'assignee': 'Rowan',
+    'priority': 'high',  # or 'urgent' if blocking
+    'tags': ['rowan', '<topic-tag>']
+}).encode()
+
+req = urllib.request.Request(f'{base}/tasks', data=payload,
+    headers={'Content-Type': 'application/json'}, method='POST')
+with urllib.request.urlopen(req) as resp:
+    task = json.load(resp)['data']
+    print('Created:', task['id'], task['title'])
+```
+
+To update an existing task (replace description, not append):
+
+```python
+req = urllib.request.Request(f'{base}/tasks/{task_id}',
+    data=json.dumps({'description': desc, 'taskType': 'feature', 'assignee': 'Rowan'}).encode(),
+    headers={'Content-Type': 'application/json'}, method='PATCH')
+```
+
+Note: `tasks_api_client.py patch --description` **appends** to the existing description. Use direct API calls to replace.
+
+---
+
+## Checklist before declaring done
+
+- [ ] Spec written at `brain/tasks/specs/` (or existing spec identified)
+- [ ] `**Spec:**` line is exact path, no trailing text
+- [ ] ACs are observable outcomes, not implementation steps
+- [ ] Branch name uses first 8 chars of task ID
+- [ ] `taskType: feature` and `assignee: Rowan` set via API
+- [ ] Task status is `open` (Lobster will advance it once spec is approved)

--- a/docs/systems/agent-orchestration.md
+++ b/docs/systems/agent-orchestration.md
@@ -308,7 +308,7 @@ flowchart LR
 |---|---|---|
 | `brain/bookmarks/` | Inbound material (X, links, research) | x-bookmark-ingest |
 | `brain/reviews/` | Our opinions / analysis on bookmarks | Quinn |
-| `brain/specs/` | Implementation plans derived from reviews | spec-author skill |
+| `brain/tasks/specs/` | Implementation-target docs for feature tasks | Quinn / Rowan |
 | `brain/posts/` | Public content (blog, social) | Ivy |
 | `brain/ops/notes/` | Daily content signals (feeds weekly review) | Quinn / Lox |
 | `brain/content/sindustries-weekly-content/` | Weekly review files for Tom triage | Quinn |
@@ -319,7 +319,7 @@ flowchart LR
 **Rule of thumb (from AGENTS.md):**
 - raw / inbound idea → `brain/bookmarks/`
 - interpretation / opinion → `brain/reviews/`
-- build-against plan → `brain/specs/`
+- build-against plan → `brain/tasks/specs/`
 - publishable content → `brain/posts/`
 - daily content signal → `brain/ops/notes/`
 - weekly review for triage → `brain/content/sindustries-weekly-content/`


### PR DESCRIPTION
## Summary
- Renames the canonical spec location for feature tasks from `brain/specs/` to `brain/tasks/specs/`
- Keeps `brain/bookmarks/specs/` separate (bookmark pipeline output — untouched)
- `brain/specs/` was effectively empty in iCloud; new `brain/tasks/specs/` dir created there
- Updates AGENTS.md, agent-orchestration.md, and Ivy's HEARTBEAT.md to use the new path

## Files changed
- `agents/definitions/quinn/AGENTS.md` — doc structure + rule-of-thumb updated
- `docs/systems/agent-orchestration.md` — doc tree table + rule-of-thumb updated
- `agents/definitions/ivy/HEARTBEAT.md` — lobster spec path updated

## Not changed
- Tests (`test_bookmark_workflow.py` etc.) use `brain/specs/` as fixture path strings — these reflect bookmark pipeline output paths and are separate from this rename

🤖 Generated with Quinn