### PR TITLE
feat(feature-task): move AC text check to doing → acceptance gate

### DIFF
--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -299,6 +299,8 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
         failures.push("Missing `[rowan-prs]` task comment with at least one PR URL.".to_string());
     }
     env.lobster_state.pr_urls = pr_urls.clone();
+    let task_acs =
+        task_description_acs(&env.task.description.clone().unwrap_or_default());
     for url in &pr_urls {
         match inspect_pr(url) {
             Ok(review) => {
@@ -315,6 +317,9 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
                 ));
             }
             for ac_failure in verify_pr_acs_failures(&body) {
+                failures.push(format!("PR {url} — {ac_failure}"));
+            }
+            for ac_failure in task_ac_vs_open_pr_failures(&task_acs, &body, url) {
                 failures.push(format!("PR {url} — {ac_failure}"));
             }
         }
@@ -415,72 +420,42 @@ fn task_description_acs(description: &str) -> Vec<(String, String)> {
         .collect()
 }
 
-/// Parse all AC lines from a PR body's AC section.
-/// Returns label -> (description without evidence, is_checked).
-fn pr_acs_all(body: &str) -> HashMap<String, (String, bool)> {
-    let section = extract_ac_section(body);
-    let re = Regex::new(r"(?m)^\s*-\s*\[([xX ])\]\s+(AC\d+):\s*(.+)$").unwrap();
-    re.captures_iter(section)
-        .map(|cap| {
-            let checked = cap[1].to_lowercase() == "x";
-            let label = cap[2].to_string();
-            let text = strip_trailing_evidence(cap[3].trim());
-            (label, (text, checked))
-        })
-        .collect()
-}
-
-/// Extract the numeric PR number from a GitHub PR URL for ordering.
-fn pr_number(url: &str) -> u64 {
-    url.rsplit('/')
-        .next()
-        .and_then(|n| n.parse::<u64>().ok())
-        .unwrap_or(0)
-}
-
-/// Return the URL of the most recently merged Rowan PR (highest PR number).
-fn latest_merged_pr_url(task: &Task) -> Option<String> {
-    rowan_pr_urls(task)
-        .into_iter()
-        .filter(|url| matches!(inspect_pr(url), Ok(ReviewState::Merged)))
-        .max_by_key(|url| pr_number(url))
-}
-
-/// Compare task description ACs against the latest merged PR.
+/// Compare task description ACs against an open PR body at the doing → acceptance gate.
 ///
