### PR TITLE
feat(lobster): enforce PR AC evidence at verify-delivery

### DIFF
--- a/agents/skills/dev/pr-open/SKILL.md
+++ b/agents/skills/dev/pr-open/SKILL.md
@@ -53,3 +53,20 @@ Co-Authored-By: <Your Name> <your-email>
 
 **Test plan:** concrete, checkable steps. Not "tests pass" — what specifically should a reviewer verify? For non-functional changes, it's fine to write "No logic changes — diff is purely structural."
 
+**Acceptance Criteria (feature-task PRs only):** the lobster enforces a per-AC evidence rule at the `doing → acceptance` gate. Every checked `- [x]` AC line must end with one of:
+
+- `(testID: <id>)` — Playwright test ID reference
+- `(file: <path>:<line>)` — file and line reference
+- `(not tested: <reason>)` — explicit reason when no test exists
+
+Example:
+
+```markdown
+## Acceptance Criteria
+- [x] AC1: Task detail shows dependency links. (testID: 4)
+- [x] AC2: Card click-to-copy affordance. (file: apps/tasks/src/components/TaskCardSummary.jsx:42)
+- [x] AC3: Reduced opacity for archived tasks. (not tested: design tokens supply color; visual review only)
+```
+
+PRs without the required annotations are blocked from acceptance with a clear comment listing the ACs that need evidence.
+

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -267,6 +267,9 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
                     "PR {url} does not show checked acceptance criteria in its body."
                 ));
             }
