### PR TITLE
fix(feature-task): don't count dependency-blocked doing tasks against capacity

### DIFF
--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -76,6 +76,8 @@ struct Task {
     #[serde(default)]
     blocked: bool,
     #[serde(default)]
+    dependency_blocked: bool,
+    #[serde(default)]
     task_type: Option<String>,
     #[serde(default)]
     spec_checksum: Option<String>,
@@ -851,6 +853,7 @@ fn rowan_doing_capacity_failures(tasks: &[Task], current_id: &str) -> Vec<String
             task.id != current_id
                 && task.status == "doing"
                 && !task.blocked
+                && !task.dependency_blocked
                 && task.assignee.as_deref() == Some("Rowan")
         })
         .count();
@@ -1972,6 +1975,53 @@ mod tests {
             assignee: Some("Rowan".to_string()),
             ..Task::default()
         }];
+
+        assert_eq!(
+            rowan_doing_capacity_failures(&tasks, "current-task"),
+            vec!["Rowan already has an active task in `doing`.".to_string()]
+        );
+    }
+
+    #[test]
+    fn rowan_capacity_allows_dependency_blocked_doing_task() {
+        // A task in `doing` that is blocked by an unresolved dependency
+        // is not actually consuming Rowan's capacity — it is stuck waiting
+        // on another task. The capacity check should treat it the same
+        // as a non-`doing` task (Tom: 2026-07-01 — "needs to be taken
+        // into account for all states").
+        let tasks = vec![Task {
+            id: "other-doing".to_string(),
+            status: "doing".to_string(),
+            assignee: Some("Rowan".to_string()),
+            dependency_blocked: true,
+            ..Task::default()
+        }];
+
+        assert!(rowan_doing_capacity_failures(&tasks, "current-task").is_empty());
+    }
+
+    #[test]
+    fn rowan_capacity_still_blocks_unblocked_doing_when_manual_blocked_present() {
+        // Sanity: manual block continues to free capacity (existing
+        // behaviour), but a task that is `doing` and neither manually
+        // nor dependency-blocked still blocks. This pins down that the
+        // new `!dependency_blocked` check did not weaken the original
+        // guard.
+        let tasks = vec![
+            Task {
+                id: "manual-blocked".to_string(),
+                status: "doing".to_string(),
+                assignee: Some("Rowan".to_string()),
+                blocked: true,
+                ..Task::default()
+            },
+            Task {
+                id: "actually-progressing".to_string(),
+                status: "doing".to_string(),
+                assignee: Some("Rowan".to_string()),
+                ..Task::default()
+            },
+        ];
 
         assert_eq!(
             rowan_doing_capacity_failures(&tasks, "current-task"),


### PR DESCRIPTION
## What

The capacity check in `rowan_doing_capacity_failures` blocked any new task in `doing` from advancing when another Rowan task was already in `doing` — even if that other task was dependency-blocked and therefore not actually consuming Rowan's time.

A task in `doing` that is blocked by an unresolved dependency is stuck waiting on another task, not progressing. It should not be counted as occupying capacity.

## Why

Tom's exact words on the heartbeat: 'The task in doing is infact blocked by its dependant, that needs to be taken into account for all states'. The Tasks API already exposes `dependencyBlocked` as a computed flag on every task; the lobster just wasn't reading it.

## Changes

- `Task` struct: add `dependency_blocked: bool` (camelCase `dependencyBlocked`, matches the API contract).
- `rowan_doing_capacity_failures`: add `!task.dependency_blocked` to the filter. A task in `doing` that is dependency-blocked is now skipped, same as a manually-blocked task.
- Two new unit tests:
  - `rowan_capacity_allows_dependency_blocked_doing_task` — pins down the new behaviour.
  - `rowan_capacity_still_blocks_unblocked_doing_when_manual_blocked_present` — pins down that the original guard is unchanged for a task that is genuinely progressing.
- Existing tests unchanged: `Task::default()` makes `dependency_blocked` default to `false`, so the existing `rowan_capacity_blocks_existing_doing_task` test continues to assert the original behaviour.

## Test

```bash
cd agents/workflows/feature-task && cargo test
# 72 passed; 0 failed (was 70, +2 new tests)
```