-/// Three failure states:
-/// - AC missing from latest PR entirely → next PR must include it
-/// - AC present but unchecked in latest PR → not implemented
-/// - AC text differs between task and PR → spec altered, needs new PR
-fn task_ac_vs_latest_pr_failures(task: &Task) -> Vec<String> {
-    let description = task.description.clone().unwrap_or_default();
-    let task_acs = task_description_acs(&description);
+/// Fails if any task AC is missing from the PR, has altered text, or lacks a valid evidence annotation.
+fn task_ac_vs_open_pr_failures(
+    task_acs: &[(String, String)],
+    body: &str,
+    pr_url: &str,
+) -> Vec<String> {
     if task_acs.is_empty() {
         return vec![];
     }
-    let Some(latest_url) = latest_merged_pr_url(task) else {
-        return vec!["No merged PR found — cannot verify task ACs.".to_string()];
-    };
-    let body = match pr_body(&latest_url) {
-        Ok(b) => b,
-        Err(e) => return vec![format!("Could not fetch body for {latest_url}: {e}.")],
-    };
-    let pr_acs = pr_acs_all(&body);
+    let section = extract_ac_section(body);
+    let re = Regex::new(r"(?m)^\s*-\s*\[([xX ])\]\s+(AC\d+):\s*(.+)$").unwrap();
+    let mut pr_ac_map: HashMap<String, (String, Option<Evidence>)> = HashMap::new();
+    for cap in re.captures_iter(section) {
+        let label = cap[2].to_string();
+        let raw = cap[3].trim().to_string();
+        let evidence = parse_evidence(&raw);
+        let text = strip_trailing_evidence(&raw);
+        pr_ac_map.insert(label, (text, evidence));
+    }
     let mut failures = Vec::new();
-    for (label, task_text) in &task_acs {
-        match pr_acs.get(label) {
+    for (label, task_text) in task_acs {
+        match pr_ac_map.get(label) {
             None => failures.push(format!(
-                "{label} missing from latest PR {latest_url} — next PR must include all task ACs."
+                "{label} missing from open PR {pr_url} — include all task ACs with evidence."
             )),
-            Some((pr_text, checked)) => {
-                if !checked {
-                    failures.push(format!(
-                        "{label} is unchecked in latest PR {latest_url} — AC was not completed."
-                    ));
-                }
+            Some((pr_text, evidence)) => {
                 if task_text.to_lowercase() != pr_text.to_lowercase() {
                     failures.push(format!(
-                        "{label} text altered — task: \"{task_text}\", PR: \"{pr_text}\". Open a new PR addressing the updated AC."
+                        "{label} text altered — task: \"{task_text}\", PR: \"{pr_text}\". Copy the AC text verbatim from the task description."
+                    ));
+                }
+                if evidence.is_none() {
+                    failures.push(format!(
+                        "{label} — missing evidence. Append `(testID: <id>)`, `(file: <path>:<line>)`, `(not tested: <reason>)`, or `(not code: <reason>)`."
                     ));
                 }
             }
@@ -500,46 +475,8 @@ fn post_merge(args: StageArgs) -> Result<Envelope> {
         return block_with_manual_block(&args, env, "post_merge", manual_failures);
     }
 
-    // AC drift check: compare task description ACs against the latest merged PR.
-    // Runs before the qa_ac_verified gate — if the latest PR doesn't cover all ACs,
-    // bounce back to doing regardless of any existing [qa-ac-verified] comment.
-    let ac_failures = task_ac_vs_latest_pr_failures(&env.task);
-    if !ac_failures.is_empty() {
-        let target_status = if is_past(&env.task, "acceptance") {
-            // Task was already moved to done — revert to acceptance first,
-            // let next heartbeat bounce it further once Rowan opens a fix PR.
-            "acceptance"
-        } else {
-            "doing"
-        };
-        if !args.dry_run {
-            api_patch::<Task>(
-                &args.base_url,
-                &env.task.id,
-                json!({"status": target_status}),
-            )?;
-            env.task = api_get_task(&args.base_url, &env.task.id)?;
-            let fingerprint = ac_failures.join("\n");
-            if env.lobster_state.failure_fingerprint.as_deref() != Some(&fingerprint) {
-                env.lobster_state.failure_fingerprint = Some(fingerprint);
-                add_comment(
-                    &args.base_url,
-                    &env.task.id,
-                    &format!(
-                        "[feature-task-progress-checklist]\nQA failed — task bounced back to `{target_status}`. Next PR must include all task ACs checked with evidence.\n{}",
-                        ac_failures.join("\n")
-                    ),
-                )?;
-                write_state(&args.base_url, &env.task.id, &env.lobster_state, None)?;
-            }
-        }
-        env.criteria_met = false;
-        env.action_taken = format!("post_merge_bounced_to_{target_status}");
-        env.failures = ac_failures;
-        return Ok(env);
-    }
-
-    // AC coverage looks good — require Tom's explicit sign-off before closing.
+    // AC text check runs pre-merge at the doing → acceptance gate (verify_delivery).
+    // Require Tom's explicit sign-off before closing.
     let qa_failures = qa_ac_verified_failures(&env.task);
     if is_past(&env.task, "acceptance") {
         if !qa_failures.is_empty() {
@@ -3465,64 +3402,52 @@ mod tests {
         assert!(task_description_acs("No ACs here.").is_empty());
     }
 
-    // ---- pr_acs_all ----
+    // ---- task_ac_vs_open_pr_failures ----
 
     #[test]
-    fn pr_acs_all_captures_checked_and_unchecked() {
-        let body =
-            "## Acceptance Criteria\n- [x] AC1: Done thing (testID: 1)\n- [ ] AC2: Pending thing\n";
-        let acs = pr_acs_all(body);
-        assert_eq!(acs.get("AC1"), Some(&("Done thing".to_string(), true)));
-        assert_eq!(acs.get("AC2"), Some(&("Pending thing".to_string(), false)));
+    fn task_ac_vs_open_pr_passes_when_all_acs_match_with_evidence() {
+        let task_acs = vec![
+            ("AC1".to_string(), "Do the thing".to_string()),
+            ("AC2".to_string(), "Verify the result".to_string()),
+        ];
+        let body = "## Acceptance Criteria\n\
+            - [x] AC1: Do the thing (testID: test_do_thing)\n\
+            - [x] AC2: Verify the result (not tested: manual verification)\n";
+        let failures = task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
+        assert!(failures.is_empty(), "expected no failures, got: {failures:?}");
     }
 
     #[test]
-    fn pr_acs_all_strips_evidence() {
-        let body = "- [x] AC1: Build it (testID: 7)\n";
-        let acs = pr_acs_all(body);
-        assert_eq!(acs.get("AC1"), Some(&("Build it".to_string(), true)));
-    }
-
-    // ---- pr_number ----
-
-    #[test]
-    fn pr_number_extracts_from_url() {
-        assert_eq!(
-            pr_number("https://github.com/Stoffer-Industries/sindustries/pull/142"),
-            142
-        );
-        assert_eq!(pr_number("not-a-url"), 0);
-    }
-
-    // ---- task_ac_vs_latest_pr_failures ----
-
-    #[test]
-    fn task_ac_vs_latest_pr_returns_empty_when_no_task_acs() {
-        let task = Task {
-            description: Some("No ACs".to_string()),
-            ..Task::default()
-        };
-        assert!(task_ac_vs_latest_pr_failures(&task).is_empty());
-    }
-
-    #[test]
-    fn task_ac_vs_latest_pr_returns_error_when_no_merged_pr() {
-        let task = Task {
-            description: Some("- [ ] AC1: Something\n".to_string()),
-            ..Task::default()
-        };
-        let failures = task_ac_vs_latest_pr_failures(&task);
+    fn task_ac_vs_open_pr_blocks_on_text_mismatch() {
+        let task_acs = vec![("AC1".to_string(), "Do the thing".to_string())];
+        let body = "## Acceptance Criteria\n\
+            - [x] AC1: Do the other thing (testID: test_do_thing)\n";
+        let failures = task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
         assert_eq!(failures.len(), 1);
-        assert!(failures[0].contains("No merged PR found"));
+        assert!(failures[0].contains("text altered"), "got: {}", failures[0]);
     }
 
-    // ---- pr_acs_all: case-insensitive checkbox ----
+    #[test]
+    fn task_ac_vs_open_pr_blocks_on_missing_ac() {
+        let task_acs = vec![
+            ("AC1".to_string(), "Do the thing".to_string()),
+            ("AC2".to_string(), "Extra requirement".to_string()),
+        ];
+        let body = "## Acceptance Criteria\n\
+            - [x] AC1: Do the thing (testID: test_do_thing)\n";
+        let failures = task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("AC2") && failures[0].contains("missing"), "got: {}", failures[0]);
+    }
 
     #[test]
-    fn pr_acs_all_handles_uppercase_x() {
-        let body = "- [X] AC1: Done (testID: 1)\n";
-        let acs = pr_acs_all(body);
-        assert_eq!(acs.get("AC1"), Some(&("Done".to_string(), true)));
+    fn task_ac_vs_open_pr_blocks_on_missing_evidence() {
+        let task_acs = vec![("AC1".to_string(), "Do the thing".to_string())];
+        let body = "## Acceptance Criteria\n\
+            - [x] AC1: Do the thing\n";
+        let failures = task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("missing evidence"), "got: {}", failures[0]);
     }
 
     // ---- approval marker ----

--- a/docs/systems/feature-task-workflow.md
+++ b/docs/systems/feature-task-workflow.md
@@ -59,11 +59,12 @@ The Rust CLI under `agents/workflows/feature-task/` owns parsing, gate enforceme
   - CI on the merged commits is green
   - System spec exists at `docs/systems/<file>.md` (gated via `[system-spec]` task comment) OR a substantive `[no-system-spec-change] <reason>` is recorded
   - No `[openclaw-needed]` pending without matching `[openclaw-done]` from Quinn
-  - Latest merged PR body covers all task description ACs — each checked with evidence (see QA bounce below)
   - `[qa-ac-verified] true` task comment from Tom
 - Rust commands: `feature-task feedback-aggregate`, then `feature-task post-merge`
 
-**QA bounce (acceptance → doing):** the lobster compares every AC in the task description against the latest merged PR body at the `post-merge` stage. If any AC is missing from the PR, unchecked, or has altered text, the task is bounced back to `doing` and a `[feature-task-progress-checklist]` comment is posted. The next fix PR must re-list *all* task ACs. Tom may edit ACs in the task description during QA — spec drift does not block at `post-merge` (it is covered by the resync feature; see task b2ab54db).
+**AC text check (doing → acceptance, pre-merge):** before the lobster will let the task advance from `doing` to `acceptance`, it compares every task description AC against the **open** PR body. If any AC is missing from the PR, has altered text, or lacks a valid evidence annotation `(testID|file|not tested|not code)`, the transition is blocked with a `[feature-task-progress-checklist]` comment listing the specific failures — the task stays in `doing` until Rowan opens a fix PR that lists every AC verbatim with evidence. Tom may edit ACs in the task description during QA — spec drift does not block this gate (it is covered by the resync feature; see task b2ab54db).
+
+Note: prior versions of this workflow ran an equivalent AC text check at the `post-merge` stage (the "QA bounce") that moved a task back from `acceptance` to `doing` if the latest merged PR's AC text didn't match. That path was removed because it triggered after merge, forcing a wasteful revert + fix-PR round-trip. The check now runs pre-merge so mistakes are caught before the PR is merged.
 
 **PR AC evidence formats** (every checked `[x]` AC line must end with one of):
 - `(testID: <id>)` — Playwright test ID reference
@@ -138,7 +139,7 @@ Until first-class Tasks API fields exist, the workflow reads these tags from tas
 | `[system-spec] docs/systems/<file>.md` | implementer | System spec reference |
 | `[no-system-spec-change] <reason>` | implementer | Bypass for code-only changes |
 | `[qa-ac-verified] true` | Tom | Explicit QA sign-off; required before `acceptance -> done` |
-| `[feature-task-progress-checklist] ...` | Lobster | Posted when QA bounce detected; lists ACs missing/unchecked/altered in latest PR |
+| `[feature-task-progress-checklist] ...` | Lobster | Posted when the pre-merge AC text check (doing → acceptance) finds a missing, altered, or unannotated AC in the open PR body. Also posted for other gate failures (missing `[rowan-prs]`, missing `[system-spec]`, manual block, etc.) |
 | `[lobster-state] { ... }` | Lobster | Reconciler state — `version`, `last_orchestrated_at`, gate outcomes |
 | `[scope-add] <summary>` | Quinn / Tom | Document a scope change after spec approval (used in factory-v2 grandfathering) |
 
@@ -240,7 +241,8 @@ The `.openclaw/` directory is outside this repo. Any required `.openclaw` change
 | Spec checksum mismatch | ACs edited after spec approval | Hits `PATCH /tasks/:id` when the description ACs change. Treat as spec drift: Lobster unchecks `**Approved by Tom**`, waits for Tom to re-check, then performs the resync path. Comments are drift-tolerant and remain usable for progress/checklist/resync signals. |
 | `PATCH` succeeds despite stale ACs | Other event types (status change, dependency add, tag edit) don't re-check the checksum | Pass the updated `description` through `PATCH /tasks/:id` first so the drift check fires there. |
 | CI green but PR not merged | Reviewer has not approved | Wait for `APPROVED` review state; Lobster will not mark `done` until GitHub merge is recorded |
-| Task bounced to `doing` from `acceptance` | QA AC check failed — AC missing, unchecked, or text differs in latest PR | Open a fix PR that includes ALL task ACs checked with evidence; `[feature-task-progress-checklist]` comment details what failed |
+| Task bounced to `doing` from `acceptance` | (legacy — the post-merge QA bounce path was removed; AC text mismatches now block at the doing → acceptance gate before merge instead) | n/a |
+| `doing -> acceptance` blocked on AC text | Open PR body is missing an AC, has altered AC text, or lacks a valid evidence annotation `(testID|file|not tested|not code)` | Update the PR body so every task AC appears verbatim with evidence; `[feature-task-progress-checklist]` comment lists the specific failures |
 | `acceptance -> done` blocked with "Missing `[qa-ac-verified] true`" | Tom has not signed off | Tom posts `[qa-ac-verified] true` after verifying ACs on staging |
 
 ---


### PR DESCRIPTION
## Summary
- Moves the AC text + evidence annotation check from the post-merge QA bounce path (`post_merge` stage) to the pre-merge `doing → acceptance` gate (`verify_delivery` stage). PRs with mismatched AC text or missing evidence are now blocked *before* merge, not bounced *after*.
- Removes the bounce-back branch from `post_merge` that previously moved a task back from `acceptance` to `doing` (or from `done` to `acceptance`) when the merged PR's AC text didn't match the task description.
- Updates `docs/systems/feature-task-workflow.md` to reflect the gate move.

## Why now
Task `2cee0bcd` (tasks_api_client.py patch --description) is stuck in a bounce loop because the post-merge check still compares against the latest merged PR (`#151`), whose ACs had trailing periods that don't match the task description ACs. PR `#166` already has the corrected AC text, but the old post-merge check fires before any pre-merge validation can pass. Moving the check pre-merge makes this fail-fast at the open-PR stage instead of after a merge — the same PR body that bounces today will now simply not advance past `doing` until the next fix PR (which would also be unnecessary since `#166` already matches).

## Test plan
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml --bin feature-task` — 118 passed, 0 failed (4 new tests covering the new `task_ac_vs_open_pr_failures` function)
- [x] `cargo check --manifest-path agents/workflows/feature-task/Cargo.toml` — clean (only 2 pre-existing dead-code warnings unrelated to this change)

## Acceptance Criteria
- [x] AC1: At the doing → acceptance gate, the lobster checks that every task description AC appears in the open PR body with matching text and a valid evidence annotation. (file: agents/workflows/feature-task/src/main.rs:319-326, agents/workflows/feature-task/src/main.rs:426-470)
- [x] AC2: If any AC is missing, has altered text, or lacks evidence, the transition is blocked with a [feature-task-progress-checklist] comment listing the specific failures. (file: agents/workflows/feature-task/src/main.rs:319-326, agents/workflows/feature-task/src/main.rs:426-470 — failures returned as Vec<String>; existing lobster wrapping at the verify_delivery call site posts the comment)
- [x] AC3: The post-merge QA bounce path no longer fires for AC text mismatches — that check is removed from the done stage. (file: agents/workflows/feature-task/src/main.rs:475-481 — post_merge comment updated; task_ac_vs_latest_pr_failures call removed; the helper functions pr_acs_all / pr_number / latest_merged_pr_url / task_ac_vs_latest_pr_failures are deleted)
- [x] AC4: Rust unit tests cover: all ACs present with evidence (passes), AC text mismatch (blocks), missing AC (blocks), missing evidence (blocks). (testID: task_ac_vs_open_pr_passes_when_all_acs_match_with_evidence, task_ac_vs_open_pr_blocks_on_text_mismatch, task_ac_vs_open_pr_blocks_on_missing_ac, task_ac_vs_open_pr_blocks_on_missing_evidence)
- [x] AC5: The feature-task-workflow system doc is updated to reflect the gate move. (file: docs/systems/feature-task-workflow.md — acceptance-criteria section, comment table, troubleshooting table)

## System spec
[system-spec] docs/systems/feature-task-workflow.md (updated in this PR)

🤖 Generated with Claude Code