### PR TITLE
cod—audit: sindustries weekly review 2026-W28

### DIFF
--- a/docs/repo-audits/2026-W28.md
+++ b/docs/repo-audits/2026-W28.md
@@ -1,0 +1,231 @@
+# Repo Audit — sindustries — 2026-W28 (2026-07-06 → 2026-07-12)
+
+**Generated:** 2026-07-06 (Monday cron)
+**Auditor:** Rowan (Staff Engineer)
+**Target:** `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`
+**Type:** Full four-phase audit
+
+---
+
+## Executive Summary
+
+**Health grade: B-** (unchanged from W27 — two W27 fixes landed, but no movement on the two Critical `budget-api` findings, and a new Vite+React scaffold shipped without a CI job).
+
+This audit covers the work that merged after the W27 audit closed: the new `apps/mission-control` Vite+React "Pulse" shell (`bad14fb`, three tabs + 23 vitest cases), the Grafana tool-activity dashboard section (`cc4f609`), the tasks-app markdown-checkbox toggle (`b75f014`), the new website releases/system-proofs content (`1916153`), and the `spec-archive-on-done` tech-design doc (`c0e4038`). The good news: the two W27 hygiene findings — the `20260627000000` migration-prefix collision and the missing `target/` gitignore rule — are both fixed on `main` (`services/tasks-api/prisma/migrations/20260627000100_add_task_spec_checksum/`, `.gitignore:6-7`). The bad news: every Critical W27 finding still ships on `main` unchanged — `budget-api` reads `userId` from the request/URL on every route except `/me`, `AkahuConnection.accessToken` is still a plaintext `String` column (`services/budget-api/prisma/schema.prisma:42`), and `cards.ts`/`alerts.ts` still resolve records purely from URL ids without ownership lookups. The new mission-control app landed with 23 vitest tests but no CI job, hard-coded `localhost:5173` iframe embed for Tasks, and a `@types/react` ^19 pinned against `react` ^18 mismatch — all of which will bite the first time someone tries to ship or refactor the shell.
+
+**Top 3 risks:** (1) `budget-api` still ships every non-`/me` route without a session check and the `cards`/`alerts` routers still trust URL-supplied ids without ownership lookups — unchanged IDOR on transactions, balances, budgets, alert configs, and Akahu connections (W27 carry); (2) Akahu bearer tokens are still stored plaintext in `AkahuConnection.accessToken` (`services/budget-api/prisma/schema.prisma:42`), so a DB read yields live banking-aggregation access (W27 carry); (3) `apps/mission-control` shipped 23 vitest tests but no CI job — the design-system-sync job runs the sibling `@sindustries/ui` and `@sindustries/design-tokens` tests but nothing runs `npm test --workspace @sindustries/mission-control`, so shell regressions ship silently.
+
+**Top 3 opportunities:** (1) Add a `mission-control-tests` job to `.github/workflows/ci.yml` mirroring the `otel-node-tests` job — one workspace, one `npm test`, no infra, wires the existing 23 tests into merge gates; (2) Land the W26 Theme-1 `requireSession` middleware on `budget-api` and add ownership lookups on every path-parameter route (unchanged from W27); (3) Replace the hard-coded `localhost:5173` iframe URL in `apps/mission-control/src/tabs/TasksTab.jsx:12` and the hard-coded `sindustriesRepo` default in `agents/workflows/feature-task/feature-task.lobster.yaml:8` with env-driven defaults so both surfaces run outside Quinn's laptop.
+
+---
+
+## Repo Map
+
+**Purpose:** Mono-repo for Stoffer Industries product surfaces — Tasks API + React app, a budgeting product (mobile + API + shared domain), a public-facing website, a new "Pulse" shell app that hosts multiple operational surfaces behind one URL, shared UI/design-token/OTel packages, and an AI agent operations layer (bookmark pipeline, content skills, cron definitions, feature-factory workflow).
+
+**Stack:**
+- Node 22, npm workspaces (`package.json:9-13`).
+- Web apps: React 18 + Vite (`apps/tasks`, `apps/website`, `apps/mission-control` new this week).
+- Mobile app: React Native + Expo SDK 54 (`apps/budget-mobile`).
+- Services: Express 4 + Prisma 5 + PostgreSQL 16 (`services/tasks-api`, `services/budget-api`).
+- Shared packages: `@sindustries/ui` (component kit), `@sindustries/design-tokens` (token pipeline), `@sindustries/otel-node` (OTel auto-instrumentation), `@sindustries/budget-domain` (categorization + budget rules).
+- Workflows: Rust binary + Lobster pipeline + Python launcher in `agents/workflows/feature-task`.
+- Tests: Vitest everywhere; Playwright for tasks-app e2e; Python `unittest` for agent workflows; Rust `cargo test` for feature-task.
+- Local runtime: Docker Compose (Postgres) + Tilt (host-run API/app); CI on GitHub Actions with service-container Postgres.
+
+**Architecture sketch:**
+```
+React (apps/mission-control :5173)  ── iframe ──▶ React (apps/tasks :5173)   [same-port assumption; see Audit]
+  ├─ TasksTab       ── iframe embed
+  ├─ BookmarksTab   ── placeholder
+  └─ FlowMetricsTab ── fetch ──▶ Express (services/tasks-api :4001)
+
+React (apps/tasks)
+  └─ tasksApi.ts ── fetch ──▶ Express (services/tasks-api :4000/:4001)
+                                   └─ Prisma ──▶ Postgres (schema: tasks_api)
+                                   └─ OTel SDK ──▶ OTLP ──▶ Tempo/Prometheus
+
+React (apps/website) [static JSON content; Vercel deploy]
+
+Expo / RN (apps/budget-mobile) ── fetch ──▶ Express (services/budget-api :4002)
+                                                  └─ Prisma ──▶ Postgres (schema: budget_api)
+                                                  └─ fetch ──▶ Akahu OAuth + API
+                                                  └─ @sindustries/budget-domain
+
+AI agents (agents/)
+  └─ tasks-api-ops skill ── HTTP ──▶ tasks-api
+  └─ lobster bookmark pipeline ── state JSON + tasks-api
+  └─ feature-task workflow (Rust) ── HTTP ──▶ tasks-api + gh CLI for PR inspection
+```
+
+**Key directories:**
+- `apps/mission-control/` — new: Pulse shell (Vite+React), tab registry, port-based dev routing, 23 vitest cases, no CI job (audit finding H1).
+- `apps/tasks/` — Kanban + backlog task manager. `App.jsx` grew from 952 (W27) → 989 lines this week with the markdown-checkbox feature landing there instead of in a helper module.
+- `apps/website/` — Public website; JSON-file CMS. Added `Feature Factory v2`, `Task dependency UI`, `Task type filter`, and `Fluid spec drift lifecycle` release entries this week.
+- `apps/budget-mobile/` — Expo React Native app; budgeting MVP screens.
+- `services/tasks-api/` — Express API; Tasks CRUD + tags + comments + dependencies + spec checksums. Migration folder is now clean of the W27 duplicate-timestamp finding.
+- `services/tasks-api/src/routes/tasks/` — helper modules (`_constants.ts`, `_deps.ts`, `_mapper.ts`, `_pagination.ts`, `_spec.ts`, `_validation.ts`) extracted from `tasks.ts`.
+- `services/budget-api/` — Express API; session + Akahu OAuth + accounts/transactions/alerts. All W27 IDOR findings persist unchanged.
+- `packages/budget-domain/` — Pure functions: categorization, budget thresholds, merchant normalization.
+- `packages/ui/`, `packages/design-tokens/`, `packages/otel-node/` — shared libraries.
+- `infra/` — Docker Compose, Tilt, Prometheus/Grafana/Tempo. Grafana `openclaw-diagnostics` dashboard gained a "Tool Activity" section this week driven by new `gen_ai.tool.name` / `openclaw.toolName` span-metrics dimensions in `infra/otel-collector/config.yaml`.
+- `agents/workflows/feature-task/` — Rust CLI (`src/main.rs`) + Python launcher + Lobster pipeline. `run.py:20` still hard-codes `/Users/quinnstoffer/.openclaw/workspace` but now falls back if the path doesn't exist; the Lobster YAML default is still hard-coded.
+- `docs/` — Architecture, specs, system docs, audit history (`docs/repo-audits/`). New this week: `docs/specs/spec-archive-on-done-tech-design.md`.
+
+**Surprises from discovery:**
+- The new `apps/mission-control` app has 23 vitest cases (`src/App.test.jsx`, `src/flowMetrics.test.js`) but no CI job — `.github/workflows/ci.yml` runs otel-node, tasks-api, feature-task, budget-api, tasks, tasks-e2e, website, and design-system-sync jobs, but nothing invokes `npm test --workspace @sindustries/mission-control`. Regressions will not be caught by CI.
+- `apps/mission-control/package.json` pins `react ^18.3.1` but `@types/react ^19.2.14` and `@types/react-dom ^19.2.3`. The sources are `.jsx` so TS type-checks don't run today, but the mismatch will bite the first person to add a `.tsx` file or wire up `tsc --noEmit`.
+- `apps/mission-control/src/tabs/TasksTab.jsx:6-14` iframe-embeds Tasks via a hard-coded `http://localhost:5173` fallback with a port-based lookup table (`5173→5173`, `5174→5174`, etc.). There is no discussion of production deploy, no reverse-proxy story, and no `VITE_TASKS_APP_URL` env override sibling to the one that exists for the Tasks API.
+- `apps/mission-control/src/tasksApi.js:5-10` uses a port-based auto-detect for the API base URL and — when the port doesn't match — falls back to `http://localhost:4001/api/v1`. `services/tasks-api/src/server.ts:4` sets the default API port to `4000`, so the "no port match" fallback disagrees with the tasks-api default and CI setup.
+- `apps/mission-control/src/tabs/TasksTab.jsx:3-14` maps Pulse's port `5173` → tasks-app iframe URL `http://localhost:5173` (identical) — since Pulse itself runs on `5173`, this maps the shell at itself. Every entry in the map is same-port. The concept ("run each app on a different port and pick the neighbouring one") isn't the code's actual behaviour.
+- The Pulse shell falls back to the Tasks tab for any unknown path with no user-visible indication — the `App.test.jsx` "unknown path" test confirms this is intentional, but a `/no-such-tab` URL rendering the Tasks app with no signal is a surprising choice for a shell app.
+- `apps/tasks/src/App.jsx` grew from 952 → 989 lines this week (the markdown-checkbox toggle landed in the monolith rather than a helper module). No `TaskEditor.jsx` extraction happened despite the W25 audit's explicit "extract" recommendation.
+- Two W27 Critical findings and the W27 High feature-task hard-code all persist unchanged on `main`.
+- `apps/mission-control/SPEC.md:37` says "the Playwright e2e suite for Pulse is **deferred** until the shell lands in production" — deliberately skipping the e2e that the tasks app already invests heavily in (`.github/workflows/ci.yml:188+ tasks app e2e (ui + api + db)`).
+
+---
+
+## Audit Report
+
+### Architecture & design
+
+**H1 — Pulse Tasks tab embeds via iframe with a hard-coded `localhost:5173` fallback (High).** `apps/mission-control/src/tabs/TasksTab.jsx:6-18` maps `window.location.port` → `http://localhost:517X` and falls back to `http://localhost:5173` when the port doesn't match. There is no env override sibling to `VITE_TASKS_API_BASE_URL`, no discussion in `SPEC.md` of how Pulse and Tasks coexist in production, and no consideration of same-origin/cookie/frame-ancestor concerns. Consequence: Pulse cannot be deployed as a single-URL shell today without either building the tasks app into the mission-control bundle or fronting both with a reverse proxy neither exists yet.
+
+**H2 — Pulse `TasksTab` port map is same-port and its API fallback disagrees with tasks-api default (High).** Two related mistakes in the same feature:
+- `apps/mission-control/src/tabs/TasksTab.jsx:3-14` maps Pulse's Vite port to an iframe URL on the *same* port (`5173 → 5173`, `5174 → 5174`). Since Pulse itself runs on `5173`, the iframe would recursively load Pulse. The intent seems to be "iframe the tasks app on a neighbouring port," but the map doesn't encode that.
+- `apps/mission-control/src/tasksApi.js:5-10` maps `5173 → tasks-api :4000` (correct — matches `services/tasks-api/src/server.ts:4`), but the "no port match" fallback returns `http://localhost:4001/api/v1`. `services/tasks-api` doesn't run on `4001` by default; `4001` is the WIP second-instance dev port (`server.ts:8-9`). Any Pulse dev server on a non-mapped port silently talks to the wrong tasks-api.
+
+Consequence: TasksTab in a fresh dev environment either infinite-loops (same-port map) or, once fixed, hits the wrong tasks-api port. The mistake reflects a port model that isn't documented anywhere in the repo — either flatten the map to "Pulse always talks to `4000` and iframes `<VITE_TASKS_APP_URL>`" or write down the multi-instance port scheme in `apps/mission-control/README.md`.
+
+**M1 — Pulse shell falls back to Tasks for any unknown path silently (Medium).** `apps/mission-control/src/pulseTabs.js:37-40` returns `getDefaultTab()` for any path not in the registry, and `App.jsx` renders it without a "no route" banner or `Location:` change. The behavior is asserted in `App.test.jsx:23-27` so this is by design, but the design silently swallows typos like `/task` (missing "s") and links from external systems ("/tasksummary"). A `NotFoundTab` component in the registry would keep the pattern the shell advertises ("adding a tab needs only a route + registry entry") while surfacing the mistake to the user.
+
+**M2 — `apps/tasks/src/App.jsx` grew again — 952 → 989 lines this week (Medium, W25 carry).** The `feat(tasks): toggle markdown checkboxes in descriptions` commit (`b75f014`) added state, handlers, and DOM listeners to the top-level `App` component rather than to the sibling `TaskEditor` or `MarkdownContent` files. Consequence: the largest UI file in the repo continues to grow with every feature; extracting `TaskEditor` state remains the highest-leverage refactor for the tasks app.
+
+**M3 — `services/tasks-api/src/routes/tasks.ts` in-memory sort still fights Prisma cursor pagination (Medium, W26 carry).** Lines 151, 163-189: Prisma `findMany` orders by `[createdAt desc, id desc]` with `take: limit + 1`, then the code re-sorts in memory by `priority`/`dueAt`/other. The `cursor` is a `createdAt/id` pair, so if the caller passes `sort=priority` and pages with the returned `nextCursor`, the second page is drawn from a `createdAt`-ordered slice and re-sorted by `priority` per-page — so priority ordering is only guaranteed within a page, not across the result set. Unchanged from W26.
+
+### Code quality
+
+**L1 — Pulse `useLocation` dispatches its own `popstate` after `pushState` (Low).** `apps/mission-control/src/useLocation.js:19-21`: `navigate()` calls `window.history.pushState(...)` then `window.dispatchEvent(new PopStateEvent('popstate'))`. This works but conflates two events — real browser back/forward and programmatic navigation — and any listener that treats `popstate` as "user pressed back" will now fire on programmatic navigation too. The idiomatic fix is a custom `pulse:navigate` event or a shared subscription set in the hook module; not urgent while Pulse is the only listener but likely to bite a future third-party subscriber.
+
+**L2 — Pulse `flowMetrics.js` per-tab window `new Date()` recomputed inside `useMemo(fn, [])` (Low).** `apps/mission-control/src/tabs/FlowMetricsTab.jsx:22`: `const now = useMemo(() => new Date(), []);` freezes a single timestamp for the tab's whole lifetime. Users who leave the shell open overnight see stale "last 30 days" windows without a refresh signal. Non-critical while the shell is a demo; worth revisiting when the dashboard becomes daily-driver.
+
+### Security
+
+**C1 — `budget-api` still ships every non-`/me` route without a session check (Critical, W25/W26/W27 carry).** `services/budget-api/src/routes/cards.ts:9`, `alerts.ts:9,19`, `transactions.ts`, `categories.ts`, `akahu.ts` all read `userId` from `req.query`, `req.body`, or URL path parameters and immediately operate on the associated records. No `requireSession` middleware exists. Any client that guesses or brute-forces `userId` values reads or mutates arbitrary users' data. This has now been Critical for three straight audits.
+
+**C2 — Akahu bearer tokens are still stored plaintext in Postgres (Critical, W25/W26/W27 carry).** `services/budget-api/prisma/schema.prisma:42`: `accessToken String`. There is no `@db.Text @encrypted` or KMS-envelope pattern; a compromise of the Postgres role, a leaked backup, or a rogue query gets live Akahu banking-aggregation credentials. Unchanged for three audits.
+
+**C3 — `cards.ts` and `alerts.ts` still trust URL-supplied `:cardId` / `:alertId` without ownership lookup (Critical, W27 carry).** `services/budget-api/src/routes/cards.ts:95-117` (`POST /cards/:cardId/budget`) resolves `card` by id only and uses `card.userId` — anyone hitting the URL can set a budget on any card. `routes/cards.ts:119-147` (`GET /cards/:cardId/spend-summary`) reads transactions with no ownership check. `routes/alerts.ts:39-45` (`DELETE /alerts/:alertId`) deletes purely from path id. `routes/alerts.ts:47-104` (`GET/POST/DELETE /cards/:cardId/alert-config`) same pattern. Unchanged from W27.
+
+**M4 — Pulse iframe embed has no `sandbox` or `frame-ancestors` policy (Medium).** `apps/mission-control/src/tabs/TasksTab.jsx:24-31`: the `<iframe>` is emitted with no `sandbox` attribute, no `referrerpolicy`, and Pulse has no CSP header story. Once tasks-api gains authentication (a stated goal in `docs/systems/`), the tasks app inside Pulse will share the parent origin's cookies. Even in the internal-only case, a `sandbox="allow-scripts allow-same-origin allow-forms"` narrows the surface without breaking Tasks. Judgment: Medium — no immediate exploit path today but the shell is the wrong place to defer this decision.
+
+### Testing
+
+**H3 — mission-control has 23 vitest cases but no CI job (High).** `.github/workflows/ci.yml` runs jobs for `otel-node-tests`, `tasks-api-tests`, `feature-task-workflow-tests`, `budget-api-tests`, `tasks app tests`, `tasks app e2e`, `website app tests`, and `design-system-sync`. There is no `mission-control-tests` job. `apps/mission-control/src/App.test.jsx` (4 cases) and `apps/mission-control/src/flowMetrics.test.js` (~19 cases) exist and pass locally per the merge commit's test plan, but nothing runs them on PR. Adding a job that mirrors `otel-node-tests` — `npm ci` + `npm test --workspace @sindustries/mission-control` — is a single CI-file edit and closes the gap.
+
+**M5 — Pulse SPEC.md defers Playwright e2e until "after production" (Medium).** `apps/mission-control/SPEC.md:37-45` says the e2e suite is deferred pending viewport styling. The tasks app already has a full Playwright setup with a Postgres service container (`.github/workflows/ci.yml:188-263`); reusing that pattern for Pulse's tab-navigation and iframe-embed contracts is cheap and would catch the H1/H2 dev-environment breakages before merge.
+
+### Performance
+
+**L3 — Pulse `fetchAllTasks` requests up to 10,000 tasks with no pagination follow-through (Low).** `apps/mission-control/src/tasksApi.js:39-53` fetches `?limit=10000&includeArchived=true&sort=priority` and returns whatever comes back; the comment acknowledges "the API may not support cursors today" but the tasks-api DOES support cursors (`services/tasks-api/src/routes/tasks/_pagination.ts`). At current task volumes (well under 1000) this is fine; at 5,000+ it becomes a single fat request and the metrics render blocks on it. Low today, worth revisiting when the corpus grows.
+
+### Dependencies
+
+**M6 — mission-control `@types/react` v19 pinned against `react` v18 (Medium).** `apps/mission-control/package.json`: `"react": "^18.3.1"`, `"@types/react": "^19.2.14"`. React 19 types are not a strict superset of React 18 types and can produce silent inference regressions the moment a `.tsx` file lands in the workspace. The correct pin is `@types/react: ^18.x` matching the runtime. Same mismatch on `react-dom` / `@types/react-dom`.
+
+### DevEx & operations
+
+**H4 — `feature-task.lobster.yaml` still hard-codes Quinn's repo path (High, W27 carry).** `agents/workflows/feature-task/feature-task.lobster.yaml:8`: `sindustriesRepo: default: /Users/quinnstoffer/workspaces/rowan/sindustries`. The W27 audit called this out and it remains unchanged. `run.py` at least added an "if not exists" fallback for the workspace root this week; the Lobster YAML still has no fallback for the repo path. Any invocation outside Quinn's laptop needs `--sindustriesRepo=<path>` explicitly.
+
+### Documentation
+
+**Healthy.** The new `docs/specs/spec-archive-on-done-tech-design.md` is precise about scope, `.openclaw` boundaries, and acceptance criteria. `apps/mission-control/SPEC.md` follows the docs/CONVENTIONS.md pattern established for `apps/*` and is unusually clear about non-goals (mobile responsive) and deferrals (e2e). Website release notes (`apps/website/src/content/releases.json`) landed with the shipped features.
+
+### Strengths
+
+- The two smallest W27 findings (migration prefix collision, `target/` gitignore) were fixed the correct way — a real timestamp change (`20260627000100`) rather than a rename, and a repo-level ignore rule rather than local `.git/info/exclude`.
+- `agents/workflows/feature-task/run.py:20` gained an "if not path exists, fall back to `REPO.parents[1]`" branch this week — partial fix on the W27 hard-coded path finding, and the right shape (env-independent fallback).
+- The `feat(observability): break down tool activity by tool name in Grafana` change is a well-scoped OTel dashboard update — new `gen_ai.tool.name` and `openclaw.toolName` dimensions in `infra/otel-collector/config.yaml`, two new panels in `openclaw-diagnostics.json`, and an explicit `[openclaw-needed]` note about which cross-service join is out of scope.
+- The `_deps.ts` / `_pagination.ts` / `_spec.ts` / `_mapper.ts` / `_validation.ts` split in `services/tasks-api/src/routes/tasks/` continues to keep `tasks.ts` at a workable size (486 lines) despite the surface growth.
+- `apps/mission-control/src/flowMetrics.js` is exactly the right shape — pure functions, exported for tests, no React entanglement. If the shell picks up more surfaces, this file is the model.
+- `docs/repo-audits/2026-W27.md` was landed to `main` and the audit-PR cadence held. Small process wins are still process wins.
+
+---
+
+## Improvement Strategy
+
+Five themes explain every finding this week.
+
+**Theme 1 — `budget-api` still ships without authentication or ownership checks.** The `requireSession` middleware, the router-level ownership predicates, and the schema-level encryption of Akahu tokens are three motions of the same fix — build the security layer that the routers assume exists. This has now been the top theme for four consecutive audits. Target state: every mutating route asserts the session's user matches the record's owner before touching the DB; Akahu tokens are stored envelope-encrypted with the key held outside Postgres. Principle: never trust a client-supplied identity in a service that holds someone else's money.
+
+**Theme 2 — mission-control is a scaffold that hasn't earned merge-gate coverage.** 23 tests, no CI job, wrong port defaults, wrong dependency pins. The pattern to break is landing a new workspace without the same CI story as its siblings. Target state: `mission-control-tests` job in `ci.yml`, `@types/react` corrected to v18, port map corrected to `services/tasks-api` docs, iframe URL made env-configurable. Principle: a new workspace becomes real when CI runs its tests on PR — before that, it's a demo.
+
+**Theme 3 — the tasks-app monolith keeps growing.** `App.jsx` is 989 lines and the markdown-checkbox feature landed inside it this week when the sibling `TaskEditor.jsx` was the natural home. Target state: `TaskEditor` owns its own state + reducer, `App` becomes a routing/layout shell. Principle: features land where their state naturally lives, not where the closest existing state happens to be.
+
+**Theme 4 — hard-coded paths and dev-only defaults keep escaping into repo config.** `feature-task.lobster.yaml`, `TasksTab.jsx`, `tasksApi.js` — three different files this quarter shipped absolute paths or laptop-shaped port assumptions. Target state: every default is either environment-derived or explicitly `null` with a clear error; PR-level linting flags absolute `~/` or `/Users/` strings. Principle: config that lives in the repo runs in every environment; anything Quinn-shaped is a bug.
+
+**Theme 5 — the tasks-api pagination + in-memory sort mismatch remains a latent correctness bug.** Two audits have flagged it, no fix has landed. Target state: sorts are pushed into the Prisma query, cursors encode the sort field, cross-page ordering is guaranteed. Principle: cursor pagination that "mostly works" is a landmine — either the API contract commits to stable ordering or drops it.
+
+**Explicit non-goals this week.**
+- Not recommending any change to `agents/workflows/feature-task/src/main.rs` (1600+ lines); the file's complexity is inherent to the workflow it drives and each cell has passing tests. Leave alone.
+- Not recommending a rewrite of Pulse's iframe embed pattern into a route-level React mount. The team explicitly chose iframe to avoid duplicating tasks-app internals; that's the right call while both apps stay Vite dev servers.
+- Not recommending upgrades of Vite/React/Node this week — the eco-mismatch inside mission-control is a bigger risk than any pin drift.
+
+**"Done" signals.**
+- Theme 1: `budget-api` routes redirect anonymous requests to 401 in the integration test suite; `AkahuConnection.accessToken` column is a `Bytes` type with a plaintext-forbidding check in tests.
+- Theme 2: `mission-control-tests` job appears in the CI check list for a random recent PR; `@types/react` pin is `^18.x`; Pulse dev port map matches `services/tasks-api/README.md`.
+- Theme 3: `apps/tasks/src/App.jsx` drops below 700 lines; `TaskEditor.jsx` owns markdown state.
+- Theme 4: `grep -rn "/Users/quinnstoffer" apps services agents packages` returns nothing.
+- Theme 5: `?sort=priority&cursor=...` requests return a globally-sorted result set in the DB integration test.
+
+---
+
+## Task Plan
+
+### Quick wins (S effort, high impact) — flagged separately
+
+- **Q1 — Add `mission-control-tests` CI job.** Mirror `otel-node-tests` in `.github/workflows/ci.yml`. Adds a real merge gate for the 23 existing tests. S / low risk. (Theme 2, ties H3.)
+- **Q2 — Fix mission-control `@types/react`/`@types/react-dom` pins.** Downgrade to `^18.x` matching the runtime. S / low risk. (Theme 2, ties M6.)
+- **Q3 — Fix Pulse `TasksTab` iframe port map and `tasksApi.js` fallback.** The iframe map at `apps/mission-control/src/tabs/TasksTab.jsx:3-14` maps ports to themselves (same-port iframe); replace with a `VITE_TASKS_APP_URL` env with a documented default. The `tasksApi.js` fallback should point at `4000` (the tasks-api default), not `4001`. S / low risk. (Theme 2/4, ties H1/H2.)
+
+### Milestone 0 — Safety net
+
+- **M0.1 — Add an ADR (or `docs/systems/pulse-shell.md`) documenting the iframe embed choice.** Locks the decision in prose so H1 and M4 can be revisited against a written baseline instead of tribal knowledge. Files: new `docs/systems/pulse-shell.md`. Acceptance: doc exists, links from `apps/mission-control/SPEC.md`. S / low risk. (Theme 2.)
+- **M0.2 — Add a repo-level lint rule that fails on absolute `~/` or `/Users/` strings in `apps/`, `services/`, `packages/`, `agents/workflows/`.** A ripgrep-based `scripts/check-no-absolute-paths.mjs` invoked in CI. Prevents Theme 4 regressions before they enter the repo. Files: new script + one CI step. Acceptance: script rejects a synthesized offender; passes today post-fixes. S / low risk. (Theme 4.)
+
+### Milestone 1 — Critical fixes
+
+- **M1.1 — Add `requireSession` middleware to `budget-api`.** Mount before every non-`/session/*` router; assert `req.session.userId` matches any body/query/path `userId`; return 401 otherwise. Files: `services/budget-api/src/middleware/requireSession.ts`, `services/budget-api/src/server.ts`. Acceptance: integration test asserts every mutating route rejects anonymous and cross-user requests. L / medium risk (touches every route). (Theme 1, ties C1.)
+
+  *Implementation sketch.* Introduce `middleware/requireSession.ts` that reads the session cookie, looks up `Session` by `tokenHash`, and attaches `req.userId`. Convert every `userId` read from `req.query`/`req.body` to `req.userId`. For path-param routes (`/cards/:cardId/*`, `/alerts/:alertId`), fetch the record first, compare `record.userId` to `req.userId`, and return 403 if mismatched. Add `services/budget-api/tests/authz.test.ts` that exercises the matrix.
+
+- **M1.2 — Encrypt `AkahuConnection.accessToken` at rest.** Envelope-encrypt with a KMS key or a Node `crypto.createCipheriv` + env-held key; migrate existing rows in a Prisma migration. Files: `services/budget-api/prisma/schema.prisma`, new migration, `services/budget-api/src/lib/tokenCrypto.ts`. Acceptance: `SELECT accessToken FROM AkahuConnection` returns a ciphertext blob; a test asserts the plaintext never reappears in logs or responses. L / high risk (data migration + Akahu round-trip). (Theme 1, ties C2.)
+
+- **M1.3 — Add ownership lookups on every path-parameter route in `cards.ts` and `alerts.ts`.** Bundle with M1.1's middleware — the middleware attaches `req.userId`, each router loads the record, checks ownership, then acts. Files: `services/budget-api/src/routes/cards.ts`, `alerts.ts`. Acceptance: same integration test as M1.1. M / medium risk. (Theme 1, ties C3.)
+
+### Milestone 2 — High-leverage improvements
+
+- **M2.1 — Wire mission-control into CI (see Q1).** Done as a quick win. (Theme 2, ties H3.)
+- **M2.2 — Move Pulse `TasksTab` iframe URL behind a `VITE_TASKS_APP_URL` env with a documented default.** Files: `apps/mission-control/src/tabs/TasksTab.jsx`, `apps/mission-control/SPEC.md`. Acceptance: no absolute `localhost` string in the source; `VITE_TASKS_APP_URL` documented in the app README. S / low risk. (Theme 2/4, ties H1.)
+
+  *Implementation sketch.* Replace `TASKS_APP_HOSTS` with a single `import.meta.env.VITE_TASKS_APP_URL ?? 'http://localhost:5173'` and add a `sandbox="allow-scripts allow-same-origin"` while touching the file. Update `apps/mission-control/SPEC.md` Data Sources to name the env var.
+
+- **M2.3 — Replace `feature-task.lobster.yaml` `sindustriesRepo` default with `${SINDUSTRIES_REPO}` and require the invoker to set it.** Files: `agents/workflows/feature-task/feature-task.lobster.yaml`. Acceptance: run.py passes `SINDUSTRIES_REPO` derived from `Path(__file__).parents[3]`; CI job sets the env before invocation. S / low risk. (Theme 4, ties H4.)
+- **M2.4 — Extract `TaskEditor` state from `App.jsx`.** Move the description/tag/toggle state and handlers into `TaskEditor.jsx`. Files: `apps/tasks/src/App.jsx`, `apps/tasks/src/components/TaskEditor.jsx`. Acceptance: `App.jsx` drops below 700 lines; existing vitest and Playwright suites pass. L / medium risk. (Theme 3, ties M2.)
+
+### Milestone 3 — Quality & polish
+
+- **M3.1 — Push tasks-api sort into the Prisma query and encode sort field in cursor.** Files: `services/tasks-api/src/routes/tasks.ts`, `services/tasks-api/src/routes/tasks/_pagination.ts`. Acceptance: cross-page priority ordering asserted in `db.test.ts`. L / medium risk. (Theme 5, ties M3.)
+- **M3.2 — Add a `NotFoundTab` component and register it as the fallback in `pulseTabs.js`.** Files: `apps/mission-control/src/tabs/NotFoundTab.jsx`, `apps/mission-control/src/pulseTabs.js`. Acceptance: `/no-such-tab` renders "no such tab" with a Return to Tasks link. S / low risk. (Theme 2, ties M1.)
+- **M3.3 — Emit a custom `pulse:navigate` event from `useLocation.navigate` instead of a synthetic `popstate`.** Files: `apps/mission-control/src/useLocation.js`. Acceptance: `popstate` listeners no longer fire on programmatic navigation. S / low risk. (Theme 2, ties L1.)
+- **M3.4 — Refresh `FlowMetricsTab` `now` on tab focus or via `useEffect` interval.** Files: `apps/mission-control/src/tabs/FlowMetricsTab.jsx`. Acceptance: leaving the tab open overnight refreshes the 30-day window on the next focus. S / low risk. (Theme 2, ties L2.)
+
+---
+
+## Open Questions
+
+1. **Deployment story for Pulse.** Does Pulse ship as (a) a Vite build fronted by a reverse proxy that also serves the tasks app, (b) a Vite build that iframes the deployed tasks-app URL, or (c) something else? H1 and M4 hinge on this and M0.1 wants a written answer.
+2. **Akahu token encryption target.** Envelope-encrypt with a locally-held key derived from `AKAHU_TOKEN_KEY` env, or push to a KMS (AWS/GCP/Vercel envelope)? M1.2's shape depends on the answer; local-key is faster to ship, KMS is the durable answer.
+3. **Ownership of budget-api authorization.** Should the middleware live in `services/budget-api/src/middleware/` or in a shared `packages/express-auth` for future services (tasks-api will need the same shape when it grows a user model)? Prefer the shared package if we're within a week of tasks-api needing sessions.
+4. **Tasks-app `App.jsx` refactor sequencing.** Is the M2.4 `TaskEditor` extraction blocked on the pending "toggle checkboxes" spec follow-ups, or can it land immediately after the drift-lifecycle work stabilizes?
+5. **Mission-control routing scope.** Does Pulse need real client-side routing (React Router, TanStack) once a fourth tab lands, or is the current registry pattern enough for the planned tabs? The answer changes M3.2's shape and the deferral of a Playwright suite (M5).


