### PR TITLE
feat(mission-control): content scheduler tab + backend

### DIFF
--- a/apps/mission-control/README.md
+++ b/apps/mission-control/README.md
@@ -1,8 +1,8 @@
 # Pulse — `@sindustries/mission-control`
 
 The Sindustries desktop shell. Hosts multiple tabs (Tasks, Bookmarks, Flow
-metrics, Design System) behind a single URL. The shell also owns the
-day/night theme toggle (bottom of the vertical sidebar) and broadcasts
+metrics, Design System, Content) behind a single URL. The shell also owns
+the day/night theme toggle (bottom of the vertical sidebar) and broadcasts
 the chosen theme to iframe-based tabs via `pulse:theme` postMessage.
 
 See `SPEC.md` for behaviour and `docs/specs/pulse-shell-app-tech-design.md`
@@ -37,3 +37,12 @@ an empty state rather than failing. Override the API base with
 1. Create a component in `src/tabs/DesignSystemTab.jsx` (or any `MyTab.jsx`).
 2. Register it in `src/pulseTabs.jsx` with `id`, `label`, `path`, `icon`, and `component`.
 3. Done — no App.jsx changes needed.
+
+## Content tab
+
+The Content tab surfaces the Content Scheduler — a single-user queue for
+X posts. Items go through `queued → approved → published`; the publish
+endpoint enforces "max one X post per day" in `Pacific/Auckland`. The
+queue is read from `services/tasks-api`; see
+`docs/specs/content-scheduler-tab-tech-design.md` for the full design and
+`services/tasks-api/README.md` for the backend endpoints it depends on.

--- a/apps/mission-control/SPEC.md
+++ b/apps/mission-control/SPEC.md
@@ -132,6 +132,12 @@ specimen mount.
   the full archive (including done/closed tasks) without per-page pagination.
   This is the only Tasks API request the dashboard makes — see
   `apps/mission-control/src/tasksApi.js` (`getTasks`).
+- **Content Scheduler** state is read from the Tasks API at
+  `/api/v1/content-scheduler/items` and `/api/v1/content-scheduler/today-status`.
+  The publish flow is server-side (Tasks API posts to X with bearer auth);
+  the Mission Control client never holds X credentials. The "max one
+  X post per day" rule is computed in `Pacific/Auckland`. See
+  `docs/specs/content-scheduler-tab-tech-design.md` for the full design.
 - **Bookmark state** is read by the Bookmarks tab from
   `brain/state/bookmark-review-state.json` and
   `brain/state/bookmark-transitions.jsonl` via the dev-only Vite plugin

--- a/apps/mission-control/src/contentSchedulerApi.js
+++ b/apps/mission-control/src/contentSchedulerApi.js
@@ -1,0 +1,92 @@
+// Thin client for the Content Scheduler Tasks API endpoints.
+//
+// Mirrors the patterns in tasksApi.js — uses the same Tasks API base URL
+// (port-overridable via VITE_TASKS_API_BASE_URL). All methods throw on
+// non-2xx with the parsed error body attached.
+//
+// Task: 115e8d89-be43-4b81-9e0e-9ab422810f5f
+// Tech design: docs/specs/content-scheduler-tab-tech-design.md
+
+const DEFAULT_API_BASE_BY_PORT = {
+  '5173': 'http://localhost:4000/api/v1',
+  '5174': 'http://localhost:4001/api/v1',
+  '5175': 'http://localhost:4002/api/v1',
+  '5176': 'http://localhost:4003/api/v1'
+};
+
+function baseUrl() {
+  return (
+    import.meta.env.VITE_TASKS_API_BASE_URL
+    ?? DEFAULT_API_BASE_BY_PORT[window.location.port]
+    ?? 'http://localhost:4001/api/v1'
+  );
+}
+
+async function request(path, { method = 'GET', body, actor } = {}) {
+  const res = await fetch(`${baseUrl()}${path}`, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      ...(actor ? { 'x-actor': actor } : {})
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined
+  });
+  let parsed = null;
+  try {
+    parsed = await res.json();
+  } catch {
+    parsed = null;
+  }
+  if (!res.ok) {
+    const error = new Error(parsed?.error?.message ?? `Content Scheduler API ${res.status}`);
+    error.code = parsed?.error?.code ?? 'UNKNOWN';
+    error.status = res.status;
+    throw error;
+  }
+  return parsed?.data ?? null;
+}
+
+export async function listItems(status) {
+  const qs = status ? `?status=${encodeURIComponent(status)}` : '';
+  return request(`/content-scheduler/items${qs}`);
+}
+
+export async function createItem({ body, source, sourceRef, scheduledFor, actor }) {
+  return request('/content-scheduler/items', {
+    method: 'POST',
+    body: { body, source, sourceRef, scheduledFor },
+    actor
+  });
+}
+
+export async function updateItem(id, patch, { actor } = {}) {
+  return request(`/content-scheduler/items/${id}`, {
+    method: 'PATCH',
+    body: patch,
+    actor
+  });
+}
+
+export async function approveItem(id, actor) {
+  return request(`/content-scheduler/items/${id}/approve`, { method: 'POST', actor });
+}
+
+export async function unapproveItem(id, actor) {
+  return request(`/content-scheduler/items/${id}/unapprove`, { method: 'POST', actor });
+}
+
+export async function publishItem(id, actor) {
+  return request(`/content-scheduler/items/${id}/publish`, { method: 'POST', actor });
+}
+
+export async function removeItem(id, actor) {
+  return request(`/content-scheduler/items/${id}/remove`, { method: 'POST', actor });
+}
+
+export async function reorderItems(ids, actor) {
+  return request('/content-scheduler/reorder', { method: 'POST', body: { ids }, actor });
+}
+
+export async function getTodayStatus() {
+  return request('/content-scheduler/today-status');
+}

--- a/apps/mission-control/src/pulseTabs.jsx
+++ b/apps/mission-control/src/pulseTabs.jsx
@@ -17,6 +17,7 @@ import { FlowMetricsTab } from './tabs/FlowMetricsTab.jsx';
 import { TasksTab } from './tabs/TasksTab.jsx';
 import { BookmarksTab } from './tabs/BookmarksTab.jsx';
 import { DesignSystemTab } from './tabs/DesignSystemTab.jsx';
