### PR TITLE
content(website): weekly content review 2026-07-03

### DIFF
--- a/apps/website/src/content/experiments.json
+++ b/apps/website/src/content/experiments.json
@@ -13,7 +13,7 @@
       "Fulfilment approach TBD: exploring direct-to-consumer vs marketplace to understand control/effort tradeoff."
     ],
     "startedAt": "2026-05-28",
-    "updatedAt": "2026-05-28",
+    "updatedAt": "2026-07-03",
     "links": [],
     "image": "/brand/studio/drop-1-hero.png",
     "visibility": "published"
@@ -53,7 +53,7 @@
       "Recurring scans need a lightweight template to avoid inconsistent depth between cycles."
     ],
     "startedAt": "2026-05-28",
-    "updatedAt": "2026-05-28",
+    "updatedAt": "2026-07-03",
     "links": [],
     "image": "/brand/studio/product-market-scans-hero.png",
     "visibility": "published"
@@ -62,17 +62,18 @@
     "title": "Plano model routing",
     "slug": "plano-model-routing",
     "tag": "Agent ops",
-    "status": "active",
+    "status": "killed",
     "summary": "Local model routing for cheaper, faster, more autonomous agent work across routine operations.",
     "why": "As agent workflows scale, the cost and latency of routing everything through frontier models becomes a real constraint. Not every task needs Claude Opus or GPT-4. Most routine operations — summarisation, classification, formatting, simple transformations — are well within the capability of smaller, faster, cheaper models.\n\nPlano is an experiment in building the routing layer: classifying tasks by complexity and routing them to appropriate models. The hypothesis is that 60-70% of routine agent work can be offloaded to local or cheaper models with acceptable quality degradation, reducing cost by a significant margin.\n\nThe secondary benefit is latency: local models have sub-second response times for many tasks, which matters for interactive operations.",
     "successCriteria": "A routing layer is operational that classifies incoming tasks and routes them to appropriate models. At least 50% of routine operations run through non-frontier models.\n\nQuality benchmarks are established for key task types so routing decisions are evidence-based, not arbitrary. The system degrades gracefully — unclear cases escalate to frontier models rather than producing bad outputs silently.\n\nCost metrics are tracked before and after routing implementation to quantify the actual saving.",
     "currentLearning": [
       "Initial routing prototype showed promising results for summarisation and classification tasks with llama3 variants.",
       "Boundary conditions are harder than expected: tasks that seem simple often require judgment that smaller models handle poorly.",
-      "Routing by task type (summarise, classify, generate) works better than routing by estimated complexity."
+      "Routing by task type (summarise, classify, generate) works better than routing by estimated complexity.",
+      "Experiment killed 2026-07-03. The routing layer added complexity without sufficient quality/cost benefit at current workload scale. Frontier model costs are manageable; the overhead of maintaining routing logic and quality benchmarks outweighed the savings. Revisit if agent volume grows significantly."
     ],
     "startedAt": "2026-05-28",
-    "updatedAt": "2026-05-28",
+    "updatedAt": "2026-07-03",
     "links": [],
     "image": "/brand/studio/plano-model-routing-hero.png",
     "visibility": "published"

--- a/apps/website/src/content/releases.json
+++ b/apps/website/src/content/releases.json
@@ -138,5 +138,45 @@
     "links": [],
     "evidence": "The X bookmark tagger now returns descriptive tags such as agent architecture and token optimisation after moving through the OpenClaw gateway provider route.",
     "visibility": "draft"
+  },
+  {
+    "title": "Feature Factory v2",
+    "slug": "feature-factory-v2",
+    "releasedAt": "2026-06-29",
+    "summary": "Agents can now take an approved spec and self-orchestrate it through ready → doing → acceptance → done without Tom or Quinn driving transitions by hand.",
+    "type": "system",
+    "links": [],
+    "evidence": "Feature task workflow shipped 2026-06-29 (PR #117). The lobster handles spec approval, tech design gates, PR tracking, QA verification, and system spec requirements as a fully automated orchestration loop.",
+    "visibility": "draft"
+  },
+  {
+    "title": "Task dependency UI",
+    "slug": "task-dependency-ui",
+    "releasedAt": "2026-06-29",
+    "summary": "Tasks now express blocking relationships. The UI shows what blocks each task, supports add/remove with title validation, and lets you copy task IDs from cards.",
+    "type": "system",
+    "links": [],
+    "evidence": "Task dependency backend (PR #128) and dependency UI (PR #129) shipped 2026-06-27–29. First capability to run the full spec → factory pipeline end-to-end.",
+    "visibility": "draft"
+  },
+  {
+    "title": "Task type filter and selector",
+    "slug": "task-type-filter-and-selector",
+    "releasedAt": "2026-06-30",
+    "summary": "The tasks app now filters by type, edits type on existing cards, and exposes feature as a creatable task type.",
+    "type": "system",
+    "links": [],
+    "evidence": "Task type filter and editor shipped 2026-06-30 (PR #145), closing task 5dbf2967.",
+    "visibility": "draft"
+  },
+  {
+    "title": "Fluid spec drift lifecycle",
+    "slug": "fluid-spec-drift-lifecycle",
+    "releasedAt": "2026-07-03",
+    "summary": "Spec changes after approval no longer hard-block the pipeline. The lobster unhecks Tom's approval and posts an AC diff; after Tom re-checks, the spec is resynced automatically.",
+    "type": "system",
+    "links": [],
+    "evidence": "Shipped across PRs #161, #163, #165, and #167 (2026-07-01 to 2026-07-03). Drift detection unchecks the approval marker, posts AC diff comments, and the resync path rewrites the brain spec from the task description after Tom re-approves.",
+    "visibility": "draft"
   }
 ]

