### PR TITLE
fix(lobster): scope task AC vs PR check by ### Task <id> subsection

### DIFF
--- a/agents/skills/dev/pr-open/SKILL.md
+++ b/agents/skills/dev/pr-open/SKILL.md
@@ -74,6 +74,20 @@ Example:
 
 PRs without the required annotations are blocked from acceptance with a clear comment listing the ACs that need evidence.
 
+**Multi-task combined deliveries:** when one PR covers two or more feature tasks (e.g. a combined delivery), use one `## Acceptance Criteria` section containing a `### Task <task-id> — <short description>` subsection per task. The lobster scopes the AC vs task comparison by `### Task <id>` heading, so AC labels (`AC1`, `AC2`, ...) in different subsections do not collide. Each task's ACs still need their own evidence annotation.
+
+```markdown
+## Acceptance Criteria
+### Task 513b3b02 — Pulse shell scaffold
+- [x] AC1: Pulse loads at a single URL and renders a persistent tab bar. (testID: 4)
+- [x] AC2: Tab bar shows Tasks, Bookmarks, and Flow metrics tabs. (not tested: design tokens; visual review only)
+### Task e2e647b1 — Flow metrics dashboard
+- [x] AC1: Dashboard shows cycle time (median and p90) for tasks completed. (testID: 5)
+- [x] AC2: Dashboard is reachable from the Flow metrics tab. (file: apps/mission-control/src/dashboard.test.jsx: flow metrics reachable)
+```
+
+The lobster walks the AC section line-by-line and tracks the current `### Task <id>` heading. ACs in a sibling task's subsection are not considered for the current task's text/evidence comparison. PR bodies without any `### Task <id>` heading fall back to the pre-#183 behavior (the whole AC section is implicitly one subsection).
+
 **QA bounce:** after merge, the lobster compares the latest merged PR body against the task description ACs. If any AC is missing, unchecked, or has altered text, the task bounces back to `doing` and a `[feature-task-progress-checklist]` comment is posted explaining what the next PR must address.
 
 ---

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -328,7 +328,7 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
     }
     if let Some(url) = &latest_pr_url {
         if let Ok(body) = pr_body(url) {
-            for ac_failure in task_ac_vs_open_pr_failures(&task_acs, &body, url) {
+            for ac_failure in task_ac_vs_open_pr_failures(&env.task.id, &task_acs, &body, url) {
                 failures.push(format!("PR {url} — {ac_failure}"));
             }
         }
@@ -440,7 +440,15 @@ fn task_description_acs(description: &str) -> Vec<(String, String)> {
 /// Compare task description ACs against an open PR body at the doing → acceptance gate.
 ///
 /// Fails if any task AC is missing from the PR, has altered text, or lacks a valid evidence annotation.
+///
+/// When the PR body's AC section contains one or more `### Task <id>` subsections,
+/// only ACs in the subsection matching `task_id` are considered for this task's check.
+/// Sibling subsections (other tasks in the same combined delivery) are not consulted,
+/// so AC labels (`AC1`, `AC2`, ...) from different tasks don't collide in the
+/// underlying HashMap. PR bodies without any `### Task <id>` heading fall back to
+/// consuming the whole AC section — preserving the pre-#183 single-task behavior.
 fn task_ac_vs_open_pr_failures(
+    task_id: &str,
     task_acs: &[(String, String)],
     body: &str,
     pr_url: &str,
@@ -449,14 +457,33 @@ fn task_ac_vs_open_pr_failures(
         return vec![];
     }
     let section = extract_ac_section(body);
-    let re = Regex::new(r"(?m)^\s*-\s*\[([xX ])\]\s+(AC\d+):\s*(.+)$").unwrap();
+    // H3-or-deeper `Task <id>` subheadings carve the AC section into per-task
+    // subsections. The first whitespace-delimited token after `Task` is the id.
+    let subsection_re =
+        Regex::new(r"(?m)^\s*#{3,}\s+Task\s+(\S+)").unwrap();
+    let ac_re = Regex::new(r"(?m)^\s*-\s*\[([xX ])\]\s+(AC\d+):\s*(.+)$").unwrap();
     let mut pr_ac_map: HashMap<String, (String, Option<Evidence>)> = HashMap::new();
-    for cap in re.captures_iter(section) {
-        let label = cap[2].to_string();
-        let raw = cap[3].trim().to_string();
-        let evidence = parse_evidence(&raw);
-        let text = strip_trailing_evidence(&raw);
-        pr_ac_map.insert(label, (text, evidence));
+    let mut matching_section = true; // assume single-section (no `### Task`) until proven otherwise
+    let mut saw_any_subsection = false;
+    for line in section.lines() {
+        if let Some(cap) = subsection_re.captures(line) {
+            matching_section = cap[1] == *task_id;
+            saw_any_subsection = true;
+            continue;
+        }
+        if saw_any_subsection && !matching_section {
+            // AC line in a sibling task's subsection — ignore for this caller's
+            // HashMap. Without scoping, two tasks' ACs would collide on labels
+            // and the second subsection's text would silently overwrite the first.
+            continue;
+        }
+        if let Some(cap) = ac_re.captures(line) {
+            let label = cap[2].to_string();
+            let raw = cap[3].trim().to_string();
+            let evidence = parse_evidence(&raw);
+            let text = strip_trailing_evidence(&raw);
+            pr_ac_map.insert(label, (text, evidence));
+        }
     }
     let mut failures = Vec::new();
     for (label, task_text) in task_acs {
@@ -3541,8 +3568,12 @@ Lead-in.
         let body = "## Acceptance Criteria\n\
             - [x] AC1: Do the thing (testID: test_do_thing)\n\
             - [x] AC2: Verify the result (not tested: manual verification)\n";
-        let failures =
-            task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
+        let failures = task_ac_vs_open_pr_failures(
+            "alpha",
+            &task_acs,
+            body,
+            "https://github.com/org/repo/pull/1",
+        );
         assert!(
             failures.is_empty(),
             "expected no failures, got: {failures:?}"
@@ -3554,8 +3585,12 @@ Lead-in.
         let task_acs = vec![("AC1".to_string(), "Do the thing".to_string())];
         let body = "## Acceptance Criteria\n\
             - [x] AC1: Do the other thing (testID: test_do_thing)\n";
-        let failures =
-            task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
+        let failures = task_ac_vs_open_pr_failures(
+            "alpha",
+            &task_acs,
+            body,
+            "https://github.com/org/repo/pull/1",
+        );
         assert_eq!(failures.len(), 1);
         assert!(failures[0].contains("text altered"), "got: {}", failures[0]);
     }
@@ -3568,8 +3603,12 @@ Lead-in.
         ];
         let body = "## Acceptance Criteria\n\
             - [x] AC1: Do the thing (testID: test_do_thing)\n";
-        let failures =
-            task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
+        let failures = task_ac_vs_open_pr_failures(
+            "alpha",
+            &task_acs,
+            body,
+            "https://github.com/org/repo/pull/1",
+        );
         assert_eq!(failures.len(), 1);
         assert!(
             failures[0].contains("AC2") && failures[0].contains("missing"),
@@ -3583,13 +3622,198 @@ Lead-in.
         let task_acs = vec![("AC1".to_string(), "Do the thing".to_string())];
         let body = "## Acceptance Criteria\n\
             - [x] AC1: Do the thing\n";
-        let failures =
-            task_ac_vs_open_pr_failures(&task_acs, body, "https://github.com/org/repo/pull/1");
+        let failures = task_ac_vs_open_pr_failures(
+            "alpha",
+            &task_acs,
+            body,
+            "https://github.com/org/repo/pull/1",
+        );
         assert_eq!(failures.len(), 1);
         assert!(
             failures[0].contains("missing evidence"),
             "got: {}",
             failures[0]
+        );
+    }
+
+    #[test]
+    fn task_ac_vs_open_pr_handles_multi_task_body() {
+        // Regression for the lobster bug: when a PR body's AC section contains
+        // two `### Task <id>` subsections, each task's HashMap should only see
+        // its own subsection. Without scoping, AC labels collide and the
+        // second subsection's text silently overwrites the first.
+        let body = "## Acceptance Criteria\n\
+            ### Task alpha — Pulse shell scaffold\n\
+            - [x] AC1: Pulse loads at a single URL and renders a persistent tab bar (testID: pulse-shells-tab-bar)\n\
+            - [x] AC2: Tab bar shows Tasks, Bookmarks, and Flow metrics tabs (testID: pulse-shells-tabs-render)\n\
+            ### Task beta — Flow metrics dashboard\n\
+            - [x] AC1: Dashboard shows cycle time (median and p90) for tasks completed (testID: flow-metrics-cycle-time)\n\
+            - [x] AC2: Dashboard is reachable from the Flow metrics tab (testID: flow-metrics-reachable)\n";
+        let alpha_acs = vec![
+            (
+                "AC1".to_string(),
+                "Pulse loads at a single URL and renders a persistent tab bar".to_string(),
+            ),
+            (
+                "AC2".to_string(),
+                "Tab bar shows Tasks, Bookmarks, and Flow metrics tabs".to_string(),
+            ),
+        ];
+        let beta_acs = vec![
+            (
+                "AC1".to_string(),
+                "Dashboard shows cycle time (median and p90) for tasks completed".to_string(),
+            ),
+            (
+                "AC2".to_string(),
+                "Dashboard is reachable from the Flow metrics tab".to_string(),
+            ),
+        ];
+        let alpha_failures = task_ac_vs_open_pr_failures(
+            "alpha",
+            &alpha_acs,
+            body,
+            "https://github.com/org/repo/pull/185",
+        );
+        assert!(
+            alpha_failures.is_empty(),
+            "expected alpha to pass, got: {alpha_failures:?}"
+        );
+        let beta_failures = task_ac_vs_open_pr_failures(
+            "beta",
+            &beta_acs,
+            body,
+            "https://github.com/org/repo/pull/185",
+        );
+        assert!(
+            beta_failures.is_empty(),
+            "expected beta to pass, got: {beta_failures:?}"
+        );
+    }
+
+    #[test]
+    fn task_ac_vs_open_pr_falls_back_when_no_subsection_heading() {
+        // Single-task PR body — no `### Task <id>` headings anywhere. The whole
+        // AC section is implicitly one subsection for this task, matching the
+        // pre-#183 behavior that single-task deliveries relied on.
+        let task_acs = vec![
+            ("AC1".to_string(), "Do the thing".to_string()),
+            ("AC2".to_string(), "Verify the result".to_string()),
+        ];
+        let body = "## Acceptance Criteria\n\
+            - [x] AC1: Do the thing (testID: test_do_thing)\n\
+            - [x] AC2: Verify the result (not tested: manual verification)\n";
+        let failures = task_ac_vs_open_pr_failures(
+            "anything",
+            &task_acs,
+            body,
+            "https://github.com/org/repo/pull/1",
+        );
+        assert!(
+            failures.is_empty(),
+            "expected no failures, got: {failures:?}"
+        );
+    }
+
+    #[test]
+    fn task_ac_vs_open_pr_reports_missing_when_no_matching_subsection() {
+        // PR body has a `### Task <other_id>` subsection but no subsection for
+        // this task's id. The function should report every task AC as missing
+        // rather than silently passing or borrowing from the sibling subsection.
+        let task_acs = vec![
+            ("AC1".to_string(), "Do the thing".to_string()),
+            ("AC2".to_string(), "Do the other thing".to_string()),
+        ];
+        let body = "## Acceptance Criteria\n\
+            ### Task other — something else\n\
+            - [x] AC1: Other-task text (testID: test_other)\n\
+            - [x] AC2: Other-task second thing (testID: test_other_two)\n";
+        let failures = task_ac_vs_open_pr_failures(
+            "alpha",
+            &task_acs,
+            body,
+            "https://github.com/org/repo/pull/1",
+        );
+        assert_eq!(failures.len(), 2, "got: {failures:?}");
+        assert!(
+            failures.iter().all(|f| f.contains("missing")),
+            "expected missing-AC failures, got: {failures:?}"
+        );
+        assert!(
+            failures.iter().any(|f| f.contains("AC1")),
+            "expected AC1 in failures, got: {failures:?}"
+        );
+        assert!(
+            failures.iter().any(|f| f.contains("AC2")),
+            "expected AC2 in failures, got: {failures:?}"
+        );
+    }
+
+    #[test]
+    fn task_ac_vs_open_pr_isolates_text_per_subsection() {
+        // Same `AC1` label appears in both subsections with intentionally
+        // different texts. Calling for task `alpha` should match alpha's text,
+        // calling for task `beta` should match beta's — proving there's no
+        // collision leaking across subsections.
+        let body = "## Acceptance Criteria\n\
+            ### Task alpha\n\
+            - [x] AC1: Alpha-specific AC1 text (testID: alpha_ac1)\n\
+            ### Task beta\n\
+            - [x] AC1: Beta-specific AC1 text (testID: beta_ac1)\n";
+        let alpha_acs = vec![(
+            "AC1".to_string(),
+            "Alpha-specific AC1 text".to_string(),
+        )];
+        let beta_acs = vec![(
+            "AC1".to_string(),
+            "Beta-specific AC1 text".to_string(),
+        )];
+
+        let alpha_failures = task_ac_vs_open_pr_failures(
+            "alpha",
+            &alpha_acs,
+            body,
+            "https://github.com/org/repo/pull/1",
+        );
+        assert!(
+            alpha_failures.is_empty(),
+            "expected alpha to match its own AC1, got: {alpha_failures:?}"
+        );
+
+        let beta_failures = task_ac_vs_open_pr_failures(
+            "beta",
+            &beta_acs,
+            body,
+            "https://github.com/org/repo/pull/1",
+        );
+        assert!(
+            beta_failures.is_empty(),
+            "expected beta to match its own AC1, got: {beta_failures:?}"
+        );
+
+        // Cross-check: if a caller is keyed on `alpha` but the task description
+        // contains beta's text, the function should report a text-mismatch
+        // failure rather than borrowing alpha's text. This proves the HashMap
+        // is correctly scoped.
+        let cross_acs = vec![(
+            "AC1".to_string(),
+            "Beta-specific AC1 text".to_string(),
+        )];
+        let cross_failures = task_ac_vs_open_pr_failures(
+            "alpha",
+            &cross_acs,
+            body,
+            "https://github.com/org/repo/pull/1",
+        );
+        assert_eq!(
+            cross_failures.len(),
+            1,
+            "expected one cross-subsection mismatch, got: {cross_failures:?}"
+        );
+        assert!(
+            cross_failures[0].contains("text altered"),
+            "got: {}",
+            cross_failures[0]
         );
     }
 

--- a/docs/specs/lobster-task-ac-subsection-scope-tech-design.md
+++ b/docs/specs/lobster-task-ac-subsection-scope-tech-design.md
@@ -1,0 +1,123 @@
+# Tech Design — Scope lobster `task_ac_vs_open_pr_failures` by `### Task <id>` subsection
+
+**Task:** `0fdb4bfe-e7e7-48a8-b188-ba0135b736bc`
+**Branch:** `fix/lobster-task-ac-subsection-scope` (from `origin/main` @ `c339203`)
+**Authored:** 2026-07-06 NZST
+**Reviewers:** Quinn
+
+## Background
+
+`task_ac_vs_open_pr_failures` runs at the `doing → acceptance` gate. It compares a task's ACs (parsed from the task description) against the AC section of the latest open PR body and reports any AC that is missing, has altered text, or lacks a valid evidence annotation.
+
+The function builds a flat `HashMap<String, (String, Option<Evidence>)>` keyed by AC label (`AC1`, `AC2`, ...), not scoped by `### Task <id>` subsection.
+
+`extract_ac_section` (PR #183) preserves `### Task …` subheadings inside the H2 AC section. So multi-task PR bodies — one `## Acceptance Criteria` containing several `### Task …` subsections — share a single key namespace. Two tasks' ACs collide on `AC1`/`AC2`/... in the HashMap; whichever subsection comes last in markdown wins; the earlier task's ACs are silently overwritten.
+
+Quinn confirmed the regression against `target/release/feature-task` on PR #185 (tasks 513b3b02 Pulse shell + e2e647b1 Flow metrics dashboard). 513b3b02's ACs were overwritten by e2e647b1's, so the gate reported five "AC1 text altered — task: `<513b3b02 text>`, PR: `<e2e647b1 text>`" failures on 513b3b02.
+
+## Goal
+
+Scope the per-AC comparison to the matching `### Task <task_id>` subsection. Keep `verify_pr_acs_failures` unchanged (evidence format is checked per-line and does not collide on labels). Preserve today's behavior for single-task PR bodies.
+
+## Design
+
+### Signature change
+
+`task_ac_vs_open_pr_failures` gains the current task's `id` as a new first parameter:
+
+```rust
+fn task_ac_vs_open_pr_failures(
+    task_id: &str,
+    task_acs: &[(String, String)],
+    body: &str,
+    pr_url: &str,
+) -> Vec<String>
+```
+
+Caller in `verify_delivery` (line 331) becomes:
+
+```rust
+for ac_failure in task_ac_vs_open_pr_failures(&env.task.id, &task_acs, &body, url) {
+    failures.push(format!("PR {url} — {ac_failure}"));
+}
+```
+
+### Section walker
+
+Replace the single `re.captures_iter(section)` with a line-by-line pass over `extract_ac_section(body)`:
+
+1. Two regexes:
+   - `subsection_re`: `r"(?m)^\s*#{3,}\s+Task\s+(\S+)"` — matches `### Task <id>`, `#### Task <id>`, etc. Capture group 1 is the bare task identifier (first whitespace-delimited token after `Task`).
+   - `ac_re`: same regex as today — `r"(?m)^\s*-\s*\[([xX ])\]\s+(AC\d+):\s*(.+)$"`.
+2. State: `current_sub_id: Option<String>`, `saw_any_subsection: bool`, `matching_section: bool`, `pr_ac_map: HashMap<String, (String, Option<Evidence>)>`.
+3. Loop:
+   - On a line matching `subsection_re`, set `current_sub_id = Some(cap[1])`. Update `matching_section = current_sub_id == task_id`. Set `saw_any_subsection = true`.
+   - If `saw_any_subsection && !matching_section`, skip the line (it's an AC in a sibling task's subsection).
+   - Otherwise, if the line matches `ac_re`, insert `(label, (text, evidence))` into `pr_ac_map`. Same `parse_evidence` + `strip_trailing_evidence` calls as today.
+4. If `saw_any_subsection` is `false` (no `### Task <id>` headings anywhere), every AC line is in the implicit single-task section — same as today's behavior.
+
+### Failure messages
+
+Identical wording to today. If the matching subsection is empty (or missing), `pr_ac_map` is empty and the failure loop reports one `ACn missing from open PR <url>` per task AC. No new failure class is needed for the "subsection absent" case — the existing message is informative enough.
+
+### `verify_pr_acs_failures` is unchanged
+
+It operates on the whole section by design. Evidence format checking does not depend on which task an AC belongs to: every checked `- [x] ACn: ...` line in the PR body must carry `(testID: ...)`, `(file: ...)`, `(not tested: ...)`, or `(not code: ...)`. The function continues to scan the whole section.
+
+## Edge cases
+
+| Input | Expected |
+|-------|----------|
+| Single-task PR body, all ACs match | empty failures (regression) |
+| Single-task PR body, AC text altered | one `AC1 text altered — task: ..., PR: ...` (regression) |
+| Two-task PR body, each task's ACs match its own subsection | empty failures for both call sites |
+| Two-task PR body, first task referenced again as second caller | first call still clear (its subsection's text matches); second call… |
+| Two-task PR body, no `### Task <id>` heading | falls back to whole-section behavior (preserves today) |
+| Two-task PR body, no matching subsection for current task | all task ACs reported missing from PR |
+| Body with `### Task <id>` followed by subsection ACs | ACs collected only for matching `<id>` |
+| Body with `#### Task <id>` (deep heading) | subsection regex `#{3,}` accepts; behavior same |
+
+## Tests
+
+Eight total cases (4 existing + 4 new). Test names follow the existing convention.
+
+Existing tests (require adding `task_id` as first argument):
+
+1. `task_ac_vs_open_pr_passes_when_all_acs_match_with_evidence` — single-task happy path. Pass `task_id = "alpha"` (single-task body has no `### Task` heading, so falls back to whole-section).
+2. `task_ac_vs_open_pr_blocks_on_text_mismatch` — single-task text mismatch.
+3. `task_ac_vs_open_pr_blocks_on_missing_ac` — single-task missing AC.
+4. `task_ac_vs_open_pr_blocks_on_missing_evidence` — single-task missing evidence.
+
+New tests:
+
+5. `task_ac_vs_open_pr_handles_multi_task_body` — regression fixture: two `### Task <id>` subsections with overlapping `AC1`/`AC2`/... labels. Each task gets its own subsection's text. Two calls (one per task id), both pass.
+6. `task_ac_vs_open_pr_falls_back_when_no_subsection_heading` — body with `## Acceptance Criteria` but no `### Task` subheadings. Pass `task_id = "anything"` — every AC line is consumed as if single-task.
+7. `task_ac_vs_open_pr_reports_missing_when_no_matching_subsection` — body has `### Task other_id` headings, current `task_id` has none. Reports N missing-AC failures.
+8. `task_ac_vs_open_pr_isolates_text_per_subsection` — body has two subsections with intentionally different `AC1` texts; calling with `task_id` of subsection A matches subsection A's text, not subsection B's.
+
+## Out of scope
+
+- Changing `extract_ac_section`. Its current behavior of preserving `### Task …` subheadings inside the H2 AC section is correct and is the foundation this fix builds on.
+- Changing `verify_pr_acs_failures` or the existing `evidence_format` rules.
+- Docstring / comment updates in `extract_ac_section` (its existing comment already documents the multi-task convention).
+- Auto-creating tasks from PR body subsections or any cross-task derivation logic.
+
+## Files
+
+| Path | Change |
+|------|--------|
+| `agents/workflows/feature-task/src/main.rs` | `task_ac_vs_open_pr_failures` signature + body; update 1 production call site in `verify_delivery`; update 4 existing tests; add 4 new tests |
+| `agents/skills/dev/pr-open/SKILL.md` | One paragraph in the "Acceptance Criteria" section: multi-task convention + minimal example |
+| `docs/specs/lobster-task-ac-subsection-scope-tech-design.md` | This file |
+
+## Validation
+
+- `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml` — all 4 new + 4 updated tests pass; total suite increases from 49 to ~57 (4 added).
+- `cargo build --release --manifest-path agents/workflows/feature-task/Cargo.toml` — clean.
+- After merge: Quinn re-runs the lobster on tasks 513b3b02 and e2e647b1 with the new binary; both should clear the gate.
+
+## Linked work
+
+- PR #185 — combined 513b3b02 + e2e647b1 delivery; blocked at gate until this PR lands.
+- PR #183 — made `extract_ac_section` level-aware; the regression trigger that surfaced this issue.
+- PR #149 (and before it the in-crate parser work) — same evidence-format hardening arc.


### PR DESCRIPTION
## Summary
- Hardens the lobster against the `task_ac_vs_open_pr_failures` collision that Quinn flagged on PR #185: when a PR body's AC section contains multiple `### Task <id>` subsections, the HashMap was keyed only by AC label (`AC1`, `AC2`, ...), so each task's ACs shared a single key namespace. Whichever subsection came last in markdown won, silently overwriting earlier tasks' ACs — the lobster then reported "AC text altered" failures for tasks whose PR body text was correct verbatim.
- `task_ac_vs_open_pr_failures` now takes the current task's `id` as a new first parameter and walks the AC section line-by-line to track the active `### Task <id>` heading; ACs in a sibling task's subsection are skipped. PR bodies without any `### Task <id>` heading fall back to today's behavior (whole section), preserving backward compatibility for every existing single-task PR.
- Skill doc (`agents/skills/dev/pr-open/SKILL.md` "Multi-task combined deliveries") now documents the `### Task <id>` convention so future PR authors know to use it; PRs without it still validate correctly thanks to the fallback.

## Test plan
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml` — 127/127 pass (8 in the `task_ac_vs_open_pr_*` family: 4 updated regression cases + 4 new tests covering multi-task happy path, no-subsection fallback, no-matching-subsection failure case, cross-subsection text isolation).
- [x] `cargo build --release --manifest-path agents/workflows/feature-task/Cargo.toml` — clean (only pre-existing dead-code warnings unrelated to this change).
- [x] Smoke test against the actual PR #185 body fetched via `gh pr view 185`: `task_ac_vs_open_pr_failures` returns empty failures for both 513b3b02 and e2e647b1 when called with their respective `id`s. Quinn can re-run the lobster locally against PR #185's body to confirm.
- [x] Skill doc note points future PR authors at the multi-task convention. PR description itself is the one-line pointer Quinn asked for (this bullet: see `agents/skills/dev/pr-open/SKILL.md` § "Multi-task combined deliveries").

🤖 Generated with [Claude Code](https://claude.com/claude-code)