### PR TITLE
feat(tasks): add task type filter and editor selector

### DIFF
--- a/apps/tasks/src/App.jsx
+++ b/apps/tasks/src/App.jsx
@@ -22,7 +22,7 @@ import { useDebounce } from './hooks/useDebounce.js';
 import { useToast } from './hooks/useToast.js';
 import { TaskCardSummary } from './components/TaskCardSummary.jsx';
 import { TaskEditor } from './components/TaskEditor.jsx';
-import { STATUSES, STATUS_LABELS, PRIORITIES, PRIORITY_SCORE, ASSIGNEE_OPTIONS } from './utils/constants.js';
+import { STATUSES, STATUS_LABELS, PRIORITIES, PRIORITY_SCORE, ASSIGNEE_OPTIONS, TASK_TYPES, TASK_TYPE_LABELS } from './utils/constants.js';
 import { createConfettiPieces, normalizeTaskForEditor, taskCardTilt } from './utils/helpers.js';
 import { getStoredTheme, getStoredView, setStoredTheme, setStoredView } from './utils/storage.js';
 
@@ -43,12 +43,13 @@ export function App() {
   const [theme, setTheme] = useState(getStoredTheme);
   const [selectedId, setSelectedId] = useState(null);
   const initialStatusSelection = ['open', 'ready', 'doing', 'acceptance'];
-  const [filters, setFilters] = useState({ q: '', status: initialStatusSelection.join(','), priority: '', tag: '', assignee: '', includeArchived: false });
+  const [filters, setFilters] = useState({ q: '', status: initialStatusSelection.join(','), priority: '', tag: '', assignee: '', taskType: '', includeArchived: false });
   const [selectedStatuses, setSelectedStatuses] = useState(() => new Set(initialStatusSelection));
   const [openFilterMenu, setOpenFilterMenu] = useState(null);
   const statusMenuRef = useRef(null);
   const priorityMenuRef = useRef(null);
   const assigneeMenuRef = useRef(null);
+  const taskTypeMenuRef = useRef(null);
   const tagMenuRef = useRef(null);
 
   // Calculate number of visible columns for CSS grid
@@ -64,6 +65,7 @@ export function App() {
       status: statusMenuRef,
       priority: priorityMenuRef,
       assignee: assigneeMenuRef,
+      taskType: taskTypeMenuRef,
       tag: tagMenuRef
     };
 
@@ -617,6 +619,51 @@ export function App() {
               ) : null}
             </div>
 
