### PR TITLE
refactor(morning-brief): streamline focus context and update output s…

### DIFF
--- a/agents/crons/prompts/morning-brief.md
+++ b/agents/crons/prompts/morning-brief.md
@@ -45,35 +45,7 @@ except Exception as e:
     print(json.dumps({'error': str(e), 'in_progress': [], 'blocked': []}))
 "
 
-5) Read Lox and Quinn incident/ops state for anything needing Tom's attention:
-
-   a) Lox incidents — read brain/state/lox-incident-state.json, filter for status "blocked" or "repair_attempted":
-   python3 -c "
-import json
-try:
-    with open('/Users/quinnstoffer/.openclaw/workspace/brain/state/lox-incident-state.json') as f:
-        state = json.load(f)
-    blocked = [(k, v) for k, v in state.get('incidents', {}).items()
-               if v.get('status') in ('blocked', 'repair_attempted')]
-    print(json.dumps(blocked))
-except Exception as e:
-    print('[]')
-"
-
-   b) Quinn ops findings — read brain/state/quinn-ops-state.json, filter for needsTom: true or status "escalated":
-   python3 -c "
-import json
-try:
-    with open('/Users/quinnstoffer/.openclaw/workspace/brain/state/quinn-ops-state.json') as f:
-        state = json.load(f)
-    flagged = [(k, v) for k, v in state.get('ops', {}).items()
-               if v.get('needsTom') or v.get('status') == 'escalated']
-    print(json.dumps(flagged))
-except Exception as e:
-    print('[]')
-"
-
-6) Check MEMORY.md for focus context.
+5) Check MEMORY.md for focus context.
 
 Output format:
 🌅 Good morning Tom!
@@ -82,7 +54,7 @@ Output format:
 [Calendar events — convert times from UTC to NZT. Note which calendar each event is from.]
 
 🧠 OVERNIGHT
