### PR TITLE
fix(lobster): accept file evidence test names

### DIFF
--- a/agents/skills/dev/pr-open/SKILL.md
+++ b/agents/skills/dev/pr-open/SKILL.md
@@ -56,7 +56,7 @@ Co-Authored-By: <Your Name> <your-email>
 **Acceptance Criteria (feature-task PRs only):** the lobster enforces a per-AC evidence rule at the `doing → acceptance` gate. Every checked `- [x]` AC line must end with one of:
 
 - `(testID: <id>)` — Playwright test ID reference
-- `(file: <path>:<line>)` — file and line reference
+- `(file: <path>:<test-name>)` — file plus test name reference
 - `(not tested: <reason>)` — implemented in code but not testable
 - `(not code: <reason>)` — AC fulfilled outside the codebase (brain file, spec doc, etc.)
 
@@ -67,7 +67,7 @@ Example:
 ```markdown
 ## Acceptance Criteria
 - [x] AC1: Task detail shows dependency links. (testID: 4)
-- [x] AC2: Card click-to-copy affordance. (file: apps/tasks/src/components/TaskCardSummary.jsx:42)
+- [x] AC2: Card click-to-copy affordance. (file: apps/tasks/src/components/TaskCardSummary.test.jsx: click-to-copy affordance)
 - [x] AC3: Reduced opacity for archived tasks. (not tested: design tokens supply color; visual review only)
 - [x] AC4: Feature factory v2 spec updated. (not code: updated brain/bookmarks/specs/feature-factory-v2-2026-06-04.md)
 ```

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -299,8 +299,7 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
         failures.push("Missing `[rowan-prs]` task comment with at least one PR URL.".to_string());
     }
     env.lobster_state.pr_urls = pr_urls.clone();
-    let task_acs =
-        task_description_acs(&env.task.description.clone().unwrap_or_default());
+    let task_acs = task_description_acs(&env.task.description.clone().unwrap_or_default());
     // AC text match only checks the *latest* PR (highest PR number). Earlier PRs
     // may legitimately have drifted from the current task description (e.g.
     // trailing-period fixes landed in a follow-up PR). The latest PR is the one
@@ -473,7 +472,7 @@ fn task_ac_vs_open_pr_failures(
                 }
                 if evidence.is_none() {
                     failures.push(format!(
-                        "{label} — missing evidence. Append `(testID: <id>)`, `(file: <path>:<line>)`, `(not tested: <reason>)`, or `(not code: <reason>)`."
+                        "{label} — missing evidence. Append `(testID: <id>)`, `(file: <path>:<test-name>)`, `(not tested: <reason>)`, or `(not code: <reason>)`."
                     ));
                 }
             }
@@ -2174,8 +2173,9 @@ fn body_has_checked_acceptance(body: &str) -> bool {
 enum Evidence {
     /// Playwright test ID reference, e.g. `(testID: 1234)`
     TestId(String),
-    /// File path and line reference, e.g. `(file: apps/tasks/src/App.jsx:42)`
-    FileRef { path: String, line: u64 },
+    /// File path plus a test name, e.g.
+    /// `(file: agents/workflows/feature-task/src/main.rs: parse_evidence_recognises_file_test_name)`.
+    FileRef { path: String, test_name: String },
     /// Explicit reason for not adding a test, e.g. `(not tested: design tokens)`
     NotTested { reason: String },
     /// AC fulfilled outside the codebase, e.g. `(not code: updated brain/bookmarks/specs/foo.md)`
@@ -2226,12 +2226,16 @@ fn parse_evidence(text: &str) -> Option<Evidence> {
             reason: cap[1].trim().to_string(),
         });
     }
