### PR TITLE
test(feature-task): annotate tech_design_approved tests for task 44f5ed65 AC mapping

### DIFF
--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -2390,6 +2390,20 @@ mod tests {
     }
 
     // ---- AC evidence parsing (task 6e70deb8) ----
+    //
+    // Task 44f5ed65 covers the seven tech_design_approved tests above:
+    //   AC1 (accept rationale after true):
+    //     tech_design_approved_accepts_bare_true
+    //     tech_design_approved_accepts_rationale_after_true
+    //     tech_design_approved_accepts_uppercase_true
+    //     tech_design_approved_accepts_leading_whitespace
+    //   AC2 (reject false / missing value / unrelated token):
+    //     tech_design_approved_rejects_false
+    //     tech_design_approved_rejects_missing_value
+    //     tech_design_approved_rejects_unrelated_token
+    //   AC3 (Rust unit tests cover both accept and reject cases):
+    //     all seven tests above.
+    //
 
     #[test]
     fn parse_evidence_recognises_test_id() {


### PR DESCRIPTION
## Summary
AC verification PR for task 44f5ed65. The implementation shipped in PR #150. This PR carries the exact AC text (verbatim from the task description, no trailing periods) so the lobster's post-merge AC text check passes, and adds an inline annotation mapping each Rust unit test to its parent AC.

The diff is a single doc-comment block in the existing `tests` module — no behaviour change.

## Test plan
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml tech_design_approved` (7 tests pass)
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml` (120 tests pass)

## Acceptance Criteria
- [x] AC1: `[tech-design-approved] true — any rationale` is accepted by the parser (file: agents/workflows/feature-task/src/main.rs:tech_design_approved_accepts_bare_true, agents/workflows/feature-task/src/main.rs:tech_design_approved_accepts_rationale_after_true, agents/workflows/feature-task/src/main.rs:tech_design_approved_accepts_uppercase_true, agents/workflows/feature-task/src/main.rs:tech_design_approved_accepts_leading_whitespace)
- [x] AC2: `[tech-design-approved] false` and `[tech-design-approved]` (missing value) still rejected correctly (file: agents/workflows/feature-task/src/main.rs:tech_design_approved_rejects_false, agents/workflows/feature-task/src/main.rs:tech_design_approved_rejects_missing_value, agents/workflows/feature-task/src/main.rs:tech_design_approved_rejects_unrelated_token)
- [x] AC3: Rust unit tests cover both accept and reject cases (file: agents/workflows/feature-task/src/main.rs:tech_design_approved_accepts_bare_true, agents/workflows/feature-task/src/main.rs:tech_design_approved_accepts_rationale_after_true, agents/workflows/feature-task/src/main.rs:tech_design_approved_accepts_uppercase_true, agents/workflows/feature-task/src/main.rs:tech_design_approved_accepts_leading_whitespace, agents/workflows/feature-task/src/main.rs:tech_design_approved_rejects_false, agents/workflows/feature-task/src/main.rs:tech_design_approved_rejects_missing_value, agents/workflows/feature-task/src/main.rs:tech_design_approved_rejects_unrelated_token)

## System spec
[no-system-spec-change] Pure parser-relaxation behaviour change in the lobster CLI; no durable system contract, persisted data, or workflow protocol change. The factory v2 spec documents `[tech-design-approved]` as a marker but doesn't specify strict equality semantics on the value token — this aligns the parser with how humans already write the comment. No `docs/systems/` update warranted.

🤖 Generated with OpenClaw