### PR TITLE
fix(tasks-api): don't reject comments on spec-drifted tasks

### DIFF
--- a/docs/systems/task-tracking.md
+++ b/docs/systems/task-tracking.md
@@ -137,7 +137,7 @@ Base path: `/api/v1`
 | GET | /tags | List tags with usage counts |
 | GET | /health | Health check |
 
-**Spec drift guard:** PATCH with `specChecksum` rejects if the task's stored checksum differs. Rowan must resolve spec drift before patching.
+**Spec drift guard:** PATCH with `specChecksum` rejects if the task's stored checksum differs. Rowan must resolve spec drift before patching. `POST /tasks/:id/comments` does **not** apply the drift guard — comments are meta-discussion, not scope changes, and an agent should be able to discuss drift on the task without first having to resolve it.
 
 **Cursor pagination:** `GET /tasks` returns a `nextCursor` token. Pass as `cursor=` to page. Default limit: 50.
 

--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -444,7 +444,10 @@ tasksRouter.post('/tasks/:id/comments', async (req, res, next) => {
     const { id } = req.params;
     const existing = await prisma.task.findFirst({ where: { id, archivedAt: null } });
     if (!existing) return notFound(res, 'TASK_NOT_FOUND', 'Task not found');
-    if (rejectSpecDrift(res, existing, existing.description)) return;
+    // Comments are meta-discussion, not scope changes. The drift check
+    // belongs on PATCH (where ACs can actually be modified), not on comment
+    // creation. Checking here blocks all discussion on drifted tasks, which
+    // is the opposite of what we want — the new ACs need to be discussed.
 
     const author = normalizeString(req.body?.author);
     const text = normalizeString(req.body?.text);

--- a/services/tasks-api/test/read-endpoints.test.ts
+++ b/services/tasks-api/test/read-endpoints.test.ts
@@ -373,7 +373,7 @@ describe('tasks api endpoints', () => {
     expect(prismaMock.task.update).not.toHaveBeenCalled();
   });
 
-  it('POST /api/v1/tasks/:id/comments blocks when current ACs drifted after spec approval', async () => {
+  it('POST /api/v1/tasks/:id/comments succeeds even when current ACs drifted after spec approval', async () => {
     const checksum = checksumForAcceptanceCriteria(['AC1: Build it']);
     prismaMock.task.findFirst.mockResolvedValueOnce(
       task({
@@ -382,15 +382,24 @@ describe('tasks api endpoints', () => {
         specChecksum: checksum
       })
     );
+    prismaMock.taskComment.create.mockResolvedValueOnce({
+      id: 'c1000000-0000-0000-0000-000000000000',
+      taskId: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+      author: 'Rowan',
+      body: 'trying to comment',
+      createdAt: new Date('2026-07-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-01T00:00:00.000Z')
+    });
 
     const app = createApp();
     const response = await request(app)
       .post('/api/v1/tasks/2527ff9d-4369-444f-995d-4d4bb0ac7b70/comments')
       .send({ author: 'Rowan', text: 'trying to comment' });
 
-    expect(response.status).toBe(409);
-    expect(response.body.error.code).toBe('SPEC_CHECKSUM_MISMATCH');
-    expect(prismaMock.taskComment.create).not.toHaveBeenCalled();
+    expect(response.status).toBe(201);
+    expect(response.body.data.author).toBe('Rowan');
+    expect(response.body.data.text).toBe('trying to comment');
+    expect(prismaMock.taskComment.create).toHaveBeenCalledTimes(1);
   });
 
   it('GET /api/v1/tasks formats task titles with taskType emoji without duplication', async () => {


### PR DESCRIPTION
## What

`POST /tasks/:id/comments` was calling `rejectSpecDrift`, which meant any task whose stored `specChecksum` no longer matched its current ACs could not be commented on at all. The check belongs on `PATCH /tasks/:id` (where ACs can actually be modified), not on the comment endpoint.

Removed the wrong guard. Flipped the test that asserted the rejection to assert the comment now succeeds. System spec note updated to match.

## Why

Surfaced when Tom tried to comment on the in-flight `b2ab54db` (spec resync) task after its ACs were edited. The endpoint returned `409 SPEC_CHECKSUM_MISMATCH` even though no AC was being modified — the comment was pure meta-discussion. Drift is the thing to be discussed, not something that should suppress discussion.

The data fix (resetting the stored `specChecksum` on `b2ab54db` to match its current ACs) was applied directly in the prodlike DB with an audit comment, since that's a one-off. This PR covers the underlying bug for all future cases.

## Test

- `npx vitest run` in `services/tasks-api` → 35/35 pass (28 in `read-endpoints.test.ts`, including the flipped test)
- Manual: `POST /api/v1/tasks/b2ab54db-…/comments` now returns 201 instead of 409

🤖 Generated with [opencode](https://opencode.ai)