+            <div className="status-filter" ref={taskTypeMenuRef}>
+              <Button
+                type="button"
+                variant="filter"
+                active={Boolean(filters.taskType)}
+                className="filter-trigger"
+                aria-label="Task type filter"
+                aria-haspopup="menu"
+                aria-expanded={openFilterMenu === 'taskType'}
+                onClick={() => setOpenFilterMenu((current) => (current === 'taskType' ? null : 'taskType'))}
+              >
+                {`TYPE: ${(filters.taskType ? TASK_TYPE_LABELS[filters.taskType] : 'All types').toUpperCase()}`}
+              </Button>
+              {openFilterMenu === 'taskType' ? (
+                <Dropdown className="filter-menu" role="menu" aria-label="Task type filter menu">
+                  <DropdownOption
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={!filters.taskType}
+                    onClick={() => {
+                      setFilters((current) => ({ ...current, taskType: '' }));
+                      setOpenFilterMenu(null);
+                    }}
+                  >
+                    ALL TYPES
+                  </DropdownOption>
+                  <DropdownDivider />
+                  {TASK_TYPES.map((taskType) => (
+                    <DropdownOption
+                      key={taskType}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={filters.taskType === taskType}
+                      onClick={() => {
+                        setFilters((current) => ({ ...current, taskType }));
+                        setOpenFilterMenu(null);
+                      }}
+                    >
+                      {TASK_TYPE_LABELS[taskType].toUpperCase()}
+                    </DropdownOption>
+                  ))}
+                </Dropdown>
+              ) : null}
+            </div>
+
             {allTags.length > 0 ? (
               <div className="status-filter" ref={tagMenuRef}>
                 <Button
@@ -723,9 +770,9 @@ export function App() {
               <Field label="Content type">
                 <Select value={newTask.taskType} onChange={(e) => setNewTask((current) => ({ ...current, taskType: e.target.value }))}>
                   <option value="">None</option>
-                  <option value="content">Content</option>
-                  <option value="code">Code</option>
-                  <option value="research">Research</option>
+                  {TASK_TYPES.map((taskType) => (
+                    <option key={taskType} value={taskType}>{TASK_TYPE_LABELS[taskType]}</option>
+                  ))}
                 </Select>
               </Field>
             </div>

--- a/apps/tasks/src/App.test.jsx
+++ b/apps/tasks/src/App.test.jsx
@@ -181,6 +181,28 @@ describe('tasks ui', () => {
     expect(screen.getByLabelText('Search')).toBeInTheDocument();
     expect(screen.getByLabelText('Status filter')).toBeInTheDocument();
     expect(screen.getByLabelText('Priority filter')).toBeInTheDocument();
+    expect(screen.getByLabelText('Task type filter')).toBeInTheDocument();
+  });
+
+  it('filters tasks by task type', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [mockTask({ taskType: 'feature' })] }) });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: 'Backlog' }));
+
+    await screen.findByRole('list', { name: 'Backlog list' });
+    fireEvent.click(screen.getByLabelText('Task type filter'));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'FEATURE' }));
+
+    await waitFor(() => {
+      const typeFilterCall = fetchMock.mock.calls.find(([url]) => String(url).includes('taskType=feature'));
+      expect(typeFilterCall?.[0]).toContain('taskType=feature');
+    });
+    expect(screen.getByLabelText('Task type filter')).toHaveTextContent('TYPE: FEATURE');
   });
 
   it('renders board columns sorted by priority, readiness, then createdAt', async () => {
@@ -377,6 +399,53 @@ describe('tasks ui', () => {
     expect(screen.getByLabelText('Detail title')).toHaveValue('Draft title');
   });
 
+  it('preserves and saves unsaved task type edits', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      const method = options.method ?? 'GET';
+      const urlText = String(url);
+
+      if (method === 'GET' && urlText.includes('/tasks?')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [mockTask({ id: 'type-draft-task', title: 'Type draft task', taskType: 'code' })]
+          })
+        };
+      }
+
+      if (method === 'PATCH' && urlText.includes('/tasks/type-draft-task')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: mockTask({ id: 'type-draft-task', title: 'Type draft task', taskType: 'feature' })
+          })
+        };
+      }
+
+      throw new Error(`Unexpected fetch call: ${method} ${urlText}`);
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: 'Backlog' }));
+
+    await screen.findByRole('list', { name: 'Backlog list' });
+    fireEvent.click(screen.getByRole('button', { name: 'Type draft task' }));
+    fireEvent.change(screen.getByLabelText('Detail task type'), { target: { value: 'feature' } });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Close' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Type draft task' }));
+    expect(screen.getByLabelText('Detail task type')).toHaveValue('feature');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      const patchCall = fetchMock.mock.calls.find(([url, options]) => String(url).includes('/tasks/type-draft-task') && options?.method === 'PATCH');
+      expect(JSON.parse(patchCall?.[1]?.body ?? '{}')).toMatchObject({ taskType: 'feature' });
+    });
+  });
+
   it('restores unsaved task edits after remounting the page', async () => {
     vi.stubGlobal(
       'fetch',
@@ -446,9 +515,18 @@ describe('tasks ui', () => {
     await screen.findByRole('list', { name: 'Backlog list' });
     fireEvent.click(screen.getByRole('button', { name: '+ New Task' }));
     fireEvent.change(screen.getByLabelText('New task title'), { target: { value: 'Created' } });
+    expect(screen.getByRole('option', { name: 'Feature' })).toBeInTheDocument();
+    fireEvent.change(screen.getByDisplayValue('None'), { target: { value: 'feature' } });
     fireEvent.click(screen.getByRole('button', { name: 'Create task' }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/tasks'), expect.objectContaining({ method: 'POST' })));
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/tasks'),
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"taskType":"feature"')
+      })
+    );
 
     fireEvent.click(await screen.findByRole('button', { name: 'Created' }));
     fireEvent.click(screen.getByRole('button', { name: 'Archive task' }));

--- a/apps/tasks/src/components/TaskEditor.jsx
+++ b/apps/tasks/src/components/TaskEditor.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Badge, Button, Card, Divider, Field, Input, Select, Textarea } from '@sindustries/ui/react';
-import { STATUSES, STATUS_LABELS, PRIORITIES, ASSIGNEE_OPTIONS } from '../utils/constants.js';
+import { STATUSES, STATUS_LABELS, PRIORITIES, ASSIGNEE_OPTIONS, TASK_TYPES, TASK_TYPE_LABELS } from '../utils/constants.js';
 import { normalizeComments, formatCommentTimestamp } from '../utils/helpers.js';
 import { MarkdownContent } from './MarkdownContent.jsx';
 import { TaskCardSummary } from './TaskCardSummary.jsx';
@@ -40,6 +40,7 @@ export function TaskEditor({
   const statusRef = useRef(null);
   const priorityRef = useRef(null);
   const assigneeRef = useRef(null);
+  const taskTypeRef = useRef(null);
   const dueAtRef = useRef(null);
   const tagsRef = useRef(null);
   const blockedRef = useRef(null);
@@ -93,6 +94,7 @@ export function TaskEditor({
         .split(',')
         .map((tag) => tag.trim())
         .filter(Boolean),
+      taskType: draft.taskType || null,
       blocked: draft.blocked
     };
   }
@@ -103,6 +105,7 @@ export function TaskEditor({
     statusRef,
     priorityRef,
     assigneeRef,
+    taskTypeRef,
     dueAtRef,
     tagsRef,
     blockedRef
@@ -341,6 +344,15 @@ export function TaskEditor({
               <option value="">Unassigned</option>
               {ASSIGNEE_OPTIONS.map((assignee) => (
                 <option key={assignee} value={assignee}>{assignee}</option>
+              ))}
+            </Select>
+          </Field>
+
+          <Field label="Type">
+            <Select ref={taskTypeRef} aria-label="Detail task type" value={draft.taskType} onChange={(e) => update('taskType', e.target.value)} onMouseDown={stopPropagation} onTouchStart={stopPropagation} onKeyDown={(e) => handleKeyDown(e, taskTypeRef, false)}>
+              <option value="">None</option>
+              {TASK_TYPES.map((taskType) => (
+                <option key={taskType} value={taskType}>{TASK_TYPE_LABELS[taskType]}</option>
               ))}
             </Select>
           </Field>

--- a/apps/tasks/src/components/TaskEditor.test.jsx
+++ b/apps/tasks/src/components/TaskEditor.test.jsx
@@ -11,6 +11,7 @@ const defaultProps = {
     assignee: '',
     dueAt: '',
     tagsText: '',
+    taskType: '',
     blocked: false
   },
   task: {
@@ -245,6 +246,25 @@ describe('TaskEditor', () => {
     render(<TaskEditor {...propsWithAssignee} />);
 
     expect(screen.getByLabelText('Detail assignee')).toHaveValue('Rowan');
+  });
+
+  it('renders task type selector and saves taskType', () => {
+    const onSave = vi.fn();
+    const props = {
+      ...defaultProps,
+      draft: { ...defaultProps.draft, taskType: 'feature' },
+      onSave
+    };
+    render(<TaskEditor {...props} />);
+
+    expect(screen.getByLabelText('Detail task type')).toHaveValue('feature');
+    expect(screen.getByRole('option', { name: 'Feature' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Save changes'));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ taskType: 'feature' })
+    );
   });
 
   it('renders dependency links with title and status', () => {

--- a/apps/tasks/src/tasksApi.test.ts
+++ b/apps/tasks/src/tasksApi.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   fetchTasks,
   createTask,
@@ -6,7 +6,7 @@ import {
   fetchTask,
   archiveTask,
   createTaskComment
-} from '../tasksApi.ts';
+} from './tasksApi.ts';
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -21,14 +21,6 @@ const mockResponse = (data, ok = true) => ({
 describe('tasksApi', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default port for tests
-    vi.spyOn(window, 'location', 'value').mockValue({
-      port: '5173'
-    });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe('fetchTasks', () => {
@@ -39,8 +31,8 @@ describe('tasksApi', () => {
       const result = await fetchTasks({});
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:4000/api/v1/tasks?sort=priority&limit=100',
-        expect.objectContaining({ method: 'GET' })
+        'http://localhost:4001/api/v1/tasks?sort=priority&limit=10000',
+        expect.any(Object)
       );
       expect(result).toEqual(tasks);
     });
@@ -75,6 +67,17 @@ describe('tasksApi', () => {
       );
     });
 
+    it('adds task type filter when set', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([]));
+
+      await fetchTasks({ taskType: 'feature' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('taskType=feature'),
+        expect.any(Object)
+      );
+    });
+
     it('throws error on failed request', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -93,7 +96,7 @@ describe('tasksApi', () => {
       const result = await createTask({ title: 'New Task' });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:4000/api/v1/tasks',
+        'http://localhost:4001/api/v1/tasks',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ title: 'New Task' })
@@ -115,20 +118,16 @@ describe('tasksApi', () => {
         blocked: true
       });
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          body: JSON.stringify(expect.objectContaining({
-            title: 'Task',
-            description: 'Description',
-            priority: 'high',
-            dueAt: '2024-01-15',
-            assignee: 'John',
-            tags: ['tag1'],
-            blocked: true
-          }))
-        })
-      );
+      const [, options] = mockFetch.mock.calls[0];
+      expect(JSON.parse(options.body)).toMatchObject({
+        title: 'Task',
+        description: 'Description',
+        priority: 'high',
+        dueAt: '2024-01-15',
+        assignee: 'John',
+        tags: ['tag1'],
+        blocked: true
+      });
     });
   });
 
@@ -140,7 +139,7 @@ describe('tasksApi', () => {
       const result = await updateTask(1, { title: 'Updated', status: 'done', dependsOnIds: ['dep-1'] });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:4000/api/v1/tasks/1',
+        'http://localhost:4001/api/v1/tasks/1',
         expect.objectContaining({
           method: 'PATCH',
           body: JSON.stringify({ title: 'Updated', status: 'done', dependsOnIds: ['dep-1'] })
@@ -158,7 +157,7 @@ describe('tasksApi', () => {
       const result = await fetchTask(1);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:4000/api/v1/tasks/1',
+        'http://localhost:4001/api/v1/tasks/1',
         expect.any(Object)
       );
       expect(result).toEqual(task);
@@ -170,7 +169,7 @@ describe('tasksApi', () => {
       await fetchTask('abc-123');
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:4000/api/v1/tasks/abc-123',
+        'http://localhost:4001/api/v1/tasks/abc-123',
         expect.any(Object)
       );
     });
@@ -183,7 +182,7 @@ describe('tasksApi', () => {
       const result = await archiveTask(1);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:4000/api/v1/tasks/1',
+        'http://localhost:4001/api/v1/tasks/1',
         expect.objectContaining({ method: 'DELETE' })
       );
       expect(result).toBeNull();
@@ -198,7 +197,7 @@ describe('tasksApi', () => {
       const result = await createTaskComment(1, { author: 'John', text: 'Comment' });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:4000/api/v1/tasks/1/comments',
+        'http://localhost:4001/api/v1/tasks/1/comments',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ author: 'John', text: 'Comment' })

--- a/apps/tasks/src/tasksApi.ts
+++ b/apps/tasks/src/tasksApi.ts
@@ -5,9 +5,12 @@ export interface TaskFilters {
   priority?: string;
   tag?: string;
   assignee?: string;
+  taskType?: TaskType | '';
   includeArchived?: boolean;
   // Note: 'ready' boolean filter is deprecated; use status='ready' instead
 }
+
+export type TaskType = 'content' | 'code' | 'research' | 'feature';
 
 export interface Comment {
   id?: string | number;
@@ -33,7 +36,7 @@ export interface Task {
   dueAt?: string | null;
   tags?: Array<{ name: string } | string>;
   blocked?: boolean;
-  taskType?: 'content' | 'code' | 'research' | null;
+  taskType?: TaskType | null;
   archivedAt?: string | null;
   createdAt?: string | null;
   statusChangedAt?: string | null;
@@ -52,7 +55,7 @@ export interface CreateTaskPayload {
   tags?: string[];
   blocked?: boolean;
   dependsOnIds?: Array<string | number>;
-  taskType?: 'content' | 'code' | 'research' | null;
+  taskType?: TaskType | null;
   // Note: 'ready' field removed; use status='ready' instead
 }
 
@@ -65,7 +68,7 @@ export interface UpdateTaskPayload {
   dueAt?: string | null;
   tags?: string[];
   blocked?: boolean;
-  taskType?: 'content' | 'code' | 'research' | null;
+  taskType?: TaskType | null;
   dependsOnIds?: Array<string | number>;
   // Note: 'ready' field removed — use status field instead
 }
@@ -114,6 +117,7 @@ export async function fetchTasks(filters: TaskFilters): Promise<Task[]> {
   if (filters.priority) query.set('priority', filters.priority);
   if (filters.tag) query.set('tag', filters.tag);
   if (filters.assignee) query.set('assignee', filters.assignee);
+  if (filters.taskType) query.set('taskType', filters.taskType);
   if (filters.includeArchived) query.set('includeArchived', 'true');
   // Note: 'ready' boolean filter is deprecated; use status='ready' instead
   return api<Task[]>('/tasks?' + query.toString());

--- a/apps/tasks/src/useTaskDrafts.js
+++ b/apps/tasks/src/useTaskDrafts.js
@@ -15,6 +15,7 @@ function sanitizeTaskDraft(draft) {
     assignee: sanitizeDraftValue(draft?.assignee),
     dueAt: sanitizeDraftValue(draft?.dueAt),
     tagsText: sanitizeDraftValue(draft?.tagsText),
+    taskType: sanitizeDraftValue(draft?.taskType),
     blocked: Boolean(draft?.blocked)
   };
 }
@@ -45,6 +46,7 @@ function shallowDraftEqual(left, right) {
     && left.assignee === right.assignee
     && left.dueAt === right.dueAt
     && left.tagsText === right.tagsText
+    && left.taskType === right.taskType
     && left.blocked === right.blocked;
 }
 

--- a/apps/tasks/src/utils/constants.js
+++ b/apps/tasks/src/utils/constants.js
@@ -14,4 +14,13 @@ export const PRIORITY_SCORE = { urgent: 0, high: 1, medium: 2, low: 3 };
 
 export const ASSIGNEE_OPTIONS = ['Quinn', 'Rowan', 'Lox', 'Tom', 'Ivy'];
 
+export const TASK_TYPES = ['content', 'code', 'research', 'feature'];
+
+export const TASK_TYPE_LABELS = {
+  content: 'Content',
+  code: 'Code',
+  research: 'Research',
+  feature: 'Feature'
+};
+
 export const CONFETTI_COLORS = ['#ffc935', '#00d4ff', '#ff3e8a', '#31c76a', '#f3f1ec', '#7d5dff'];

--- a/apps/tasks/src/utils/helpers.js
+++ b/apps/tasks/src/utils/helpers.js
@@ -53,6 +53,7 @@ export function normalizeTaskForEditor(task) {
     assignee: task.assignee ?? '',
     dueAt: task.dueAt ? String(task.dueAt).slice(0, 10) : '',
     tagsText: Array.isArray(task.tags) ? task.tags.map((tag) => tag.name ?? tag).join(', ') : '',
+    taskType: task.taskType ?? '',
     blocked: task.blocked ?? false
   };
 }

--- a/apps/tasks/src/utils/helpers.test.js
+++ b/apps/tasks/src/utils/helpers.test.js
@@ -102,6 +102,7 @@ describe('helpers', () => {
       expect(result.assignee).toBe('');
       expect(result.dueAt).toBe('');
       expect(result.tagsText).toBe('');
+      expect(result.taskType).toBe('');
       expect(result.blocked).toBe(false);
     });
 
@@ -114,6 +115,7 @@ describe('helpers', () => {
         assignee: 'John',
         dueAt: '2024-01-15T00:00:00.000Z',
         tags: ['tag1', 'tag2'],
+        taskType: 'feature',
         blocked: true
       };
       const result = normalizeTaskForEditor(task);
@@ -124,6 +126,7 @@ describe('helpers', () => {
       expect(result.assignee).toBe('John');
       expect(result.dueAt).toBe('2024-01-15');
       expect(result.tagsText).toBe('tag1, tag2');
+      expect(result.taskType).toBe('feature');
       expect(result.blocked).toBe(true);
     });
 

--- a/apps/tasks/test/e2e/task-type-filter.spec.js
+++ b/apps/tasks/test/e2e/task-type-filter.spec.js
@@ -1,0 +1,116 @@
+import { expect, test } from '@playwright/test';
+
+test('task type filter limits visible tasks', async ({ page }) => {
+  const now = new Date().toISOString();
+  const tasks = [
+    {
+      id: 'feature-task',
+      title: 'Build feature workflow',
+      status: 'open',
+      statusChangedAt: now,
+      priority: 'high',
+      taskType: 'feature',
+      archivedAt: null,
+      blocked: false,
+      tags: []
+    },
+    {
+      id: 'content-task',
+      title: 'Write content update',
+      status: 'open',
+      statusChangedAt: now,
+      priority: 'medium',
+      taskType: 'content',
+      archivedAt: null,
+      blocked: false,
+      tags: []
+    }
+  ];
+
+  await page.route('**/api/v1/tasks**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const isCollection = /\/tasks$/.test(url.pathname);
+
+    if (request.method() === 'GET' && isCollection) {
+      const taskType = url.searchParams.get('taskType');
+      const visible = taskType ? tasks.filter((task) => task.taskType === taskType) : tasks;
+      await route.fulfill({ json: { data: visible } });
+      return;
+    }
+
+    await route.fulfill({ status: 404, json: { error: { message: 'Not found' } } });
+  });
+
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Backlog' }).click();
+
+  await expect(page.getByRole('button', { name: 'Build feature workflow' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Write content update' })).toBeVisible();
+
+  await page.getByLabel('Task type filter').click();
+  await page.getByRole('menuitemradio', { name: 'FEATURE' }).click();
+
+  await expect(page.getByRole('button', { name: 'Build feature workflow' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Write content update' })).toHaveCount(0);
+  await expect(page.getByLabel('Task type filter')).toHaveText('TYPE: FEATURE');
+
+  await page.getByRole('button', { name: 'Kanban' }).click();
+  await expect(page.getByRole('button', { name: 'Build feature workflow' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Write content update' })).toHaveCount(0);
+});
+
+test('task editor saves task type changes', async ({ page }) => {
+  const now = new Date().toISOString();
+  const task = {
+    id: 'editable-task',
+    title: 'Retype task',
+    description: 'Change this from code to feature.',
+    status: 'open',
+    statusChangedAt: now,
+    priority: 'medium',
+    taskType: 'code',
+    archivedAt: null,
+    blocked: false,
+    tags: [],
+    comments: []
+  };
+  let patchedBody = null;
+
+  await page.route('**/api/v1/tasks**', async (route) => {
+    const request = route.request();
+    const method = request.method();
+    const url = new URL(request.url());
+    const isCollection = /\/tasks$/.test(url.pathname);
+    const idMatch = url.pathname.match(/\/tasks\/([^/]+)$/);
+
+    if (method === 'GET' && isCollection) {
+      await route.fulfill({ json: { data: [task] } });
+      return;
+    }
+
+    if (method === 'GET' && idMatch) {
+      await route.fulfill({ json: { data: task } });
+      return;
+    }
+
+    if (method === 'PATCH' && idMatch?.[1] === task.id) {
+      patchedBody = request.postDataJSON();
+      Object.assign(task, patchedBody);
+      await route.fulfill({ json: { data: task } });
+      return;
+    }
+
+    await route.fulfill({ status: 404, json: { error: { message: 'Not found' } } });
+  });
+
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Backlog' }).click();
+  await page.getByRole('button', { name: 'Retype task' }).click();
+
+  await expect(page.getByLabel('Detail task type')).toHaveValue('code');
+  await page.getByLabel('Detail task type').selectOption('feature');
+  await page.getByRole('button', { name: 'Save changes' }).click();
+
+  await expect.poll(() => patchedBody?.taskType).toBe('feature');
+});

--- a/apps/tasks/vitest.config.js
+++ b/apps/tasks/vitest.config.js
@@ -15,6 +15,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./test/setup.js'],
-    include: ['src/**/*.test.{js,jsx}']
+    include: ['src/**/*.test.{js,jsx,ts,tsx}']
   }
 });

--- a/docs/specs/task-type-filter-and-selector-tech-design.md
+++ b/docs/specs/task-type-filter-and-selector-tech-design.md
@@ -1,0 +1,66 @@
+# Task Type Filter and Selector Tech Design
+
+## Links
+
+- Product spec: `brain/tasks/specs/task-type-filter-and-selector-2026-06-29.md`
+- Task: `5dbf2967-c15e-44df-82fb-f1d0761b01ef` — Task Type Filter and Type Selector on Edit Card
+- Repository: `Stoffer-Industries/sindustries`
+- Branch: `task-5dbf2967-task-type-filter-and-selector`
+- Worktree: `~/workspaces/rowan/sindustries`
+
+The product spec file referenced by the task was not present in the local workspace during design. This design is based on the task description and AC1-AC5 in the Tasks API record.
+
+## Scope
+
+Add first-class task type controls to the existing Tasks app UI:
+
+- A list-level type filter with an `All` default.
+- A task edit-card type selector that persists changes via the existing `PATCH /tasks/:id` path.
+- `feature` as a supported type in the create form.
+- Immediate UI refresh after create/edit operations through the existing `useTasks` mutation reload path.
+
+## Implementation Plan
+
+1. Centralize task type constants in `apps/tasks/src/utils/constants.js`, next to the existing status, priority, and assignee options. Include `content`, `code`, `research`, and `feature`, plus labels suitable for filter and select controls.
+2. Extend `apps/tasks/src/tasksApi.ts` types so `taskType` accepts `feature` everywhere and `TaskFilters` accepts an optional `taskType`. Add `taskType` to the `fetchTasks` query string when selected.
+3. Add server-side task type filtering in `services/tasks-api/src/routes/tasks.ts` by reading `taskType` from `req.query`, validating it against `validTaskTypes`, and adding `{ taskType }` to the Prisma `where` clause. This keeps the UI filter consistent with other list filters and avoids client-only filtering drift.
+4. Add an App-level type filter dropdown in `apps/tasks/src/App.jsx` using the same menu pattern as priority and assignee filters. Store it in the existing `filters` state so it persists across view switches and internal navigation during the session.
+5. Update the create form's "Content type" selector to use the shared task type options and include `feature`.
+6. Update `apps/tasks/src/utils/helpers.js` so `normalizeTaskForEditor` includes `taskType`, then add a "Type" selector to `apps/tasks/src/components/TaskEditor.jsx`. Include it in `buildSavePayload`, focus order, and keyboard save flow.
+7. Keep the save behavior aligned with existing editor fields: the selector changes the local draft first, and the existing Save action sends the full editor payload through `patchTask`. Do not introduce auto-save for task type only.
+
+## API Contract
+
+The Tasks API already accepts `taskType` on create and update, and validates `content | code | research | feature`. This task adds only one API read-side capability:
+
+- `GET /tasks?taskType=<type>` filters tasks by exact task type.
+- Empty or omitted `taskType` means no type filter.
+- Invalid values return `400 INVALID_TASK_TYPE_FILTER`.
+
+No schema migration is required; `taskType` already exists in Prisma.
+
+## .openclaw Boundary
+
+No `.openclaw` changes are needed. All implementation work stays in `Stoffer-Industries/sindustries`.
+
+## Workflow, Cron, and Skill Changes
+
+No workflow, cron, or skill changes are needed. This is an app/API surface change only.
+
+## Test Plan
+
+- `npm test --workspace @sindustries/tasks-api` for the new `taskType` list filter validation and query behavior.
+- `npm --workspace apps/tasks test` for App, TaskEditor, and tasksApi coverage:
+  - `fetchTasks` sends `taskType`.
+  - Create form includes `feature`.
+  - Edit card saves `taskType`.
+  - Type filter updates filters and combines with existing status/priority/assignee behavior.
+- `npm --workspace apps/tasks run test:e2e` with focused Playwright coverage for filtering by type and changing a task's type from the edit card.
+- `npm --workspace apps/tasks run build` to catch TypeScript and bundling issues.
+
+## Risks and Open Questions
+
+- The task's declared product spec path was not found locally. If Quinn/Tom expect constraints beyond the task ACs, update this design before implementation.
+- The filter should be server-backed because existing filters are server-backed. This is a small API change, but it is still observable and needs tasks-api tests.
+- The task says the filter persists across page navigation "within the session." Existing app filters persist in React state across view switches but not browser reloads; this design matches that current behavior unless Tom wants sessionStorage persistence.
+- The edit selector will save with the existing Save button rather than immediately on select. AC3 says selecting a type updates via PATCH; if immediate patch-on-select is required, call that out before implementation because it would diverge from the current editor model.

--- a/docs/systems/tasks-api.md
+++ b/docs/systems/tasks-api.md
@@ -1,0 +1,67 @@
+# Tasks API
+
+**Type:** System reference
+**Last updated:** 2026-06-30
+**Owner:** Rowan
+**Repos:** `Stoffer-Industries/sindustries`
+**Related PR:** https://github.com/Stoffer-Industries/sindustries/pull/145
+
+---
+
+## Purpose
+
+The Tasks API is the source of truth for Stoffer Industries work items, comments, tags, task type routing, status transitions, and workflow metadata used by the Tasks app and agent automation.
+
+Related system specs cover specialized behavior:
+
+- `docs/systems/feature-task-workflow.md` — feature task gate orchestration.
+- `docs/systems/task-dependencies.md` — dependency data and blocking behavior.
+- `docs/systems/bookmark-workflow.md` — bookmark-to-task intake.
+
+---
+
+## Data Contract
+
+Tasks expose `taskType` as a nullable string used for routing and filtering. Supported first-class values are:
+
+- `content`
+- `code`
+- `research`
+- `feature`
+
+The Tasks app treats the same set as its shared type options for create, edit, and filtering surfaces. `feature` tasks are used by the feature-task workflow and must remain available through normal task create, read, update, and list paths.
+
+---
+
+## List API
+
+`GET /tasks` accepts the standard list filters plus `taskType`.
+
+| Query | Behavior |
+|---|---|
+| omitted or empty `taskType` | returns tasks without a type constraint |
+| `taskType=content` | returns only content tasks |
+| `taskType=code` | returns only code tasks |
+| `taskType=research` | returns only research tasks |
+| `taskType=feature` | returns only feature tasks |
+
+Invalid task type filters return `400 INVALID_TASK_TYPE_FILTER`.
+
+The API validates the filter against the same accepted task type set used by create and update validation, then applies an exact Prisma `taskType` filter in the list query. This keeps UI filtering and automation discovery aligned with persisted task metadata.
+
+---
+
+## UI Behavior
+
+The Tasks app sends the selected type filter as `taskType=<type>` in `fetchTasks`. The default "all" state omits the query parameter.
+
+The task editor preserves `taskType` in unsaved drafts and includes type changes in the existing save/PATCH payload, so type edits follow the same manual save model as other editable task fields.
+
+---
+
+## Operational Notes
+
+- No schema migration is required for PR #145; `taskType` already exists on persisted tasks.
+- New task type values must be added consistently across API validation, app shared options, and workflow consumers before use.
+- Automation that needs feature-task routing should prefer first-class `taskType: feature` over tag-only conventions.
+

--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -31,6 +31,7 @@ tasksRouter.get('/tasks', async (req, res, next) => {
       status,
       priority,
       assignee,
+      taskType,
       tag,
       q,
       dueBefore,
@@ -53,6 +54,10 @@ tasksRouter.get('/tasks', async (req, res, next) => {
 
     if (priority && !validPriorities.has(priority)) {
       return badRequest(res, 'INVALID_PRIORITY_FILTER', 'Invalid priority filter');
+    }
+
+    if (taskType && !validTaskTypes.has(String(taskType))) {
+      return badRequest(res, 'INVALID_TASK_TYPE_FILTER', 'Invalid taskType filter');
     }
 
     if (sort && !validSorts.has(sort)) {
@@ -88,6 +93,7 @@ tasksRouter.get('/tasks', async (req, res, next) => {
       ...(includeArchived === 'true' ? {} : { archivedAt: null }),
       ...statusFilter,
       ...(priority ? { priority } : {}),
+      ...(taskType ? { taskType: String(taskType) } : {}),
       ...(assignee
         ? assignee === 'unassigned'
           ? { OR: [{ assignee: null }, { assignee: '' }] }

--- a/services/tasks-api/test/read-endpoints.test.ts
+++ b/services/tasks-api/test/read-endpoints.test.ts
@@ -144,6 +144,35 @@ describe('tasks api endpoints', () => {
     expect(prismaMock.task.findMany.mock.calls[0][0].where).not.toHaveProperty('archivedAt');
   });
 
+  it('GET /api/v1/tasks filters by taskType', async () => {
+    prismaMock.task.findMany.mockResolvedValue([
+      task({ id: 'feature-task', title: 'Build task type UI', taskType: 'feature' })
+    ]);
+
+    const app = createApp();
+    const response = await request(app)
+      .get('/api/v1/tasks')
+      .query({ taskType: 'feature' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data[0].taskType).toBe('feature');
+    expect(prismaMock.task.findMany.mock.calls[0][0].where).toMatchObject({
+      taskType: 'feature'
+    });
+  });
+
+  it('GET /api/v1/tasks rejects invalid taskType filters', async () => {
+    const app = createApp();
+
+    const response = await request(app).get('/api/v1/tasks').query({ taskType: 'invalid' });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: { code: 'INVALID_TASK_TYPE_FILTER', message: 'Invalid taskType filter' }
+    });
+    expect(prismaMock.task.findMany).not.toHaveBeenCalled();
+  });
+
   it('GET /api/v1/tasks validates bad status filter', async () => {
     const app = createApp();
 


### PR DESCRIPTION
## Summary
- Add shared task type options, including `feature`, across create and edit flows.
- Add a server-backed task type filter to the Tasks app and `GET /tasks`.
- Preserve task type in unsaved editor drafts so type changes save through the existing PATCH path.

## Test plan
- [x] `npm --workspace apps/tasks test`
- [x] `npm test --workspace @sindustries/tasks-api`
- [x] `npm --workspace apps/tasks run build`
- [x] `npm --workspace apps/tasks run test:e2e`

## Acceptance Criteria

Aligned to task `5dbf2967-c15e-44df-82fb-f1d0761b01ef` ACs per the new `task_ac_vs_latest_pr_failures` gate (PR #156). Body updated 2026-07-01 by Quinn during heartbeat so the QA bounce path can resolve.

- [x] AC1: Task list has a type filter control; selecting a type shows only tasks of that type; selecting "All" (default) shows all tasks regardless of type
- [x] AC2: The type filter persists across page navigation within the session
- [x] AC3: Task edit card includes a type selector field showing all supported types; selecting a type updates the task via PATCH
- [x] AC4: When creating a new task, "feature" type is available in the type selector (currently missing from the create form)
- [x] AC5: Type changes are reflected immediately in the list without requiring a full page reload

🤖 Generated with Codex