### PR TITLE
fix(tasks-api): patch --description replaces, not appends

### DIFF
--- a/agents/skills/ops/tasks-api/tasks_api_client.py
+++ b/agents/skills/ops/tasks-api/tasks_api_client.py
@@ -166,17 +166,12 @@ def cmd_patch(args):
     if args.clear_dependencies:
         payload["dependsOnIds"] = []
 
-    # Handle description: append to existing instead of replacing
+    # Handle description: replace, not concatenate. The Tasks API supports
+    # partial-PATCH and stores whatever description string it receives;
+    # previously this branch concatenated the new value onto the existing one,
+    # which caused repeated patches to multiply the description content.
     if args.description is not None:
-        try:
-            current = get_task(args.id, base_url=base)
-            existing = (current.get("description") or "") if current else ""
-            if existing:
-                payload["description"] = f"{existing}\n\n{args.description}"
-            else:
-                payload["description"] = args.description
-        except Exception:
-            payload["description"] = args.description
+        payload["description"] = args.description
 
     print(json.dumps(api_request("PATCH", base, f"/tasks/{args.id}", payload), indent=2))
 

--- a/agents/skills/ops/tasks-api/tests/test_tasks_api_client.py
+++ b/agents/skills/ops/tasks-api/tests/test_tasks_api_client.py
@@ -63,6 +63,80 @@ class TasksApiClientPatchTest(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 args.func(args)
 
+    # ---- patch --description replaces (task 2cee0bcd) ----
+
+    def test_patch_description_replaces_existing(self):
+        parser = tasks_api_client.build_parser()
+        args = parser.parse_args(
+            ["patch", "--id", "task-1", "--description", "new text"]
+        )
+
+        with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"), patch.object(
+            tasks_api_client, "api_request", return_value={"data": {"id": "task-1"}}
+        ) as api_request, patch.object(
+            tasks_api_client, "get_task"
+        ) as get_task, patch("builtins.print"):
+            args.func(args)
+
+        api_request.assert_called_once_with(
+            "PATCH",
+            "http://tasks.test/api/v1",
+            "/tasks/task-1",
+            {"description": "new text"},
+        )
+        get_task.assert_not_called()
+
+    def test_patch_description_called_twice_stores_only_second(self):
+        parser = tasks_api_client.build_parser()
+        captured_payloads = []
+
+        def fake_api_request(method, base, path, payload):
+            captured_payloads.append(payload)
+            return {"data": {"id": "task-1", "description": payload.get("description")}}
+
+        with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"), patch.object(
+            tasks_api_client, "api_request", side_effect=fake_api_request
+        ), patch("builtins.print"):
+            args1 = parser.parse_args(
+                ["patch", "--id", "task-1", "--description", "first"]
+            )
+            args1.func(args1)
+            args2 = parser.parse_args(
+                ["patch", "--id", "task-1", "--description", "second"]
+            )
+            args2.func(args2)
+
+        self.assertEqual(captured_payloads[0], {"description": "first"})
+        self.assertEqual(captured_payloads[1], {"description": "second"})
+        self.assertNotIn("first", captured_payloads[1]["description"])
+
+    def test_patch_other_fields_unaffected_by_description(self):
+        parser = tasks_api_client.build_parser()
+        args = parser.parse_args(
+            [
+                "patch",
+                "--id",
+                "task-1",
+                "--status",
+                "doing",
+                "--priority",
+                "high",
+            ]
+        )
+
+        with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"), patch.object(
+            tasks_api_client, "api_request", return_value={"data": {"id": "task-1"}}
+        ) as api_request, patch("builtins.print"):
+            args.func(args)
+
+        api_request.assert_called_once_with(
+            "PATCH",
+            "http://tasks.test/api/v1",
+            "/tasks/task-1",
+            {"status": "doing", "priority": "high"},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/docs/specs/tasks-api-patch-description-replace-tech-design.md
+++ b/docs/specs/tasks-api-patch-description-replace-tech-design.md
@@ -1,0 +1,81 @@
+---
+status: draft
+task_id: 2cee0bcd-1976-4569-86d1-907f05515c6f
+product_spec: brain/bookmarks/specs/feature-factory-v2-2026-06-04.md
+shipped_pr: null
+shipped_date: null
+---
+
+# Tasks API Patch Description Replace — Tech Design
+
+## Links
+
+- Task: `2cee0bcd-1976-4569-86d1-907f05515c6f` (`🔧 🐛 tasks_api_client.py patch --description appends instead of replacing`)
+- Task API detail: `http://localhost:4001/api/v1/tasks/2cee0bcd-1976-4569-86d1-907f05515c6f`
+
+## Scope
+
+- Repository: `Stoffer-Industries/sindustries`
+- Branch: `task-2cee0bcd-patch-description-replace`
+- Worktree: `~/workspaces/rowan/sindustries`
+- Primary code surface: `agents/skills/ops/tasks-api/tasks_api_client.py` (single function: `cmd_patch`)
+
+No `.openclaw` runtime change. No API change. No data migration. The Tasks API already does partial-PATCH correctly; the bug is purely in the client wrapper.
+
+## Product Summary
+
+`tasks_api_client.py patch --description "..."` currently reads the existing task, then sends `{existing}\n\n{new}` as the description — three successive patches tripled the description, as observed on task `44f5ed65` this morning. The Tasks API itself does a partial-PATCH and stores whatever description string it receives (`updates.description = description || null` in `services/tasks-api/src/routes/tasks.ts`), so the API behaviour is correct. The fix is to drop the append branch in the client and pass the value through directly.
+
+This makes the client consistent with how every other field (`title`, `priority`, `status`, `assignee`, `tags`, `blocked`, `ready`) already behaves — replace, not concatenate.
+
+## Implementation Plan
+
+### 1. Drop the description-append branch in `cmd_patch`
+
+Replace the current block:
+
+```python
+# Handle description: append to existing instead of replacing
+if args.description is not None:
+    try:
+        current = get_task(args.id, base_url=base)
+        existing = (current.get("description") or "") if current else ""
+        if existing:
+            payload["description"] = f"{existing}\n\n{args.description}"
+        else:
+            payload["description"] = args.description
+    except Exception:
+        payload["description"] = args.description
+```
+
+with:
+
+```python
+if args.description is not None:
+    payload["description"] = args.description
+```
+
+The Tasks API already handles partial-PATCH (it only updates fields whose keys are present in the request body), so no other change is required.
+
+### 2. Tests
+
+Add tests in `agents/skills/ops/tasks-api/tests/test_tasks_api_client.py` (or a new test file if that file is for a different concern):
+
+- `patch_description_replaces_existing` — mock the API client; assert a single `patch --description "new"` call sets `payload["description"] = "new"` (no fetch of current description, no concatenation).
+- `patch_description_called_twice_stores_only_second` — mock API state across two calls; assert the second value is what's stored (covered by replacing behaviour plus the API's partial-PATCH).
+- `patch_other_fields_unaffected_by_description_change` — call `patch --status foo --priority bar`; assert no `description` key is added to the payload.
+
+The existing test suite uses `urllib` mocks — follow the same pattern.
+
+## Test Plan
+
+- `PYTHONPATH=agents/skills/tasks-api-ops python3 -m unittest discover -s agents/skills/ops/tasks-api/tests -p 'test_*.py'` — all existing tests pass + new tests pass.
+- Manual smoke:
+  - create a task with description `"a"`
+  - `tasks_api_client.py patch --id <id> --description "b"` → stored value is `"b"` (not `"a\n\nb"`)
+  - `tasks_api_client.py patch --id <id> --description "c"` → stored value is `"c"` (not `"a\n\nb\n\nc"`)
+
+## Open Questions and Risks
+
+- None blocking. The change is a behavioural correction that aligns `--description` with every other field's semantics. The Tasks API already expects and stores whatever description string it receives.
+- A side-effect of the fix: anyone who was relying on the append behaviour (likely nobody, given the bug reports) will need to switch to explicit fetch-then-patch workflows. No such callers were observed in the workspace.