+            for ac_failure in verify_pr_acs_failures(&body) {
+                failures.push(format!("PR {url} — {ac_failure}"));
+            }
         }
     }
     if workstreams(&env.task).is_empty() {
@@ -1133,6 +1136,123 @@ fn body_has_checked_acceptance(body: &str) -> bool {
         .is_match(body)
 }
 
+/// Evidence annotation recognised on a feature-task PR AC line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Evidence {
+    /// Playwright test ID reference, e.g. `(testID: 1234)`
+    TestId(String),
+    /// File path and line reference, e.g. `(file: apps/tasks/src/App.jsx:42)`
+    FileRef { path: String, line: u64 },
+    /// Explicit reason for not adding a test, e.g. `(not tested: design tokens)`
+    NotTested { reason: String },
+}
+
+/// One parsed AC line from a PR body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AcEvidence {
+    ac_label: String,
+    description: String,
+    evidence: Option<Evidence>,
+}
+
+/// Extract the Acceptance Criteria section from a PR body.
+///
+/// Recognises `## Acceptance Criteria` and `## ACs` / `## AC` headings. When
+/// no header is found, the whole body is returned so PRs without a section
+/// still get validated.
+fn extract_ac_section(body: &str) -> &str {
+    let header_re =
+        Regex::new(r"(?im)^\s{0,3}#{2,6}\s+(?:Acceptance Criteria|ACs?)\s*:?\s*$").unwrap();
+    let Some(header) = header_re.find(body) else {
+        return body;
+    };
+    let start = header.end();
+    let tail = &body[start..];
+    // Same-or-higher heading ends the section.
+    let next_re = Regex::new(r"(?im)^\s{0,3}#{2,6}\s+\S").unwrap();
+    match next_re.find(tail) {
+        Some(next) => &tail[..next.start()],
+        None => tail,
+    }
+}
+
+/// Recognise an evidence annotation that anchors the end of a string.
+fn parse_evidence(text: &str) -> Option<Evidence> {
+    // (not tested: <reason>) comes first so the reason may contain colons.
+    let not_tested = Regex::new(r"\(not tested:\s*([^)]+)\)\s*$").unwrap();
+    if let Some(cap) = not_tested.captures(text) {
+        return Some(Evidence::NotTested {
+            reason: cap[1].trim().to_string(),
+        });
+    }
+    // (file: <path>:<line>)
+    let file_ref = Regex::new(r"\(file:\s*([^)]+?):(\d+)\)\s*$").unwrap();
+    if let Some(cap) = file_ref.captures(text) {
+        return Some(Evidence::FileRef {
+            path: cap[1].trim().to_string(),
+            line: cap[2].parse().unwrap_or(0),
+        });
+    }
+    // (testID: <value>)
+    let test_id = Regex::new(r"\(testID:\s*([^)]+)\)\s*$").unwrap();
+    if let Some(cap) = test_id.captures(text) {
+        return Some(Evidence::TestId(cap[1].trim().to_string()));
+    }
+    None
+}
+
+/// Strip a trailing evidence annotation from a description string.
+/// Returns the description with the trailing `(...)` evidence removed.
+fn strip_trailing_evidence(text: &str) -> String {
+    let re =
+        Regex::new(r"\s+\((testID|file|not tested):\s*[^)]+\)\s*$").unwrap();
+    match re.find(text) {
+        Some(m) => text[..m.start()].trim_end().to_string(),
+        None => text.to_string(),
+    }
+}
+
+/// Parse a single AC line. Returns `None` if the line isn't a checked AC.
+fn parse_ac_line(line: &str) -> Option<AcEvidence> {
+    let ac_re = Regex::new(r"^\s*-\s*\[[xX]\]\s+(AC\d+):\s*(.+)$").unwrap();
+    let cap = ac_re.captures(line.trim())?;
+    let ac_label = cap[1].to_string();
+    let rest = cap[2].to_string();
+    if let Some(ev) = parse_evidence(&rest) {
+        let description = strip_trailing_evidence(&rest);
+        Some(AcEvidence {
+            ac_label,
+            description,
+            evidence: Some(ev),
+        })
+    } else {
+        Some(AcEvidence {
+            ac_label,
+            description: rest,
+            evidence: None,
+        })
+    }
+}
+
+/// Build failure messages for ACs that lack evidence. Empty list = all ACs
+/// in the section carry `(testID: ...)`, `(file: path:line)`, or
+/// `(not tested: reason)` annotations.
+fn verify_pr_acs_failures(body: &str) -> Vec<String> {
+    let section = extract_ac_section(body);
+    let mut failures = Vec::new();
+    for line in section.lines() {
+        if let Some(ac) = parse_ac_line(line) {
+            if ac.evidence.is_none() {
+                failures.push(format!(
+                    "AC {} — missing evidence. Append `(testID: <id>)`, `(file: <path>:<line>)`, or `(not tested: <reason>)`.",
+                    ac.ac_label
+                ));
+            }
+        }
+    }
+    failures
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1165,6 +1285,130 @@ mod tests {
         assert!(parse_product_spec_ref("Product spec: brain/bookmarks/specs/example.md").is_none());
         let spec = parse_product_spec_ref("**Spec:** brain/bookmarks/specs/example.md").unwrap();
         assert_eq!(spec.path, "brain/bookmarks/specs/example.md");
+    }
+
+    // ---- AC evidence parsing (task 6e70deb8) ----
+
+    #[test]
+    fn parse_evidence_recognises_test_id() {
+        assert_eq!(
+            parse_evidence("foo (testID: 1234)"),
+            Some(Evidence::TestId("1234".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_evidence_recognises_file_ref() {
+        assert_eq!(
+            parse_evidence("bar (file: apps/tasks/src/X.jsx:42)"),
+            Some(Evidence::FileRef {
+                path: "apps/tasks/src/X.jsx".to_string(),
+                line: 42,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_evidence_recognises_not_tested_reason() {
+        assert_eq!(
+            parse_evidence("baz (not tested: requires manual click flow)"),
+            Some(Evidence::NotTested {
+                reason: "requires manual click flow".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_evidence_rejects_bare_not_tested() {
+        assert_eq!(parse_evidence("qux (not tested)"), None);
+        assert_eq!(parse_evidence("quux"), None);
+    }
+
+    #[test]
+    fn parse_ac_line_extracts_label_description_evidence() {
+        let ac = parse_ac_line("- [x] AC1: Build it (testID: 7)").unwrap();
+        assert_eq!(ac.ac_label, "AC1");
+        assert_eq!(ac.description, "Build it");
+        assert_eq!(ac.evidence, Some(Evidence::TestId("7".to_string())));
+    }
+
+    #[test]
+    fn parse_ac_line_ignores_unchecked_lines() {
+        assert!(parse_ac_line("- [ ] AC2: Unchecked (testID: 1)").is_none());
+    }
+
+    #[test]
+    fn parse_ac_line_ignores_non_ac_bullets() {
+        assert!(parse_ac_line("- [x] `npm test`").is_none());
+        assert!(parse_ac_line("- [x] Some other bullet").is_none());
+    }
+
+    #[test]
+    fn parse_ac_line_handles_description_with_parens() {
+        let ac = parse_ac_line("- [x] AC1: Allow (paren) text (testID: 1)").unwrap();
+        assert_eq!(ac.ac_label, "AC1");
+        assert_eq!(ac.description, "Allow (paren) text");
+        assert_eq!(ac.evidence, Some(Evidence::TestId("1".to_string())));
+    }
+
+    #[test]
+    fn extract_ac_section_returns_section_when_header_present() {
+        let body = "## Summary\nFoo.\n\n## Acceptance Criteria\n- [x] AC1: First\n- [x] AC2: Second (testID: 1)\n\n## Test plan\n- [x] run tests\n";
+        let section = extract_ac_section(body);
+        assert!(section.contains("AC1: First"));
+        assert!(section.contains("AC2: Second"));
+        assert!(!section.contains("Test plan"));
+        assert!(!section.contains("run tests"));
+    }
+
+    #[test]
+    fn extract_ac_section_falls_back_to_whole_body() {
+        let body = "- [x] AC1: First (testID: 1)";
+        let section = extract_ac_section(body);
+        assert!(section.contains("AC1: First"));
+    }
+
+    #[test]
+    fn extract_ac_section_handles_acs_header() {
+        let body = "## ACs\n- [x] AC1: First (testID: 1)\n";
+        let section = extract_ac_section(body);
+        assert!(section.contains("AC1: First"));
+    }
+
+    #[test]
+    fn verify_pr_acs_passes_when_all_have_evidence() {
+        let body = "## Acceptance Criteria\n- [x] AC1: Foo (testID: 1)\n- [x] AC2: Bar (file: src/x.js:2)\n- [x] AC3: Baz (not tested: design tokens)\n";
+        assert!(verify_pr_acs_failures(body).is_empty());
+    }
+
+    #[test]
+    fn verify_pr_acs_blocks_one_missing_evidence() {
+        let body = "## Acceptance Criteria\n- [x] AC1: Foo (testID: 1)\n- [x] AC2: Bar\n- [x] AC3: Baz (testID: 3)\n";
+        let failures = verify_pr_acs_failures(body);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("AC2"));
+        assert!(failures[0].contains("missing evidence"));
+    }
+
+    #[test]
+    fn verify_pr_acs_blocks_all_missing_evidence() {
+        let body = "## Acceptance Criteria\n- [x] AC1: Foo\n- [x] AC2: Bar\n";
+        let failures = verify_pr_acs_failures(body);
+        assert_eq!(failures.len(), 2);
+        assert!(failures[0].contains("AC1"));
+        assert!(failures[1].contains("AC2"));
+    }
+
+    #[test]
+    fn verify_pr_acs_ignores_unchecked_lines() {
+        let body = "## Acceptance Criteria\n- [ ] AC1: Pending\n- [x] AC2: Done (testID: 1)\n";
+        assert!(verify_pr_acs_failures(body).is_empty());
+    }
+
+    #[test]
+    fn verify_pr_acs_skips_other_sections() {
+        let body = "## Test plan\n- [x] AC1: Not really an AC\n\n## Acceptance Criteria\n- [x] AC1: Real AC (testID: 1)\n";
+        assert!(verify_pr_acs_failures(body).is_empty());
     }
 
     #[test]

--- a/docs/specs/add-e2e-to-feature-factory-tech-design.md
+++ b/docs/specs/add-e2e-to-feature-factory-tech-design.md
@@ -1,0 +1,139 @@
+---
+status: draft
+task_id: 6e70deb8-9266-4198-92b4-3839eecf292d
+product_spec: brain/bookmarks/specs/add-e2e-to-feature-factory-2026-06-29.md
+shipped_pr: null
+shipped_date: null
+---
+
+# Add E2E Evidence to Feature Factory — Tech Design
+
+## Links
+
+- Product spec: `brain/bookmarks/specs/add-e2e-to-feature-factory-2026-06-29.md`
+- Task: `6e70deb8-9266-4198-92b4-3839eecf292d` (`🔧 Add e2e to feature factory`)
+- Task API detail: `http://localhost:4001/api/v1/tasks/6e70deb8-9266-4198-92b4-3839eecf292d`
+
+## Scope
+
+- Repository: `Stoffer-Industries/sindustries`
+- Branch: `task-6e70deb8-pr-ac-evidence`
+- Worktree: `~/workspaces/rowan/sindustries`
+- Primary code surfaces:
+  - `agents/workflows/feature-task/src/main.rs` — lobster Rust worker (this is where validation lives)
+  - `agents/workflows/feature-task/fixtures/` — new fixture bodies for tests
+  - `agents/skills/dev/pr-open/SKILL.md` — Rowan PR template guidance (add AC evidence guidance to PR body section)
+  - `agents/definitions/rowan/HEARTBEAT.md` — already references feature factory v2; no edit required for this task
+
+No `.openclaw` runtime change is required. No schema or API surface changes — this is purely a PR-body validation gate added to the lobster and an enablement comment in the PR-open skill.
+
+## Product Summary
+
+The feature factory v2 spec already states that every AC in a feature-task PR needs at least one E2E test unless explicitly marked not possible with a reason. Until now this was a human convention rather than a machine check. This task makes the lobster enforce it at the `doing → acceptance` gate.
+
+A PR is treated as compliant when each AC line in the PR body provides either:
+
+- A test reference, formatted as either `(testID: <id>)` or `(file: <path>:<line>)`, appended to the AC line; or
+- An explicit annotation `not tested: <reason>` justifying why no test exists.
+
+If any AC is checked (`- [x]`) and lacks evidence, the lobster blocks acceptance and posts a task comment listing every AC that needs evidence along with the expected formats.
+
+The PR template (in `agents/skills/dev/pr-open/SKILL.md`) prompts Rowan to attach the annotation when opening a feature-task PR so evidence is captured at write time rather than caught later.
+
+## PR Body Evidence Format
+
+Each `- [x] AC<N>: <description>` line may be suffixed with one of:
+
+```markdown
+- [x] AC1: Title reflects stored value. (testID: 1234)
+- [x] AC2: Board view supports sort by priority. (file: apps/tasks/src/BoardView.jsx:42)
+- [x] AC3: Archived tasks render with reduced opacity. (not tested: visual treatment is a manual review step; design system token supplies the color)
+```
+
+Recognition rules:
+
+- A single space followed by `(testID: <value>)`, `(file: <path>:<line>)`, or `(not tested: <text up to closing paren>)` is treated as evidence.
+- A bare `not tested` without a reason is treated as missing evidence — the lobster surfaces it.
+- Multi-PR tasks (where a task is split into workstreams across PRs): each PR's body only needs evidence for the ACs it claims. Uncovered ACs simply don't appear on that PR's Acceptance Criteria list. The lobster validates per-PR, not per-task, so each PR independently needs evidence for what it advertises.
+
+The lobster matches the same `- [ ] AC<N>` style that the product spec / task description uses. It does not currently and will not require evidence on `- [ ]` (unchecked) lines because those represent ACs not yet claimed in the current PR.
+
+## Implementation Plan
+
+### 1. Add evidence parsing helpers in `agents/workflows/feature-task/src/main.rs`
+
+- New function `parse_pr_evidence(body: &str) -> Vec<AcEvidence>` returning one record per `- [x]` AC line:
+  - `ac_label: String` — captured `AC<number>` token
+  - `description: String` — the AC body without evidence
+  - `evidence: Option<Evidence>` — `TestId(String)`, `FileRef { path, line }`, or `NotTested { reason }`
+- New function `verify_pr_acs(body: &str) -> Vec<String>` returning a list of human-readable failure strings (empty on success). It scans only the `## Acceptance Criteria` (or `## ACs`) section header, parses each checked AC line, and emits one failure per AC missing evidence.
+- Helper `extract_ac_section(body: &str) -> &str` returns just the AC section text or the entire body when no header is present (defensive default so PRs without a header still get validated).
+
+### 2. Hook into `verify_delivery`
+
+In the existing `verify_delivery` step:
+
+```rust
+for url in &pr_urls {
+    // existing review + AC checkbox checks
+    if let Ok(body) = pr_body(url) {
+        if !body_has_checked_acceptance(&body) {
+            failures.push(format!("PR {url} does not show checked acceptance criteria in its body."));
+        }
+        failures.extend(verify_pr_acs_failures(&body, url));
+    }
+}
+```
+
+Failure messages follow the existing pattern (`"PR {url} — AC{label} ({head}): missing evidence..."`) so the lobster comment list stays consistent.
+
+### 3. Update the PR template
+
+In `agents/skills/dev/pr-open/SKILL.md`, expand the body template section to include a reminder that each AC line must end with `(testID: <id>)`, `(file: <path>:<line>)`, or `(not tested: <reason>)`. The template already lists ACs; the change is a one-line note explaining the evidence requirement.
+
+### 4. Tests
+
+New tests in `agents/workflows/feature-task/src/main.rs` `mod tests`:
+
+- `parse_pr_evidence_recognises_test_id` — `- [x] AC1: Foo (testID: 1234)` parses to `Some(TestId("1234"))`.
+- `parse_pr_evidence_recognises_file_ref` — `(file: apps/tasks/src/X.jsx:42)` parses to `FileRef` with both fields.
+- `parse_pr_evidence_recognises_not_tested_reason` — `(not tested: requires manual click flow)` parses to a reason.
+- `parse_pr_evidence_rejects_bare_not_tested` — bare `not tested` without parens or reason is `None`.
+- `verify_pr_acs_passes_when_all_have_evidence` — full body with annotations returns empty failures.
+- `verify_pr_acs_blocks_one_missing_evidence` — body with one AC lacking evidence returns one failure naming that AC.
+- `verify_pr_acs_ignores_unchecked_lines` — `- [ ] AC2` lines do not require evidence.
+- `verify_pr_acs_skips_other_sections` — `- [x]` lines in Test plan / Summary headings don't get re-parsed as ACs.
+- `verify_pr_acs_handles_unheaded_bodies` — defensive default still parses top-level `- [x] AC` lines.
+
+Fixtures go under `agents/workflows/feature-task/fixtures/pr-bodies/` with one file per scenario to keep the test inputs readable.
+
+### 5. Documentation
+
+- Optional: short addendum paragraph in `brain/bookmarks/specs/feature-factory-v2-2026-06-04.md` worked in via a separate Quinn-side AC5 commit; out of scope here.
+
+## Test Plan
+
+- `cd agents/workflows/feature-task && cargo test`
+  - all existing tests still pass (no surface change to `verify_delivery` other than additive `failures.extend`)
+  - new evidence tests listed above all pass
+- `cargo build --manifest-path agents/workflows/feature-task/Cargo.toml` compiles cleanly
+- Manual smoke:
+  - open a feature-task PR with one AC missing evidence
+  - inspect `verify-delivery` output (via `feature-task.lobster.yaml` step on the task) — should report one failure
+  - amend the PR body to include `(file: ...)` or `(not tested: ...)` for the missing AC
+  - re-run `verify-delivery` — empty failures
+
+Coverage summary:
+
+- AC1 (lobster parses and verifies evidence) — covered by `parse_pr_evidence_*` and `verify_pr_acs_*` tests
+- AC2 (blocked-from-acceptance with clear comment) — covered by `verify_delivery` integration plus a fixture-driven test
+- AC3 (PR template prompts for evidence) — covered by manual review of the updated `agents/skills/dev/pr-open/SKILL.md`
+- AC4 (Rust unit tests cover parse + validation scenarios) — covered by the tests above
+- AC5 (factory v2 spec amendment) — Quinn owner; out of this task's scope
+
+## Open Questions and Risks
+
+- **Multi-PR workstreams:** a parent task with three PRs (workstream A/B/C) will have each PR advertising only the ACs that workstream claims. The validation is per-PR, which matches the existing `body_has_checked_acceptance` per-PR behaviour. If product decides the lobster should additionally verify the union of ACs across all PRs covers every AC in the task description, that becomes a follow-up — out of scope here, flagged for later.
+- **Test ID vs file ref choice:** the spec lets `testID` and `file:line` coexist. The lobster does not need to validate that the file exists on disk — that responsibility stays with Tom/Quinn at review time. Risk is moderate but bounded.
+- **PR body header drift:** the lobster matches `## Acceptance Criteria` and `## ACs` (case-insensitive). If a PR uses a different heading (e.g. `## ✅ Acceptance Criteria`), the defensive `extract_ac_section` falls back to scanning the whole body, which still works because AC lines are uniquely tagged with `AC<N>`.
+- **No system spec change.** The lobster binary is internal agent tooling, not a user-facing system. No `docs/systems/` update. The PR-side skill change is documentation, not system behaviour. The `no-system-spec-change` rationale will be posted on the PR.


### PR DESCRIPTION
## Summary
- Adds per-AC evidence validation to the feature-task lobster verify_delivery stage. Each checked AC line in a feature-task PR body must end with `(testID: <id>)`, `(file: <path>:<line>)`, or `(not tested: <reason>)`; PRs missing evidence are blocked from acceptance with a failure message naming the offending ACs.
- New Rust helpers in `agents/workflows/feature-task/src/main.rs`: `Evidence` / `AcEvidence` data types, `parse_evidence`, `parse_ac_line`, `strip_trailing_evidence`, `extract_ac_section`, and `verify_pr_acs_failures`.
- Hooked into `verify_delivery` alongside the existing `body_has_checked_acceptance` check (additive only — does not change the body_has_checked_acceptance contract).
- Adds 16 new Rust unit tests covering: each evidence pattern recognised, bare `not tested` rejected, parens-in-description handling, header variants (`## Acceptance Criteria`, `## ACs`, `## AC`), unchecked-line ignored, non-AC bullets ignored, multi-AC failure list, and section-boundary detection.

## Test plan
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml` (42 tests pass, 16 new)
- [x] `PYTHONPATH=agents/skills/tasks-api-ops python3 -m unittest discover -s tests -p 'test_*.py'` (110 tests pass)
- [x] `npm test --workspace apps/tasks` (126 tests pass)
- [x] `npm test --workspace @sindustries/tasks-api` (35 tests pass)

## Acceptance Criteria

Aligned to task `6e70deb8-9266-4198-92b4-3839eecf292d` ACs per the new `task_ac_vs_latest_pr_failures` gate (PR #156). Body updated 2026-07-01 by Quinn during heartbeat so the QA bounce path can resolve. AC5 (Quinn owner workstream — spec amendment) was completed by Quinn per the task comment and is now checked.

- [x] AC1: Feature-task lobster parses the PR body, extracts ACs, and verifies each one has either a test reference (e.g. `(testID: 1234)`, `(file: path: testName)`) or an explicit `not tested: <reason>` annotation (file: agents/workflows/feature-task/src/main.rs:1296)
- [x] AC2: PRs missing evidence on any AC are blocked from acceptance with a clear task comment listing the ACs that need evidence and the expected format (file: agents/workflows/feature-task/src/main.rs:1325)
- [x] AC3: PR body template / checklist in the lobster prompts Rowan for the test reference or "not tested" reason when opening a feature-task PR (file: agents/skills/dev/pr-open/SKILL.md:55)
- [x] AC4: Rust unit tests cover the lobster validation: missing evidence on one AC, partial evidence, all valid, malformed ACs that fail to parse (file: agents/workflows/feature-task/src/main.rs:1295)
- [x] AC5: Feature factory v2 spec updated to call out the e2e evidence requirement as a hard gate in PR Requirements and Acceptance Checks sections (not code: Quinn-owned spec amendment completed outside this PR)

## System spec
[no-system-spec-change] Pure validation-gate behaviour change in the lobster CLI; no durable system contract, persisted data, or workflow protocol change beyond what factory v2 AC10 already documents. The PR template skill change is documentation, not system behaviour. No `docs/systems/` update is warranted.

🤖 Generated with Claude Code
