### PR TITLE
docs(rowan): prioritize ready task tech designs

### DIFF
--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -24,6 +24,8 @@ Check for active feature tasks assigned to you:
 Follow WORKFLOW.md for full per-state instructions (tech design, implementation, system spec, acceptance):
 `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/definitions/rowan/WORKFLOW.md`
 
+**Ready-task tech design priority:** If any assigned feature task is in `ready` and does not yet have a posted/approved tech design, prioritize writing and posting that tech design before continuing implementation on `doing` tasks. Tech design prep is not considered parallel implementation WIP; it is the unblocker for the next task. After posting the tech design, return to the active `doing`/`acceptance` work unless Tom says otherwise.
+
 **Note on `[feature-task-progress-checklist]` comments:** Lobster posts this to list what's still outstanding. It is not a signal that work is blocked or waiting on someone else — it means you need to produce those items. Keep working.
 
 ---
@@ -35,4 +37,4 @@ Read and follow:
 
 **Limit:** Open at most 1 code-garden PR at a time. Check for open PRs first — if one exists, skip this step.
 
-**Skip code gardening entirely** if you have an active unblocked feature task in `doing` or `acceptance`.
+**Skip code gardening entirely** if you have any assigned feature task in `ready` waiting for tech design, or any active unblocked feature task in `doing` or `acceptance`.

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -99,7 +99,7 @@ Before writing any code on a feature task, write the tech design:
 
 ### Implementation
 - Work on dedicated worktree branches; all changes come via PRs — no direct pushes to main
-- Capacity: 1 unblocked feature task per state at a time
+- Capacity: 1 unblocked feature task per implementation state at a time. `ready` tech design work is the exception: if an assigned `ready` task lacks a posted/approved tech design, write and post that tech design ASAP even when another task is already in `doing`; then return to the active implementation task.
 - When `.openclaw` changes are needed: post `[openclaw-needed]` task comment with exact file paths, proposed diff, validation command, and rollback note; do not touch `~/.openclaw/` yourself
 - When all implementation PRs are open: post `[rowan-prs] <url1>, <url2>` as a task comment
 


### PR DESCRIPTION
## Summary
- Update Rowan HEARTBEAT to prioritize assigned `ready` tasks that lack posted/approved tech designs before continuing implementation WIP.
- Clarify that tech design prep is an unblocker, not parallel implementation WIP.
- Skip code gardening when any assigned ready task is waiting on tech design.

## Test plan
- [x] Documentation/instruction-only change; inspected HEARTBEAT and WORKFLOW updates.