### PR TITLE
fix(skills): bold **Approved by Tom** in spec template

### DIFF
--- a/agents/skills/product/feature-task-create/SKILL.md
+++ b/agents/skills/product/feature-task-create/SKILL.md
@@ -43,7 +43,7 @@ Do **not** amend an existing approved spec unless the task is explicitly an amen
 # Spec — <Title>
 
 **Status:** Draft
-- [ ] Approved by Tom
+- [ ] **Approved by Tom**
 
 ## Outcome
 


### PR DESCRIPTION
## Summary
- The `feature-task-create` skill spec template had `- [ ] Approved by Tom` without bold markers
- The lobster regex requires `- [ ] **Approved by Tom**` (bold) to match
- Fixes the template so new specs generated from the skill will pass the approval check

🤖 Generated with Quinn