### PR TITLE
content(website): add releases and update system proofs — 2026-07-03 (Quinn-approval)

### DIFF
--- a/apps/website/src/content/releases.json
+++ b/apps/website/src/content/releases.json
@@ -138,5 +138,45 @@
     "links": [],
     "evidence": "The X bookmark tagger now returns descriptive tags such as agent architecture and token optimisation after moving through the OpenClaw gateway provider route.",
     "visibility": "draft"
+  },
+  {
+    "title": "Feature Factory v2",
+    "slug": "feature-factory-v2",
+    "releasedAt": "2026-06-29",
+    "summary": "Agents can now take an approved spec and self-orchestrate it through ready → doing → acceptance → done without Tom or Quinn driving transitions by hand.",
+    "type": "system",
+    "links": [],
+    "evidence": "Feature task workflow shipped 2026-06-29 (PR #117). The lobster handles spec approval, tech design gates, PR tracking, QA verification, and system spec requirements as a fully automated orchestration loop.",
+    "visibility": "draft"
+  },
+  {
+    "title": "Task dependency UI",
+    "slug": "task-dependency-ui",
+    "releasedAt": "2026-06-29",
+    "summary": "Tasks now express blocking relationships. The UI shows what blocks each task, supports add/remove with title validation, and lets you copy task IDs from cards.",
+    "type": "system",
+    "links": [],
+    "evidence": "Task dependency backend (PR #128) and dependency UI (PR #129) shipped 2026-06-27–29. First capability to run the full spec → factory pipeline end-to-end.",
+    "visibility": "draft"
+  },
+  {
+    "title": "Task type filter and selector",
+    "slug": "task-type-filter-and-selector",
+    "releasedAt": "2026-06-30",
+    "summary": "The tasks app now filters by type, edits type on existing cards, and exposes feature as a creatable task type.",
+    "type": "system",
+    "links": [],
+    "evidence": "Task type filter and editor shipped 2026-06-30 (PR #145), closing task 5dbf2967.",
+    "visibility": "draft"
+  },
+  {
+    "title": "Fluid spec drift lifecycle",
+    "slug": "fluid-spec-drift-lifecycle",
+    "releasedAt": "2026-07-03",
+    "summary": "Spec changes after approval no longer hard-block the pipeline. The lobster unchecks Tom's approval and posts an AC diff; after Tom re-checks, the spec is resynced automatically.",
+    "type": "system",
+    "links": [],
+    "evidence": "Shipped across PRs #161, #163, #165, and #167 (2026-07-01 to 2026-07-03). Drift detection unchecks the approval marker, posts AC diff comments, and the resync path rewrites the brain spec from the task description after Tom re-approves.",
+    "visibility": "draft"
   }
 ]

--- a/apps/website/src/content/systems.json
+++ b/apps/website/src/content/systems.json
@@ -7,8 +7,8 @@
     "summary": "The operating layer for agents, memory, tools, messaging, and human-in-the-loop work.",
     "problem": "Delegated agent work needs continuity, tools, memory, and human review boundaries to become operationally useful.",
     "howItWorks": "OpenClaw connects agents to workspace files, skills, messaging, tasks, and runtime context so work can move through explicit handoffs.",
-    "proof": "Active operating layer for SIndustries agents, task execution, daily ops note capture, weekly content review workflows, and multi-agent content operations — Quinn orchestrates, Ivy authors, Tom approves, Lobster merges. The SIndustries skill library has grown with spec-author, website-content, and operating-notes skills, and spec authoring for the bookmark pipeline is now heartbeat-queued through OpenClaw for auditable, rate-controlled LLM work. Scheduled workflows are now first-class OpenClaw jobs: a weekly repo-audit cron writes a markdown audit and opens an idempotent Tom-approval PR labelled code-audit against main, bookmark approvals route through OpenClaw messaging, and the daily morning brief now escalates blocked agent-layer incidents and Quinn ops findings that need Tom attention.",
-    "updatedAt": "2026-06-22",
+    "proof": "Active operating layer for SIndustries agents, task execution, daily ops note capture, weekly content review workflows, and multi-agent content operations — Quinn orchestrates, Ivy authors, Tom approves, Lobster merges. The SIndustries skill library has grown with spec-author, website-content, and operating-notes skills, and spec authoring for the bookmark pipeline is now heartbeat-queued through OpenClaw for auditable, rate-controlled LLM work. Scheduled workflows are now first-class OpenClaw jobs: a weekly repo-audit cron writes a markdown audit and opens an idempotent Tom-approval PR labelled code-audit against main, bookmark approvals route through OpenClaw messaging, and the daily morning brief now escalates blocked agent-layer incidents and Quinn ops findings that need Tom attention. Feature Factory v2 is now an operating workflow inside OpenClaw: agents self-orchestrate approved specs from ready through doing, acceptance, and done without manual status transitions — the first time SIndustries shipped a workflow-as-product through its own pipeline.",
+    "updatedAt": "2026-07-03",
     "links": [],
     "image": "/brand/systems/openclaw-lobster.jpg",
     "visibility": "published"
@@ -35,8 +35,8 @@
     "summary": "Task state, ownership, comments, reviews, and heartbeat-driven operating discipline.",
     "problem": "Agent work needs a shared source of truth for ownership, status, review, and handoff.",
     "howItWorks": "The Tasks API tracks tasks, comments, tags, readiness, and status transitions for SIndustries work.",
-    "proof": "SIndustries tasks are tracked through the API and driven by agent heartbeat and cron workflows. Task history shipped across the API, schema, and UI tab. Task automation tooling is now maintained in the SIndustries repo as the canonical location.",
-    "updatedAt": "2026-06-12",
+    "proof": "SIndustries tasks are tracked through the API and driven by agent heartbeat and cron workflows. Task history shipped across the API, schema, and UI tab. Task automation tooling is now maintained in the SIndustries repo as the canonical location. Dependency links, task type UI, and feature-task workflow gates (spec approval, tech design, QA verification, system spec) are now part of the operating surface. The fluid spec drift lifecycle means approved specs can be amended without breaking the pipeline — the lobster handles drift detection, re-approval routing, and spec resync automatically.",
+    "updatedAt": "2026-07-03",
     "links": [],
     "image": "/brand/systems/tasks-api-hero.png",
     "visibility": "published"


### PR DESCRIPTION
## Summary
4 new releases and system proof updates for the 2026-07-03 weekly content review.

Task: 4c7027a5-13e4-4f9f-82bd-d652c2a03342

## Acceptance criteria
- [x] ADD release — "Feature Factory v2" (system, releasedAt: 2026-06-29): agents self-orchestrate approved specs through delivery
- [x] ADD release — "Task dependency UI" (system, releasedAt: 2026-06-29): dependency links, add/remove with validation, copy task IDs
- [x] ADD release — "Task type filter and selector" (system, releasedAt: 2026-06-30): filter by type, edit type on cards, feature type
- [x] ADD release — "Fluid spec drift lifecycle" (system, releasedAt: 2026-07-03): drift unchecks approval, posts AC diffs, resyncs after re-approval
- [x] EDIT system/tasks-api — update proof to include dependency links, task type UI, feature-task workflow gates, and fluid spec drift handling
- [x] EDIT system/openclaw — update proof to include Feature Factory v2 as an operating workflow

## Test plan
- [x] Website renders all 4 new releases
- [x] openclaw and tasks-api system proof text reads correctly