-    // (file: <path>:<line>)
-    let file_ref = Regex::new(r"\(file:\s*([^)]+?):(\d+)\)\s*$").unwrap();
+    // (file: <path>:<test-name>)
+    let file_ref = Regex::new(r"\(file:\s*([^)]+?):\s*([^)]+)\)\s*$").unwrap();
     if let Some(cap) = file_ref.captures(text) {
+        let test_name = cap[2].trim();
+        if test_name.parse::<u64>().is_ok() {
+            return None;
+        }
         return Some(Evidence::FileRef {
             path: cap[1].trim().to_string(),
-            line: cap[2].parse().unwrap_or(0),
+            test_name: test_name.to_string(),
         });
     }
     // (testID: <value>)
@@ -2275,7 +2279,7 @@ fn parse_ac_line(line: &str) -> Option<AcEvidence> {
 }
 
 /// Build failure messages for ACs that lack evidence. Empty list = all ACs
-/// in the section carry `(testID: ...)`, `(file: path:line)`, `(not tested: reason)`,
+/// in the section carry `(testID: ...)`, `(file: path:test-name)`, `(not tested: reason)`,
 /// or `(not code: reason)` annotations.
 fn verify_pr_acs_failures(body: &str) -> Vec<String> {
     let section = extract_ac_section(body);
@@ -2284,7 +2288,7 @@ fn verify_pr_acs_failures(body: &str) -> Vec<String> {
         if let Some(ac) = parse_ac_line(line) {
             if ac.evidence.is_none() {
                 failures.push(format!(
-                    "AC {} — missing evidence. Append `(testID: <id>)`, `(file: <path>:<line>)`, `(not tested: <reason>)`, or `(not code: <reason>)`.",
+                    "AC {} — missing evidence. Append `(testID: <id>)`, `(file: <path>:<test-name>)`, `(not tested: <reason>)`, or `(not code: <reason>)`.",
                     ac.ac_label
                 ));
             }
@@ -2396,12 +2400,17 @@ mod tests {
     }
 
     #[test]
-    fn parse_evidence_recognises_file_ref() {
+    fn parse_evidence_rejects_file_line_ref() {
+        assert_eq!(parse_evidence("bar (file: apps/tasks/src/X.jsx:42)"), None);
+    }
+
+    #[test]
+    fn parse_evidence_recognises_file_test_name_ref() {
         assert_eq!(
-            parse_evidence("bar (file: apps/tasks/src/X.jsx:42)"),
+            parse_evidence("bar (file: agents/workflows/feature-task/src/main.rs: parse_evidence_recognises_file_test_name_ref)"),
             Some(Evidence::FileRef {
-                path: "apps/tasks/src/X.jsx".to_string(),
-                line: 42,
+                path: "agents/workflows/feature-task/src/main.rs".to_string(),
+                test_name: "parse_evidence_recognises_file_test_name_ref".to_string(),
             })
         );
     }
@@ -2507,7 +2516,7 @@ mod tests {
 
     #[test]
     fn verify_pr_acs_passes_when_all_have_evidence() {
-        let body = "## Acceptance Criteria\n- [x] AC1: Foo (testID: 1)\n- [x] AC2: Bar (file: src/x.js:2)\n- [x] AC3: Baz (not tested: design tokens)\n";
+        let body = "## Acceptance Criteria\n- [x] AC1: Foo (testID: 1)\n- [x] AC2: Bar (file: src/x.test.js: bar handles evidence)\n- [x] AC3: Baz (not tested: design tokens)\n";
         assert!(verify_pr_acs_failures(body).is_empty());
     }
 
@@ -3440,8 +3449,12 @@ mod tests {
         let body = "## Acceptance Criteria\n\
             - [x] AC1: Do the thing (testID: test_do_thing)\n\
             - [x] AC2: Verify the result (not tested: manual verification)\n";
-        let failures = task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
-        assert!(failures.is_empty(), "expected no failures, got: {failures:?}");
+        let failures =
+            task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
+        assert!(
+            failures.is_empty(),
+            "expected no failures, got: {failures:?}"
+        );
     }
 
     #[test]
@@ -3449,7 +3462,8 @@ mod tests {
         let task_acs = vec![("AC1".to_string(), "Do the thing".to_string())];
         let body = "## Acceptance Criteria\n\
             - [x] AC1: Do the other thing (testID: test_do_thing)\n";
-        let failures = task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
+        let failures =
+            task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
         assert_eq!(failures.len(), 1);
         assert!(failures[0].contains("text altered"), "got: {}", failures[0]);
     }
@@ -3462,9 +3476,14 @@ mod tests {
         ];
         let body = "## Acceptance Criteria\n\
             - [x] AC1: Do the thing (testID: test_do_thing)\n";
-        let failures = task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
+        let failures =
+            task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
         assert_eq!(failures.len(), 1);
-        assert!(failures[0].contains("AC2") && failures[0].contains("missing"), "got: {}", failures[0]);
+        assert!(
+            failures[0].contains("AC2") && failures[0].contains("missing"),
+            "got: {}",
+            failures[0]
+        );
     }
 
     #[test]
@@ -3472,9 +3491,14 @@ mod tests {
         let task_acs = vec![("AC1".to_string(), "Do the thing".to_string())];
         let body = "## Acceptance Criteria\n\
             - [x] AC1: Do the thing\n";
-        let failures = task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
+        let failures =
+            task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
         assert_eq!(failures.len(), 1);
-        assert!(failures[0].contains("missing evidence"), "got: {}", failures[0]);
+        assert!(
+            failures[0].contains("missing evidence"),
+            "got: {}",
+            failures[0]
+        );
     }
 
     // ---- approval marker ----

--- a/docs/specs/add-e2e-to-feature-factory-tech-design.md
+++ b/docs/specs/add-e2e-to-feature-factory-tech-design.md
@@ -33,7 +33,7 @@ The feature factory v2 spec already states that every AC in a feature-task PR ne
 
 A PR is treated as compliant when each AC line in the PR body provides either:
 
-- A test reference, formatted as either `(testID: <id>)` or `(file: <path>:<line>)`, appended to the AC line; or
+- A test reference, formatted as either `(testID: <id>)` or `(file: <path>:<test-name>)`, appended to the AC line; or
 - An explicit annotation `not tested: <reason>` justifying why no test exists.
 
 If any AC is checked (`- [x]`) and lacks evidence, the lobster blocks acceptance and posts a task comment listing every AC that needs evidence along with the expected formats.
@@ -52,7 +52,7 @@ Each `- [x] AC<N>: <description>` line may be suffixed with one of:
 
 Recognition rules:
 
-- A single space followed by `(testID: <value>)`, `(file: <path>:<line>)`, or `(not tested: <text up to closing paren>)` is treated as evidence.
+- A single space followed by `(testID: <value>)`, `(file: <path>:<test-name>)`, or `(not tested: <text up to closing paren>)` is treated as evidence.
 - A bare `not tested` without a reason is treated as missing evidence — the lobster surfaces it.
 - Multi-PR tasks (where a task is split into workstreams across PRs): each PR's body only needs evidence for the ACs it claims. Uncovered ACs simply don't appear on that PR's Acceptance Criteria list. The lobster validates per-PR, not per-task, so each PR independently needs evidence for what it advertises.
 
@@ -65,7 +65,7 @@ The lobster matches the same `- [ ] AC<N>` style that the product spec / task de
 - New function `parse_pr_evidence(body: &str) -> Vec<AcEvidence>` returning one record per `- [x]` AC line:
   - `ac_label: String` — captured `AC<number>` token
   - `description: String` — the AC body without evidence
-  - `evidence: Option<Evidence>` — `TestId(String)`, `FileRef { path, line }`, or `NotTested { reason }`
+  - `evidence: Option<Evidence>` — `TestId(String)`, `FileRef { path, test_name }`, or `NotTested { reason }`
 - New function `verify_pr_acs(body: &str) -> Vec<String>` returning a list of human-readable failure strings (empty on success). It scans only the `## Acceptance Criteria` (or `## ACs`) section header, parses each checked AC line, and emits one failure per AC missing evidence.
 - Helper `extract_ac_section(body: &str) -> &str` returns just the AC section text or the entire body when no header is present (defensive default so PRs without a header still get validated).
 
@@ -89,14 +89,14 @@ Failure messages follow the existing pattern (`"PR {url} — AC{label} ({head}):
 
 ### 3. Update the PR template
 
-In `agents/skills/dev/pr-open/SKILL.md`, expand the body template section to include a reminder that each AC line must end with `(testID: <id>)`, `(file: <path>:<line>)`, or `(not tested: <reason>)`. The template already lists ACs; the change is a one-line note explaining the evidence requirement.
+In `agents/skills/dev/pr-open/SKILL.md`, expand the body template section to include a reminder that each AC line must end with `(testID: <id>)`, `(file: <path>:<test-name>)`, or `(not tested: <reason>)`. The template already lists ACs; the change is a one-line note explaining the evidence requirement.
 
 ### 4. Tests
 
 New tests in `agents/workflows/feature-task/src/main.rs` `mod tests`:
 
 - `parse_pr_evidence_recognises_test_id` — `- [x] AC1: Foo (testID: 1234)` parses to `Some(TestId("1234"))`.
-- `parse_pr_evidence_recognises_file_ref` — `(file: apps/tasks/src/X.jsx:42)` parses to `FileRef` with both fields.
+- `parse_pr_evidence_recognises_file_ref` — `(file: agents/workflows/feature-task/src/main.rs: test_name)` parses to `FileRef`; numeric line-only file refs are rejected so the implementation matches the task AC.
 - `parse_pr_evidence_recognises_not_tested_reason` — `(not tested: requires manual click flow)` parses to a reason.
 - `parse_pr_evidence_rejects_bare_not_tested` — bare `not tested` without parens or reason is `None`.
 - `verify_pr_acs_passes_when_all_have_evidence` — full body with annotations returns empty failures.


### PR DESCRIPTION
## Summary
- Fixes the feature-task lobster evidence parser so `(file: <path>:<test name>)` is accepted for file evidence, matching task AC1 exactly.
- Rejects numeric line-only file refs like `(file: <path>:42)` so file evidence cannot silently drift back to the old line-number format.
- Updates the PR-opening guidance and task tech design to document `test-name` file evidence.

## Test plan
- [x] `cargo fmt --manifest-path agents/workflows/feature-task/Cargo.toml`
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml parse_evidence -- --nocapture` (6 tests pass; includes rejecting numeric file line refs)
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml` (120 tests pass)

## Acceptance Criteria
- [x] AC1: Feature-task lobster parses the PR body, extracts ACs, and verifies each one has either a test reference (e.g. `(testID: 1234)`, `(file: path: testName)`) or an explicit `not tested: <reason>` annotation (file: agents/workflows/feature-task/src/main.rs: parse_evidence_recognises_file_test_name_ref)
- [x] AC2: PRs missing evidence on any AC are blocked from acceptance with a clear task comment listing the ACs that need evidence and the expected format (file: agents/workflows/feature-task/src/main.rs:472)
- [x] AC3: PR body template / checklist in the lobster prompts Rowan for the test reference or "not tested" reason when opening a feature-task PR (file: agents/skills/dev/pr-open/SKILL.md:59)
- [x] AC4: Rust unit tests cover the lobster validation: missing evidence on one AC, partial evidence, all valid, malformed ACs that fail to parse (file: agents/workflows/feature-task/src/main.rs:2403)
- [x] AC5: Feature factory v2 spec updated to call out the e2e evidence requirement as a hard gate in PR Requirements and Acceptance Checks sections (not code: Quinn completed the brain spec amendment; this PR updates the shipped tech design wording to match the corrected accepted evidence format)

## System spec
[no-system-spec-change] Parser/guidance correction for internal feature-task lobster evidence validation. No public API, persisted data, schema, or user-facing product behaviour changes.

🤖 Generated with OpenClaw
