### PR TITLE
chore(code-garden): supersede stale tasks-one-pager.md [2026-W27]

### DIFF
--- a/docs/repo-audits/2026-W27.md
+++ b/docs/repo-audits/2026-W27.md
@@ -385,7 +385,7 @@ AI agents (agents/)
 | 3-A | Pagination unit tests assert post-fix correctness | M |
 | 3-B | Wrap budget-api Akahu sync card/balance loop in `prisma.$transaction` | S |
 | 3-C | Add structured logging with `trace_id` to both APIs' error middleware | M |
-| 3-D | Update `docs/specs/tasks-one-pager.md` and `docs/architecture.md` to match current behavior | S |
+| 3-D | Update `docs/specs/tasks-one-pager.md` and `docs/architecture.md` to match current behavior | S | ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD) — tasks-one-pager.md now leads with a SUPERSEDED banner pointing to `docs/systems/task-tracking.md`; `docs/architecture.md` was deleted in `6148efc`, so its portion of this task is moot.
 | 3-E | Evaluate Prisma 6 migration; document decision | M |
 | 3-F | Add per-IP rate limit (`express-rate-limit`) on `/akahu/exchange` and `/session/dev-login` | S |
 | 3-G | Bump feature-task `ureq` and `base64` to current majors | S |

--- a/docs/repo-audits/2026-W27.md
+++ b/docs/repo-audits/2026-W27.md
@@ -385,7 +385,7 @@ AI agents (agents/)
 | 3-A | Pagination unit tests assert post-fix correctness | M |
 | 3-B | Wrap budget-api Akahu sync card/balance loop in `prisma.$transaction` | S |
 | 3-C | Add structured logging with `trace_id` to both APIs' error middleware | M |
-| 3-D | Update `docs/specs/tasks-one-pager.md` and `docs/architecture.md` to match current behavior | S | ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD) — tasks-one-pager.md now leads with a SUPERSEDED banner pointing to `docs/systems/task-tracking.md`; `docs/architecture.md` was deleted in `6148efc`, so its portion of this task is moot.
+| 3-D | Update `docs/specs/tasks-one-pager.md` and `docs/architecture.md` to match current behavior | S | ✅ [PR #179](https://github.com/Stoffer-Industries/sindustries/pull/179) — tasks-one-pager.md now leads with a SUPERSEDED banner pointing to `docs/systems/task-tracking.md`; `docs/architecture.md` was deleted in `6148efc`, so its portion of this task is moot.
 | 3-E | Evaluate Prisma 6 migration; document decision | M |
 | 3-F | Add per-IP rate limit (`express-rate-limit`) on `/akahu/exchange` and `/session/dev-login` | S |
 | 3-G | Bump feature-task `ureq` and `base64` to current majors | S |

--- a/docs/specs/tasks-one-pager.md
+++ b/docs/specs/tasks-one-pager.md
@@ -1,5 +1,9 @@
 # Tasks App One-Pager Spec
 
+> ⚠️ **SUPERSEDED.** This V1 spec is preserved for historical reference but no longer reflects the current status flow, data model, or API surface. The actual source of truth is **`docs/systems/task-tracking.md`** (status lifecycle, data model, API contract, consumers, runbook). The status enum listed here (`todo`, `doing`, `done`) was replaced by `open → ready → doing → acceptance → done`; many other details (comments, tags, dependencies, specChecksum, taskType, assignee allowlist) have also moved on. New work should consult `docs/systems/task-tracking.md` instead.
+>
+> Original V1 spec retained below for context.
+
 > Canonical source of truth for Tasks App scope and milestones.
 > Any derived docs (handoffs, status summaries, PR notes) must reference this file and must not redefine milestones.
 


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W27.md
- **Finding:** [S] 3-D — Update `docs/specs/tasks-one-pager.md` and `docs/architecture.md` to match current behavior
- Annotates `docs/specs/tasks-one-pager.md` as superseded by `docs/systems/task-tracking.md` (the actual current spec — status lifecycle `open → ready → doing → acceptance → done`, full data model, API contract, consumers, runbook). Audit marker added on the 3-D row; the `docs/architecture.md` portion is called out as already-resolved-by-deletion (`6148efc`).

## Test plan
- [x] No logic changes — diff is purely documentation
- [x] Docs only; no application code touched; no test runs required
- [x] Audit marker references the PR number placeholder

🌱 Code garden — non-functional cleanup only