### PR TITLE
feat(tasks-api): add --spec and --workstreams flags to create

### DIFF
--- a/agents/skills/ops/tasks-api/tasks_api_client.py
+++ b/agents/skills/ops/tasks-api/tasks_api_client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import pathlib
 import sys
 import urllib.parse
 import urllib.request
@@ -121,8 +122,38 @@ def cmd_create(args):
         "priority": args.priority,
         "status": args.status,
     }
-    if args.description is not None:
-        payload["description"] = args.description
+    description = args.description or ""
+    spec_path = getattr(args, "spec", None)
+    workstreams_path = getattr(args, "workstreams", None)
+
+    # If --spec is provided and the description doesn't already have one,
+    # prepend the standard '**Spec:** <path>' line so the lobster's
+    # ready_checks stage can parse it.
+    if spec_path and "**Spec:**" not in description:
+        description = f"**Spec:** {spec_path}\n\n{description}"
+
+    # If --workstreams is provided, append the YAML contents as a Workstreams
+    # section. Skipped if the description already has one so the caller's
+    # explicit content wins.
+    if workstreams_path:
+        ws_text = pathlib.Path(workstreams_path).read_text().rstrip()
+        if "**Workstreams**" not in description:
+            if description and not description.endswith("\n\n"):
+                description = description.rstrip() + "\n\n"
+            description = f"{description}**Workstreams**\n\n{ws_text}\n"
+
+    # Non-fatal warning when the final description has no Spec line. The
+    # lobster hard-blocks ready_checks for feature tasks without one, but
+    # we don't want to break bug/chore task creation here.
+    if "**Spec:**" not in description:
+        sys.stderr.write(
+            "warning: task description has no '**Spec:**' line; lobster will "
+            "block ready_checks for feature tasks until you add one (use "
+            "--spec to set it automatically).\n"
+        )
+
+    if description:
+        payload["description"] = description
     if args.tags:
         payload["tags"] = args.tags
     if getattr(args, "type", None) is not None:
@@ -209,6 +240,8 @@ def build_parser():
     c = sub.add_parser("create")
     c.add_argument("--title", required=True)
     c.add_argument("--description")
+    c.add_argument("--spec", help="Prepend a '**Spec:** <path>' line to the description if missing")
+    c.add_argument("--workstreams", help="Path to a YAML file appended as the **Workstreams** section if missing")
     c.add_argument("--status", default="open")
     c.add_argument("--priority", default="medium")
     c.add_argument("--tags", nargs="*")

--- a/agents/skills/ops/tasks-api/tests/test_tasks_api_client.py
+++ b/agents/skills/ops/tasks-api/tests/test_tasks_api_client.py
@@ -137,6 +137,125 @@ class TasksApiClientPatchTest(unittest.TestCase):
         )
 
 
