### PR TITLE
fix(feature-task): skip merged/closed PRs in pre-merge AC text check

### DIFF
--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -152,7 +152,7 @@ struct Workstream {
     body: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReviewState {
     Approved,
     Required,
@@ -301,10 +301,16 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
     env.lobster_state.pr_urls = pr_urls.clone();
     let task_acs =
         task_description_acs(&env.task.description.clone().unwrap_or_default());
+    // AC text match only checks the *latest* PR (highest PR number). Earlier PRs
+    // may legitimately have drifted from the current task description (e.g.
+    // trailing-period fixes landed in a follow-up PR). The latest PR is the one
+    // that will be merged at this gate, so it's the only one that needs to match.
+    let latest_pr_url = pr_urls.iter().max_by_key(|url| pr_number(url)).cloned();
     for url in &pr_urls {
-        match inspect_pr(url) {
-            Ok(review) => {
-                if let Some(failure) = verify_delivery_review_failure(url, review) {
+        let review = inspect_pr(url);
+        match review {
+            Ok(r) => {
+                if let Some(failure) = verify_delivery_review_failure(url, r) {
                     failures.push(failure);
                 }
             }
@@ -319,6 +325,10 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
             for ac_failure in verify_pr_acs_failures(&body) {
                 failures.push(format!("PR {url} — {ac_failure}"));
             }
+        }
+    }
+    if let Some(url) = &latest_pr_url {
+        if let Ok(body) = pr_body(url) {
             for ac_failure in task_ac_vs_open_pr_failures(&task_acs, &body, url) {
                 failures.push(format!("PR {url} — {ac_failure}"));
             }
@@ -388,6 +398,14 @@ fn verify_delivery_review_failure(url: &str, review: ReviewState) -> Option<Stri
         ReviewState::ClosedUnmerged => Some(format!("PR {url} is closed without merge.")),
         _ => None,
     }
+}
+
+/// Extract the PR number from a GitHub PR URL for ordering.
+fn pr_number(url: &str) -> u64 {
+    url.rsplit('/')
+        .next()
+        .and_then(|n| n.parse::<u64>().ok())
+        .unwrap_or(0)
 }
 
 fn feedback_review_failure(url: &str, review: ReviewState) -> Option<String> {
@@ -3041,6 +3059,15 @@ mod tests {
             verify_delivery_review_failure(url, ReviewState::ClosedUnmerged),
             Some(format!("PR {url} is closed without merge."))
         );
+    }
+
+    #[test]
+    fn pr_number_extracts_from_url() {
+        assert_eq!(
+            pr_number("https://github.com/Stoffer-Industries/sindustries/pull/142"),
+            142
+        );
+        assert_eq!(pr_number("not-a-url"), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- PR #170 moved the AC text + evidence check from the post-merge QA bounce path to the pre-merge `doing → acceptance` gate, but the new check iterated every PR URL in `rowan_pr_urls` and ran against them all — so historical merged PRs got re-checked against the current task description ACs (e.g. task `2cee0bcd` PR #151 had trailing periods that follow-up PR #166 corrected; #151's drifted text kept re-failing the task).
- Simplest fix: only run the AC text-match check against the **latest** PR (highest PR number). That's the one being merged at this gate; earlier PRs may legitimately have drifted (their AC text was accepted when they merged).

## Why this design
The first attempt (now superseded) added a `pr_open_for_ac_text_check(review)` helper to filter out merged/closed PRs in the loop. Simpler: pick the latest PR by PR number and check it once. No per-PR review-state bookkeeping, one body fetch on the live PR.

## Test plan
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml --bin feature-task` — 119 passed, 0 failed
- [x] `cargo build --release --manifest-path agents/workflows/feature-task/Cargo.toml` — clean

## Acceptance Criteria
- [x] AC1: AC text match check runs only against the latest PR (highest PR number). (file: agents/workflows/feature-task/src/main.rs:296-302)
- [x] AC2: Earlier PRs are not subjected to the AC text-match check at this gate. (file: agents/workflows/feature-task/src/main.rs:296-302)
- [x] AC3: Other per-PR checks still iterate every PR URL in `[rowan-prs]`. (file: agents/workflows/feature-task/src/main.rs:304-325)
- [x] AC4: Task 2cee0bcd advances `doing → acceptance` once this PR merges (latest PR is #166, body matches task ACs verbatim). (not tested: requires merge + lobster pass)

🤖 Generated with Claude Code
