### PR TITLE
fix(lobster): accept rationale text after [tech-design-approved] true

### DIFF
--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -855,7 +855,12 @@ fn tech_design_url(task: &Task) -> Option<String> {
 fn tech_design_approved(task: &Task) -> bool {
     tagged_values(task, "[tech-design-approved]")
         .into_iter()
-        .any(|v| v.eq_ignore_ascii_case("true"))
+        .any(|v| {
+            // Match a leading "true" token (case-insensitive). Rationale text
+            // after the token is allowed and ignored.
+            let token = v.trim_start().split_whitespace().next().unwrap_or("");
+            token.eq_ignore_ascii_case("true")
+        })
 }
 
 fn rowan_pr_urls(task: &Task) -> Vec<String> {
@@ -1285,6 +1290,63 @@ mod tests {
         assert!(parse_product_spec_ref("Product spec: brain/bookmarks/specs/example.md").is_none());
         let spec = parse_product_spec_ref("**Spec:** brain/bookmarks/specs/example.md").unwrap();
         assert_eq!(spec.path, "brain/bookmarks/specs/example.md");
+    }
+
+    // ---- tech_design_approved parser relaxation (task 44f5ed65) ----
+
+    fn task_with_approval_comment(comment: &str) -> Task {
+        Task {
+            id: "task-44f5ed65".to_string(),
+            comments: vec![TaskComment {
+                text: Some(comment.to_string()),
+                body: None,
+            }],
+            ..Task::default()
+        }
+    }
+
+    #[test]
+    fn tech_design_approved_accepts_bare_true() {
+        let task = task_with_approval_comment("[tech-design-approved] true");
+        assert!(tech_design_approved(&task));
+    }
+
+    #[test]
+    fn tech_design_approved_accepts_rationale_after_true() {
+        let task = task_with_approval_comment(
+            "[tech-design-approved] true \u{2014} Approved by Quinn on behalf of Tom 2026-06-30",
+        );
+        assert!(tech_design_approved(&task));
+    }
+
+    #[test]
+    fn tech_design_approved_accepts_uppercase_true() {
+        let task = task_with_approval_comment("[tech-design-approved] TRUE");
+        assert!(tech_design_approved(&task));
+    }
+
+    #[test]
+    fn tech_design_approved_accepts_leading_whitespace() {
+        let task = task_with_approval_comment("[tech-design-approved]    true with rationale");
+        assert!(tech_design_approved(&task));
+    }
+
+    #[test]
+    fn tech_design_approved_rejects_false() {
+        let task = task_with_approval_comment("[tech-design-approved] false \u{2014} pending review");
+        assert!(!tech_design_approved(&task));
+    }
+
+    #[test]
+    fn tech_design_approved_rejects_missing_value() {
+        let task = task_with_approval_comment("[tech-design-approved]");
+        assert!(!tech_design_approved(&task));
+    }
+
+    #[test]
+    fn tech_design_approved_rejects_unrelated_token() {
+        let task = task_with_approval_comment("[tech-design-approved] maybe");
+        assert!(!tech_design_approved(&task));
     }
 
     // ---- AC evidence parsing (task 6e70deb8) ----

--- a/docs/specs/lobster-comment-parser-strictness-tech-design.md
+++ b/docs/specs/lobster-comment-parser-strictness-tech-design.md
@@ -1,0 +1,85 @@
+---
+status: draft
+task_id: 44f5ed65-5a45-4df8-95d7-8c874feeed12
+product_spec: brain/bookmarks/specs/feature-factory-v2-2026-06-04.md
+shipped_pr: null
+shipped_date: null
+---
+
+# Lobster Comment Parser Strictness — Tech Design
+
+## Links
+
+- Task: `44f5ed65-5a45-4df8-95d7-8c874feeed12` (`🔧 🐛 Relax lobster comment-parser strictness for tagged values`)
+- Product spec: `brain/bookmarks/specs/feature-factory-v2-2026-06-04.md` (the feature-factory v2 spec is the parent contract; the lobster's tag parsing behaviour is its implementation detail)
+- Task API detail: `http://localhost:4001/api/v1/tasks/44f5ed65-5a45-4df8-95d7-8c874feeed12`
+
+## Scope
+
+- Repository: `Stoffer-Industries/sindustries`
+- Branch: `task-44f5ed65-parser-strictness`
+- Worktree: `~/workspaces/rowan/sindustries`
+- Primary code surface: `agents/workflows/feature-task/src/main.rs` (single function + tests)
+
+No `.openclaw` runtime change. No API/data/UI surface change. Pure parser relaxation in the lobster's `tech_design_approved` check.
+
+## Product Summary
+
+`tech_design_approved` currently does an exact `eq_ignore_ascii_case("true")` comparison against the trimmed value of every `[tech-design-approved]` comment. That rejects any comment with trailing text — e.g. `[tech-design-approved] true — Approved by Tom 2026-06-30` — even though the leading `true` is unambiguous. We've hit this twice (tasks `5dbf2967`, `6e70deb8`); each time the workaround was a clean re-post from the approver.
+
+The fix relaxes the check to `starts_with_ignore_ascii_case("true")` so leading-token equality is enough. Reject cases (missing value, explicit `false`, unrelated tokens) stay rejected.
+
+## Implementation Plan
+
+### 1. Update `tech_design_approved` in `agents/workflows/feature-task/src/main.rs`
+
+```rust
+fn tech_design_approved(task: &Task) -> bool {
+    tagged_values(task, "[tech-design-approved]")
+        .into_iter()
+        .any(|v| {
+            // Match a leading "true" token, case-insensitive, ignoring leading whitespace.
+            // Rationale text after the token is allowed and ignored.
+            let trimmed = v.trim_start();
+            let token = trimmed.split_whitespace().next().unwrap_or("");
+            token.eq_ignore_ascii_case("true")
+        })
+}
+```
+
+This is equivalent to `starts_with_ignore_ascii_case("true")` but uses whitespace splitting so trailing punctuation/em-dash attached directly to the token doesn't break it. The implementation matches what humans naturally write after `[tech-design-approved] true`.
+
+The function is the only `tagged_values`-based site that required exact-equality semantics, so this change is localised.
+
+### 2. Tests
+
+Add the following tests in the existing `mod tests`:
+
+- `tech_design_approved_accepts_rationale_after_true`
+- `tech_design_approved_accepts_uppercase_true`
+- `tech_design_approved_accepts_leading_whitespace`
+- `tech_design_approved_rejects_false`
+- `tech_design_approved_rejects_missing_value`
+- `tech_design_approved_rejects_unrelated_token`
+
+Each test builds a `Task` with a single relevant comment and calls `tech_design_approved` directly.
+
+### 3. Documentation
+
+No spec amendment needed — factory v2 already documents `[tech-design-approved]` as a marker, the relaxation is implementation-level. The PR template / workflow docs don't need updates because the comment format was never strictly defined as `[tech-design-approved] true` with nothing else; humans were already writing `[tech-design-approved] true — ...` and only the parser rejected it.
+
+## Test Plan
+
+- `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml`
+  - all existing 42 tests still pass (relaxation is a superset of strictness)
+  - 6 new tests pass
+- Run the lobster on task `44f5ed65` after the PR is merged to confirm the workflow can close out using a single `[tech-design-approved] true — rationale` comment.
+
+## Open Questions and Risks
+
+- None blocking. The relaxation is local and the test coverage is symmetric (accept + reject). If reviewers prefer `starts_with("true")` to the `split_whitespace().next()` form, either is acceptable; the latter is more permissive about punctuation.
+- Behaviour change is technically a parser relaxation, but it's a no-op for the existing test suite (which doesn't depend on the strictness) so risk is bounded.
+
+## Task description note
+
+This task description was created without `**Spec:**` and `**Workstreams**` fields. Rowan patched the description to add those fields so the lobster's `spec_check` stage can validate the workflow. The bug itself is not a feature; the spec reference points to `feature-factory-v2-2026-06-04.md` as the parent contract because the lobster's tag semantics are governed there.


### PR DESCRIPTION
## Summary
- Relaxes the lobster's `tech_design_approved` check so comments like `[tech-design-approved] true — rationale text` are accepted (only the leading `true` token is compared, case-insensitive).
- Rejection cases (`[tech-design-approved] false`, missing value, unrelated tokens) still rejected.
- 7 new Rust unit tests cover the accept + reject scenarios; full `cargo test` 49/49 pass.

## Test plan
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml` (49 tests pass, 7 new)
- [x] `PYTHONPATH=agents/skills/tasks-api-ops python3 -m unittest discover -s tests -p 'test_*.py'` (110 tests pass)
- [x] `npm test --workspace apps/tasks` (126 tests pass)
- [x] `npm test --workspace @sindustries/tasks-api` (35 tests pass)

## Acceptance Criteria
- [x] AC1: `[tech-design-approved] true — any rationale` is accepted by the parser (testID: tech_design_approved_accepts_rationale_after_true)
- [x] AC2: `[tech-design-approved] false` and `[tech-design-approved]` (missing value) still rejected correctly (testID: tech_design_approved_rejects_false, tech_design_approved_rejects_missing_value, tech_design_approved_rejects_unrelated_token)
- [x] AC3: Rust unit tests cover both accept and reject cases (testID: tech_design_approved_accepts_rationale_after_true, tech_design_approved_rejects_false, tech_design_approved_rejects_missing_value, tech_design_approved_rejects_unrelated_token)

## System spec
[no-system-spec-change] Pure parser-relaxation behaviour change in the lobster CLI; no durable system contract, persisted data, or workflow protocol change. The factory v2 spec documents `[tech-design-approved]` as a marker but doesn't specify strict equality semantics on the value token — this aligns the parser with how humans already write the comment. No `docs/systems/` update warranted.

🤖 Generated with Claude Code