### PR DESCRIPTION
## Executive Summary

**Health grade: B-** (unchanged from W27 — two W27 fixes landed, but no movement on the two Critical `budget-api` findings, and a new Vite+React scaffold shipped without a CI job).

This audit covers the work that merged after the W27 audit closed: the new `apps/mission-control` Vite+React "Pulse" shell (`bad14fb`, three tabs + 23 vitest cases), the Grafana tool-activity dashboard section (`cc4f609`), the tasks-app markdown-checkbox toggle (`b75f014`), the new website releases/system-proofs content (`1916153`), and the `spec-archive-on-done` tech-design doc (`c0e4038`). The good news: the two W27 hygiene findings — the `20260627000000` migration-prefix collision and the missing `target/` gitignore rule — are both fixed on `main` (`services/tasks-api/prisma/migrations/20260627000100_add_task_spec_checksum/`, `.gitignore:6-7`). The bad news: every Critical W27 finding still ships on `main` unchanged — `budget-api` reads `userId` from the request/URL on every route except `/me`, `AkahuConnection.accessToken` is still a plaintext `String` column (`services/budget-api/prisma/schema.prisma:42`), and `cards.ts`/`alerts.ts` still resolve records purely from URL ids without ownership lookups. The new mission-control app landed with 23 vitest tests but no CI job, hard-coded `localhost:5173` iframe embed for Tasks, and a `@types/react` ^19 pinned against `react` ^18 mismatch — all of which will bite the first time someone tries to ship or refactor the shell.