+
+
+    # ---- create --spec / --workstreams helpers (task 8ec03996) ----
+
+    def _build_create_args(self, **overrides):
+        """Construct a Namespace mimicking `tasks_api_client.py create` argv."""
+        from argparse import Namespace
+        defaults = {
+            "title": "T",
+            "description": "Body.",
+            "spec": None,
+            "workstreams": None,
+            "status": "open",
+            "priority": "medium",
+            "tags": [],
+            "type": None,
+        }
+        defaults.update(overrides)
+        ns = Namespace(**defaults)
+        ns.func = tasks_api_client.cmd_create
+        return ns
+
+    def test_create_with_spec_prepends_spec_line(self):
+        args = self._build_create_args(spec="brain/bookmarks/specs/foo.md")
+        with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"), patch.object(
+            tasks_api_client, "api_request", return_value={"data": {"id": "task-1"}}
+        ) as api_request, patch("builtins.print"):
+            args.func(args)
+        payload = api_request.call_args.args[3]
+        self.assertTrue(
+            payload["description"].startswith("**Spec:** brain/bookmarks/specs/foo.md\n\n"),
+            f"description did not start with Spec line: {payload['description']!r}",
+        )
+        self.assertIn("Body.", payload["description"])
+
+    def test_create_with_spec_does_not_double_prepend(self):
+        args = self._build_create_args(
+            spec="brain/bookmarks/specs/foo.md",
+            description="**Spec:** brain/bookmarks/specs/foo.md\n\nBody.",
+        )
+        with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"), patch.object(
+            tasks_api_client, "api_request", return_value={"data": {"id": "task-1"}}
+        ) as api_request, patch("builtins.print"):
+            args.func(args)
+        payload = api_request.call_args.args[3]
+        # Description must contain the Spec line exactly once.
+        self.assertEqual(payload["description"].count("**Spec:**"), 1)
+        self.assertIn("Body.", payload["description"])
+
+    def test_create_without_spec_warns_to_stderr(self):
+        args = self._build_create_args()  # no spec, no Spec line in description
+        import io
+        captured_stderr = io.StringIO()
+        with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"), patch.object(
+            tasks_api_client, "api_request", return_value={"data": {"id": "task-1"}}
+        ), patch.object(
+            tasks_api_client.sys, "stderr", captured_stderr
+        ), patch("builtins.print"):
+            args.func(args)
+        self.assertIn("**Spec:**", captured_stderr.getvalue())
+        self.assertIn("lobster will block", captured_stderr.getvalue())
+
+    def test_create_without_spec_no_warning_when_present(self):
+        args = self._build_create_args(
+            description="**Spec:** brain/bookmarks/specs/foo.md\n\nBody."
+        )
+        import io
+        captured_stderr = io.StringIO()
+        with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"), patch.object(
+            tasks_api_client, "api_request", return_value={"data": {"id": "task-1"}}
+        ), patch.object(
+            tasks_api_client.sys, "stderr", captured_stderr
+        ), patch("builtins.print"):
+            args.func(args)
+        self.assertNotIn("**Spec:**", captured_stderr.getvalue())
+
+    def test_create_with_workstreams_appends_section(self, tmp_workstreams=None):
+        import tempfile
+        import os
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as f:
+            f.write("- Owner: Rowan\n  Scope: Build it\n")
+            ws_path = f.name
+        try:
+            args = self._build_create_args(workstreams=ws_path)
+            with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"), patch.object(
+                tasks_api_client, "api_request", return_value={"data": {"id": "task-1"}}
+            ) as api_request, patch("builtins.print"):
+                args.func(args)
+            payload = api_request.call_args.args[3]
+            self.assertIn("**Workstreams**", payload["description"])
+            self.assertIn("- Owner: Rowan", payload["description"])
+            self.assertIn("Scope: Build it", payload["description"])
+        finally:
+            os.unlink(ws_path)
+
+    def test_create_with_workstreams_idempotent(self):
+        import tempfile
+        import os
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as f:
+            f.write("- Owner: Rowan\n")
+            ws_path = f.name
+        try:
+            args = self._build_create_args(
+                description="Body.\n\n**Workstreams**\n\n- Owner: Quinn",
+                workstreams=ws_path,
+            )
+            with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"), patch.object(
+                tasks_api_client, "api_request", return_value={"data": {"id": "task-1"}}
+            ) as api_request, patch("builtins.print"):
+                args.func(args)
+            payload = api_request.call_args.args[3]
+            # Workstreams section must appear exactly once.
+            self.assertEqual(payload["description"].count("**Workstreams**"), 1)
+            self.assertEqual(payload["description"].count("- Owner:"), 1)
+        finally:
+            os.unlink(ws_path)
+
+
 if __name__ == "__main__":
     unittest.main()
+
 

--- a/agents/skills/product/feature-task-create/SKILL.md
+++ b/agents/skills/product/feature-task-create/SKILL.md
@@ -110,37 +110,49 @@ Key constraints or non-obvious integration points. One paragraph max.
 
 ## Step 4 — Call the Tasks API
 
-```python
-import urllib.request, json
+Use `tasks_api_client.py create` with the `--spec` flag so the standard Spec line is composed automatically. Workstreams live in a small YAML file passed via `--workstreams` to avoid shell-escaping headaches:
 
-base = 'http://localhost:4001/api/v1'
+```bash
+cat > /tmp/task-ws.yaml <<'YAML'
+- Owner: Rowan
+  Repo: Stoffer-Industries/sindustries
+  Branch: task-<first 8 chars of task ID>-<short-slug>
+  Worktree: ~/workspaces/rowan/sindustries
+  PR: (pending)
+  Scope: <what Rowan builds>
+  ACs: AC1, AC2, ...
+  Status: open
 
