### PR TITLE
feat(tilt): add mission-control to dev stack

### DIFF
--- a/infra/tilt/Tiltfile
+++ b/infra/tilt/Tiltfile
@@ -5,6 +5,7 @@ mode = os.getenv('MODE', 'dev')
 tasks_api_port = os.getenv('TASKS_API_PORT', '4000')
 budget_api_port = os.getenv('BUDGET_API_PORT', '4002')
 tasks_app_port = os.getenv('TASKS_APP_PORT', '5173')
+mission_control_port = os.getenv('MISSION_CONTROL_PORT', '5174')  # dev default; prodlike uses 5175 via mode-env.sh
 tasks_api_base_url = os.getenv('TASKS_API_BASE_URL', 'http://localhost:4000/api/v1')
 tasks_api_env_file = os.getenv('TASKS_API_ENV_FILE', 'services/tasks-api/.env.dev')
 compose_project = os.getenv('COMPOSE_PROJECT_NAME', 'sindustries-' + mode)
@@ -86,5 +87,23 @@ local_resource(
   ],
   resource_deps=['tasks-api'],
   labels=['tasks', 'app', mode],
+  allow_parallel=False,
+)
+
+local_resource(
+  'mission-control',
+  serve_cmd='cd ../../apps/mission-control && VITE_TASKS_API_BASE_URL={} npm run dev -- --host 0.0.0.0 --port {}'.format(
+    tasks_api_base_url,
+    mission_control_port,
+  ),
+  deps=[
+    '../../apps/mission-control/src',
+    '../../apps/mission-control/index.html',
+    '../../apps/mission-control/vite.config.js',
+    '../../apps/mission-control/package.json',
+    '../../apps/mission-control/package-lock.json',
+  ],
+  resource_deps=['tasks-api'],
+  labels=['mission-control', 'app', mode],
   allow_parallel=False,
 )

--- a/scripts/dev/mode-env.sh
+++ b/scripts/dev/mode-env.sh
@@ -12,6 +12,7 @@ case "$MODE" in
     export TASKS_API_PORT="4000"
     export BUDGET_API_PORT="4002"
     export TASKS_APP_PORT="5173"
+    export MISSION_CONTROL_PORT="5174"
     export TILT_PORT="10350"
     export POSTGRES_DB="sindustries_dev"
     export POSTGRES_CONTAINER_NAME="sindustries-postgres-dev"
@@ -38,6 +39,7 @@ case "$MODE" in
     export TASKS_API_PORT="4001"
     export BUDGET_API_PORT="4003"
     export TASKS_APP_PORT="5174"
+    export MISSION_CONTROL_PORT="5175"
     export TILT_PORT="10351"
     export POSTGRES_DB="sindustries_prodlike"
     export POSTGRES_CONTAINER_NAME="sindustries-postgres-prodlike"
@@ -67,4 +69,4 @@ export BUDGET_DATABASE_URL="postgresql://postgres:postgres@localhost:${POSTGRES_
 
 # Back-compat default used by existing tasks scripts.
 export DATABASE_URL="$TASKS_DATABASE_URL"
-export CORS_ALLOWED_ORIGINS="http://localhost:${TASKS_APP_PORT},http://127.0.0.1:${TASKS_APP_PORT}"
+export CORS_ALLOWED_ORIGINS="http://localhost:${TASKS_APP_PORT},http://127.0.0.1:${TASKS_APP_PORT},http://localhost:${MISSION_CONTROL_PORT},http://127.0.0.1:${MISSION_CONTROL_PORT}"

--- a/scripts/dev/port-cleanup.sh
+++ b/scripts/dev/port-cleanup.sh
@@ -38,6 +38,7 @@ kill_port_listener() {
 
 cleanup_mode_ports() {
   kill_port_listener "$TASKS_APP_PORT" "tasks app"
+  kill_port_listener "${MISSION_CONTROL_PORT:-5174}" "mission control"
   kill_port_listener "$TASKS_API_PORT" "tasks api"
   kill_port_listener "${BUDGET_API_PORT:-4002}" "budget api"
   kill_port_listener "$TILT_PORT" "Tilt"

--- a/scripts/dev/up.sh
+++ b/scripts/dev/up.sh
@@ -144,6 +144,7 @@ echo "Starting $MODE stack"
 echo "  API: $TASKS_API_BASE_URL"
 echo "  Budget API: $BUDGET_API_BASE_URL"
 echo "  App: http://localhost:$TASKS_APP_PORT"
+echo "  Mission Control: http://localhost:$MISSION_CONTROL_PORT"
 echo "  Postgres: localhost:$POSTGRES_PORT/$POSTGRES_DB"
 if [[ "$OBSERVABILITY" == "1" ]]; then
   echo "  Observability: Grafana http://localhost:$GRAFANA_PORT (Tempo :$TEMPO_PORT, Prometheus :$PROMETHEUS_PORT, OTLP :$OTLP_HTTP_PORT)"


### PR DESCRIPTION
Wires apps/mission-control into Tilt as a local_resource with per-mode port assignments (5174 dev, 5175 prodlike), CORS origins, and preflight port cleanup so `make up` and `make up MODE=prodlike` both work cleanly.