**Top 3 risks:** (1) `budget-api` still ships every non-`/me` route without a session check and the `cards`/`alerts` routers still trust URL-supplied ids without ownership lookups — unchanged IDOR on transactions, balances, budgets, alert configs, and Akahu connections (W27 carry); (2) Akahu bearer tokens are still stored plaintext in `AkahuConnection.accessToken` (`services/budget-api/prisma/schema.prisma:42`), so a DB read yields live banking-aggregation access (W27 carry); (3) `apps/mission-control` shipped 23 vitest tests but no CI job — the design-system-sync job runs the sibling `@sindustries/ui` and `@sindustries/design-tokens` tests but nothing runs `npm test --workspace @sindustries/mission-control`, so shell regressions ship silently.

**Top 3 opportunities:** (1) Add a `mission-control-tests` job to `.github/workflows/ci.yml` mirroring the `otel-node-tests` job — one workspace, one `npm test`, no infra, wires the existing 23 tests into merge gates; (2) Land the W26 Theme-1 `requireSession` middleware on `budget-api` and add ownership lookups on every path-parameter route (unchanged from W27); (3) Replace the hard-coded `localhost:5173` iframe URL in `apps/mission-control/src/tabs/TasksTab.jsx:12` and the hard-coded `sindustriesRepo` default in `agents/workflows/feature-task/feature-task.lobster.yaml:8` with env-driven defaults so both surfaces run outside Quinn's laptop.

---

Full audit: [`docs/repo-audits/2026-W28.md`](docs/repo-audits/2026-W28.md)

🤖 Generated with Claude Code