### PR TITLE
chore(ci): add mission-control-tests job [2026-W28]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,26 @@ jobs:
       - name: Run otel-node tests
         run: npm test --workspace @sindustries/otel-node
 
+  mission-control-tests:
+    name: mission-control tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Run mission-control tests
+        run: npm test --workspace @sindustries/mission-control
+
   tasks-api-tests:
     name: tasks-api tests (unit + db integration)
     runs-on: ubuntu-latest

--- a/docs/repo-audits/2026-W28.md
+++ b/docs/repo-audits/2026-W28.md
@@ -184,7 +184,7 @@ Five themes explain every finding this week.
 
 ### Quick wins (S effort, high impact) — flagged separately
 
-- **Q1 — Add `mission-control-tests` CI job.** Mirror `otel-node-tests` in `.github/workflows/ci.yml`. Adds a real merge gate for the 23 existing tests. S / low risk. (Theme 2, ties H3.) ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+- **Q1 — Add `mission-control-tests` CI job.** Mirror `otel-node-tests` in `.github/workflows/ci.yml`. Adds a real merge gate for the 23 existing tests. S / low risk. (Theme 2, ties H3.) ✅ [PR #189](https://github.com/Stoffer-Industries/sindustries/pull/189)
 - **Q2 — Fix mission-control `@types/react`/`@types/react-dom` pins.** Downgrade to `^18.x` matching the runtime. S / low risk. (Theme 2, ties M6.)
 - **Q3 — Fix Pulse `TasksTab` iframe port map and `tasksApi.js` fallback.** The iframe map at `apps/mission-control/src/tabs/TasksTab.jsx:3-14` maps ports to themselves (same-port iframe); replace with a `VITE_TASKS_APP_URL` env with a documented default. The `tasksApi.js` fallback should point at `4000` (the tasks-api default), not `4001`. S / low risk. (Theme 2/4, ties H1/H2.)
 

--- a/docs/repo-audits/2026-W28.md
+++ b/docs/repo-audits/2026-W28.md
@@ -184,7 +184,7 @@ Five themes explain every finding this week.
 
 ### Quick wins (S effort, high impact) — flagged separately
 
-- **Q1 — Add `mission-control-tests` CI job.** Mirror `otel-node-tests` in `.github/workflows/ci.yml`. Adds a real merge gate for the 23 existing tests. S / low risk. (Theme 2, ties H3.)
+- **Q1 — Add `mission-control-tests` CI job.** Mirror `otel-node-tests` in `.github/workflows/ci.yml`. Adds a real merge gate for the 23 existing tests. S / low risk. (Theme 2, ties H3.) ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 - **Q2 — Fix mission-control `@types/react`/`@types/react-dom` pins.** Downgrade to `^18.x` matching the runtime. S / low risk. (Theme 2, ties M6.)
 - **Q3 — Fix Pulse `TasksTab` iframe port map and `tasksApi.js` fallback.** The iframe map at `apps/mission-control/src/tabs/TasksTab.jsx:3-14` maps ports to themselves (same-port iframe); replace with a `VITE_TASKS_APP_URL` env with a documented default. The `tasksApi.js` fallback should point at `4000` (the tasks-api default), not `4001`. S / low risk. (Theme 2/4, ties H1/H2.)
 


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W28.md
- **Finding:** [Q1] Add mission-control-tests CI job
- Add a `mission-control-tests` job to `.github/workflows/ci.yml` that mirrors the `otel-node-tests` job (npm ci + `npm test --workspace @sindustries/mission-control`). The 23 vitest cases in `apps/mission-control/src/{App.test.jsx, flowMetrics.test.js}` were shipping without a CI gate, so shell regressions entered `main` silently. Adds the missing merge-gate coverage called out in audit Theme 2 / finding H3.

## Test plan
- [x] Verified locally: `npm test --workspace @sindustries/mission-control` → 23 tests pass (2 files, ~825ms)
- [x] YAML is well-formed (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] No logic changes — diff is purely structural (new CI job, audit marker)

🌱 Code garden — non-functional cleanup only