### PR TITLE
fix(feature-task): handle merged lobster PRs

### DIFF
--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -294,7 +294,7 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
         return Ok(env);
     }
     let mut failures = Vec::new();
-    let pr_urls = rowan_active_pr_urls(&env.task);
+    let pr_urls = rowan_pr_urls(&env.task);
     if pr_urls.is_empty() {
         failures.push("Missing `[rowan-prs]` task comment with at least one PR URL.".to_string());
     }
@@ -678,6 +678,17 @@ fn transition_or_block(
 
 const BRAIN_DIR: &str = "brain";
 
+fn is_typescript_spec_path(spec_path: &str) -> bool {
+    let path = spec_path.trim();
+    path.ends_with("_spec.ts") || path.ends_with(".spec.ts")
+}
+
+fn task_product_spec_is_typescript_spec(task: &Task) -> bool {
+    product_spec(task)
+        .map(|spec| is_typescript_spec_path(&spec.path))
+        .unwrap_or(false)
+}
+
 fn safe_brain_spec_path(spec_path_str: &str, workspace_root: &Path) -> Result<PathBuf> {
     let stripped = spec_path_str.trim();
     if stripped.is_empty() {
@@ -1057,6 +1068,17 @@ fn block_on_spec_drift_fluid(
         return Ok(Some(env));
     }
     let description = env.task.description.clone().unwrap_or_default();
+    if task_product_spec_is_typescript_spec(&env.task) {
+        env.criteria_met = false;
+        env.action_taken = format!("{action}_blocked_spec_drift");
+        let mut failures = raw_failures;
+        failures.push(
+            "Spec drift was detected for a TypeScript spec test file; the lobster will not auto-uncheck `**Approved by Tom**` for `_spec.ts`/`.spec.ts` specs. Resolve the drift manually or post a fresh `[spec-resynced]` record."
+                .to_string(),
+        );
+        env.failures = failures;
+        return Ok(Some(env));
+    }
     let marker_state = approval_marker_state(&description);
     match marker_state {
         ApprovalMarker::Checked => {
@@ -1481,7 +1503,8 @@ fn product_spec(task: &Task) -> Option<ProductSpecRef> {
 }
 
 fn parse_product_spec_ref(text: &str) -> Option<ProductSpecRef> {
-    let re = Regex::new(r"(?im)^\s*\*\*Spec:\*\*\s*`?([^`\s]+\.md)`?\s*$").unwrap();
+    let re =
+        Regex::new(r"(?im)^\s*\*\*Spec:\*\*\s*`?([^`\s]+(?:\.md|[._]spec\.ts))`?\s*$").unwrap();
     re.captures(text)
         .and_then(|cap| cap.get(1))
         .map(|m| ProductSpecRef {
@@ -1871,6 +1894,20 @@ fn tech_design_approved(task: &Task) -> bool {
         })
 }
 
+fn tagged_path_values(task: &Task, tag: &str) -> Vec<String> {
+    tagged_values(task, tag)
+        .into_iter()
+        .filter_map(|value| {
+            value
+                .trim_start()
+                .split_whitespace()
+                .next()
+                .map(|token| token.trim_matches('`').trim_matches(',').to_string())
+        })
+        .filter(|path| !path.is_empty())
+        .collect()
+}
+
 fn rowan_pr_urls(task: &Task) -> Vec<String> {
     let re = Regex::new(r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+").unwrap();
     let mut urls = Vec::new();
@@ -1885,10 +1922,6 @@ fn rowan_pr_urls(task: &Task) -> Vec<String> {
     urls
 }
 
-fn rowan_active_pr_urls(task: &Task) -> Vec<String> {
-    rowan_active_pr_urls_with(task, inspect_pr)
-}
-
 fn rowan_active_pr_urls_with<F>(task: &Task, inspect: F) -> Vec<String>
 where
     F: Fn(&str) -> Result<ReviewState>,
@@ -1897,6 +1930,35 @@ where
         .into_iter()
         .filter(|url| !matches!(inspect(url), Ok(ReviewState::Merged)))
         .collect()
+}
+
+fn system_spec_source_pr_urls_with<F>(task: &Task, inspect: F) -> Vec<String>
+where
+    F: Fn(&str) -> Result<ReviewState>,
+{
+    let urls = rowan_pr_urls(task);
+    let active: Vec<String> = urls
+        .iter()
+        .filter(|url| !matches!(inspect(url), Ok(ReviewState::Merged)))
+        .cloned()
+        .collect();
+    if active.is_empty() {
+        urls
+    } else {
+        active
+    }
+}
+
+fn pr_branch_for_system_spec<I, B>(url: &str, inspect: I, branch_for_pr: B) -> Result<String>
+where
+    I: Fn(&str) -> Result<ReviewState> + Copy,
+    B: Fn(&str) -> Result<String> + Copy,
+{
+    match inspect(url) {
+        Ok(ReviewState::Merged) => Ok("main".to_string()),
+        Ok(_) => branch_for_pr(url),
+        Err(err) => Err(err),
+    }
 }
 
 fn openclaw_needed(task: &Task) -> bool {
@@ -1934,7 +1996,7 @@ where
     I: Fn(&str) -> Result<ReviewState> + Copy,
     B: Fn(&str) -> Result<String> + Copy,
 {
-    let system_specs = tagged_values(task, "[system-spec]");
+    let system_specs = tagged_path_values(task, "[system-spec]");
     if system_specs.is_empty() {
         let reasons = tagged_values(task, "[no-system-spec-change]");
         if reasons.iter().any(|reason| reason.len() >= 12) {
@@ -1942,26 +2004,22 @@ where
         }
         return vec!["Missing `[system-spec] docs/systems/<file>.md` or substantive `[no-system-spec-change]` reason.".to_string()];
     }
-    let active_prs = rowan_active_pr_urls_with(task, inspect);
-    let Some(active_pr_url) = active_prs.first() else {
+    let candidate_prs = system_spec_source_pr_urls_with(task, inspect);
+    let Some(source_pr_url) = candidate_prs.first() else {
         return vec![
-            "Missing active `[rowan-prs]` PR URL to read system specs from a PR branch."
+            "Missing `[rowan-prs]` PR URL to read system specs from a PR branch or main."
                 .to_string(),
         ];
     };
-    let (owner, repo_name) = match parse_pr_repo(active_pr_url) {
+    let (owner, repo_name) = match parse_pr_repo(source_pr_url) {
         Ok(parts) => parts,
-        Err(err) => {
-            return vec![format!(
-                "Could not parse active PR URL `{active_pr_url}`: {err}."
-            )]
-        }
+        Err(err) => return vec![format!("Could not parse PR URL `{source_pr_url}`: {err}.")],
     };
-    let branch = match branch_for_pr(active_pr_url) {
+    let branch = match pr_branch_for_system_spec(source_pr_url, inspect, branch_for_pr) {
         Ok(branch) => branch,
         Err(err) => {
             return vec![format!(
-                "Could not determine head branch for active PR `{active_pr_url}`: {err}."
+                "Could not determine branch for PR `{source_pr_url}`: {err}."
             )]
         }
     };
@@ -3030,6 +3088,7 @@ mod tests {
         let url = "https://github.com/Stoffer-Industries/sindustries/pull/117";
         assert!(verify_delivery_review_failure(url, ReviewState::Required).is_none());
         assert!(verify_delivery_review_failure(url, ReviewState::CommentsPresent).is_none());
+        assert!(verify_delivery_review_failure(url, ReviewState::Merged).is_none());
         assert_eq!(
             verify_delivery_review_failure(url, ReviewState::ChangesRequested),
             Some(format!("Changes requested on {url}."))
@@ -3037,6 +3096,31 @@ mod tests {
         assert_eq!(
             verify_delivery_review_failure(url, ReviewState::ClosedUnmerged),
             Some(format!("PR {url} is closed without merge."))
+        );
+    }
+
+    #[test]
+    fn rowan_pr_urls_preserve_merged_prs_for_delivery() {
+        let merged_url = "https://github.com/Stoffer-Industries/sindustries/pull/161";
+        let open_url = "https://github.com/Stoffer-Industries/sindustries/pull/164";
+        let task = Task {
+            comments: vec![TaskComment {
+                text: Some(format!("[rowan-prs] {merged_url} {open_url}")),
+                body: None,
+            }],
+            ..Task::default()
+        };
+
+        assert_eq!(rowan_pr_urls(&task), vec![merged_url, open_url]);
+        assert_eq!(
+            rowan_active_pr_urls_with(&task, |url| {
+                if url == merged_url {
+                    Ok(ReviewState::Merged)
+                } else {
+                    Ok(ReviewState::Approved)
+                }
+            }),
+            vec![open_url]
         );
     }
 
@@ -3084,6 +3168,33 @@ mod tests {
     }
 
     #[test]
+    fn system_spec_tag_uses_first_path_token_only() {
+        let mut task = Task::default();
+        task.comments.push(TaskComment {
+            text: Some(
+                "[system-spec] docs/systems/feature-task-workflow.md (updated in PR #163)"
+                    .to_string(),
+            ),
+            body: None,
+        });
+        task.comments.push(TaskComment {
+            text: Some(
+                "[system-spec] `docs/systems/quoted.md`\n\nPR #161 merged; extra context"
+                    .to_string(),
+            ),
+            body: None,
+        });
+
+        assert_eq!(
+            tagged_path_values(&task, "[system-spec]"),
+            vec![
+                "docs/systems/feature-task-workflow.md".to_string(),
+                "docs/systems/quoted.md".to_string()
+            ]
+        );
+    }
+
+    #[test]
     fn validates_existing_current_system_spec() {
         let repo = tempdir().unwrap();
         let task = Task {
@@ -3112,6 +3223,41 @@ mod tests {
             repo.path(),
             |_| Ok(ReviewState::Approved),
             |_| Ok("task-456c92a8-depends-on".to_string()),
+            &fetcher,
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn validates_system_spec_from_main_when_all_prs_are_merged() {
+        let repo = tempdir().unwrap();
+        let task = Task {
+            id: "task-1".to_string(),
+            comments: vec![
+                TaskComment {
+                    text: Some("[system-spec] docs/systems/feature-task.md".to_string()),
+                    body: None,
+                },
+                TaskComment {
+                    text: Some(
+                        "[rowan-prs] https://github.com/Stoffer-Industries/sindustries/pull/161"
+                            .to_string(),
+                    ),
+                    body: None,
+                },
+            ],
+            ..Task::default()
+        };
+        let fetcher = StubFetcher {
+            body: "References task-1".to_string(),
+            error: None,
+        };
+
+        assert!(system_spec_failures_with(
+            &task,
+            repo.path(),
+            |_| Ok(ReviewState::Merged),
+            |_| panic!("merged PRs must read system specs from main, not a head branch"),
             &fetcher,
         )
         .is_empty());
@@ -3467,6 +3613,47 @@ mod tests {
         let result =
             block_on_spec_drift_fluid(&args, env, "spec_check").expect("no-drift should not error");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn fluid_drift_does_not_auto_uncheck_typescript_spec_files() {
+        let args = StageArgs {
+            base_url: "http://example.invalid".to_string(),
+            repo: PathBuf::from("."),
+            workspace_root: None,
+            dry_run: true,
+        };
+        let approved = Task {
+            description: Some("## Acceptance Criteria\n- [ ] AC1: Build it".to_string()),
+            ..Task::default()
+        };
+        let task = Task {
+            id: "task-ts-spec".to_string(),
+            description: Some(
+                "**Spec:** apps/tasks/src/feature_task_workflow_spec.ts\n\n- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n- [ ] AC2: Drift"
+                    .to_string(),
+            ),
+            status: "ready".to_string(),
+            spec_checksum: Some(spec_checksum(&approved)),
+            ..Task::default()
+        };
+        let env = Envelope {
+            criteria_met: true,
+            already_past: false,
+            action_taken: String::new(),
+            task,
+            lobster_state: LobsterState::default(),
+            failures: Vec::new(),
+        };
+
+        let result = block_on_spec_drift_fluid(&args, env, "ready_checks")
+            .expect("dry-run should not error");
+        let blocked = result.expect("should block without auto-unchecking");
+        assert!(!blocked.criteria_met);
+        assert!(blocked
+            .failures
+            .iter()
+            .any(|failure| failure.contains("will not auto-uncheck")));
     }
 
     #[test]

--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -20,7 +20,7 @@ import {
 } from './tasks/_validation.ts';
 import { decodeCursor, encodeCursor } from './tasks/_pagination.ts';
 import { formatTaskTitle, mapTask, mapTaskComment } from './tasks/_mapper.ts';
-import { rejectSpecDrift } from './tasks/_spec.ts';
+import { descriptionWithSpecDriftApprovalState } from './tasks/_spec.ts';
 import { connectTags, validateDependsOnIds } from './tasks/_deps.ts';
 
 export const tasksRouter = Router();
@@ -320,7 +320,9 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
       return badRequest(res, 'INVALID_DEPENDS_ON_IDS', 'dependsOnIds must be an array of UUID strings');
     }
 
-    if (description !== undefined) updates.description = description || null;
+    if (description !== undefined) {
+      updates.description = descriptionWithSpecDriftApprovalState(existing, description || null);
+    }
     if (assignee !== undefined) {
       if (assignee && !validAssignees.has(assignee)) {
         return badRequest(res, 'INVALID_ASSIGNEE', 'Assignee must be one of: Tom, Quinn, Rowan, Lox, Ivy');
@@ -384,10 +386,6 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
         );
       }
       updates.specChecksum = specChecksum || null;
-    }
-
-    if (rejectSpecDrift(res, existing, description === undefined ? existing.description : description || null)) {
-      return;
     }
 
     const hasTagUpdate = req.body?.tags !== undefined;

--- a/services/tasks-api/src/routes/tasks/_spec.ts
+++ b/services/tasks-api/src/routes/tasks/_spec.ts
@@ -1,5 +1,4 @@
 import { createHash } from 'node:crypto';
-import { sendError } from '../../lib/http.ts';
 import { acceptanceCriteriaText } from './_validation.ts';
 
 // Spec-checksum helpers extracted from tasks.ts. Encapsulates the canonical
@@ -18,13 +17,10 @@ export function specChecksumForDescription(description) {
   return createHash('sha256').update(JSON.stringify(canonical)).digest('hex');
 }
 
-export function specDriftMessage(taskId, stored, current) {
-  return `ACs modified after spec approval -- write a new spec to change scope. Task ${taskId} stored specChecksum \`${stored}\` but current AC checksum is \`${current}\`.`;
-}
-
-// The `**Approved by Tom**` marker line that the lobster toggles during the
-// fluid AC lifecycle. Toggling it does NOT change the AC checksum (it lives
-// outside the acceptance criteria block).
+// The `**Approved by Tom**` marker line is owned by the Tasks API. When Tom
+// edits ACs after approval, the API accepts the edit but unchecks the marker
+// so the lobster can block until Tom re-checks it.
+const CHECKED_APPROVAL_MARKER_LINE = /^(\s*-\s*)\[[xX]\](\s+\*\*Approved by Tom\*\*\s*)$/m;
 const APPROVAL_MARKER_LINE = /^\s*-\s*\[[ xX]\]\s+\*\*Approved by Tom\*\*\s*$/;
 
 function stripApprovalMarker(text) {
@@ -48,16 +44,16 @@ export function descriptionsDifferOnlyByApprovalMarker(oldDescription, newDescri
   return stripApprovalMarker(oldDescription ?? '') === stripApprovalMarker(newDescription ?? '');
 }
 
-export function rejectSpecDrift(res, task, description) {
-  if (!task.specChecksum) return false;
-  const current = specChecksumForDescription(description ?? task.description);
-  if (current === task.specChecksum) return false;
-  // Marker-only exception: the lobster is unchecking `**Approved by Tom**`
-  // as part of the fluid AC lifecycle. The AC text is byte-identical so the
-  // drift is intentional and the checksum guard must not fire.
-  if (descriptionsDifferOnlyByApprovalMarker(task.description, description)) {
-    return false;
-  }
-  sendError(res, 409, 'SPEC_CHECKSUM_MISMATCH', specDriftMessage(task.id, task.specChecksum, current));
-  return true;
+export function uncheckApprovalMarker(description) {
+  if (!description) return description;
+  return description.replace(CHECKED_APPROVAL_MARKER_LINE, '$1[ ]$2');
 }
+
+export function descriptionWithSpecDriftApprovalState(task, description) {
+  const nextDescription = description ?? task.description;
+  if (!task.specChecksum) return nextDescription;
+  const current = specChecksumForDescription(nextDescription);
+  if (current === task.specChecksum) return nextDescription;
+  return uncheckApprovalMarker(nextDescription);
+}
+

--- a/services/tasks-api/test/read-endpoints.test.ts
+++ b/services/tasks-api/test/read-endpoints.test.ts
@@ -353,24 +353,43 @@ describe('tasks api endpoints', () => {
     expect(prismaMock.task.update.mock.calls[0][0].data.specChecksum).toBe(checksum);
   });
 
-  it('PATCH /api/v1/tasks/:id blocks AC drift after spec approval', async () => {
-    const approvedDescription = '## Acceptance Criteria\n- [ ] AC1: Build it';
+  it('PATCH /api/v1/tasks/:id allows AC drift and unchecks approval after spec approval', async () => {
+    const approvedDescription = '- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it';
+    const driftedDescription = `${approvedDescription}\n- [ ] AC2: Drift`;
+    const expectedDescription = '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n- [ ] AC2: Drift';
     const checksum = checksumForAcceptanceCriteria(['AC1: Build it']);
-    prismaMock.task.findFirst.mockResolvedValueOnce(
-      task({ id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70', description: approvedDescription, specChecksum: checksum })
+    prismaMock.task.findFirst
+      .mockResolvedValueOnce(
+        task({
+          id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+          description: approvedDescription,
+          specChecksum: checksum
+        })
+      )
+      .mockResolvedValueOnce(
+        task({
+          id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+          description: expectedDescription,
+          specChecksum: checksum
+        })
+      );
+    prismaMock.task.update.mockResolvedValue(
+      task({
+        id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+        description: expectedDescription,
+        specChecksum: checksum
+      })
     );
 
     const app = createApp();
     const response = await request(app)
       .patch('/api/v1/tasks/2527ff9d-4369-444f-995d-4d4bb0ac7b70')
-      .send({ description: `${approvedDescription}\n- [ ] AC2: Drift` });
+      .send({ description: driftedDescription });
 
-    expect(response.status).toBe(409);
-    expect(response.body.error.code).toBe('SPEC_CHECKSUM_MISMATCH');
-    expect(response.body.error.message).toContain('ACs modified after spec approval');
-    expect(response.body.error.message).toContain('write a new spec to change scope');
-    expect(response.body.error.message).toContain('2527ff9d-4369-444f-995d-4d4bb0ac7b70');
-    expect(prismaMock.task.update).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(response.body.data.description).toBe(expectedDescription);
+    expect(prismaMock.task.update).toHaveBeenCalledTimes(1);
+    expect(prismaMock.task.update.mock.calls[0][0].data.description).toBe(expectedDescription);
   });
 
   it('POST /api/v1/tasks/:id/comments succeeds even when current ACs drifted after spec approval', async () => {
@@ -439,16 +458,30 @@ describe('tasks api endpoints', () => {
     expect(prismaMock.task.update).toHaveBeenCalledTimes(1);
   });
 
-  it('PATCH /api/v1/tasks/:id rejects AC drift bundled with the marker uncheck', async () => {
+  it('PATCH /api/v1/tasks/:id preserves an already-unchecked approval marker during AC drift', async () => {
     const checksum = checksumForAcceptanceCriteria(['AC1: Build it']);
-    const storedDescription = '- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n';
-    // Description change attempts BOTH a marker uncheck AND a new AC line.
+    const storedDescription = '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n';
     const updatedDescription =
       '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n- [ ] AC2: Sneaky drift\n';
-    prismaMock.task.findFirst.mockResolvedValueOnce(
+    prismaMock.task.findFirst
+      .mockResolvedValueOnce(
+        task({
+          id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+          description: storedDescription,
+          specChecksum: checksum
+        })
+      )
+      .mockResolvedValueOnce(
+        task({
+          id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+          description: updatedDescription,
+          specChecksum: checksum
+        })
+      );
+    prismaMock.task.update.mockResolvedValue(
       task({
         id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
-        description: storedDescription,
+        description: updatedDescription,
         specChecksum: checksum
       })
     );
@@ -458,9 +491,9 @@ describe('tasks api endpoints', () => {
       .patch('/api/v1/tasks/2527ff9d-4369-444f-995d-4d4bb0ac7b70')
       .send({ description: updatedDescription });
 
-    expect(response.status).toBe(409);
-    expect(response.body.error.code).toBe('SPEC_CHECKSUM_MISMATCH');
-    expect(prismaMock.task.update).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(response.body.data.description).toBe(updatedDescription);
+    expect(prismaMock.task.update.mock.calls[0][0].data.description).toBe(updatedDescription.trim());
   });
 
   it('GET /api/v1/tasks formats task titles with taskType emoji without duplication', async () => {


### PR DESCRIPTION
## Summary
- Let `verify_delivery` evaluate merged `[rowan-prs]` URLs instead of dropping them before review/body checks.
- Allow system-spec validation to fall back to `main` when all Rowan PRs are already merged, and parse `[system-spec]` comments as a path token so explanatory prose does not become part of the file path.
- Move AC-drift uncheck ownership into the Tasks API: description PATCHes that change ACs are accepted and automatically uncheck `**Approved by Tom**` instead of returning `SPEC_CHECKSUM_MISMATCH`.
- Prevent lobster spec-drift handling from auto-unchecking Tom approval for TypeScript spec test files.

## Test plan
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml`
- [x] `PATH=/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/node_modules/.bin:$PATH NODE_PATH=/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/node_modules npm --workspace @sindustries/tasks-api test`

## Acceptance Criteria
- [x] AC1: Quinn auto-populates `- [x] **Approved by Tom**` in the task description when a spec is approved (open → ready transition) (file: agents/workflows/feature-task/src/main.rs:244)
- [x] AC2: When spec drift is detected during any pipeline stage or after edits, the marker in the task description is unchecked and posts an AC diff comment on the task (file: services/tasks-api/src/routes/tasks/_spec.ts:56)
- [x] AC3: The pipeline blocks at the drift-detected stage until `- [x] **Approved by Tom**` is restored (file: agents/workflows/feature-task/src/main.rs:1088)
- [x] AC4: Quinn detects the re-check (during heartbeat), resyncs the brain spec file from the task description ACs, resets the stored checksum, and posts a `[spec-resynced]` comment (file: agents/workflows/feature-task/src/main.rs:969)
- [x] AC5: Resync is source-of-truth-aware: in `open` state the brain spec wins; in all other states the task description wins (file: agents/workflows/feature-task/src/main.rs:1063)
- [x] AC6: The spec drift block removed from `post_merge` (done in PR #156) is covered by regression tests (file: agents/workflows/feature-task/src/main.rs:494)
- [x] AC7: Rust unit tests cover drift detection unchecking the marker, re-check detection, and resync diff comment format (file: agents/workflows/feature-task/src/main.rs:3577)

🤖 Generated with OpenClaw