--- a/apps/website/src/content/systems.json
+++ b/apps/website/src/content/systems.json
@@ -7,8 +7,8 @@
     "summary": "The operating layer for agents, memory, tools, messaging, and human-in-the-loop work.",
     "problem": "Delegated agent work needs continuity, tools, memory, and human review boundaries to become operationally useful.",
     "howItWorks": "OpenClaw connects agents to workspace files, skills, messaging, tasks, and runtime context so work can move through explicit handoffs.",
-    "proof": "Active operating layer for SIndustries agents, task execution, daily ops note capture, weekly content review workflows, and multi-agent content operations — Quinn orchestrates, Ivy authors, Tom approves, Lobster merges. The SIndustries skill library has grown with spec-author, website-content, and operating-notes skills, and spec authoring for the bookmark pipeline is now heartbeat-queued through OpenClaw for auditable, rate-controlled LLM work. Scheduled workflows are now first-class OpenClaw jobs: a weekly repo-audit cron writes a markdown audit and opens an idempotent Tom-approval PR labelled code-audit against main, bookmark approvals route through OpenClaw messaging, and the daily morning brief now escalates blocked agent-layer incidents and Quinn ops findings that need Tom attention.",
-    "updatedAt": "2026-06-22",
+    "proof": "Active operating layer for SIndustries agents, task execution, daily ops note capture, weekly content review workflows, and multi-agent content operations — Quinn orchestrates, Ivy authors, Tom approves, Lobster merges. The SIndustries skill library has grown with spec-author, website-content, and operating-notes skills, and spec authoring for the bookmark pipeline is now heartbeat-queued through OpenClaw for auditable, rate-controlled LLM work. Scheduled workflows are now first-class OpenClaw jobs: a weekly repo-audit cron writes a markdown audit and opens an idempotent Tom-approval PR labelled code-audit against main, bookmark approvals route through OpenClaw messaging, and the daily morning brief now escalates blocked agent-layer incidents and Quinn ops findings that need Tom attention. Feature Factory v2 is now an operating workflow inside OpenClaw: agents self-orchestrate approved specs from ready through doing, acceptance, and done without manual status transitions — the first time SIndustries shipped a workflow-as-product through its own pipeline.",
+    "updatedAt": "2026-07-03",
     "links": [],
     "image": "/brand/systems/openclaw-lobster.jpg",
     "visibility": "published"
@@ -35,8 +35,8 @@
     "summary": "Task state, ownership, comments, reviews, and heartbeat-driven operating discipline.",
     "problem": "Agent work needs a shared source of truth for ownership, status, review, and handoff.",
     "howItWorks": "The Tasks API tracks tasks, comments, tags, readiness, and status transitions for SIndustries work.",
-    "proof": "SIndustries tasks are tracked through the API and driven by agent heartbeat and cron workflows. Task history shipped across the API, schema, and UI tab. Task automation tooling is now maintained in the SIndustries repo as the canonical location.",
-    "updatedAt": "2026-06-12",
+    "proof": "SIndustries tasks are tracked through the API and driven by agent heartbeat and cron workflows. Task history shipped across the API, schema, and UI tab. Task automation tooling is now maintained in the SIndustries repo as the canonical location. Dependency links, task type UI, and feature-task workflow gates (spec approval, tech design, QA verification, system spec) are now part of the operating surface. The fluid spec drift lifecycle means approved specs can be amended without breaking the pipeline — the lobster handles drift detection, re-approval routing, and spec resync automatically.",
+    "updatedAt": "2026-07-03",
     "links": [],
     "image": "/brand/systems/tasks-api-hero.png",
     "visibility": "published"


### PR DESCRIPTION
## Summary
- 4 new releases: Feature Factory v2, Task dependency UI, Task type filter, Fluid spec drift lifecycle
- system/tasks-api and system/openclaw proof updated to reflect current capabilities
- experiment/plano-model-routing marked killed with rationale
- experiment/drop-1 and product-market-scans: updatedAt bumped (reviewed, no new findings)

## Acceptance criteria from task
- [x] ADD release — "Feature Factory v2" (system, releasedAt: 2026-06-29): agents self-orchestrate approved specs through delivery
- [x] ADD release — "Task dependency UI" (system, releasedAt: 2026-06-29): dependency links, add/remove with validation, copy task IDs
- [x] ADD release — "Task type filter and selector" (system, releasedAt: 2026-06-30): filter by type, edit type on cards, feature type
- [x] ADD release — "Fluid spec drift lifecycle" (system, releasedAt: 2026-07-03): drift unchecks approval, posts AC diffs, resyncs after re-approval
- [x] EDIT system/tasks-api — update proof to include dependency links, task type UI, feature-task workflow gates, and fluid spec drift handling
- [x] EDIT system/openclaw — update proof to include Feature Factory v2 as an operating workflow
- [x] EDIT experiment/plano-model-routing — status → killed; kill rationale added

## Test plan
- [x] Website renders all 4 new releases
- [x] tasks-api and openclaw system proof text reads correctly
- [x] plano-model-routing shows as killed on the experiments page

🤖 Generated with Claude Code