### PR DESCRIPTION
## Summary
- Drops the read-and-concat branch in `tasks_api_client.py patch --description` so the value is passed through directly to the Tasks API (which already supports partial-PATCH correctly). The previous behaviour caused repeated `--description` patches to multiply the description content.
- 3 new unit tests cover: replacement (no current-value fetch), idempotence across consecutive patches, and isolation from other patch fields.

## Test plan
- [x] `PYTHONPATH=agents/skills/tasks-api-ops python3 -m unittest discover -s agents/skills/ops/tasks-api/tests -p 'test_*.py'` (6 tests pass, 3 new)
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml` (49 tests pass)
- [x] `PYTHONPATH=agents/skills/tasks-api-ops python3 -m unittest discover -s tests -p 'test_*.py'` (110 tests pass)
- [x] `npm test --workspace apps/tasks` (126 tests pass)
- [x] `npm test --workspace @sindustries/tasks-api` (35 tests pass)

## Acceptance Criteria
- [x] AC1: `tasks_api_client.py patch <task-id> --description "new text"` replaces the task description with `"new text"` (does not append). (testID: test_patch_description_replaces_existing)
- [x] AC2: Patching `--description` twice in sequence results in only the second value being stored. (testID: test_patch_description_called_twice_stores_only_second)
- [x] AC3: Other patch flags (e.g. `--status`, `--priority`) are unaffected. (testID: test_patch_other_fields_unaffected_by_description)

## System spec
[no-system-spec-change] Pure client-side behavioural correction; no API contract change, no persisted data migration. The Tasks API itself already did partial-PATCH correctly — the bug was isolated to the client wrapper.

🤖 Generated with Claude Code