-[What happened since yesterday — agent activity, things resolved, things that came up]
+[What happened since yesterday — agent activity, workflow milestones, things resolved. Do NOT include ops/infra incidents or outages — those are surfaced in real-time by Lox and don't need replaying here.]
 
 ⚠️ PENDING APPROVALS
 [Only if pending bookmark approvals exist. For each: topic | title ~50 chars | #ap<id>]
@@ -93,15 +65,10 @@ Output format:
 [Active tasks — one line each: Assignee · title · status (doing/acceptance) · [BLOCKED] if blocked]
 [If no active tasks, say "no active tasks"]
 
-🚨 NEEDS YOUR ATTENTION
-[Items requiring Tom's decision, sourced from lox-incident-state.json (blocked/repair_attempted) and quinn-ops-state.json (needsTom: true). For each item:
- • [source: Lox|Quinn] slug — one-line description of what's blocked and why Lox/Quinn can't resolve it
-If nothing in either state file needs Tom: write "nothing blocking — all clear"]
-
 🎯 FOCUS
 [Top 2-3 priorities for today based on all of the above]
 
-Keep concise, practical, no fluff. The NEEDS YOUR ATTENTION section is the most important — if it's empty, say so clearly so Tom knows the agents are running clean.
+Keep concise, practical, no fluff.
 
 # notify-soft-fails
 Read /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/notify-soft-fail/SKILL.md and follow it.

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -107,6 +107,9 @@ Before writing any code on a feature task, write the tech design:
 - PR body must include all parent task ACs, with `- [x]` for done and `- [ ]` for not yet done
 - Each PR body must list which parent ACs its sub-ACs contribute to
 
+### AC checkboxes on the task — hands off
+**Never tick or untick AC checkboxes in the task description.** That is Tom/QA's gate, applied only once the task reaches `acceptance`. Rowan's evidence belongs in the PR body only.
+
 ### System spec (required before acceptance)
 
 Before the task can move from `doing` to `acceptance`, use the system-spec skill:

--- a/agents/skills/dev/pr-open/SKILL.md
+++ b/agents/skills/dev/pr-open/SKILL.md
@@ -76,3 +76,30 @@ PRs without the required annotations are blocked from acceptance with a clear co
 
 **QA bounce:** after merge, the lobster compares the latest merged PR body against the task description ACs. If any AC is missing, unchecked, or has altered text, the task bounces back to `doing` and a `[feature-task-progress-checklist]` comment is posted explaining what the next PR must address.
 
+---
+
+## After Opening — Update Task Workstreams
+
+For feature-task PRs, patch the task description to record the branch and PR URL in the workstreams section. The task ID is the first 8 chars of the branch name (`task-{8chars}-...`).
+
+Find the task by ID prefix, then PATCH the description to fill in the workstream entry:
+
+```bash
+# Get the task (first 8 chars of branch = task ID prefix)
+TASK_ID_PREFIX="<first-8-chars>"
+TASK=$(TASKS_API_BASE_URL=http://localhost:4001/api/v1 \
+  python3 agents/skills/ops/tasks-api/tasks_api_client.py list | \
+  python3 -c "import json,sys; tasks=json.load(sys.stdin)['data']; \
+    t=next((t for t in tasks if t['id'].startswith('$TASK_ID_PREFIX')), None); \
+    print(t['id'], t['description']) if t else print('NOT FOUND')")
+
+# Then PATCH the description: replace the pending Branch/PR placeholders
+# with the actual branch name and PR URL
+TASKS_API_BASE_URL=http://localhost:4001/api/v1 \
+  python3 agents/skills/ops/tasks-api/tasks_api_client.py patch \
+    --id <full-task-id> \
+    --description '<updated description with Branch and PR filled in>'
+```
+
+If this PR covers only a subset of ACs, add a new workstream entry for the remaining ACs (still `Branch: (pending)`, `PR: (pending)`) so the task description reflects what's still outstanding.
+

--- a/agents/skills/product/feature-task-create/SKILL.md
+++ b/agents/skills/product/feature-task-create/SKILL.md
@@ -87,19 +87,12 @@ Key constraints or non-obvious integration points. One paragraph max.
 **Workstreams**
 
 - Owner: Rowan
-  Repo: Stoffer-Industries/sindustries
-  Branch: task-<first 8 chars of task ID>-<short-slug>
-  Worktree: ~/workspaces/rowan/sindustries
-  PR: (pending)
-  Scope: <what Rowan builds>
   ACs: AC1, AC2, ...
-  Status: open
-
-- Owner: Quinn          ← only if Quinn has ACs
-  Scope: <what Quinn does>
-  ACs: AC3, ...
-  Status: open
+  Branch: (pending)
+  PR: (pending)
 ```
+
+Do not add a Quinn workstream. If Quinn needs to make `.openclaw` changes, Rowan posts `[openclaw-needed]` via the established handoff. The pr-open skill fills in Branch and PR when Rowan opens a PR.
 
 **Spec line rules:**
 - Must be exactly `**Spec:** <path>` — no parentheticals after the path
@@ -115,18 +108,9 @@ Use `tasks_api_client.py create` with the `--spec` flag so the standard Spec lin
 ```bash
 cat > /tmp/task-ws.yaml <<'YAML'
 - Owner: Rowan
-  Repo: Stoffer-Industries/sindustries
-  Branch: task-<first 8 chars of task ID>-<short-slug>
-  Worktree: ~/workspaces/rowan/sindustries
-  PR: (pending)
-  Scope: <what Rowan builds>
   ACs: AC1, AC2, ...
-  Status: open
-
-- Owner: Quinn          # only if Quinn has ACs
-  Scope: <what Quinn does>
-  ACs: AC3, ...
-  Status: open
+  Branch: (pending)
+  PR: (pending)
 YAML
 
 TASKS_API_BASE_URL=${TASKS_API_BASE_URL:-http://localhost:4001/api/v1} \


### PR DESCRIPTION
…ections

Removed detailed instructions for reading incident states from Lox and Quinn, simplifying the morning brief. Updated the output format to clarify the exclusion of ops/infra incidents from the overnight summary. Enhanced the focus section to emphasize concise communication without fluff.