### PR TITLE
docs(system-spec): cite worktree cleanup task ba116063 + PR #208

### DIFF
--- a/docs/systems/feature-task-workflow.md
+++ b/docs/systems/feature-task-workflow.md
@@ -75,7 +75,7 @@ Note: prior versions of this workflow ran an equivalent AC text check at the `po
 ### 4. `done` — terminal
 
 - Lobster writes `done` after `post-merge` checks pass
-- After moving to `done`, the lobster's `post-merge` stage runs a best-effort **worktree cleanup** that removes the Rowan feature worktree (e.g. `~/workspaces/rowan/sindustries-task-<8char-prefix>-<slug>`) registered with the primary `sindustries` worktree. The cleanup is idempotent (missing paths are no-ops) and non-fatal (a failure is logged via `[feature-task-progress-checklist]` but does not block `done`)
+- After moving to `done`, the lobster's `post-merge` stage runs a best-effort **worktree cleanup** that removes the Rowan feature worktree (e.g. `~/workspaces/rowan/sindustries-task-<8char-prefix>-<slug>`) registered with the primary `sindustries` worktree. The cleanup is idempotent (missing paths are no-ops) and non-fatal (a failure is logged via `[feature-task-progress-checklist]` but does not block `done`). Shipped by feature task `ba116063-382a-446c-ab91-c01b60d9a7c3` (PR https://github.com/Stoffer-Industries/sindustries/pull/208, merge commit `8c6a16f`).
 - No further workflow steps
 
 ---

--- a/docs/systems/feature-task-workflow.md
+++ b/docs/systems/feature-task-workflow.md
@@ -75,7 +75,7 @@ Note: prior versions of this workflow ran an equivalent AC text check at the `po
 ### 4. `done` — terminal
 
 - Lobster writes `done` after `post-merge` checks pass
-- After moving to `done`, the lobster's `post-merge` stage runs a best-effort **worktree cleanup** that removes the Rowan feature worktree (e.g. `~/workspaces/rowan/sindustries-task-<8char-prefix>-<slug>`) registered with the primary `sindustries` worktree. The cleanup is idempotent (missing paths are no-ops) and non-fatal (a failure is logged via `[feature-task-progress-checklist]` but does not block `done`). Shipped by feature task `ba116063-382a-446c-ab91-c01b60d9a7c3` (PR https://github.com/Stoffer-Industries/sindustries/pull/208, merge commit `8c6a16f`).
+- After moving to `done`, the lobster's `post-merge` stage runs a best-effort **worktree cleanup** that removes the Rowan feature worktree (e.g. `~/workspaces/rowan/sindustries-task-<8char-prefix>-<slug>`) registered with the primary `sindustries` worktree. The cleanup is idempotent (missing paths are no-ops) and non-fatal (a failure is logged via `[feature-task-progress-checklist]` but does not block `done`). Tracked as task `ba116063-382a-446c-ab91-c01b60d9a7c3`.
 - No further workflow steps
 
 ---


### PR DESCRIPTION
Adds the task UUID + PR #208 citation to the worktree cleanup line in docs/systems/feature-task-workflow.md.

**Why:** PR #208 (commit 8c6a16f) shipped the worktree-cleanup behaviour description but did not embed the citation reference. The lobster's verify_delivery system-spec gate (PR #156 era, hardened in feature-task-workflow.md main.rs:2544) requires either the task UUID or a [rowan-prs] URL to be present in any system spec the task points to. Without the citation, task ba116063 sits at post_merge_blocked indefinitely.

**Scope:** 1 line, 0 behaviour change. Same branch (quinn/spec-citation-ba116063).

**Affects:** task ba116063 (Lobster worktree cleanup) -- unblocks verify_delivery so the task can advance to acceptance for Tom [qa-ac-verified] gate.

Quinn authored. Code-garden classification (docs-only). Tom: please approve + merge (or Quinn will self-merge after Tom approves per pr-process skill convention).