### PR TITLE
feat(heartbeat): add pending-tech-design-approvals helper script

### DIFF
--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -30,12 +30,15 @@ Quinn approves tech designs on behalf of Tom during heartbeat. Tom has delegated
 
 Each heartbeat:
 1. Run the feature task workflow check (see FEATURE TASK LOBSTER CHECK below).
-2. For any task blocked on `[tech-design-approved]` that already has a `[tech-design]` comment:
+2. Find feature tasks with a `[tech-design]` comment but no proper `[tech-design-approved] true` comment:
+   `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py --json`
+   The script mirrors the lobster's parser (`tagged_values` + `tech_design_approved` in `agents/workflows/feature-task/src/main.rs`): a comment counts as approval only if its trimmed text STARTS WITH the tag and the first whitespace-separated token after the tag is `true` (case-insensitive). Substring matches in the lobster's progress-checklist complaints (e.g. `Missing task comment [tech-design-approved] true`) are intentionally NOT counted.
+3. For each pending task:
    - Read the design at the linked path.
    - Check: all required sections present, aligned with spec, no unbounded scope, `.openclaw` boundary notes where relevant.
    - If it looks good: post task comment `[tech-design-approved] true`
    - If something looks wrong or risky: flag to Tom via Telegram instead of approving.
-3. Do not approve a design that was written in the same heartbeat pass (let Rowan write it, Quinn approves next pass).
+4. Do not approve a design that was written in the same heartbeat pass (let Rowan write it, Quinn approves next pass).
 
 ---
 

