### PR TITLE
docs(systems): reference task ba116063 / PR #208 in feature-task-workflow

### DIFF
--- a/docs/systems/feature-task-workflow.md
+++ b/docs/systems/feature-task-workflow.md
@@ -254,3 +254,7 @@ The `.openclaw/` directory is outside this repo. Any required `.openclaw` change
 - `brain/bookmarks/specs/feature-factory-v2-2026-06-04.md` — factory-v2 product spec
 - `docs/systems/agent-orchestration.md` — wider agent map
 - `docs/systems/bookmark-workflow.md` — bookmark-driven spec intake (parallel pipeline)
+
+## Related Tasks / PRs
+
+- Task `ba116063-382a-446c-ab91-c01b60d9a7c3` — Lobster worktree cleanup after merge (PR #208): the source of the post-merge worktree cleanup step in the `done` section above


### PR DESCRIPTION
Unblocks the lobster's `[system-spec]` gate for task `ba116063-382a-446c-ab91-c01b60d9a7c3` (Lobster worktree cleanup after merge).

The post-merge worktree cleanup step in the `done` section of `docs/systems/feature-task-workflow.md` was introduced by PR #208 (merged 2026-07-08), but the system spec did not reference the task or PR. The lobster's gate (`system_spec_failures_with` in `agents/workflows/feature-task/src/main.rs`) requires the system spec file to contain either the task UUID or one of `rowan_pr_urls(task)`.

This PR adds a 'Related Tasks / PRs' section linking the worktree-cleanup step to its source task so the gate passes.

**Change:**
- `docs/systems/feature-task-workflow.md`: new `## Related Tasks / PRs` subsection with a one-line reference to task `ba116063-...` and PR #208.

**Test plan:**
- After merge, the lobster's system-spec check on task ba116063 should pass; `[system-spec] docs/systems/feature-task-workflow.md` will be posted by Rowan to advance the task through `acceptance` → `done`.