+import { ContentSchedulerTab } from './tabs/ContentSchedulerTab.jsx';
 
 function IconClipboard() {
   return (
@@ -59,6 +60,15 @@ function IconPalette() {
   );
 }
 
+function IconContent() {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round">
+      <rect x="4" y="5" width="16" height="14" rx="2" />
+      <path d="M8 9h8M8 13h6" />
+    </svg>
+  );
+}
+
 export const PULSE_TABS = [
   {
     id: 'tasks',
@@ -87,6 +97,13 @@ export const PULSE_TABS = [
     path: '/design-system',
     icon: <IconPalette />,
     component: DesignSystemTab
+  },
+  {
+    id: 'content-scheduler',
+    label: 'Content',
+    path: '/content-scheduler',
+    icon: <IconContent />,
+    component: ContentSchedulerTab
   }
 ];
 

--- a/apps/mission-control/src/tabs/ContentSchedulerTab.jsx
+++ b/apps/mission-control/src/tabs/ContentSchedulerTab.jsx
@@ -1,0 +1,451 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button, Card, CardContainer, Field, Select, Textarea } from '@sindustries/ui/react';
+import {
+  approveItem,
+  createItem,
+  getTodayStatus,
+  listItems,
+  publishItem,
+  removeItem,
+  reorderItems,
+  unapproveItem,
+  updateItem
+} from '../contentSchedulerApi.js';
+
+const ACTOR = 'Tom';
+
+const SOURCES = [
+  { value: 'ops_notes', label: 'Ops notes' },
+  { value: 'cto_craft', label: 'CTO Craft' },
+  { value: 'manual', label: 'Manual' },
+  { value: 'other', label: 'Other' }
+];
+
+const STATUS_LABELS = {
+  queued: 'Queued',
+  approved: 'Approved',
+  published: 'Published'
+};
+
+function defaultScheduledFor() {
+  const d = new Date(Date.now() + 60_000);
+  d.setSeconds(0, 0);
+  // Snap to nearest 5 minutes.
+  const minutes = d.getMinutes();
+  d.setMinutes(minutes - (minutes % 5));
+  // datetime-local needs YYYY-MM-DDTHH:mm in local time.
+  const pad = (n) => `${n}`.padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function toDatetimeLocal(value) {
+  if (!value) return '';
+  const d = new Date(value);
+  if (Number.isNaN(d.valueOf())) return '';
+  const pad = (n) => `${n}`.padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function fromDatetimeLocal(value) {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.valueOf()) ? null : d.toISOString();
+}
+
+function dayStatusLabel(today) {
+  if (!today) return '';
+  if (today.publishedCount >= today.cap) {
+    return `✓ ${today.publishedCount} / ${today.cap} posts published today (max reached)`;
+  }
+  return `✓ ${today.publishedCount} / ${today.cap} posts published today`;
+}
+
+function isPublishDisabled(item, today) {
+  if (!item.approvedAt) return true;
+  if (!today) return false;
+  if (today.publishedCount >= today.cap && today.publishedItemId !== item.id) return true;
+  return false;
+}
+
+function publishTooltip(item, today) {
+  if (!item.approvedAt) return 'Approve before publishing (AC6).';
+  if (today?.publishedCount >= today?.cap && today?.publishedItemId !== item.id) {
+    return 'Max one X post per day — already published today.';
+  }
+  return '';
+}
+
+function ItemRow({ item, today, onApprove, onUnapprove, onPublish, onRemove, onSave, onDragStart, onDragOver, onDrop, isDragOver }) {
+  const [editing, setEditing] = useState(false);
+  const [draftBody, setDraftBody] = useState(item.body);
+  const [draftSchedule, setDraftSchedule] = useState(toDatetimeLocal(item.scheduledFor));
+
+  useEffect(() => {
+    setDraftBody(item.body);
+    setDraftSchedule(toDatetimeLocal(item.scheduledFor));
+  }, [item.body, item.scheduledFor]);
+
+  const disabled = isPublishDisabled(item, today);
+  const tip = publishTooltip(item, today);
+  const published = item.status === 'published';
+
+  return (
+    <Card
+      className="content-scheduler-row"
+      data-testid={`content-scheduler-row-${item.id}`}
+      draggable={!published}
+      onDragStart={(e) => onDragStart(e, item.id)}
+      onDragOver={(e) => onDragOver(e, item.id)}
+      onDrop={(e) => onDrop(e, item.id)}
+      style={isDragOver ? { outline: '2px dashed var(--si-color-brand-500, #b46a00)' } : undefined}
+    >
+      <div className="content-scheduler-row__body">
+        {editing ? (
+          <Field label="Body">
+            <Textarea
+              value={draftBody}
+              onChange={(e) => setDraftBody(e.target.value)}
+              maxLength={1000}
+              data-testid={`content-scheduler-edit-body-${item.id}`}
+            />
+          </Field>
+        ) : (
+          <p data-testid={`content-scheduler-body-${item.id}`}>{item.body}</p>
+        )}
+        <div className="content-scheduler-row__meta">
+          <span>Source: {item.source}</span>
+          {item.scheduledFor && <span>Scheduled: {new Date(item.scheduledFor).toLocaleString()}</span>}
+          {item.approvedAt && <span>Approved by {item.approvedBy ?? 'unknown'} at {new Date(item.approvedAt).toLocaleString()}</span>}
+          {item.publishedAt && (
+            <span>
+              Published at {new Date(item.publishedAt).toLocaleString()}
+              {item.publishedUrl && (
+                <>
+                  {' '}
+                  —{' '}
+                  <a href={item.publishedUrl} target="_blank" rel="noreferrer">
+                    view
+                  </a>
+                </>
+              )}
+            </span>
+          )}
+          {item.publishError && <span style={{ color: 'var(--si-color-danger-500, #a3312b)' }}>Publish error: {item.publishError}</span>}
+        </div>
+        {editing && (
+          <Field label="Scheduled for">
+            <input
+              type="datetime-local"
+              value={draftSchedule}
+              onChange={(e) => setDraftSchedule(e.target.value)}
+              data-testid={`content-scheduler-edit-schedule-${item.id}`}
+              className="si-input"
+            />
+          </Field>
+        )}
+      </div>
+      <div className="content-scheduler-row__actions">
+        {editing ? (
+          <>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={async () => {
+                await onSave(item.id, { body: draftBody, scheduledFor: fromDatetimeLocal(draftSchedule) });
+                setEditing(false);
+              }}
+              data-testid={`content-scheduler-save-${item.id}`}
+            >
+              Save
+            </Button>
+            <Button variant="ghost" size="sm" onClick={() => setEditing(false)}>
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <>
+            {!published && (
+              <Button variant="ghost" size="sm" onClick={() => setEditing(true)} data-testid={`content-scheduler-edit-${item.id}`}>
+                Edit
+              </Button>
+            )}
+            {item.status === 'queued' && (
+              <Button variant="primary" size="sm" onClick={() => onApprove(item.id)} data-testid={`content-scheduler-approve-${item.id}`}>
+                Approve
+              </Button>
+            )}
+            {item.status === 'approved' && (
+              <Button variant="ghost" size="sm" onClick={() => onUnapprove(item.id)} data-testid={`content-scheduler-unapprove-${item.id}`}>
+                Unapprove
+              </Button>
+            )}
+            {item.status !== 'published' && item.status !== 'removed' && (
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => onPublish(item.id)}
+                disabled={disabled}
+                title={tip}
+                data-testid={`content-scheduler-publish-${item.id}`}
+              >
+                Publish
+              </Button>
+            )}
+            {item.status !== 'published' && item.status !== 'removed' && (
+              <Button variant="danger" size="sm" onClick={() => onRemove(item.id)} data-testid={`content-scheduler-remove-${item.id}`}>
+                Remove
+              </Button>
+            )}
+            {item.status === 'published' && (
+              <span className="content-scheduler-row__badge" data-testid={`content-scheduler-published-${item.id}`}>
+                Published
+              </span>
+            )}
+          </>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+export function ContentSchedulerTab() {
+  const [items, setItems] = useState(null);
+  const [today, setToday] = useState(null);
+  const [error, setError] = useState(null);
+  const [body, setBody] = useState('');
+  const [source, setSource] = useState('manual');
+  const [scheduledFor, setScheduledFor] = useState(defaultScheduledFor());
+  const [dragOverId, setDragOverId] = useState(null);
+
+  const reload = useCallback(async () => {
+    try {
+      const [list, status] = await Promise.all([listItems(), getTodayStatus()]);
+      setItems(list ?? []);
+      setToday(status);
+      setError(null);
+    } catch (err) {
+      setError(err?.message ?? String(err));
+    }
+  }, []);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const grouped = useMemo(() => {
+    const out = { queued: [], approved: [], published: [] };
+    for (const item of items ?? []) {
+      if (out[item.status]) out[item.status].push(item);
+    }
+    for (const status of Object.keys(out)) {
+      out[status].sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+    }
+    return out;
+  }, [items]);
+
+  const handleCreate = useCallback(async () => {
+    if (!body.trim()) return;
+    try {
+      await createItem({
+        body: body.trim(),
+        source,
+        scheduledFor: fromDatetimeLocal(scheduledFor),
+        actor: ACTOR
+      });
+      setBody('');
+      setScheduledFor(defaultScheduledFor());
+      await reload();
+    } catch (err) {
+      setError(err?.message ?? String(err));
+    }
+  }, [body, source, scheduledFor, reload]);
+
+  const handleApprove = useCallback(
+    async (id) => {
+      try {
+        await approveItem(id, ACTOR);
+        await reload();
+      } catch (err) {
+        setError(err?.message ?? String(err));
+      }
+    },
+    [reload]
+  );
+
+  const handleUnapprove = useCallback(
+    async (id) => {
+      try {
+        await unapproveItem(id, ACTOR);
+        await reload();
+      } catch (err) {
+        setError(err?.message ?? String(err));
+      }
+    },
+    [reload]
+  );
+
+  const handlePublish = useCallback(
+    async (id) => {
+      try {
+        await publishItem(id, ACTOR);
+        await reload();
+      } catch (err) {
+        setError(err?.message ?? String(err));
+      }
+    },
+    [reload]
+  );
+
+  const handleRemove = useCallback(
+    async (id) => {
+      try {
+        await removeItem(id, ACTOR);
+        await reload();
+      } catch (err) {
+        setError(err?.message ?? String(err));
+      }
+    },
+    [reload]
+  );
+
+  const handleSave = useCallback(
+    async (id, patch) => {
+      try {
+        await updateItem(id, patch, { actor: ACTOR });
+        await reload();
+      } catch (err) {
+        setError(err?.message ?? String(err));
+      }
+    },
+    [reload]
+  );
+
+  const handleReorder = useCallback(
+    async (sourceId, targetId) => {
+      if (sourceId === targetId) return;
+      const current = (items ?? []).filter((i) => i.status === 'queued');
+      const fromIdx = current.findIndex((i) => i.id === sourceId);
+      const toIdx = current.findIndex((i) => i.id === targetId);
+      if (fromIdx < 0 || toIdx < 0) return;
+      const reordered = [...current];
+      const [moved] = reordered.splice(fromIdx, 1);
+      reordered.splice(toIdx, 0, moved);
+      try {
+        await reorderItems(reordered.map((i) => i.id), ACTOR);
+        await reload();
+      } catch (err) {
+        setError(err?.message ?? String(err));
+      }
+    },
+    [items, reload]
+  );
+
+  if (error && !items) {
+    return (
+      <div className="pulse-tab" data-testid="pulse-content-scheduler-error">
+        <h2>Content Scheduler</h2>
+        <p>Failed to load: {error}</p>
+        <Button onClick={reload} data-testid="pulse-content-scheduler-retry">Retry</Button>
+      </div>
+    );
+  }
+
+  if (!items) {
+    return (
+      <div className="pulse-tab" data-testid="pulse-content-scheduler-loading">
+        <h2>Content Scheduler</h2>
+        <p>Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pulse-tab content-scheduler-tab" data-testid="pulse-content-scheduler">
+      <h2>Content Scheduler</h2>
+      <Card className="content-scheduler-composer" data-testid="pulse-content-scheduler-composer">
+        <Field label="Tweet body">
+          <Textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            maxLength={1000}
+            placeholder="Draft the tweet text…"
+            data-testid="pulse-content-scheduler-body"
+          />
+        </Field>
+        <div className="content-scheduler-composer__meta">
+          <Field label="Source">
+            <Select
+              aria-label="Source"
+              value={source}
+              onChange={(e) => setSource(e.target.value)}
+              data-testid="pulse-content-scheduler-source"
+            >
+              {SOURCES.map((s) => (
+                <option key={s.value} value={s.value}>{s.label}</option>
+              ))}
+            </Select>
+          </Field>
+          <Field
+            label="Scheduled for"
+          >
+            <input
+              type="datetime-local"
+              value={scheduledFor}
+              onChange={(e) => setScheduledFor(e.target.value)}
+              data-testid="pulse-content-scheduler-schedule"
+              className="si-input"
+            />
+          </Field>
+        </div>
+        <Button variant="primary" onClick={handleCreate} disabled={!body.trim()} data-testid="pulse-content-scheduler-add">
+          Add to queue
+        </Button>
+        {error && <p className="content-scheduler-error" data-testid="pulse-content-scheduler-error">{error}</p>}
+      </Card>
+
+      {(['queued', 'approved', 'published']).map((status) => (
+        <section
+          key={status}
+          className={`content-scheduler-group content-scheduler-group--${status}`}
+          data-testid={`pulse-content-scheduler-group-${status}`}
+        >
+          <h3>{STATUS_LABELS[status]} ({grouped[status].length})</h3>
+          {grouped[status].length === 0 ? (
+            <p className="content-scheduler-empty">No {STATUS_LABELS[status].toLowerCase()} items.</p>
+          ) : (
+            <CardContainer>
+              {grouped[status].map((item) => (
+                <ItemRow
+                  key={item.id}
+                  item={item}
+                  today={today}
+                  onApprove={handleApprove}
+                  onUnapprove={handleUnapprove}
+                  onPublish={handlePublish}
+                  onRemove={handleRemove}
+                  onSave={handleSave}
+                  onDragStart={(e, id) => e.dataTransfer.setData('text/plain', id)}
+                  onDragOver={(e, id) => {
+                    e.preventDefault();
+                    setDragOverId(id);
+                  }}
+                  onDrop={async (e, id) => {
+                    e.preventDefault();
+                    const sourceId = e.dataTransfer.getData('text/plain');
+                    setDragOverId(null);
+                    await handleReorder(sourceId, id);
+                  }}
+                  isDragOver={dragOverId === item.id}
+                />
+              ))}
+            </CardContainer>
+          )}
+        </section>
+      ))}
+
+      <div className="content-scheduler-day-strip" data-testid="pulse-content-scheduler-day-strip">
+        {dayStatusLabel(today)}
+      </div>
+    </div>
+  );
+}

--- a/apps/mission-control/src/tabs/ContentSchedulerTab.test.jsx
+++ b/apps/mission-control/src/tabs/ContentSchedulerTab.test.jsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('../contentSchedulerApi.js', () => ({
+  listItems: vi.fn(),
+  createItem: vi.fn(),
+  updateItem: vi.fn(),
+  approveItem: vi.fn(),
+  unapproveItem: vi.fn(),
+  publishItem: vi.fn(),
+  removeItem: vi.fn(),
+  reorderItems: vi.fn(),
+  getTodayStatus: vi.fn()
+}));
+
+import {
+  listItems,
+  createItem,
+  approveItem,
+  publishItem,
+  removeItem,
+  reorderItems,
+  getTodayStatus
+} from '../contentSchedulerApi.js';
+import { ContentSchedulerTab } from './ContentSchedulerTab.jsx';
+
+const QUEUED_ID = '11111111-1111-1111-1111-111111111111';
+const APPROVED_ID = '22222222-2222-2222-2222-222222222222';
+const PUBLISHED_ID = '33333333-3333-3333-3333-333333333333';
+
+function fixture() {
+  return [
+    {
+      id: QUEUED_ID,
+      body: 'Queued tweet body',
+      source: 'manual',
+      sourceRef: null,
+      status: 'queued',
+      scheduledFor: null,
+      position: 0,
+      approvedAt: null,
+      approvedBy: null,
+      publishedAt: null,
+      publishedUrl: null,
+      publishError: null,
+      createdAt: '2026-07-10T00:00:00.000Z',
+      updatedAt: '2026-07-10T00:00:00.000Z',
+      removedAt: null
+    },
+    {
+      id: APPROVED_ID,
+      body: 'Approved tweet body',
+      source: 'ops_notes',
+      sourceRef: null,
+      status: 'approved',
+      scheduledFor: null,
+      position: 0,
+      approvedAt: '2026-07-10T01:00:00.000Z',
+      approvedBy: 'Tom',
+      publishedAt: null,
+      publishedUrl: null,
+      publishError: null,
+      createdAt: '2026-07-10T00:00:00.000Z',
+      updatedAt: '2026-07-10T01:00:00.000Z',
+      removedAt: null
+    },
+    {
+      id: PUBLISHED_ID,
+      body: 'Published tweet body',
+      source: 'cto_craft',
+      sourceRef: null,
+      status: 'published',
+      scheduledFor: null,
+      position: 0,
+      approvedAt: '2026-07-09T22:00:00.000Z',
+      approvedBy: 'Tom',
+      publishedAt: '2026-07-10T03:00:00.000Z',
+      publishedUrl: 'https://x.com/sindustries/status/abc',
+      publishError: null,
+      createdAt: '2026-07-09T20:00:00.000Z',
+      updatedAt: '2026-07-10T03:00:00.000Z',
+      removedAt: null
+    }
+  ];
+}
+
+const TODAY_OK = { date: '2026-07-10', publishedCount: 0, publishedItemId: null, cap: 1 };
+const TODAY_FULL = { date: '2026-07-10', publishedCount: 1, publishedItemId: PUBLISHED_ID, cap: 1 };
+
+describe('ContentSchedulerTab', () => {
+  beforeEach(() => {
+    listItems.mockResolvedValue(fixture());
+    getTodayStatus.mockResolvedValue(TODAY_OK);
+    createItem.mockResolvedValue({ id: 'new-id', body: 'New tweet', status: 'queued', source: 'manual', position: 1 });
+    approveItem.mockResolvedValue({});
+    publishItem.mockResolvedValue({});
+    removeItem.mockResolvedValue({});
+    reorderItems.mockResolvedValue({ ok: true, count: 3 });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading state then the full tab on mount', async () => {
+    render(<ContentSchedulerTab />);
+    expect(screen.getByTestId('pulse-content-scheduler-loading')).toBeTruthy();
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    expect(screen.getByTestId('pulse-content-scheduler-composer')).toBeTruthy();
+    expect(screen.getByTestId('pulse-content-scheduler-group-queued')).toBeTruthy();
+    expect(screen.getByTestId('pulse-content-scheduler-group-approved')).toBeTruthy();
+    expect(screen.getByTestId('pulse-content-scheduler-group-published')).toBeTruthy();
+    expect(screen.getByTestId('pulse-content-scheduler-day-strip').textContent).toContain('0 / 1');
+  });
+
+  it('shows an error state when fetch fails and recovers on retry', async () => {
+    listItems.mockRejectedValueOnce(new Error('boom'));
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler-error')).toBeTruthy());
+    expect(screen.getByText(/boom/)).toBeTruthy();
+    listItems.mockResolvedValue(fixture());
+    fireEvent.click(screen.getByTestId('pulse-content-scheduler-retry'));
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+  });
+
+  it('disables the publish button until approval is recorded', async () => {
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    const queuedPublish = screen.getByTestId(`content-scheduler-publish-${QUEUED_ID}`);
+    expect(queuedPublish.hasAttribute('disabled')).toBe(true);
+    const approvedPublish = screen.getByTestId(`content-scheduler-publish-${APPROVED_ID}`);
+    expect(approvedPublish.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('disables publish on approved items when day cap is reached', async () => {
+    getTodayStatus.mockResolvedValue(TODAY_FULL);
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    const approvedPublish = screen.getByTestId(`content-scheduler-publish-${APPROVED_ID}`);
+    expect(approvedPublish.hasAttribute('disabled')).toBe(true);
+    expect(approvedPublish.getAttribute('title')).toMatch(/max one/i);
+  });
+
+  it('approve button calls the approve endpoint and refreshes', async () => {
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    const callsBefore = approveItem.mock.calls.length;
+    fireEvent.click(screen.getByTestId(`content-scheduler-approve-${QUEUED_ID}`));
+    await waitFor(() => expect(approveItem.mock.calls.length).toBe(callsBefore + 1));
+    expect(approveItem).toHaveBeenCalledWith(QUEUED_ID, 'Tom');
+  });
+
+  it('publish button on an approved item calls the publish endpoint', async () => {
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    fireEvent.click(screen.getByTestId(`content-scheduler-publish-${APPROVED_ID}`));
+    await waitFor(() => expect(publishItem).toHaveBeenCalledWith(APPROVED_ID, 'Tom'));
+  });
+
+  it('remove button calls the remove endpoint', async () => {
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    fireEvent.click(screen.getByTestId(`content-scheduler-remove-${QUEUED_ID}`));
+    await waitFor(() => expect(removeItem).toHaveBeenCalledWith(QUEUED_ID, 'Tom'));
+  });
+
+  it('add-to-queue calls createItem with the trimmed body', async () => {
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    const textarea = screen.getByTestId('pulse-content-scheduler-body');
+    fireEvent.change(textarea, { target: { value: '   New draft tweet   ' } });
+    fireEvent.click(screen.getByTestId('pulse-content-scheduler-add'));
+    await waitFor(() => expect(createItem).toHaveBeenCalled());
+    const call = createItem.mock.calls[createItem.mock.calls.length - 1][0];
+    expect(call.body).toBe('New draft tweet');
+  });
+});

--- a/services/tasks-api/README.md
+++ b/services/tasks-api/README.md
@@ -33,6 +33,33 @@ REST API (M3 slice):
 - `GET /api/v1/tags`
 - `POST /api/v1/tags`
 
+Content Scheduler endpoints (`/api/v1/content-scheduler/*`, see
+`docs/specs/content-scheduler-tab-tech-design.md`):
+- `GET /items?status=` — list non-`removed` items; sorted by status, position, createdAt.
+- `POST /items` — create (body, source, sourceRef, scheduledFor).
+- `PATCH /items/:id` — edit body/scheduledFor/source/sourceRef; 409 on published/removed.
+- `POST /items/:id/approve` — sets `status=approved`, `approvedAt`, `approvedBy`.
+- `POST /items/:id/unapprove` — clears approval (status back to `queued`).
+- `POST /items/:id/publish` — guarded; posts to X via the configured X client.
+- `POST /items/:id/remove` — soft-delete (status=`removed`); 409 on published.
+- `POST /reorder` — `{ ids: [...] }` rewrites `position` per id in a transaction.
+- `GET /today-status` — `{ date, publishedCount, publishedItemId, cap }` for `Pacific/Auckland` today.
+
+### Content Scheduler env vars
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `X_CLIENT` | `fake` | `fake` returns a deterministic FakeXClient (dev/test). `real` calls `api.twitter.com/2/tweets`. |
+| `X_API_BEARER_TOKEN` | unset | Required when `X_CLIENT=real`; missing token → publish returns 503 `MISSING_CREDENTIALS`. |
+| `X_HANDLE` | `sindustries` | Used to build the published post URL when `X_CLIENT=real`. |
+
+### Content Scheduler timezone
+
+The "max one X post per day" rule is computed in `Pacific/Auckland` (Tom's
+local time). UTC `publishedAt` timestamps are stored; the daily window is
+derived via `Intl.DateTimeFormat('en-NZ', { timeZone: 'Pacific/Auckland' })`
+on each publish/today-status request.
+
 ## Database workflow
 ```bash
 # generate Prisma client

--- a/services/tasks-api/prisma/migrations/20260710000000_add_content_scheduler/migration.sql
+++ b/services/tasks-api/prisma/migrations/20260710000000_add_content_scheduler/migration.sql
@@ -1,0 +1,35 @@
+-- CreateEnum
+CREATE TYPE "ContentSchedulerItemStatus" AS ENUM ('draft', 'queued', 'approved', 'published', 'removed');
+
+-- CreateEnum
+CREATE TYPE "ContentSchedulerSource" AS ENUM ('ops_notes', 'cto_craft', 'manual', 'other');
+
+-- CreateTable
+CREATE TABLE "ContentSchedulerItem" (
+    "id" UUID NOT NULL,
+    "body" VARCHAR(1000) NOT NULL,
+    "source" "ContentSchedulerSource" NOT NULL DEFAULT 'manual',
+    "sourceRef" TEXT,
+    "status" "ContentSchedulerItemStatus" NOT NULL DEFAULT 'queued',
+    "scheduledFor" TIMESTAMP(3),
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "approvedAt" TIMESTAMP(3),
+    "approvedBy" TEXT,
+    "publishedAt" TIMESTAMP(3),
+    "publishedUrl" TEXT,
+    "publishError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "removedAt" TIMESTAMP(3),
+
+    CONSTRAINT "ContentSchedulerItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ContentSchedulerItem_status_position_idx" ON "ContentSchedulerItem"("status", "position");
+
+-- CreateIndex
+CREATE INDEX "ContentSchedulerItem_status_scheduledFor_idx" ON "ContentSchedulerItem"("status", "scheduledFor");
+
+-- CreateIndex
+CREATE INDEX "ContentSchedulerItem_status_publishedAt_idx" ON "ContentSchedulerItem"("status", "publishedAt");

--- a/services/tasks-api/prisma/schema.prisma
+++ b/services/tasks-api/prisma/schema.prisma
@@ -94,3 +94,40 @@ model TaskTag {
   @@id([taskId, tagId])
   @@index([tagId])
 }
+
+enum ContentSchedulerItemStatus {
+  draft
+  queued
+  approved
+  published
+  removed
+}
+
+enum ContentSchedulerSource {
+  ops_notes
+  cto_craft
+  manual
+  other
+}
+
+model ContentSchedulerItem {
+  id            String                       @id @default(uuid()) @db.Uuid
+  body          String                       @db.VarChar(1000)
+  source        ContentSchedulerSource       @default(manual)
+  sourceRef     String?
+  status        ContentSchedulerItemStatus   @default(queued)
+  scheduledFor  DateTime?
+  position      Int                          @default(0)
+  approvedAt    DateTime?
+  approvedBy    String?
+  publishedAt   DateTime?
+  publishedUrl  String?
+  publishError  String?
+  createdAt     DateTime                     @default(now())
+  updatedAt     DateTime                     @updatedAt
+  removedAt     DateTime?
+
+  @@index([status, position])
+  @@index([status, scheduledFor])
+  @@index([status, publishedAt])
+}

--- a/services/tasks-api/src/app.ts
+++ b/services/tasks-api/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { healthRouter } from './routes/health';
 import { tasksRouter } from './routes/tasks';
 import { tagsRouter } from './routes/tags';
+import { contentSchedulerRouter } from './routes/contentScheduler.ts';
 
 function getAllowedOrigins() {
   const configured = process.env.CORS_ALLOWED_ORIGINS?.split(',')
@@ -52,6 +53,7 @@ export function createApp() {
   app.use('/api/v1', healthRouter);
   app.use('/api/v1', tasksRouter);
   app.use('/api/v1', tagsRouter);
+  app.use('/api/v1', contentSchedulerRouter);
 
   app.use((error, _req, res, _next) => {
     console.error(error);

--- a/services/tasks-api/src/routes/contentScheduler.ts
+++ b/services/tasks-api/src/routes/contentScheduler.ts
@@ -1,0 +1,375 @@
+// Content Scheduler routes — Express router mounted at /api/v1/content-scheduler.
+//
+// Implements AC1-AC6 from task 115e8d89-be43-4b81-9e0e-9ab422810f5f:
+//  - GET    /items               list non-removed items, optional status filter
+//  - POST   /items               create
+//  - PATCH  /items/:id           edit body / scheduledFor / source / sourceRef
+//  - POST   /items/:id/approve   mark approved (AC6 — explicit gate)
+//  - POST   /items/:id/unapprove clear approval
+//  - POST   /items/:id/publish   publish (guarded; X integration via helper)
+//  - POST   /items/:id/remove    soft-delete
+//  - POST   /reorder             rewrite positions from an id list
+//  - GET    /today-status        daily cap (Pacific/Auckland)
+//
+// All write endpoints accept an `x-actor` header that defaults to "unknown"
+// — there is no auth in v1 (single-user MVP per the tech design).
+//
+// Tech design: docs/specs/content-scheduler-tab-tech-design.md
+
+import { Router } from 'express';
+import { prisma } from '../lib/prisma.ts';
+import { badRequest, notFound, sendError } from '../lib/http.ts';
+import {
+  guardPublish,
+  getAucklandTodayParts,
+  getXClient,
+  TERMINAL_STATUSES
+} from './contentSchedulerPublish.ts';
+
+const MAX_BODY = 1000;
+
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const validSources = new Set(['ops_notes', 'cto_craft', 'manual', 'other']);
+const validStatuses = new Set(['draft', 'queued', 'approved', 'published', 'removed']);
+
+function actor(req: any): string {
+  const header = req.headers['x-actor'];
+  if (typeof header === 'string' && header.trim().length > 0) return header.trim();
+  return 'unknown';
+}
+
+function parseId(raw: string): string | null {
+  return uuidPattern.test(raw) ? raw : null;
+}
+
+function parseDate(value: unknown): Date | null | 'invalid' {
+  if (value === undefined || value === null || value === '') return null;
+  const d = new Date(value as string);
+  return Number.isNaN(d.valueOf()) ? 'invalid' : d;
+}
+
+function validateBody(body: unknown): string | null {
+  if (typeof body !== 'string') return 'body must be a string';
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return 'body must not be empty';
+  if (body.length > MAX_BODY) return `body must be <= ${MAX_BODY} characters`;
+  return null;
+}
+
+export const contentSchedulerRouter = Router();
+
+contentSchedulerRouter.get('/content-scheduler/items', async (req, res, next) => {
+  try {
+    const statusFilter = typeof req.query.status === 'string' ? req.query.status : undefined;
+    if (statusFilter && !validStatuses.has(statusFilter)) {
+      return badRequest(res, 'INVALID_STATUS_FILTER', 'Invalid status filter');
+    }
+
+    const items = await prisma.contentSchedulerItem.findMany({
+      where: statusFilter
+        ? { status: statusFilter as any }
+        : { status: { not: 'removed' as const } },
+      orderBy: [{ status: 'asc' }, { position: 'asc' }, { createdAt: 'asc' }]
+    });
+
+    res.json({ data: items });
+  } catch (err) {
+    next(err);
+  }
+});
+
+contentSchedulerRouter.post('/content-scheduler/items', async (req, res, next) => {
+  try {
+    const { body, source, sourceRef, scheduledFor } = req.body ?? {};
+
+    const bodyError = validateBody(body);
+    if (bodyError) return badRequest(res, 'INVALID_BODY', bodyError);
+
+    if (source !== undefined && !validSources.has(source)) {
+      return badRequest(res, 'INVALID_SOURCE', 'Invalid source value');
+    }
+
+    const schedParsed = parseDate(scheduledFor);
+    if (schedParsed === 'invalid') {
+      return badRequest(res, 'INVALID_SCHEDULED_FOR', 'Invalid scheduledFor value');
+    }
+
+    // Position: append after the current max within status=queued.
+    const maxPosition = await prisma.contentSchedulerItem.aggregate({
+      where: { status: 'queued' },
+      _max: { position: true }
+    });
+    const nextPosition = (maxPosition._max.position ?? -1) + 1;
+
+    const created = await prisma.contentSchedulerItem.create({
+      data: {
+        body: (body as string).trim(),
+        source: source ?? 'manual',
+        sourceRef: typeof sourceRef === 'string' ? sourceRef : null,
+        scheduledFor: schedParsed ?? null,
+        status: 'queued',
+        position: nextPosition
+      }
+    });
+
+    res.status(201).json({ data: created });
+  } catch (err) {
+    next(err);
+  }
+});
+
+contentSchedulerRouter.patch('/content-scheduler/items/:id', async (req, res, next) => {
+  try {
+    const id = parseId(req.params.id);
+    if (!id) return badRequest(res, 'INVALID_ID', 'Invalid id');
+
+    const existing = await prisma.contentSchedulerItem.findUnique({ where: { id } });
+    if (!existing) return notFound(res, 'NOT_FOUND', 'Item not found');
+    if (TERMINAL_STATUSES.includes(existing.status as any)) {
+      return sendError(res, 409, 'TERMINAL_STATUS', `Cannot edit item in status ${existing.status}`);
+    }
+
+    const { body, source, sourceRef, scheduledFor } = req.body ?? {};
+    const updates: Record<string, unknown> = {};
+
+    if (body !== undefined) {
+      const bodyError = validateBody(body);
+      if (bodyError) return badRequest(res, 'INVALID_BODY', bodyError);
+      updates.body = (body as string).trim();
+    }
+    if (source !== undefined) {
+      if (!validSources.has(source)) {
+        return badRequest(res, 'INVALID_SOURCE', 'Invalid source value');
+      }
+      updates.source = source;
+    }
+    if (sourceRef !== undefined) {
+      updates.sourceRef = typeof sourceRef === 'string' ? sourceRef : null;
+    }
+    if (scheduledFor !== undefined) {
+      const schedParsed = parseDate(scheduledFor);
+      if (schedParsed === 'invalid') {
+        return badRequest(res, 'INVALID_SCHEDULED_FOR', 'Invalid scheduledFor value');
+      }
+      updates.scheduledFor = schedParsed ?? null;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return badRequest(res, 'NO_UPDATES', 'No updatable fields provided');
+    }
+
+    const updated = await prisma.contentSchedulerItem.update({
+      where: { id },
+      data: updates
+    });
+
+    res.json({ data: updated });
+  } catch (err) {
+    next(err);
+  }
+});
+
+contentSchedulerRouter.post('/content-scheduler/items/:id/approve', async (req, res, next) => {
+  try {
+    const id = parseId(req.params.id);
+    if (!id) return badRequest(res, 'INVALID_ID', 'Invalid id');
+
+    const existing = await prisma.contentSchedulerItem.findUnique({ where: { id } });
+    if (!existing) return notFound(res, 'NOT_FOUND', 'Item not found');
+    if (existing.status === 'published') {
+      return sendError(res, 409, 'ALREADY_PUBLISHED', 'Cannot approve a published item');
+    }
+    if (existing.status === 'removed') {
+      return sendError(res, 409, 'REMOVED', 'Cannot approve a removed item');
+    }
+
+    const updated = await prisma.contentSchedulerItem.update({
+      where: { id },
+      data: {
+        status: 'approved',
+        approvedAt: new Date(),
+        approvedBy: actor(req)
+      }
+    });
+
+    res.json({ data: updated });
+  } catch (err) {
+    next(err);
+  }
+});
+
+contentSchedulerRouter.post('/content-scheduler/items/:id/unapprove', async (req, res, next) => {
+  try {
+    const id = parseId(req.params.id);
+    if (!id) return badRequest(res, 'INVALID_ID', 'Invalid id');
+
+    const existing = await prisma.contentSchedulerItem.findUnique({ where: { id } });
+    if (!existing) return notFound(res, 'NOT_FOUND', 'Item not found');
+    if (existing.status === 'published') {
+      return sendError(res, 409, 'ALREADY_PUBLISHED', 'Cannot unapprove a published item');
+    }
+
+    const updated = await prisma.contentSchedulerItem.update({
+      where: { id },
+      data: {
+        status: 'queued',
+        approvedAt: null,
+        approvedBy: null
+      }
+    });
+
+    res.json({ data: updated });
+  } catch (err) {
+    next(err);
+  }
+});
+
+contentSchedulerRouter.post('/content-scheduler/items/:id/publish', async (req, res, next) => {
+  try {
+    const id = parseId(req.params.id);
+    if (!id) return badRequest(res, 'INVALID_ID', 'Invalid id');
+
+    const item = await prisma.contentSchedulerItem.findUnique({ where: { id } });
+    if (!item) return notFound(res, 'NOT_FOUND', 'Item not found');
+
+    const { startUtc, endUtc, date } = getAucklandTodayParts();
+    const todays = await prisma.contentSchedulerItem.findMany({
+      where: {
+        status: 'published',
+        publishedAt: { gte: startUtc, lt: endUtc }
+      },
+      select: { id: true }
+    });
+    const publishedCount = todays.length;
+    const publishedItemId = publishedCount > 0 ? todays[0].id : null;
+
+    const guard = guardPublish(item, { publishedCount, publishedItemId });
+    if (!guard.ok) {
+      return sendError(res, 409, guard.code, `Publish refused: ${guard.code}`);
+    }
+
+    const client = getXClient();
+    if (!client) {
+      return sendError(res, 503, 'MISSING_CREDENTIALS', 'X credentials are not configured');
+    }
+
+    let result: { url: string; postedAt: Date };
+    try {
+      result = await client.createTweet({ text: item.body });
+    } catch (publishError) {
+      const message = publishError instanceof Error ? publishError.message : String(publishError);
+      const updated = await prisma.contentSchedulerItem.update({
+        where: { id },
+        data: { publishError: message }
+      });
+      return sendError(res, 502, 'PUBLISH_FAILED', message);
+    }
+
+    const updated = await prisma.contentSchedulerItem.update({
+      where: { id },
+      data: {
+        status: 'published',
+        publishedAt: result.postedAt,
+        publishedUrl: result.url,
+        publishError: null
+      }
+    });
+
+    res.json({ data: updated, today: date });
+  } catch (err) {
+    next(err);
+  }
+});
+
+contentSchedulerRouter.post('/content-scheduler/items/:id/remove', async (req, res, next) => {
+  try {
+    const id = parseId(req.params.id);
+    if (!id) return badRequest(res, 'INVALID_ID', 'Invalid id');
+
+    const existing = await prisma.contentSchedulerItem.findUnique({ where: { id } });
+    if (!existing) return notFound(res, 'NOT_FOUND', 'Item not found');
+    if (existing.status === 'published') {
+      return sendError(res, 409, 'ALREADY_PUBLISHED', 'Cannot remove a published item');
+    }
+
+    const updated = await prisma.contentSchedulerItem.update({
+      where: { id },
+      data: {
+        status: 'removed',
+        removedAt: new Date()
+      }
+    });
+
+    res.json({ data: updated });
+  } catch (err) {
+    next(err);
+  }
+});
+
+contentSchedulerRouter.post('/content-scheduler/reorder', async (req, res, next) => {
+  try {
+    const { ids } = req.body ?? {};
+    if (!Array.isArray(ids)) {
+      return badRequest(res, 'INVALID_IDS', 'ids must be an array');
+    }
+    if (ids.some((id) => typeof id !== 'string' || !uuidPattern.test(id))) {
+      return badRequest(res, 'INVALID_IDS', 'ids must contain valid UUIDs');
+    }
+    const uniqueIds = Array.from(new Set(ids));
+    if (uniqueIds.length !== ids.length) {
+      return badRequest(res, 'DUPLICATE_IDS', 'ids must be unique');
+    }
+
+    const items = await prisma.contentSchedulerItem.findMany({
+      where: { id: { in: uniqueIds } },
+      select: { id: true, status: true }
+    });
+    if (items.length !== uniqueIds.length) {
+      return notFound(res, 'NOT_FOUND', 'One or more ids do not exist');
+    }
+    const blocked = items.find((i) => TERMINAL_STATUSES.includes(i.status as any));
+    if (blocked) {
+      return sendError(res, 409, 'TERMINAL_STATUS', `Cannot reorder item in status ${blocked.status}`);
+    }
+
+    await prisma.$transaction(
+      uniqueIds.map((id, index) =>
+        prisma.contentSchedulerItem.update({
+          where: { id },
+          data: { position: index }
+        })
+      )
+    );
+
+    res.json({ data: { ok: true, count: uniqueIds.length } });
+  } catch (err) {
+    next(err);
+  }
+});
+
+contentSchedulerRouter.get('/content-scheduler/today-status', async (_req, res, next) => {
+  try {
+    const { startUtc, endUtc, date } = getAucklandTodayParts();
+    const todays = await prisma.contentSchedulerItem.findMany({
+      where: {
+        status: 'published',
+        publishedAt: { gte: startUtc, lt: endUtc }
+      },
+      select: { id: true, publishedAt: true, publishedUrl: true }
+    });
+
+    res.json({
+      data: {
+        date,
+        publishedCount: todays.length,
+        publishedItemId: todays[0]?.id ?? null,
+        publishedAt: todays[0]?.publishedAt ?? null,
+        publishedUrl: todays[0]?.publishedUrl ?? null,
+        cap: 1
+      }
+    });
+  } catch (err) {
+    next(err);
+  }
+});

--- a/services/tasks-api/src/routes/contentSchedulerPublish.ts
+++ b/services/tasks-api/src/routes/contentSchedulerPublish.ts
@@ -1,0 +1,206 @@
+// Content Scheduler publish helpers.
+//
+// Pure logic (guardPublish) and an X client interface used by the
+// /content-scheduler/items/:id/publish endpoint. The fake client is the
+// default for dev/test; the real client posts to api.twitter.com/2/tweets
+// when X_CLIENT=real is set. There is no automatic cron publishing — Tom
+// clicks Publish manually per item.
+//
+// Task: 115e8d89-be43-4b81-9e0e-9ab422810f5f
+// Tech design: docs/specs/content-scheduler-tab-tech-design.md
+
+import type { ContentSchedulerItem } from '../../generated/prisma/index.js';
+
+/**
+ * Status values that block edits/removes/reorder. Mirrors the route-level
+ * 409 responses in contentScheduler.ts.
+ */
+export const TERMINAL_STATUSES = ['published', 'removed'] as const;
+
+/**
+ * Items the publish endpoint refuses with a structured error code.
+ * Each branch has a paired test in contentScheduler.test.ts.
+ */
+export type PublishGuardCode =
+  | 'NOT_APPROVED'
+  | 'ALREADY_PUBLISHED'
+  | 'DAY_CAP_REACHED'
+  | 'SCHEDULED_IN_FUTURE'
+  | 'MISSING_CREDENTIALS'
+  | 'NO_X_CLIENT';
+
+export type PublishGuardResult =
+  | { ok: true }
+  | { ok: false; code: PublishGuardCode };
+
+/**
+ * Pure guard. Returns ok=false with a code if the item is not eligible
+ * to publish right now. Reasons the guard can refuse:
+ *  - status !== 'approved' → NOT_APPROVED (also covers already-published / removed)
+ *  - scheduledFor > now + 60s → SCHEDULED_IN_FUTURE
+ *  - today.publishedCount >= 1 (and the item isn't the existing one) → DAY_CAP_REACHED
+ * The MISSING_CREDENTIALS / NO_X_CLIENT checks happen in the route, not here,
+ * because they depend on process.env which is not safe to thread into a pure
+ * function from a unit-test perspective.
+ */
+export function guardPublish(
+  item: Pick<ContentSchedulerItem, 'status' | 'scheduledFor' | 'approvedAt'>,
+  today: { publishedCount: number; publishedItemId?: string | null },
+  now: Date = new Date()
+): PublishGuardResult {
+  if (item.status === 'published') {
+    return { ok: false, code: 'ALREADY_PUBLISHED' };
+  }
+  if (item.status !== 'approved' || !item.approvedAt) {
+    return { ok: false, code: 'NOT_APPROVED' };
+  }
+  if (item.scheduledFor) {
+    const graceMs = 60_000;
+    if (item.scheduledFor.getTime() - now.getTime() > graceMs) {
+      return { ok: false, code: 'SCHEDULED_IN_FUTURE' };
+    }
+  }
+  if (
+    today.publishedCount >= 1 &&
+    today.publishedItemId !== undefined &&
+    today.publishedItemId !== null
+  ) {
+    return { ok: false, code: 'DAY_CAP_REACHED' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Tiny X client interface. Implementations post a tweet and return the
+ * canonical URL + postedAt timestamp. The fake client returns deterministic
+ * URLs so dev/test flows have stable assertions.
+ */
+export interface XClient {
+  createTweet(input: { text: string }): Promise<{ url: string; postedAt: Date }>;
+}
+
+/**
+ * Deterministic fake used in dev/test. Generates a URL based on the SHA-256
+ * prefix of the text so different inputs get different URLs but the same
+ * input always produces the same URL.
+ */
+export class FakeXClient implements XClient {
+  async createTweet({ text }: { text: string }): Promise<{ url: string; postedAt: Date }> {
+    const { createHash } = await import('node:crypto');
+    const id = createHash('sha256').update(text).digest('hex').slice(0, 16);
+    return {
+      url: `https://x.com/sindustries/status/${id}`,
+      postedAt: new Date()
+    };
+  }
+}
+
+/**
+ * Real client for production. Posts to api.twitter.com/2/tweets with bearer
+ * auth. Wraps the fetch in a 10s timeout. Returns the URL the response
+ * includes in `data.id` (i.e. https://x.com/<handle>/status/<id>).
+ */
+export class RealXClient implements XClient {
+  constructor(
+    private readonly bearerToken: string,
+    private readonly handle: string = 'sindustries',
+    private readonly timeoutMs: number = 10_000
+  ) {}
+
+  async createTweet({ text }: { text: string }): Promise<{ url: string; postedAt: Date }> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await fetch('https://api.twitter.com/2/tweets', {
+        method: 'POST',
+        signal: controller.signal,
+        headers: {
+          authorization: `Bearer ${this.bearerToken}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ text })
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`X API ${res.status}: ${body.slice(0, 200)}`);
+      }
+      const json = (await res.json()) as { data?: { id?: string } };
+      const id = json?.data?.id;
+      if (!id) {
+        throw new Error('X API returned no tweet id');
+      }
+      return {
+        url: `https://x.com/${this.handle}/status/${id}`,
+        postedAt: new Date()
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+/**
+ * Resolves the X client for the current process. Returns null when no
+ * credentials are configured so the route can return a 503 with a clear
+ * "missing credential" error.
+ *
+ * Selection rules (per tech design):
+ *  - X_CLIENT=fake (default in dev/test): returns FakeXClient
+ *  - X_CLIENT=real: requires X_API_BEARER_TOKEN; returns null otherwise
+ *  - X_CLIENT unset: defaults to fake (returns FakeXClient)
+ */
+export function getXClient(): XClient | null {
+  const kind = (process.env.X_CLIENT ?? 'fake').toLowerCase();
+  if (kind === 'real') {
+    const token = process.env.X_API_BEARER_TOKEN;
+    if (!token) return null;
+    const handle = process.env.X_HANDLE ?? 'sindustries';
+    return new RealXClient(token, handle);
+  }
+  return new FakeXClient();
+}
+
+/**
+ * "Today" in Pacific/Auckland for the daily-cap check. Returns the date
+ * portion as 'YYYY-MM-DD' along with the day-boundary Date objects so the
+ * route can run a single timestamped query.
+ */
+export function getAucklandTodayParts(now: Date = new Date()) {
+  const formatter = new Intl.DateTimeFormat('en-NZ', {
+    timeZone: 'Pacific/Auckland',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  });
+  const parts = formatter.formatToParts(now);
+  const lookup = Object.fromEntries(parts.map((p) => [p.type, p.value]));
+  const date = `${lookup.year}-${lookup.month}-${lookup.day}`;
+
+  // Compute the UTC bounds for that NZ-local calendar day.
+  // We binary-search for the start by stepping back from now until the
+  // formatter yields a different day; then for end we add 24h and repeat.
+  const startUtc = startOfAucklandDay(now);
+  const endUtc = new Date(startUtc.getTime() + 24 * 60 * 60 * 1000);
+  return { date, startUtc, endUtc };
+}
+
+function startOfAucklandDay(now: Date): Date {
+  // Walk back from now until the day string flips. Bounded to 25 hours.
+  const formatter = new Intl.DateTimeFormat('en-NZ', {
+    timeZone: 'Pacific/Auckland',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  });
+  const currentDay = formatter.format(now);
+  let cursor = now.getTime();
+  for (let i = 0; i < 25 * 60; i += 1) {
+    cursor -= 60_000;
+    if (formatter.format(new Date(cursor)) !== currentDay) {
+      // step forward 1 minute to the start of currentDay
+      return new Date(cursor + 60_000);
+    }
+  }
+  // Fallback: return now (should never hit given bounded loop).
+  return now;
+}

--- a/services/tasks-api/test/contentScheduler.test.ts
+++ b/services/tasks-api/test/contentScheduler.test.ts
@@ -1,0 +1,361 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { guardPublish, getXClient, FakeXClient, RealXClient } from '../src/routes/contentSchedulerPublish.ts';
+
+// --- Prisma mock ---------------------------------------------------------
+
+const prismaMock: any = {
+  contentSchedulerItem: {
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    aggregate: vi.fn()
+  },
+  $transaction: vi.fn()
+};
+
+vi.mock('../src/lib/prisma.ts', () => ({
+  prisma: prismaMock
+}));
+
+const { createApp } = await import('../src/app.ts');
+
+function itemFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    body: 'Hello world',
+    source: 'manual',
+    sourceRef: null,
+    status: 'queued',
+    scheduledFor: null,
+    position: 0,
+    approvedAt: null,
+    approvedBy: null,
+    publishedAt: null,
+    publishedUrl: null,
+    publishError: null,
+    createdAt: new Date('2026-07-10T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-10T00:00:00.000Z'),
+    removedAt: null,
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prismaMock.$transaction.mockImplementation(async (cbOrOps: any) => {
+    if (typeof cbOrOps === 'function') return cbOrOps(prismaMock);
+    return Promise.all(cbOrOps);
+  });
+  // Default: empty queue for list endpoint
+  prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
+  prismaMock.contentSchedulerItem.aggregate.mockResolvedValue({ _max: { position: null } });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// --- Pure guardPublish tests ---------------------------------------------
+
+describe('guardPublish', () => {
+  const now = new Date('2026-07-10T08:00:00.000Z');
+
+  it('returns ok when item is approved, no schedule, no day cap', () => {
+    const result = guardPublish(
+      itemFixture({ status: 'approved', approvedAt: now }),
+      { publishedCount: 0, publishedItemId: null },
+      now
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('refuses NOT_APPROVED when item is queued', () => {
+    const result = guardPublish(
+      itemFixture({ status: 'queued' }),
+      { publishedCount: 0, publishedItemId: null },
+      now
+    );
+    expect(result).toEqual({ ok: false, code: 'NOT_APPROVED' });
+  });
+
+  it('refuses ALREADY_PUBLISHED when status is published', () => {
+    const result = guardPublish(
+      itemFixture({ status: 'published', approvedAt: now, publishedAt: now }),
+      { publishedCount: 1, publishedItemId: itemFixture().id },
+      now
+    );
+    expect(result).toEqual({ ok: false, code: 'ALREADY_PUBLISHED' });
+  });
+
+  it('refuses DAY_CAP_REACHED when a different item already published today', () => {
+    const result = guardPublish(
+      itemFixture({ id: 'aaaa', status: 'approved', approvedAt: now }),
+      { publishedCount: 1, publishedItemId: 'bbbb' },
+      now
+    );
+    expect(result).toEqual({ ok: false, code: 'DAY_CAP_REACHED' });
+  });
+
+  it('refuses SCHEDULED_IN_FUTURE when scheduledFor > now + 60s', () => {
+    const future = new Date(now.getTime() + 5 * 60_000);
+    const result = guardPublish(
+      itemFixture({ status: 'approved', approvedAt: now, scheduledFor: future }),
+      { publishedCount: 0, publishedItemId: null },
+      now
+    );
+    expect(result).toEqual({ ok: false, code: 'SCHEDULED_IN_FUTURE' });
+  });
+
+  it('allows scheduledFor within the 60s grace window', () => {
+    const future = new Date(now.getTime() + 30_000);
+    const result = guardPublish(
+      itemFixture({ status: 'approved', approvedAt: now, scheduledFor: future }),
+      { publishedCount: 0, publishedItemId: null },
+      now
+    );
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+// --- FakeXClient ----------------------------------------------------------
+
+describe('FakeXClient', () => {
+  it('returns a deterministic URL and a postedAt timestamp', async () => {
+    const client = new FakeXClient();
+    const a = await client.createTweet({ text: 'hello' });
+    const b = await client.createTweet({ text: 'hello' });
+    const c = await client.createTweet({ text: 'world' });
+    expect(a.url).toMatch(/^https:\/\/x\.com\/sindustries\/status\/[0-9a-f]{16}$/);
+    expect(a.url).toBe(b.url);
+    expect(a.url).not.toBe(c.url);
+    expect(a.postedAt).toBeInstanceOf(Date);
+  });
+});
+
+// --- getXClient selection -------------------------------------------------
+
+describe('getXClient', () => {
+  it('returns FakeXClient by default', () => {
+    delete process.env.X_CLIENT;
+    delete process.env.X_API_BEARER_TOKEN;
+    const client = getXClient();
+    expect(client).toBeInstanceOf(FakeXClient);
+  });
+
+  it('returns FakeXClient when X_CLIENT=fake', () => {
+    process.env.X_CLIENT = 'fake';
+    const client = getXClient();
+    expect(client).toBeInstanceOf(FakeXClient);
+  });
+
+  it('returns null when X_CLIENT=real without bearer token', () => {
+    process.env.X_CLIENT = 'real';
+    delete process.env.X_API_BEARER_TOKEN;
+    expect(getXClient()).toBeNull();
+  });
+
+  it('returns RealXClient when X_CLIENT=real and bearer token is set', () => {
+    process.env.X_CLIENT = 'real';
+    process.env.X_API_BEARER_TOKEN = 'test-token';
+    const client = getXClient();
+    expect(client).toBeInstanceOf(RealXClient);
+    delete process.env.X_API_BEARER_TOKEN;
+  });
+});
+
+// --- HTTP routes ----------------------------------------------------------
+
+describe('contentScheduler routes', () => {
+  it('GET /api/v1/content-scheduler/items lists non-removed items', async () => {
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([itemFixture()]);
+    const app = createApp();
+    const res = await request(app).get('/api/v1/content-scheduler/items');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(prismaMock.contentSchedulerItem.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ status: { not: 'removed' } }) })
+    );
+  });
+
+  it('GET /api/v1/content-scheduler/items rejects unknown status filter', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/content-scheduler/items?status=bogus');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_STATUS_FILTER');
+  });
+
+  it('POST /api/v1/content-scheduler/items rejects empty body', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/content-scheduler/items')
+      .send({ body: '   ' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_BODY');
+  });
+
+  it('POST /api/v1/content-scheduler/items rejects body > 1000 chars', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/content-scheduler/items')
+      .send({ body: 'x'.repeat(1001) });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_BODY');
+  });
+
+  it('POST /api/v1/content-scheduler/items creates with position after max', async () => {
+    prismaMock.contentSchedulerItem.aggregate.mockResolvedValue({ _max: { position: 4 } });
+    prismaMock.contentSchedulerItem.create.mockResolvedValue(itemFixture({ position: 5 }));
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/content-scheduler/items')
+      .send({ body: 'Tweet body', source: 'ops_notes' });
+    expect(res.status).toBe(201);
+    expect(prismaMock.contentSchedulerItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ position: 5, status: 'queued' }) })
+    );
+  });
+
+  it('POST /content-scheduler/items/:id/approve sets approvedAt + approvedBy', async () => {
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(itemFixture({ status: 'queued' }));
+    prismaMock.contentSchedulerItem.update.mockResolvedValue(itemFixture({ status: 'approved', approvedAt: new Date(), approvedBy: 'Tom' }));
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/approve')
+      .set('x-actor', 'Tom');
+    expect(res.status).toBe(200);
+    expect(prismaMock.contentSchedulerItem.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ approvedBy: 'Tom', status: 'approved' })
+      })
+    );
+  });
+
+  it('POST /content-scheduler/items/:id/approve returns 409 on already published', async () => {
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(itemFixture({ status: 'published' }));
+    const app = createApp();
+    const res = await request(app).post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/approve');
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('ALREADY_PUBLISHED');
+  });
+
+  it('POST /content-scheduler/items/:id/publish refuses NOT_APPROVED', async () => {
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(itemFixture({ status: 'queued' }));
+    const app = createApp();
+    const res = await request(app).post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/publish');
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('NOT_APPROVED');
+  });
+
+  it('POST /content-scheduler/items/:id/publish refuses DAY_CAP_REACHED', async () => {
+    const itemId = 'aaaa1111-1111-1111-1111-111111111111';
+    const otherId = 'bbbb1111-1111-1111-1111-111111111111';
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(
+      itemFixture({ status: 'approved', approvedAt: new Date(), id: itemId })
+    );
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([{ id: otherId }]);
+    const app = createApp();
+    const res = await request(app).post(`/api/v1/content-scheduler/items/${itemId}/publish`);
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('DAY_CAP_REACHED');
+  });
+
+  it('POST /content-scheduler/items/:id/publish succeeds with fake client + sets publishedAt/Url', async () => {
+    process.env.X_CLIENT = 'fake';
+    const item = itemFixture({
+      id: 'cccc1111-1111-1111-1111-111111111111',
+      status: 'approved',
+      approvedAt: new Date()
+    });
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]); // today-status empty
+    prismaMock.contentSchedulerItem.update.mockResolvedValue({ ...item, status: 'published', publishedUrl: 'https://x.com/sindustries/status/abc', publishedAt: new Date() });
+    const app = createApp();
+    const res = await request(app).post('/api/v1/content-scheduler/items/cccc1111-1111-1111-1111-111111111111/publish');
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('published');
+    expect(res.body.data.publishedUrl).toMatch(/^https:\/\/x\.com\//);
+  });
+
+  it('POST /content-scheduler/items/:id/publish returns 503 when credentials missing', async () => {
+    process.env.X_CLIENT = 'real';
+    delete process.env.X_API_BEARER_TOKEN;
+    const item = itemFixture({
+      id: 'dddd1111-1111-1111-1111-111111111111',
+      status: 'approved',
+      approvedAt: new Date()
+    });
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
+    const app = createApp();
+    const res = await request(app).post('/api/v1/content-scheduler/items/dddd1111-1111-1111-1111-111111111111/publish');
+    expect(res.status).toBe(503);
+    expect(res.body.error.code).toBe('MISSING_CREDENTIALS');
+    delete process.env.X_CLIENT;
+  });
+
+  it('POST /content-scheduler/reorder writes positions in a transaction', async () => {
+    const idA = 'aaaa1111-1111-1111-1111-111111111111';
+    const idB = 'bbbb1111-1111-1111-1111-111111111111';
+    const idC = 'cccc1111-1111-1111-1111-111111111111';
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([
+      { id: idA, status: 'queued' },
+      { id: idB, status: 'queued' },
+      { id: idC, status: 'queued' }
+    ]);
+    prismaMock.contentSchedulerItem.update.mockImplementation(async ({ where, data }: any) => ({ id: where.id, position: data.position }));
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/content-scheduler/reorder')
+      .send({ ids: [idC, idA, idB] });
+    expect(res.status).toBe(200);
+    expect(prismaMock.$transaction).toHaveBeenCalled();
+    expect(prismaMock.contentSchedulerItem.update).toHaveBeenCalledTimes(3);
+    expect(prismaMock.contentSchedulerItem.update).toHaveBeenNthCalledWith(1, expect.objectContaining({ data: { position: 0 } }));
+    expect(prismaMock.contentSchedulerItem.update).toHaveBeenNthCalledWith(2, expect.objectContaining({ data: { position: 1 } }));
+    expect(prismaMock.contentSchedulerItem.update).toHaveBeenNthCalledWith(3, expect.objectContaining({ data: { position: 2 } }));
+  });
+
+  it('POST /content-scheduler/reorder refuses when an id is in a terminal status', async () => {
+    const idA = 'aaaa1111-1111-1111-1111-111111111111';
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([
+      { id: idA, status: 'published' }
+    ]);
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/content-scheduler/reorder')
+      .send({ ids: [idA] });
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('TERMINAL_STATUS');
+  });
+
+  it('POST /content-scheduler/items/:id/remove soft-deletes to removed', async () => {
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(itemFixture({ status: 'queued' }));
+    prismaMock.contentSchedulerItem.update.mockResolvedValue(itemFixture({ status: 'removed', removedAt: new Date() }));
+    const app = createApp();
+    const res = await request(app).post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/remove');
+    expect(res.status).toBe(200);
+    expect(prismaMock.contentSchedulerItem.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'removed' }) })
+    );
+  });
+
+  it('POST /content-scheduler/items/:id/remove refuses when already published', async () => {
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(itemFixture({ status: 'published' }));
+    const app = createApp();
+    const res = await request(app).post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/remove');
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('ALREADY_PUBLISHED');
+  });
+
+  it('GET /content-scheduler/today-status returns publishedCount + cap', async () => {
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
+    const app = createApp();
+    const res = await request(app).get('/api/v1/content-scheduler/today-status');
+    expect(res.status).toBe(200);
+    expect(res.body.data.publishedCount).toBe(0);
+    expect(res.body.data.cap).toBe(1);
+    expect(typeof res.body.data.date).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary
- Implements task 115e8d89-be43-4b81-9e0e-9ab422810f5f (Content Scheduler tab in Mission Control, AC1-AC6).
- Backend (services/tasks-api): new `ContentSchedulerItem` Prisma model + idempotent migration, new `/api/v1/content-scheduler/*` router (list/create/patch/approve/unapprove/publish/remove/reorder/today-status), pure `guardPublish()` with codes (NOT_APPROVED, ALREADY_PUBLISHED, DAY_CAP_REACHED, SCHEDULED_IN_FUTURE), `FakeXClient` (default dev/test) + `RealXClient` (bearer auth, 10s timeout, api.twitter.com/2/tweets), `getAucklandTodayParts()` computing `Pacific/Auckland` day bounds via `Intl.DateTimeFormat`.
- Frontend (apps/mission-control): new `ContentSchedulerTab` with composer + three grouped lists (Queued / Approved / Published) + drag-to-reorder on queued items + sticky day-status strip; new `contentSchedulerApi.js` client; tab registered at `/content-scheduler`.
- Companion docs: SPEC.md + READMEs updated.
- Rebased onto current `main` to integrate the Design System tab and sidebar collapse changes without dropping the Content Scheduler tab entry from `pulseTabs.jsx`.

Approval gate (AC6) and max-one-per-day rule (AC3, Pacific/Auckland) enforced server-side.

## Test plan
- [x] `npm --workspace @sindustries/tasks-api test` — 65/65 pass (including 27 new cases)
- [x] `npm --workspace @sindustries/mission-control test` — 96/96 pass (including 8 new content-scheduler cases)
- [x] `prisma validate` against the new schema — valid
- [x] Rebased onto current main; conflict in `pulseTabs.jsx` resolved by keeping both Design System and Content tabs
- [ ] Manual: `make up`, open `http://localhost:5174/content-scheduler`, compose + add + approve + publish (with `X_CLIENT=fake`), observe second publish attempt blocked, remove soft-deletes, drag-reorder rewrites `position`.
- [ ] Manual: with `X_CLIENT=real` and unset `X_API_BEARER_TOKEN`, publish returns 503 MISSING_CREDENTIALS.

## Acceptance Criteria
### Task 115e8d89 — Content Scheduler tab in Mission Control
- [x] AC1: Content Scheduler tab registered in Mission Control at its own route (file: apps/mission-control/src/pulseTabs.jsx: content-scheduler entry)
- [x] AC2: Tom can add approved content to a posting queue (file: apps/mission-control/src/tabs/ContentSchedulerTab.jsx: composer + add to queue; services/tasks-api/test/contentScheduler.test.ts: POST /items creates with position after max)
- [x] AC3: Scheduler enforces max 1 tweet published per day to X (file: services/tasks-api/src/routes/contentSchedulerPublish.ts: guardPublish DAY_CAP_REACHED; services/tasks-api/test/contentScheduler.test.ts: refuses DAY_CAP_REACHED + disables publish when cap reached)
- [x] AC4: Tom can view queue, reorder, edit, and remove items (file: apps/mission-control/src/tabs/ContentSchedulerTab.jsx: ItemRow with edit/approve/unapprove/publish/remove + drag-and-drop reorder; services/tasks-api/test/contentScheduler.test.ts: PATCH + reorder + remove tests)
- [x] AC5: Published posts marked with timestamp and X post URL (file: apps/mission-control/src/tabs/ContentSchedulerTab.jsx: published row shows timestamp + URL; services/tasks-api/src/routes/contentScheduler.ts: publish writes publishedAt + publishedUrl)
- [x] AC6: Nothing posts without Tom's explicit per-item approval (file: services/tasks-api/src/routes/contentSchedulerPublish.ts: guardPublish NOT_APPROVED; apps/mission-control/src/tabs/ContentSchedulerTab.jsx: publish button disabled until approvedAt set; services/tasks-api/test/contentScheduler.test.ts: refuses NOT_APPROVED)

🤖 Generated with Claude Code