--- a/agents/skills/ops/tasks-api/SKILL.md
+++ b/agents/skills/ops/tasks-api/SKILL.md
@@ -48,6 +48,17 @@ Heartbeat view (all active + 10 open):
 python3 tasks_api_client.py list --heartbeat
 ```
 
+## Tech-design approval queue (heartbeat helper)
+
+For Quinn's heartbeat tech-design approval pass:
+
+```bash
+python3 agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py
+python3 agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py --json
+```
+
+Mirrors the lobster's `tagged_values` + `tech_design_approved` parser so substring matches in checklist complaints (`Missing task comment [tech-design-approved] true`) are correctly NOT counted as approvals.
+
 ## Content task creation
 
 When Tom approves a weekly content review, create the task with `--type content`:

--- a/agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py
+++ b/agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""List feature tasks that have a [tech-design] comment but no proper
+[tech-design-approved] true comment, so Quinn can review them during
+heartbeat and post approvals on Tom's behalf.
+
+Mirrors the lobster's parser in agents/workflows/feature-task/src/main.rs
+(`tagged_values` + `tech_design_approved`):
+
+  - [tech-design] tag: any comment whose TRIMMED TEXT STARTS WITH the tag
+    contributes the rest (after the tag, trimmed). First non-empty value
+    wins.
+  - [tech-design-approved] tag: same prefix rule; a comment counts as
+    approval only if the first whitespace-separated token after the tag
+    is "true" (case-insensitive). Rationale text after "true" is allowed
+    and ignored.
+
+This is the parser heartbeat should use. The previous ad-hoc substring
+check (`'[tech-design-approved]' in comment_text`) was a false positive
+on the lobster's own progress-checklist complaints
+(`Missing task comment [tech-design-approved] true`).
+
+Usage:
+  TASKS_API_BASE_URL=http://localhost:4001/api/v1 \\
+    python3 agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py \\
+    --status ready --status doing --status acceptance
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+DEFAULT_BASE_URL_ENV = "TASKS_API_BASE_URL"
+DEFAULT_PAGE_SIZE = 100
+
+
+def api_request(method: str, base_url: str, path: str, payload=None) -> dict:
+    url = f"{base_url.rstrip('/')}{path}"
+    data = None
+    headers = {"content-type": "application/json"}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        body = resp.read().decode("utf-8")
+        return json.loads(body) if body else {}
+
+
+def get_base_url() -> str:
+    base = (os.getenv(DEFAULT_BASE_URL_ENV) or "").strip()
+    if not base:
+        raise SystemExit(f"{DEFAULT_BASE_URL_ENV} is required")
+    return base
+
+
+def is_feature_task(task: dict) -> bool:
+    """Mirror agents/workflows/feature-task/src/main.rs list_active_feature_tasks."""
+    if task.get("taskType") == "feature":
+        return True
+    tags = task.get("tags") or []
+    return any(t == "feature-factory" for t in tags)
+
+
+def tagged_values(comments: list[dict], tag: str) -> list[str]:
+    """Mirror agents/workflows/feature-task/src/main.rs tagged_values.
+
+    Comment text is trimmed; if it STARTS WITH `tag`, the rest (trimmed) is
+    returned. Substring matches that are not at the start are ignored — this
+    is what skips the lobster's `Missing task comment [tech-design-approved]`
+    checklist complaints.
+    """
+    out: list[str] = []
+    for comment in comments:
+        text = (comment.get("text") or "").strip()
+        if not text:
+            continue
+        if text.startswith(tag):
+            out.append(text[len(tag):].strip())
+    return out
+
+
+def tech_design_url(task: dict) -> str | None:
+    for value in tagged_values(task.get("comments") or [], "[tech-design]"):
+        if value:
+            return value
+    return None
+
+
+def tech_design_approved(task: dict) -> bool:
+    """Mirror agents/workflows/feature-task/src/main.rs tech_design_approved."""
+    for value in tagged_values(task.get("comments") or [], "[tech-design-approved]"):
+        token = value.strip().split(maxsplit=1)[0] if value.strip() else ""
+        if token.lower() == "true":
+            return True
+    return False
+
+
+def list_tasks(base_url: str, statuses: list[str]) -> list[dict]:
+    """Fetch all non-archived tasks, paginated via the API's nextCursor.
+
+    The list endpoint returns `{ data: [...], page: { nextCursor, hasNextPage } }`.
+    `includeArchived=false` excludes archived tasks. Multi-status filtering
+    isn't supported server-side, so we filter client-side.
+    """
+    status_filter = set(statuses) if statuses else None
+    out: list[dict] = []
+    cursor: str | None = None
+    while True:
+        params: list[tuple[str, str]] = [
+            ("includeArchived", "false"),
+            ("limit", str(DEFAULT_PAGE_SIZE)),
+        ]
+        if cursor:
+            params.append(("cursor", cursor))
+        path = "/tasks?" + urllib.parse.urlencode(params)
+        response = api_request("GET", base_url, path)
+        page = response.get("data") or []
+        out.extend(page)
+        page_meta = response.get("page") or {}
+        if not page_meta.get("hasNextPage"):
+            break
+        cursor = page_meta.get("nextCursor")
+        if not cursor:
+            break
+
+    if status_filter is not None:
+        out = [t for t in out if (t.get("status") or "") in status_filter]
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--status",
+        action="append",
+        default=None,
+        help="Filter to tasks with this status. May be passed multiple times. "
+        "Default: no status filter (only the is_feature_task filter applies).",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help=f"Override ${DEFAULT_BASE_URL_ENV}.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of a human summary.",
+    )
+    args = parser.parse_args()
+
+    base = (args.base_url or get_base_url()).rstrip("/")
+    statuses = args.status or []
+
+    tasks = [t for t in list_tasks(base, statuses) if is_feature_task(t)]
+    pending = []
+    for task in tasks:
+        url = tech_design_url(task)
+        if not url:
+            continue
+        if tech_design_approved(task):
+            continue
+        pending.append(
+            {
+                "id": task.get("id"),
+                "title": task.get("title"),
+                "status": task.get("status"),
+                "assignee": task.get("assignee"),
+                "techDesignUrl": url,
+            }
+        )
+
+    if args.json:
+        json.dump({"pendingApprovals": pending, "count": len(pending)}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    if not pending:
+        print(f"No feature tasks pending tech-design approval ({len(tasks)} feature tasks checked).")
+        return 0
+
+    print(f"{len(pending)} feature task(s) pending tech-design approval:")
+    for item in pending:
+        print(f"  - [{item['status']:11s}] {item['id'][:8]}  {item['title'][:60]}")
+        print(f"      design: {item['techDesignUrl']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/skills/ops/tasks-api/scripts/test_pending_tech_design_approvals.py
+++ b/agents/skills/ops/tasks-api/scripts/test_pending_tech_design_approvals.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Unit tests for pending_tech_design_approvals.
+
+Run with: python3 -m unittest agents/skills/ops/tasks-api/scripts/test_pending_tech_design_approvals.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+# Make the sibling script importable
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+
+import pending_tech_design_approvals as p  # noqa: E402
+
+
+class TaggedValuesTest(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(p.tagged_values([], "[tech-design]"), [])
+
+    def test_starts_with_tag(self):
+        comments = [
+            {"text": "[tech-design] https://example.com/design.md"},
+            {"text": "Some unrelated comment"},
+        ]
+        self.assertEqual(
+            p.tagged_values(comments, "[tech-design]"),
+            ["https://example.com/design.md"],
+        )
+
+    def test_substring_match_does_not_count(self):
+        # The lobster's progress-checklist complaint contains the tag as a
+        # SUBSTRING but not at the start. The old ad-hoc check matched this
+        # as a false positive. The lobster's parser (and this script) does not.
+        comments = [
+            {
+                "text": "[feature-task-progress-checklist]\n"
+                "Missing task comment `[tech-design-approved] true`.\n"
+                "Rowan already has an active task in `doing`."
+            },
+        ]
+        self.assertEqual(
+            p.tagged_values(comments, "[tech-design-approved]"),
+            [],
+        )
+
+
+class TechDesignApprovedTest(unittest.TestCase):
+    def test_lobster_complaint_is_not_approval(self):
+        comments = [
+            {
+                "text": "[feature-task-progress-checklist]\n"
+                "Missing task comment `[tech-design-approved] true`."
+            },
+        ]
+        self.assertFalse(p.tech_design_approved({"comments": comments}))
+
+    def test_bare_true_is_approval(self):
+        comments = [{"text": "[tech-design-approved] true"}]
+        self.assertTrue(p.tech_design_approved({"comments": comments}))
+
+    def test_true_with_rationale_is_approval(self):
+        comments = [
+            {
+                "text": "[tech-design-approved] true — Approved by Quinn on behalf of Tom 2026-06-30"
+            }
+        ]
+        self.assertTrue(p.tech_design_approved({"comments": comments}))
+
+    def test_uppercase_true_is_approval(self):
+        comments = [{"text": "[tech-design-approved] TRUE"}]
+        self.assertTrue(p.tech_design_approved({"comments": comments}))
+
+    def test_explicit_false_is_not_approval(self):
+        comments = [
+            {"text": "[tech-design-approved] false — pending review"}
+        ]
+        self.assertFalse(p.tech_design_approved({"comments": comments}))
+
+    def test_no_comments_is_not_approval(self):
+        self.assertFalse(p.tech_design_approved({"comments": []}))
+
+
+class TechDesignUrlTest(unittest.TestCase):
+    def test_first_non_empty_url(self):
+        comments = [
+            {"text": "[tech-design]"},  # empty value, skipped
+            {"text": "[tech-design] https://example.com/design.md"},
+        ]
+        self.assertEqual(
+            p.tech_design_url({"comments": comments}),
+            "https://example.com/design.md",
+        )
+
+    def test_no_url(self):
+        self.assertIsNone(p.tech_design_url({"comments": []}))
+
+
+class IsFeatureTaskTest(unittest.TestCase):
+    def test_task_type_feature(self):
+        self.assertTrue(p.is_feature_task({"taskType": "feature", "tags": []}))
+
+    def test_feature_factory_tag(self):
+        self.assertTrue(
+            p.is_feature_task({"taskType": None, "tags": ["feature-factory"]})
+        )
+
+    def test_unrelated_task(self):
+        self.assertFalse(p.is_feature_task({"taskType": "content", "tags": []}))
+
+    def test_empty(self):
+        self.assertFalse(p.is_feature_task({}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a new script that lists feature tasks awaiting [tech-design-approved] true from Quinn during heartbeat. The script mirrors the lobster's tagged_values + tech_design_approved parser: a comment counts as approval only if its trimmed text STARTS WITH the tag and the first whitespace-separated token after the tag is true (case-insensitive). Substring matches in the lobster's progress-checklist complaints (Missing task comment [tech-design-approved] true) are correctly ignored.

## Why

Tom caught me on the previous heartbeat: I missed approving the tech design on b2ab54db (spec resync). Rowan posted [tech-design] at 22:04 NZST and the lobster complained about the missing approval at 22:07 NZST — but my filter '\[tech-design-approved\]' in comment_text matched the lobster's complaint text and reported it as approved. The actual approval sat waiting 18 minutes.

Formalising the check into a script:
- Stops the runtime from re-deriving the parser in ad-hoc inline code
- Adds 15 unit tests that pin down the lobster's parser behaviour
- Makes the check auditable (call pending_tech_design_approvals.py --json and read the output)
- Lets other agents reuse the same logic if needed

## Test

```bash
python3 -m unittest agents/skills/ops/tasks-api/scripts/test_pending_tech_design_approvals.py
# 15 tests, all green
```

Manual:
```bash
TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py
# No feature tasks pending tech-design approval (10 feature tasks checked).
```

The 0 pending count is correct — b2ab54db was approved in this session before the script was written, so it shouldn't show up. To verify it WOULD have caught the previous miss, the unit test test_lobster_complaint_is_not_approval pins down the parser behaviour.