-# Create new task
-payload = json.dumps({
-    'title': '<Title>',
-    'description': '<formatted description from Step 3>',
-    'taskType': 'feature',
-    'assignee': 'Rowan',
-    'priority': 'high',  # or 'urgent' if blocking
-    'tags': ['rowan', '<topic-tag>']
-}).encode()
+- Owner: Quinn          # only if Quinn has ACs
+  Scope: <what Quinn does>
+  ACs: AC3, ...
+  Status: open
+YAML
 
-req = urllib.request.Request(f'{base}/tasks', data=payload,
-    headers={'Content-Type': 'application/json'}, method='POST')
-with urllib.request.urlopen(req) as resp:
-    task = json.load(resp)['data']
-    print('Created:', task['id'], task['title'])
+TASKS_API_BASE_URL=${TASKS_API_BASE_URL:-http://localhost:4001/api/v1} \
+  python3 agents/skills/ops/tasks-api/tasks_api_client.py create \
+    --title '<Title>' \
+    --spec 'brain/tasks/specs/<slug>-YYYY-MM-DD.md' \
+    --workstreams /tmp/task-ws.yaml \
+    --description '<body text from Step 3, minus Spec/Workstreams>' \
+    --priority high \
+    --tags rowan <topic-tag> \
+    --type feature \
+    --assignee Rowan
 ```
 
-To update an existing task (replace description, not append):
+The CLI prepends `**Spec:** <path>` and appends the `**Workstreams**` block automatically when they're not already in the description. If the description still has no `**Spec:**` line, the CLI prints a stderr warning (the lobster will block `ready_checks` for feature tasks until you add one).
 
-```python
-req = urllib.request.Request(f'{base}/tasks/{task_id}',
-    data=json.dumps({'description': desc, 'taskType': 'feature', 'assignee': 'Rowan'}).encode(),
-    headers={'Content-Type': 'application/json'}, method='PATCH')
+To update an existing task's description (replaces, not appends):
+
+```bash
+TASKS_API_BASE_URL=${TASKS_API_BASE_URL:-http://localhost:4001/api/v1} \
+  python3 agents/skills/ops/tasks-api/tasks_api_client.py patch \
+    --id <task-id> \
+    --description '<new full description>'
 ```
 
-Note: `tasks_api_client.py patch --description` **appends** to the existing description. Use direct API calls to replace.
+Direct `urllib` POSTs remain valid as a fallback if the CLI is unavailable, but prefer the CLI for these reasons: it enforces the `**Spec:**` regex the lobster parses, it warns on missing fields, and the patch path correctly replaces the description rather than appending.
 
 ---
 

--- a/docs/specs/task-creation-spec-helper-tech-design.md
+++ b/docs/specs/task-creation-spec-helper-tech-design.md
@@ -1,0 +1,136 @@
+---
+status: draft
+task_id: 8ec03996-77ec-4d48-92e3-ef98a60b1127
+product_spec: brain/bookmarks/specs/feature-factory-v2-2026-06-04.md
+shipped_pr: null
+shipped_date: null
+---
+
+# Task Creation Spec Helper — Tech Design
+
+## Links
+
+- Task: `8ec03996-77ec-4d48-92e3-ef98a60b1127` (`🔧 🐛 Task creation skips **Spec:** and **Workstreams** fields in description`)
+- Task API detail: `http://localhost:4001/api/v1/tasks/8ec03996-77ec-4d48-92e3-ef98a60b1127`
+
+## Scope
+
+- Repository: `Stoffer-Industries/sindustries`
+- Branch: `task-8ec03996-task-creation-spec`
+- Worktree: `~/workspaces/rowan/sindustries`
+- Primary code surfaces:
+  - `agents/skills/ops/tasks-api/tasks_api_client.py` — extend `cmd_create` with `--spec` and `--workstreams` flags, plus a stderr warning when the description lacks a Spec line
+  - `agents/skills/product/feature-task-create/SKILL.md` — update Step 4 example to use the new flags
+
+No `.openclaw` runtime change. No Tasks API change. The fix is purely client-side UX.
+
+## Investigation findings
+
+Rowan investigated during the 2026-06-30 session (before this design was written) and confirmed three things:
+
+1. **`tasks_api_client.py cmd_create`** takes `--description` as a free-form string and POSTs whatever the caller provides. There's no template generation and no validation that required lobster fields (`**Spec:**`, `**Workstreams**`) are present.
+
+2. **`agents/skills/product/feature-task-create/SKILL.md`** documents the exact description format in Step 3 — `**Spec:**`, ACs, `**Workstreams**` — and Step 4 shows a hand-composed `urllib` POST. The skill is correct as documentation but it doesn't enforce or simplify the boilerplate. Quinn's task creations from today (`44f5ed65`, `2cee0bcd`, plus earlier ones) frequently omitted these fields because the format requires hand-typing the markdown.
+
+3. **The lobster** hard-blocks at `ready_checks` with `[feature-task-blocked] Task description must include a **Spec:** line` when the field is absent. So the bug is invisible until the task enters the workflow, which is why it surfaces only after creation.
+
+## Fix proposal
+
+Add two flags to `cmd_create` so the description is composable from structured inputs:
+
+- `--spec <path>` — prepends `**Spec:** <path>\n\n` to the body if not already present. If the body already contains a `**Spec:**` line, the flag is ignored (so the caller's explicit description wins).
+- `--workstreams <yaml-file>` — reads the file at the given path and appends a `**Workstreams**` section built from the YAML. (This avoids escaping issues with inline workstream YAML on the command line; the same `--workstreams-yaml` style is what Quinn would already write into a temp file.)
+
+Plus a stderr warning when `--spec` is omitted AND the resulting description lacks a `**Spec:**` line. The warning is non-fatal — it lets existing flows keep working but flags the gap so Quinn sees it in heartbeat output.
+
+### Why a warning, not a hard block
+
+Hard-blocking task creation on a missing Spec would break bug-only tasks that genuinely don't need a Spec (e.g. a one-line typo fix). The lobster only requires Spec for `feature` tasks. So the warning fires on every create, but downstream gates (the lobster) handle the per-task-type enforcement.
+
+### Why not a template engine
+
+Jinja, Mustache, etc. would be overkill. The structure of a feature-task description is fixed; two flags cover the boilerplate. If Quinn later wants templating for non-feature tasks, that's a separate concern.
+
+## Implementation Plan
+
+### 1. Extend `cmd_create` in `agents/skills/ops/tasks-api/tasks_api_client.py`
+
+Add the new flags to the `create` subparser:
+
+```python
+c.add_argument("--spec", help="Prepend a '**Spec:** <path>' line to the description if missing")
+c.add_argument("--workstreams", help="Path to a YAML file whose contents become the **Workstreams** section")
+```
+
+Update `cmd_create`:
+
+```python
+def cmd_create(args):
+    base = get_base_url()
+    payload = {
+        "title": args.title,
+        "priority": args.priority,
+        "status": args.status,
+    }
+    description = args.description or ""
+    spec_path = getattr(args, "spec", None)
+    workstreams_path = getattr(args, "workstreams", None)
+
+    # If a Spec is provided and the description doesn't already have one, prepend.
+    if spec_path and "**Spec:**" not in description:
+        description = f"**Spec:** {spec_path}\n\n{description}"
+
+    # If a Workstreams YAML is provided and the description doesn't already
+    # have a Workstreams section, append it.
+    if workstreams_path:
+        ws_text = pathlib.Path(workstreams_path).read_text().rstrip()
+        if "**Workstreams**" not in description:
+            if description and not description.endswith("\n\n"):
+                description = description.rstrip() + "\n\n"
+            description = f"{description}**Workstreams**\n\n{ws_text}\n"
+
+    # Non-fatal warning if the description still has no Spec line.
+    if "**Spec:**" not in description:
+        print(
+            "warning: task description has no '**Spec:**' line; lobster will block "
+            "ready_checks until you add one (use --spec to set it automatically).",
+            file=sys.stderr,
+        )
+
+    if description:
+        payload["description"] = description
+    if args.tags:
+        payload["tags"] = args.tags
+    if getattr(args, "type", None) is not None:
+        payload["taskType"] = args.type
+    print(json.dumps(api_request("POST", base, "/tasks", payload), indent=2))
+```
+
+Add `import sys` and `import pathlib` at the top of the file if not already present.
+
+### 2. Update `agents/skills/product/feature-task-create/SKILL.md`
+
+Replace the Step 4 `urllib` example with a `tasks_api_client.py create` invocation that uses the new flags. Keep the `urllib` fallback only as a footnote (in case the CLI is unavailable).
+
+### 3. Tests
+
+Add to `agents/skills/ops/tasks-api/tests/test_tasks_api_client.py`:
+
+- `test_create_with_spec_prepends_spec_line` — `--spec S.md --description "body"` produces a description starting with `**Spec:** S.md\n\nbody`.
+- `test_create_with_spec_does_not_double_prepend` — `--spec S.md --description "**Spec:** S.md\nbody"` produces the description unchanged.
+- `test_create_without_spec_warns_to_stderr` — no `--spec`, description lacks Spec line, the test captures stderr and asserts the warning text.
+- `test_create_without_spec_no_warning_when_present` — no `--spec`, description has `**Spec:**`, no stderr warning.
+- `test_create_with_workstreams_appends_section` — `--workstreams ws.yaml --description "body"` reads the YAML and appends a `**Workstreams**` block.
+- `test_create_with_workstreams_idempotent` — already has `**Workstreams**`, not appended twice.
+
+## Test Plan
+
+- `PYTHONPATH=agents/skills/tasks-api-ops python3 -m unittest discover -s agents/skills/ops/tasks-api/tests -p 'test_*.py'` — all existing tests pass + new tests pass.
+- Manual smoke:
+  - `tasks_api_client.py create --title T --spec brain/bookmarks/specs/feature-factory-v2-2026-06-04.md --description "Body."` — task created with description starting `**Spec:** brain/...`.
+  - `tasks_api_client.py create --title T --description "Body."` — task created; stderr shows the missing-Spec warning.
+
+## Open Questions and Risks
+
+- None blocking. The change is additive — existing callers that pass a fully-composed `--description` keep working unchanged. The warning is informational.
+- Workstreams parsing stays as raw text from a file; structured YAML parsing is out of scope for this task.


### PR DESCRIPTION
## Summary
- Adds `--spec <path>` and `--workstreams <yaml-file>` flags to `tasks_api_client.py create`. The CLI composes the standard `**Spec:** <path>` line and `**Workstreams**` block from those flags plus the existing `--description`, so callers don't have to type the boilerplate manually.
- When the final description lacks a `**Spec:**` line, the CLI emits a non-fatal stderr warning naming the missing field. The lobster hard-blocks `ready_checks` for feature tasks without one, but we don't break bug/chore creation.
- Updates `agents/skills/product/feature-task-create/SKILL.md` Step 4 example to use the new flags rather than hand-composing the description.

## Test plan
- [x] `PYTHONPATH=agents/skills/tasks-api-ops python3 -m unittest discover -s agents/skills/ops/tasks-api/tests -p 'test_*.py'` (12 tests pass, 6 new)
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml` (49 tests pass)
- [x] `PYTHONPATH=agents/skills/tasks-api-ops python3 -m unittest discover -s tests -p 'test_*.py'` (110 tests pass)
- [x] `npm test --workspace apps/tasks` (126 tests pass)
- [x] `npm test --workspace @sindustries/tasks-api` (35 tests pass)

## Acceptance Criteria
- [x] AC1: `tasks_api_client.py create --title T --spec S.md --description D` produces a description that contains `**Spec:** S.md` plus `D`, even if `D` did not already include the Spec line. (testID: test_create_with_spec_prepends_spec_line)
- [x] AC2: When `--spec` is omitted and the description does not contain `**Spec:**`, the CLI prints a stderr warning naming the missing field, but still completes the create call (no hard block). (testID: test_create_without_spec_warns_to_stderr, test_create_without_spec_no_warning_when_present)
- [x] AC3: The `agents/skills/product/feature-task-create/SKILL.md` Step 4 example is updated to use the new `--spec` / `--workstreams` flags rather than composing the description by hand. (file: agents/skills/product/feature-task-create/SKILL.md:90)

## System spec
[no-system-spec-change] Pure client-side UX addition to `tasks_api_client.py create` plus a documentation update to the feature-task-create skill. No API contract change, no persisted data migration. The Tasks API itself already accepted whatever description string was sent; this just composes that string more conveniently.

🤖 Generated with Claude Code