### PR TITLE
test(tasks-api): assert --description coexists with --status/--priority

### DIFF
--- a/agents/skills/ops/tasks-api/tests/test_tasks_api_client.py
+++ b/agents/skills/ops/tasks-api/tests/test_tasks_api_client.py
@@ -136,8 +136,38 @@ class TasksApiClientPatchTest(unittest.TestCase):
             {"status": "doing", "priority": "high"},
         )
 
+    def test_patch_description_combined_with_other_fields(self):
+        # AC3 (task 2cee0bcd): --description must coexist with --status and
+        # --priority in a single PATCH. Closes the test gap where the existing
+        # `test_patch_other_fields_unaffected_by_description` only exercises
+        # status+priority WITHOUT --description, so the cross-field interaction
+        # was implicitly trusted rather than asserted.
+        parser = tasks_api_client.build_parser()
+        args = parser.parse_args(
+            [
+                "patch",
+                "--id",
+                "task-1",
+                "--description",
+                "new text",
+                "--status",
+                "doing",
+                "--priority",
+                "high",
+            ]
+        )
 
+        with patch.object(tasks_api_client, "get_base_url", return_value="http://tasks.test/api/v1"), patch.object(
+            tasks_api_client, "api_request", return_value={"data": {"id": "task-1"}}
+        ) as api_request, patch("builtins.print"):
+            args.func(args)
 
+        api_request.assert_called_once_with(
+            "PATCH",
+            "http://tasks.test/api/v1",
+            "/tasks/task-1",
+            {"description": "new text", "status": "doing", "priority": "high"},
+        )
 
     # ---- create --spec / --workstreams helpers (task 8ec03996) ----
 


### PR DESCRIPTION
## Summary
- Adds `test_patch_description_combined_with_other_fields` to the tasks-api client tests. The earlier `test_patch_other_fields_unaffected_by_description` only exercised `--status` and `--priority` WITHOUT `--description`, so the cross-field interaction was implicitly trusted rather than asserted. This new test patches all three in a single call and verifies the literal new description plus the other fields land unmodified in the PATCH payload.
- This is a follow-up to PR #151 (which landed the actual `patch --description` replace behaviour, merged 2026-06-30). The code change is already on `main`; the QA bounced task `2cee0bcd` back to `doing` because PR #151's `Acceptance Criteria` body used a trailing period that did not match the task AC text exactly, so a new PR with the canonical AC text is required for the lobster's `post_merge` AC-text check to pass.

## Test plan
- [x] `PYTHONPATH=agents/skills/tasks-api-ops python3 -m unittest discover -s agents/skills/ops/tasks-api/tests -p 'test_*.py'` (13 tests pass, 1 new)

## Acceptance Criteria
- [x] AC1: `tasks_api_client.py patch <task-id> --description "new text"` replaces the task description with `"new text"` (does not append) (testID: test_patch_description_replaces_existing)
- [x] AC2: Patching `--description` twice in sequence results in only the second value being stored (testID: test_patch_description_called_twice_stores_only_second)
- [x] AC3: Other patch flags (e.g. `--status`, `--priority`) are unaffected (testID: test_patch_description_combined_with_other_fields)

## System spec
[no-system-spec-change] Pure test coverage addition; no API contract change, no persisted data migration. The implementation under test is already on `main` via PR #151.

🤖 Generated with Claude Code