### PR TITLE
feat(agents): unify agent incident schema across Quinn and Lox (task 75ec1c8c)

### DIFF
--- a/agents/definitions/lox/HEARTBEAT.md
+++ b/agents/definitions/lox/HEARTBEAT.md
@@ -62,10 +62,22 @@ On every heartbeat:
 7. If the status is healthy, write/update state as `resolved` and stay quiet unless another item needs action.
 8. If the status is unhealthy and the runbook says repair is safe, run the repair command once.
 9. Verify the service after repair.
-10. Update state:
-    - repair succeeded + verify healthy: `resolved`
-    - repair attempted + still unhealthy: `repair_attempted`, with `nextRetryAt` at least 2 hours in the future
-    - repair blocked/not safe/no runbook: `blocked`, with `nextRetryAt` tomorrow unless new evidence appears
+10. Update state (unified agent incident schema — task 75ec1c8c, see `docs/systems/agent-incidents.md`):
+    - repair succeeded + verify healthy: `status: "resolved"`, `resolvedAt: <now>`
+    - repair attempted + still unhealthy: `status: "watching"`, `nextRetryAt` at least 2 hours in the future, increment `attempts`
+    - repair blocked/not safe/no runbook: `status: "escalated"`, `nextRetryAt` tomorrow unless new evidence appears, set `needsTom: true`
+
+    Lox must also record the four new unified fields the schema requires:
+    `firstSeen` (ISO-8601 UTC; fall back to `dailyReviewDate` if absent),
+    `attempts` (int ≥ 0), `needsTom` (bool, true when escalated), and `severity`
+    (one of `low`/`medium`/`high`/`critical`). The shared parser
+    (`agents/lib/incident_state.py`) auto-fills missing values, but Lox should
+    record them at write time so the live file validates against the schema.
+
+    The legacy statuses `repair_attempted` and `blocked` are accepted by the
+    parser and normalized to `watching` / `escalated` respectively. Stop using
+    them in new writes; only emit the canonical four (`watching` /
+    `escalated` / `resolved` / `false_positive`).
 11. Escalate to Tom with `openclaw message send --channel telegram --account lox --target 6435140143 --message "<message>"` when:
     - a repair was attempted, or
     - a repair is blocked/failed, or

--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -118,9 +118,12 @@ OPS STATE MANAGEMENT
 
 Quinn maintains a persistent operational findings registry at `brain/state/quinn-ops-state.json`. This is the equivalent of Lox's `lox-incident-state.json` but for workflow/pipeline anomalies rather than infra issues.
 
-**Schema for each entry:**
+**Schema (task 75ec1c8c — unified with Lox):** The state file uses the **unified agent incident schema** described in `docs/systems/agent-incidents.md`. Top-level key is `incidents` (renamed from the legacy `ops` key). The schema marks only `owner` and `status` as required; the rest default to safe values on read.
+
+**Minimal entry shape Quinn should write:**
 ```json
 {
+  "owner": "quinn",
   "firstSeen": "<ISO timestamp>",
   "lastCheckedAt": "<ISO timestamp>",
   "status": "watching | escalated | resolved | false_positive",
@@ -129,9 +132,27 @@ Quinn maintains a persistent operational findings registry at `brain/state/quinn
   "attempts": 1,
   "lastAction": "what was tried / what happened",
   "resolvedAt": null,
-  "escalatedAt": null
+  "escalatedAt": null,
+  "nextRetryAt": null,
+  "recurrenceCount": 0,
+  "details": {}
 }
 ```
+
+**Reading from both agents (preferred path):** Use the shared parser at `agents/lib/incident_state.py`. Import it from the agents package and call `load_all_incidents()` / `needs_tom()` instead of hand-rolling the schema. The parser handles Lox's file too and normalizes legacy shapes on the fly, so Quinn's heartbeat does not need to branch on file format.
+
+```python
+import sys
+sys.path.insert(0, "/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries")
+from agents.lib.incident_state import load_all_incidents, needs_tom
+
+all_incidents = load_all_incidents()
+for inc in needs_tom(all_incidents):
+    # Telegram Tom, set escalatedAt, etc.
+    ...
+```
+
+**Legacy compatibility:** The parser still accepts Quinn's pre-migration `ops` key. Once the migration script (`agents/lib/incident_migrate.py`) has been run against live state (Quinn does this once after PR merge via `[openclaw-needed]`), all entries are in the unified shape and the legacy normalizer is just a safety net.
 
 **What to write entries for** (after each heartbeat section above):
 - Guardrail skips on the same item for 2+ consecutive heartbeats
@@ -158,19 +179,34 @@ After completing all sections, check both `quinn-ops-state.json` and `brain/stat
   - Set `escalatedAt: <now>` on the entry so it only fires once per incident
   - Do not re-escalate already-escalated items unless they've been updated
 
-**State file read/write pattern:**
+**State file read/write pattern (unified schema, task 75ec1c8c):**
 ```python
-import json, os
+import json, os, sys
 from datetime import datetime, timezone
 
 STATE_FILE = '/Users/quinnstoffer/.openclaw/workspace/brain/state/quinn-ops-state.json'
+
+# Prefer the shared parser; fall back to a hand-rolled read if the package
+# isn't importable (e.g. when running outside the repo worktree).
+try:
+    sys.path.insert(0, "/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries")
+    from agents.lib.incident_state import load_all_incidents, needs_tom as _shared_needs_tom
+    def read_all_incidents():
+        return load_all_incidents()
+    def read_needs_tom():
+        return _shared_needs_tom(load_all_incidents())
+except Exception:
+    def read_all_incidents():
+        return []  # parser unavailable; callers should log and continue
+    def read_needs_tom():
+        return []
 
 def read_ops_state():
     try:
         with open(STATE_FILE) as f:
             return json.load(f)
     except Exception:
-        return {"ops": {}}
+        return {"incidents": {}}  # unified key (was "ops" pre-75ec1c8c)
 
 def write_ops_state(state):
     with open(STATE_FILE, 'w') as f:
@@ -178,10 +214,20 @@ def write_ops_state(state):
 
 def upsert_op(state, slug, severity, last_action, resolved=False):
     now = datetime.now(timezone.utc).isoformat()
-    ops = state.setdefault("ops", {})
-    if slug not in ops:
-        ops[slug] = {"firstSeen": now, "attempts": 0, "needsTom": False, "escalatedAt": None, "resolvedAt": None}
-    entry = ops[slug]
+    incidents = state.setdefault("incidents", {})  # unified key (was "ops")
+    if slug not in incidents:
+        incidents[slug] = {
+            "owner": "quinn",  # unified schema: owner is required
+            "firstSeen": now,
+            "attempts": 0,
+            "needsTom": False,
+            "escalatedAt": None,
+            "resolvedAt": None,
+            "nextRetryAt": None,
+            "recurrenceCount": 0,
+            "details": {},
+        }
+    entry = incidents[slug]
     entry["lastCheckedAt"] = now
     entry["lastAction"] = last_action
     entry["severity"] = severity
@@ -196,3 +242,5 @@ def upsert_op(state, slug, severity, last_action, resolved=False):
             entry["severity"] = severity if severity in ("high", "critical") else "high"
     return state
 ```
+
+**Migration note:** After task 75ec1c8c's PR merges, Quinn runs `python3 agents/lib/incident_migrate.py --in-place` once against live state to convert the legacy `ops` key to `incidents` and add the unified fields. Until that runs, the legacy `ops` key is still readable through the parser's safety-net normalizer, so heartbeats do not block.

--- a/agents/lib/__init__.py
+++ b/agents/lib/__init__.py
@@ -1,0 +1,6 @@
+"""Agents library — shared Python helpers used across agent definitions.
+
+Modules:
+- incident_state: Unified agent incident parser (Quinn + Lox) — task 75ec1c8c.
+- incident_migrate: One-shot migration script for legacy incident state files.
+"""

--- a/agents/lib/incident_migrate.py
+++ b/agents/lib/incident_migrate.py
@@ -1,0 +1,272 @@
+"""One-shot migration script for legacy agent incident state files.
+
+Task 75ec1c8c: Quinn's `quinn-ops-state.json` uses an `ops` key with most of
+the unified fields; Lox's `lox-incident-state.json` uses `incidents` but
+without firstSeen/attempts/needsTom/severity. This script reads each file,
+applies the legacy normalizer from `agents.lib.incident_state`, and writes the
+file back under the unified `incidents` key.
+
+This script is **not** invoked automatically by the PR that ships it. Quinn
+runs it manually after the PR merges against live state, via the
+`[openclaw-needed]` task comment workflow. The script:
+
+* Writes a `.bak.<timestamp>` next to each file before replacing.
+* Validates the migrated result against the JSON Schema (unless --skip-schema).
+* Supports `--dry-run` for safe inspection.
+* Supports `--reset` to start fresh (drops entries, writes empty incidents).
+* Is idempotent — running twice on the same file produces no further changes.
+
+Usage::
+
+    # Inspect what would change (safe)
+    python3 agents/lib/incident_migrate.py --dry-run
+
+    # Migrate live state in place (Quinn does this after PR merge)
+    python3 agents/lib/incident_migrate.py --in-place
+
+    # Start fresh (drops all incidents)
+    python3 agents/lib/incident_migrate.py --in-place --reset
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Make the `agents.lib` package importable when this script is run directly
+# (e.g. `python3 agents/lib/incident_migrate.py`) without installing the repo.
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from agents.lib.incident_state import (  # noqa: E402
+    LOX_STATE_RELATIVE,
+    QUINN_STATE_RELATIVE,
+    WORKSPACE_DEFAULT,
+    IncidentStateError,
+    _normalize_lox_entry,
+    _normalize_quinn_entry,
+    validate_with_schema,
+)
+
+log = logging.getLogger("incident_migrate")
+
+
+# ---------------------------------------------------------------------------
+# Migration logic
+# ---------------------------------------------------------------------------
+
+def _backup_path(target: Path) -> Path:
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return target.with_suffix(target.suffix + f".bak.{ts}")
+
+
+def migrate_file(
+    target: Path,
+    owner: str,
+    *,
+    reset: bool = False,
+    write: bool = False,
+    schema_path: Path | None = None,
+) -> dict[str, Any]:
+    """Migrate one state file in place.
+
+    Returns a dict describing what happened, suitable for printing::
+
+        {
+            "path": "<absolute>",
+            "owner": "quinn"|"lox",
+            "existed": bool,
+            "changed": bool,
+            "backup": "<path>" | None,
+            "before_keys": [...],
+            "after_keys": [...],
+            "entries_migrated": int,
+        }
+    """
+    target = Path(target).resolve()
+    result: dict[str, Any] = {
+        "path": str(target),
+        "owner": owner,
+        "existed": target.exists(),
+        "changed": False,
+        "backup": None,
+        "before_keys": [],
+        "after_keys": [],
+        "entries_migrated": 0,
+    }
+
+    if not target.exists():
+        log.warning("migrate_file: %s does not exist; skipping", target)
+        return result
+
+    raw_text = target.read_text()
+    try:
+        before = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise IncidentStateError(
+            f"{target} is not valid JSON; aborting migration: {exc}"
+        ) from exc
+
+    if not isinstance(before, dict):
+        raise IncidentStateError(
+            f"{target} is not a JSON object (got {type(before).__name__}); aborting"
+        )
+
+    # Source container detection
+    if "ops" in before and isinstance(before["ops"], dict) and "incidents" not in before:
+        source_entries = before["ops"]
+        source_key = "ops"
+    elif "incidents" in before and isinstance(before["incidents"], dict):
+        source_entries = before["incidents"]
+        source_key = "incidents"
+    else:
+        source_entries = {}
+        source_key = None
+
+    result["before_keys"] = sorted(before.keys())
+
+    if reset:
+        after_incidents: dict[str, dict] = {}
+    else:
+        normalizer = _normalize_lox_entry if owner == "lox" else _normalize_quinn_entry
+        after_incidents = {}
+        for slug, entry in source_entries.items():
+            if not isinstance(entry, dict):
+                log.warning("migrate_file: dropping non-dict entry %s in %s", slug, target)
+                continue
+            after_incidents[slug] = normalizer(entry)
+
+    # Preserve any _meta key the file already had (operator bookkeeping).
+    after = dict(before)
+    after.pop("ops", None)
+    after["incidents"] = after_incidents
+    result["after_keys"] = sorted(after.keys())
+    result["entries_migrated"] = len(after_incidents)
+
+    if source_key != "incidents":
+        result["changed"] = True
+    elif reset:
+        result["changed"] = bool(before.get("incidents"))
+    else:
+        # Same key. Still consider it changed if normalization altered entries.
+        for slug, new_entry in after_incidents.items():
+            old_entry = source_entries.get(slug, {})
+            if old_entry != new_entry:
+                result["changed"] = True
+                break
+
+    if not write:
+        return result
+
+    if not reset and not result["changed"]:
+        log.info("migrate_file: %s already in unified shape; no write", target)
+        return result
+
+    # Schema validation (if jsonschema is installed).
+    try:
+        validate_with_schema(after, schema_path=schema_path)
+    except IncidentStateError as exc:
+        # jsonschema not installed -> skip validation but continue (this is
+        # acceptable since the script's normalizer produces valid output).
+        log.warning("migrate_file: schema validation skipped (%s)", exc)
+    except Exception as exc:  # jsonschema.ValidationError or similar
+        raise IncidentStateError(
+            f"{target} would not validate against the unified schema after "
+            f"migration: {exc}"
+        ) from exc
+
+    backup = _backup_path(target)
+    backup.write_text(raw_text)
+    result["backup"] = str(backup)
+
+    target.write_text(json.dumps(after, indent=2, sort_keys=True) + "\n")
+    log.info("migrate_file: wrote %s (backup %s)", target, backup)
+    return result
+
+
+def run_migration(
+    workspace: Path,
+    *,
+    reset: bool = False,
+    write: bool = False,
+    schema_path: Path | None = None,
+) -> list[dict]:
+    quinn_target = workspace / QUINN_STATE_RELATIVE
+    lox_target = workspace / LOX_STATE_RELATIVE
+    return [
+        migrate_file(quinn_target, owner="quinn", reset=reset, write=write, schema_path=schema_path),
+        migrate_file(lox_target, owner="lox", reset=reset, write=write, schema_path=schema_path),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Migrate Quinn + Lox incident state files to the unified schema."
+    )
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=WORKSPACE_DEFAULT,
+        help=f"Workspace root (default: {WORKSPACE_DEFAULT})",
+    )
+    parser.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Write the migrated files back to disk. Default is dry-run (no writes).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Explicit dry-run (default behaviour). Suppresses --in-place.",
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Start fresh: drop all incidents and write empty `incidents: {}`.",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=None,
+        help="Override path to the JSON Schema (default: bundled).",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Verbose logging.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    write = args.in_place and not args.dry_run
+    results = run_migration(
+        args.workspace,
+        reset=args.reset,
+        write=write,
+        schema_path=args.schema,
+    )
+    for r in results:
+        print(json.dumps(r, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/lib/incident_state.py
+++ b/agents/lib/incident_state.py
@@ -1,0 +1,323 @@
+"""Unified agent incident parser — Quinn (workflow/pipeline) + Lox (infra).
+
+Task 75ec1c8c: unify the two agents' divergent incident state file schemas onto a
+single superset so heartbeat can roll up across both with a single parser.
+
+Public API:
+    load_all_incidents(workspace=None) -> list[dict]
+        Read both state files in the workspace and return a flat list of unified
+        incident records. Malformed JSON is logged and treated as empty.
+
+    parse_file(path, owner=None) -> list[dict]
+        Read one file, apply the legacy normalizer for that file's known shape,
+        return the unified list.
+
+    needs_tom(incidents) -> list[dict]
+        Filter to entries where needsTom is True or severity is high/critical.
+
+    validate_with_schema(state) -> None
+        Validate a state dict against the JSON Schema bundled in
+        agents/schemas/agent-incident-state.schema.json. Raises jsonschema
+        ValidationError on failure.
+
+Legacy shapes handled:
+    Quinn legacy: top-level `ops` key (each entry has firstSeen/attempts/needsTom/
+        severity/lastAction/resolvedAt/escalatedAt/lastCheckedAt). Missing owner
+        defaults to "quinn"; missing recurrenceCount/nextRetryAt/details default
+        to 0/null/{}. key is renamed to `incidents`.
+    Lox legacy: top-level `incidents` key (each entry has recurrenceCount/
+        nextRetryAt/owner/details plus Lox-specific fields). Missing firstSeen/
+        attempts/needsTom/severity default to safe values.
+
+Legacy entries are accepted indefinitely (the schema marks only `owner` and
+`status` as required). The normalizers are the safety net that lets us roll
+forward without breaking agents that still write a slightly different shape.
+
+Path conventions:
+    Quinn: brain/state/quinn-ops-state.json (key `incidents` after migration;
+        pre-migration key is `ops`)
+    Lox:   brain/state/lox-incident-state.json (key `incidents` always)
+
+`workspace` defaults to the OPENCLAW workspace root. Tests should pass it
+explicitly to avoid filesystem coupling.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SCHEMA_PATH_DEFAULT = (
+    Path(__file__).resolve().parent.parent / "schemas" / "agent-incident-state.schema.json"
+)
+
+QUINN_STATE_RELATIVE = Path("brain/state/quinn-ops-state.json")
+LOX_STATE_RELATIVE = Path("brain/state/lox-incident-state.json")
+
+WORKSPACE_DEFAULT = Path(os.environ.get("OPENCLAW_WORKSPACE", "/Users/quinnstoffer/.openclaw/workspace"))
+
+VALID_OWNERS = {"lox", "quinn"}
+VALID_STATUSES = {"watching", "escalated", "resolved", "false_positive"}
+VALID_SEVERITIES = {"low", "medium", "high", "critical"}
+TOM_SURFACING_SEVERITIES = {"high", "critical"}
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class IncidentStateError(Exception):
+    """Raised when an incident state file is structurally broken past recovery."""
+
+
+# ---------------------------------------------------------------------------
+# Legacy normalizers (private)
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _coerce_owner(raw: Any, fallback: str) -> str:
+    if isinstance(raw, str) and raw in VALID_OWNERS:
+        return raw
+    return fallback
+
+
+def _coerce_status(raw: Any) -> str:
+    if isinstance(raw, str) and raw in VALID_STATUSES:
+        return raw
+    # Some legacy Lox entries used "repair_attempted" — map to "watching" so the
+    # entry stays open and visible. (Legacy Quinn used "watching"/"escalated"
+    # already.)
+    if raw == "repair_attempted":
+        return "watching"
+    if raw == "blocked":
+        return "escalated"
+    return "watching"
+
+
+def _coerce_severity(raw: Any) -> str:
+    if isinstance(raw, str) and raw in VALID_SEVERITIES:
+        return raw
+    return "medium"
+
+
+def _normalize_quinn_entry(raw: dict) -> dict:
+    """Map a Quinn legacy `ops` entry onto the unified shape.
+
+    Quinn already has: firstSeen, attempts, needsTom, severity, lastAction,
+    escalatedAt, resolvedAt, lastCheckedAt.
+    Missing in Quinn: owner (set), recurrenceCount (default 0), nextRetryAt
+    (default null), details (default {}).
+    """
+    out = dict(raw)  # shallow copy so callers don't mutate their input
+    out["owner"] = _coerce_owner(out.get("owner"), "quinn")
+    out["status"] = _coerce_status(out.get("status"))
+    out["severity"] = _coerce_severity(out.get("severity"))
+    out["attempts"] = int(out.get("attempts", 0) or 0)
+    out["recurrenceCount"] = int(out.get("recurrenceCount", 0) or 0)
+    out["needsTom"] = bool(out.get("needsTom", False))
+    if "firstSeen" not in out:
+        out["firstSeen"] = _now_iso()
+    if "nextRetryAt" not in out:
+        out["nextRetryAt"] = None
+    if "details" not in out or not isinstance(out["details"], dict):
+        # Preserve other Lox-style details; do not drop a legacy `details` field.
+        existing = out.get("details")
+        out["details"] = existing if isinstance(existing, dict) else {}
+    return out
+
+
+def _normalize_lox_entry(raw: dict) -> dict:
+    """Map a Lox `incidents` entry onto the unified shape.
+
+    Lox already has: owner, recurrenceCount, nextRetryAt, details (plus Lox-
+    specific: dailyReviewDate, blastRadius in details, etc.).
+    Missing in Lox: firstSeen, attempts, needsTom, severity.
+    """
+    out = dict(raw)
+    out["owner"] = _coerce_owner(out.get("owner"), "lox")
+    out["status"] = _coerce_status(out.get("status"))
+    out["severity"] = _coerce_severity(out.get("severity"))
+    out["attempts"] = int(out.get("attempts", 0) or 0)
+    out["recurrenceCount"] = int(out.get("recurrenceCount", 0) or 0)
+    out["needsTom"] = bool(out.get("needsTom", False))
+    if "firstSeen" not in out:
+        # Fall back to dailyReviewDate if Lox recorded one.
+        drd = out.get("dailyReviewDate")
+        if isinstance(drd, str) and drd:
+            out["firstSeen"] = f"{drd}T00:00:00Z"
+        else:
+            out["firstSeen"] = _now_iso()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public parsing API
+# ---------------------------------------------------------------------------
+
+def parse_file(path: Path, owner: str | None = None) -> list[dict]:
+    """Read one state file and return a list of unified incident dicts.
+
+    `owner` is used to pick the legacy normalizer when the file's content
+    doesn't expose an unambiguous owner on each entry (e.g. Quinn's legacy
+    `ops` shape). If omitted, owner is derived from the filename:
+        * quinn-ops-state.json -> "quinn"
+        * lox-incident-state.json -> "lox"
+        * anything else -> falls back to "quinn" (Quinn is the dominant writer)
+    """
+    path = Path(path)
+    if not path.exists():
+        log.info("incident_state.parse_file: file does not exist: %s", path)
+        return []
+    try:
+        raw_text = path.read_text()
+        state = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        log.warning(
+            "incident_state.parse_file: malformed JSON in %s (%s); treating as empty",
+            path,
+            exc,
+        )
+        return []
+    except OSError as exc:
+        log.warning(
+            "incident_state.parse_file: cannot read %s (%s); treating as empty",
+            path,
+            exc,
+        )
+        return []
+
+    if not isinstance(state, dict):
+        log.warning(
+            "incident_state.parse_file: %s is not an object (got %s); treating as empty",
+            path,
+            type(state).__name__,
+        )
+        return []
+
+    # Detect which container key holds the incidents. Quinn legacy uses `ops`;
+    # everything else (including Lox and post-migration Quinn) uses `incidents`.
+    if "incidents" in state and isinstance(state["incidents"], dict):
+        entries = state["incidents"]
+        default_owner = owner or _owner_from_filename(path) or "quinn"
+    elif "ops" in state and isinstance(state["ops"], dict):
+        entries = state["ops"]
+        default_owner = owner or _owner_from_filename(path) or "quinn"
+    else:
+        log.warning(
+            "incident_state.parse_file: %s has no `incidents` or `ops` key; treating as empty",
+            path,
+        )
+        return []
+
+    out: list[dict] = []
+    for slug, raw in entries.items():
+        if not isinstance(raw, dict):
+            log.warning(
+                "incident_state.parse_file: skipping non-dict entry %s in %s",
+                slug,
+                path,
+            )
+            continue
+        normalized = _normalize_for_owner(raw, default_owner)
+        normalized.setdefault("_slug", slug)
+        out.append(normalized)
+    return out
+
+
+def _normalize_for_owner(raw: dict, default_owner: str) -> dict:
+    if default_owner == "lox":
+        return _normalize_lox_entry(raw)
+    return _normalize_quinn_entry(raw)
+
+
+def _owner_from_filename(path: Path) -> str | None:
+    name = path.name
+    if name.startswith("quinn-"):
+        return "quinn"
+    if name.startswith("lox-"):
+        return "lox"
+    return None
+
+
+def load_all_incidents(workspace: Path | None = None) -> list[dict]:
+    """Read both Quinn and Lox state files and return the unified flat list."""
+    ws = Path(workspace) if workspace else WORKSPACE_DEFAULT
+    quinn = parse_file(ws / QUINN_STATE_RELATIVE, owner="quinn")
+    lox = parse_file(ws / LOX_STATE_RELATIVE, owner="lox")
+    return quinn + lox
+
+
+def needs_tom(incidents: list[dict]) -> list[dict]:
+    """Filter to incidents that should be surfaced to Tom."""
+    out = []
+    for inc in incidents:
+        if not isinstance(inc, dict):
+            continue
+        if inc.get("needsTom"):
+            out.append(inc)
+            continue
+        sev = inc.get("severity")
+        if isinstance(sev, str) and sev in TOM_SURFACING_SEVERITIES:
+            out.append(inc)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Schema validation (lazy import so jsonschema is optional at runtime)
+# ---------------------------------------------------------------------------
+
+def _load_schema(schema_path: Path | None = None) -> dict:
+    path = Path(schema_path) if schema_path else SCHEMA_PATH_DEFAULT
+    if not path.exists():
+        raise IncidentStateError(f"Schema not found at {path}")
+    with path.open() as f:
+        return json.load(f)
+
+
+def validate_with_schema(state: Any, schema_path: Path | None = None) -> None:
+    """Validate a state dict against the unified JSON Schema.
+
+    Raises jsonschema.ValidationError on failure. The jsonschema package is
+    imported lazily so the hot heartbeat path can call parse_file without
+    needing it installed.
+    """
+    try:
+        import jsonschema  # type: ignore
+    except ImportError as exc:
+        raise IncidentStateError(
+            "jsonschema is not installed; install with `pip install jsonschema` "
+            "to run validate_with_schema(). The hot parse_file() path does not "
+            "need it."
+        ) from exc
+    schema = _load_schema(schema_path)
+    jsonschema.validate(instance=state, schema=schema)
+
+
+__all__ = [
+    "SCHEMA_PATH_DEFAULT",
+    "QUINN_STATE_RELATIVE",
+    "LOX_STATE_RELATIVE",
+    "WORKSPACE_DEFAULT",
+    "VALID_OWNERS",
+    "VALID_STATUSES",
+    "VALID_SEVERITIES",
+    "TOM_SURFACING_SEVERITIES",
+    "IncidentStateError",
+    "parse_file",
+    "load_all_incidents",
+    "needs_tom",
+    "validate_with_schema",
+]

--- a/agents/lib/test_incident_migrate.py
+++ b/agents/lib/test_incident_migrate.py
@@ -1,0 +1,168 @@
+"""Tests for agents.lib.incident_migrate — task 75ec1c8c.
+
+Run from the repo root::
+
+    python3 -m unittest agents.lib.test_incident_migrate -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from agents.lib import incident_migrate as mig  # noqa: E402
+
+
+LEGACY_QUINN = {
+    "ops": {
+        "tasks-api-down": {
+            "firstSeen": "2026-07-01T00:00:00Z",
+            "attempts": 3,
+            "needsTom": True,
+            "severity": "critical",
+            "status": "escalated",
+            "lastAction": "restart",
+            "escalatedAt": "2026-07-02T00:00:00Z",
+        }
+    }
+}
+
+UNIFIED_LOX = {
+    "_meta": {"v": 1},
+    "incidents": {
+        "firewall": {
+            "owner": "lox",
+            "status": "watching",
+            "recurrenceCount": 2,
+            "nextRetryAt": "2026-07-12T00:00:00Z",
+            "details": {"note": "still blocked"},
+        }
+    },
+}
+
+
+class MigrateFileTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _write_quinn(self) -> Path:
+        (self.tmpdir / "brain" / "state").mkdir(parents=True, exist_ok=True)
+        p = self.tmpdir / "brain" / "state" / "quinn-ops-state.json"
+        p.write_text(json.dumps(LEGACY_QUINN))
+        return p
+
+    def _write_lox(self) -> Path:
+        (self.tmpdir / "brain" / "state").mkdir(parents=True, exist_ok=True)
+        p = self.tmpdir / "brain" / "state" / "lox-incident-state.json"
+        p.write_text(json.dumps(UNIFIED_LOX))
+        return p
+
+    def test_dry_run_does_not_write(self):
+        path = self._write_quinn()
+        before_text = path.read_text()
+        result = mig.migrate_file(path, owner="quinn", write=False)
+        self.assertTrue(result["changed"])
+        self.assertEqual(path.read_text(), before_text)
+        self.assertEqual(result["entries_migrated"], 1)
+
+    def test_in_place_writes_unified_shape(self):
+        path = self._write_quinn()
+        result = mig.migrate_file(path, owner="quinn", write=True)
+        self.assertTrue(result["changed"])
+        self.assertTrue(result["backup"])
+        self.assertTrue(Path(result["backup"]).exists())
+        after = json.loads(path.read_text())
+        self.assertIn("incidents", after)
+        self.assertNotIn("ops", after)
+        self.assertEqual(after["incidents"]["tasks-api-down"]["owner"], "quinn")
+        self.assertEqual(after["incidents"]["tasks-api-down"]["recurrenceCount"], 0)
+        self.assertEqual(after["incidents"]["tasks-api-down"]["nextRetryAt"], None)
+        self.assertEqual(after["incidents"]["tasks-api-down"]["details"], {})
+
+    def test_in_place_lox_preserves_unified_entries(self):
+        path = self._write_lox()
+        result = mig.migrate_file(path, owner="lox", write=True)
+        # Lox file was already in unified shape with `incidents` key; normalize
+        # path should still produce a valid file.
+        after = json.loads(path.read_text())
+        self.assertIn("incidents", after)
+        self.assertEqual(after["incidents"]["firewall"]["owner"], "lox")
+        self.assertEqual(after["incidents"]["firewall"]["recurrenceCount"], 2)
+        self.assertIn("firstSeen", after["incidents"]["firewall"])
+
+    def test_in_place_idempotent(self):
+        path = self._write_quinn()
+        first = mig.migrate_file(path, owner="quinn", write=True)
+        self.assertTrue(first["changed"])
+        second = mig.migrate_file(path, owner="quinn", write=True)
+        # Second pass should report no change (no further .bak should be written).
+        self.assertFalse(second["changed"])
+        # Compare structural content.
+        after_first = json.loads(path.read_text())
+        # Re-migrate (dry-run) and confirm `changed` is now False on next pass.
+        third = mig.migrate_file(path, owner="quinn", write=False)
+        self.assertFalse(third["changed"])
+
+    def test_reset_drops_entries(self):
+        path = self._write_quinn()
+        mig.migrate_file(path, owner="quinn", reset=True, write=True)
+        after = json.loads(path.read_text())
+        self.assertEqual(after["incidents"], {})
+
+    def test_missing_file_returns_empty_result(self):
+        result = mig.migrate_file(self.tmpdir / "nope.json", owner="quinn")
+        self.assertFalse(result["existed"])
+        self.assertFalse(result["changed"])
+        self.assertEqual(result["entries_migrated"], 0)
+
+    def test_malformed_json_raises(self):
+        path = self._write_quinn()
+        path.write_text("{ this is not json")
+        with self.assertRaises(mig.IncidentStateError):
+            mig.migrate_file(path, owner="quinn", write=True)
+
+    def test_validates_against_schema_after_write(self):
+        path = self._write_quinn()
+        try:
+            import jsonschema  # noqa: F401
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        mig.migrate_file(path, owner="quinn", write=True)
+        # If the result didn't validate, migrate_file would have raised before
+        # writing. Read back and re-validate explicitly for the test signal.
+        from agents.lib.incident_state import validate_with_schema
+        validate_with_schema(json.loads(path.read_text()))
+
+
+class RunMigrationTests(unittest.TestCase):
+    def test_run_migration_handles_both_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            (tmpdir / "brain" / "state").mkdir(parents=True)
+            (tmpdir / "brain" / "state" / "quinn-ops-state.json").write_text(json.dumps(LEGACY_QUINN))
+            (tmpdir / "brain" / "state" / "lox-incident-state.json").write_text(json.dumps(UNIFIED_LOX))
+            results = mig.run_migration(tmpdir, write=False)
+            self.assertEqual(len(results), 2)
+            owners = [r["owner"] for r in results]
+            self.assertEqual(owners, ["quinn", "lox"])
+            # Quinn is migrated (ops -> incidents) and so changes shape; Lox
+            # already uses `incidents` but gains missing fields (firstSeen,
+            # attempts, needsTom, severity) on each entry, which is also a
+            # change.
+            self.assertTrue(results[0]["changed"])  # Quinn
+            self.assertTrue(results[1]["changed"])  # Lox (gains missing fields)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/lib/test_incident_state.py
+++ b/agents/lib/test_incident_state.py
@@ -1,0 +1,322 @@
+"""Tests for agents.lib.incident_state — task 75ec1c8c.
+
+Run from the repo root::
+
+    python3 -m unittest agents.lib.test_incident_state -v
+
+These tests do NOT require jsonschema for the hot-path cases (parse_file,
+load_all_incidents, needs_tom). validate_with_schema is exercised in a
+dedicated test that gracefully skips if jsonschema is not installed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from textwrap import dedent
+from unittest import mock
+
+# Make the `agents` package importable when run directly from repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from agents.lib import incident_state as ist  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+LEGACY_QUINN_OPS = {
+    "ops": {
+        "bookmark-tagger-acpx-401-silently-degraded": {
+            "firstSeen": "2026-06-19T16:15:00Z",
+            "lastCheckedAt": "2026-06-28T07:21:24.997602+00:00",
+            "status": "resolved",
+            "severity": "medium",
+            "needsTom": False,
+            "attempts": 5,
+            "lastAction": "PR #104 merged.",
+            "resolvedAt": "2026-06-25T23:49:28.032317+00:00",
+            "escalatedAt": None,
+            "linkedPr": "https://github.com/Stoffer-Industries/sindustries/pull/104",
+            "followUp": ["Patch pr-open reviewer default"],
+        },
+        "tasks-api-prod-down": {
+            "firstSeen": "2026-07-05T10:00:00Z",
+            "lastCheckedAt": "2026-07-10T10:00:00Z",
+            "status": "escalated",
+            "severity": "critical",
+            "needsTom": True,
+            "attempts": 7,
+            "lastAction": "Restart attempted.",
+            "escalatedAt": "2026-07-09T12:00:00Z",
+            "resolvedAt": None,
+        },
+    }
+}
+
+UNIFIED_QUINN_INCIDENTS = {
+    "incidents": {
+        "tasks-api-prod-down": {
+            "owner": "quinn",
+            "firstSeen": "2026-07-05T10:00:00Z",
+            "lastCheckedAt": "2026-07-10T10:00:00Z",
+            "status": "escalated",
+            "severity": "critical",
+            "needsTom": True,
+            "attempts": 7,
+            "escalatedAt": "2026-07-09T12:00:00Z",
+            "resolvedAt": None,
+            "nextRetryAt": None,
+            "recurrenceCount": 0,
+            "lastAction": "Restart attempted.",
+            "details": {},
+        }
+    }
+}
+
+LEGACY_LOX_INCIDENTS = {
+    "_meta": {"lastHeartbeatAt": "2026-07-11T04:30:00Z"},
+    "incidents": {
+        "bookmark-acpx-openai-401-no-scopes-2026-06-25": {
+            "dailyReviewDate": "2026-06-25",
+            "details": {"blastRadius": {"affectedBookmarks": 4}},
+            "owner": "lox",
+            "recurrenceCount": 1,
+            "nextRetryAt": None,
+            "status": "watching",
+        },
+        "firewall": {
+            "owner": "lox",
+            "recurrenceCount": 4,
+            "nextRetryAt": "2026-07-12T10:00:00Z",
+            "status": "repair_attempted",  # legacy Lox status; should normalize
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class ParseFileTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _write(self, name: str, payload: dict) -> Path:
+        p = self.tmpdir / name
+        p.write_text(json.dumps(payload))
+        return p
+
+    def test_parse_legacy_quinn_ops_returns_unified_shape(self):
+        path = self._write("quinn-ops-state.json", LEGACY_QUINN_OPS)
+        out = ist.parse_file(path)
+        self.assertEqual(len(out), 2)
+        for entry in out:
+            self.assertEqual(entry["owner"], "quinn")
+            self.assertIn("status", entry)
+            self.assertIn("severity", entry)
+            self.assertIn("attempts", entry)
+            self.assertIn("recurrenceCount", entry)
+            self.assertIn("details", entry)
+            self.assertIn("nextRetryAt", entry)
+
+    def test_parse_unified_quinn_returns_unified_shape(self):
+        path = self._write("quinn-ops-state.json", UNIFIED_QUINN_INCIDENTS)
+        out = ist.parse_file(path)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["owner"], "quinn")
+        self.assertEqual(out[0]["status"], "escalated")
+        self.assertEqual(out[0]["severity"], "critical")
+
+    def test_parse_legacy_lox_returns_unified_shape(self):
+        path = self._write("lox-incident-state.json", LEGACY_LOX_INCIDENTS)
+        out = ist.parse_file(path)
+        self.assertEqual(len(out), 2)
+        # `firewall` had legacy `repair_attempted` status — should normalize.
+        firewall = next(e for e in out if e.get("_slug") == "firewall")
+        self.assertEqual(firewall["owner"], "lox")
+        self.assertEqual(firewall["status"], "watching")  # normalized
+        # Legacy Lox entry gained firstSeen (derived from dailyReviewDate for the
+        # bookmark entry; the firewall entry has no dailyReviewDate so firstSeen
+        # is `now`).
+        self.assertIn("firstSeen", firewall)
+        # Should have gained attempts/needsTom/severity.
+        self.assertIn("attempts", firewall)
+        self.assertIn("needsTom", firewall)
+        self.assertIn("severity", firewall)
+
+    def test_parse_lox_derives_first_seen_from_daily_review_date(self):
+        path = self._write("lox-incident-state.json", LEGACY_LOX_INCIDENTS)
+        out = ist.parse_file(path)
+        bookmark = next(e for e in out if e.get("_slug", "").startswith("bookmark-acpx"))
+        self.assertEqual(bookmark["firstSeen"], "2026-06-25T00:00:00Z")
+
+    def test_parse_missing_file_returns_empty(self):
+        out = ist.parse_file(self.tmpdir / "does-not-exist.json")
+        self.assertEqual(out, [])
+
+    def test_parse_malformed_json_returns_empty(self):
+        path = self.tmpdir / "quinn-ops-state.json"
+        path.write_text("{ this is not json")
+        out = ist.parse_file(path)
+        self.assertEqual(out, [])
+
+    def test_parse_non_object_returns_empty(self):
+        path = self.tmpdir / "quinn-ops-state.json"
+        path.write_text("[1, 2, 3]")
+        out = ist.parse_file(path)
+        self.assertEqual(out, [])
+
+    def test_parse_no_known_key_returns_empty(self):
+        path = self.tmpdir / "quinn-ops-state.json"
+        path.write_text(json.dumps({"somethingElse": {}}))
+        out = ist.parse_file(path)
+        self.assertEqual(out, [])
+
+    def test_parse_skips_non_dict_entries(self):
+        payload = {"incidents": {"good": {"owner": "quinn", "status": "watching"}, "bad": "not a dict"}}
+        path = self.tmpdir / "quinn-ops-state.json"
+        path.write_text(json.dumps(payload))
+        out = ist.parse_file(path)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["_slug"], "good")
+
+
+class LoadAllIncidentsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self.tmp.name)
+        (self.tmpdir / "brain" / "state").mkdir(parents=True)
+        (self.tmpdir / "brain" / "state" / "quinn-ops-state.json").write_text(
+            json.dumps(LEGACY_QUINN_OPS)
+        )
+        (self.tmpdir / "brain" / "state" / "lox-incident-state.json").write_text(
+            json.dumps(LEGACY_LOX_INCIDENTS)
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_load_all_returns_flat_list(self):
+        out = ist.load_all_incidents(workspace=self.tmpdir)
+        # 2 Quinn + 2 Lox = 4
+        self.assertEqual(len(out), 4)
+        owners = {e["owner"] for e in out}
+        self.assertEqual(owners, {"quinn", "lox"})
+
+    def test_load_all_missing_files_returns_just_what_exists(self):
+        (self.tmpdir / "brain" / "state" / "lox-incident-state.json").unlink()
+        out = ist.load_all_incidents(workspace=self.tmpdir)
+        self.assertEqual(len(out), 2)
+        self.assertTrue(all(e["owner"] == "quinn" for e in out))
+
+
+class NeedsTomTests(unittest.TestCase):
+    def test_needs_tom_flags_needsTom_true(self):
+        out = ist.needs_tom([
+            {"owner": "quinn", "needsTom": True, "severity": "low", "status": "watching"},
+        ])
+        self.assertEqual(len(out), 1)
+
+    def test_needs_tom_flags_high_severity(self):
+        out = ist.needs_tom([
+            {"owner": "quinn", "needsTom": False, "severity": "high", "status": "watching"},
+            {"owner": "lox", "needsTom": False, "severity": "critical", "status": "watching"},
+        ])
+        self.assertEqual(len(out), 2)
+
+    def test_needs_tom_skips_low_medium(self):
+        out = ist.needs_tom([
+            {"owner": "quinn", "needsTom": False, "severity": "low", "status": "watching"},
+            {"owner": "quinn", "needsTom": False, "severity": "medium", "status": "watching"},
+        ])
+        self.assertEqual(len(out), 0)
+
+    def test_needs_tom_skips_resolved(self):
+        # Resolved high-severity entries still pass needs_tom() — callers can
+        # filter on `status` themselves if needed.
+        out = ist.needs_tom([
+            {"owner": "quinn", "needsTom": False, "severity": "high", "status": "resolved"},
+        ])
+        self.assertEqual(len(out), 1)
+
+
+class ValidateWithSchemaTests(unittest.TestCase):
+    def test_validate_unified_state_passes(self):
+        # May skip if jsonschema not installed.
+        try:
+            ist.validate_with_schema(UNIFIED_QUINN_INCIDENTS)
+        except ist.IncidentStateError as exc:
+            if "jsonschema" in str(exc):
+                self.skipTest(f"jsonschema not installed: {exc}")
+            raise
+
+    def test_validate_rejects_legacy_ops_key(self):
+        try:
+            import jsonschema  # noqa: F401
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        with self.assertRaises(Exception):
+            ist.validate_with_schema(LEGACY_QUINN_OPS)
+
+    def test_validate_requires_owner(self):
+        try:
+            import jsonschema  # noqa: F401
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        bad = {"incidents": {"x": {"status": "watching"}}}  # missing owner
+        with self.assertRaises(Exception):
+            ist.validate_with_schema(bad)
+
+    def test_validate_accepts_linkedPr_as_array(self):
+        # Quinn sometimes records multiple PRs for the same incident. The
+        # schema must accept both string and array.
+        try:
+            import jsonschema  # noqa: F401
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        state = {"incidents": {"x": {
+            "owner": "quinn",
+            "status": "resolved",
+            "linkedPr": ["https://github.com/a/b/pull/1", "https://github.com/a/b/pull/2"],
+        }}}
+        ist.validate_with_schema(state)  # should not raise
+
+
+class RoundTripTests(unittest.TestCase):
+    def test_round_trip_idempotency(self):
+        """parse_file -> write back -> parse_file again yields the same list."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            (tmpdir / "brain" / "state").mkdir(parents=True)
+            qpath = tmpdir / "brain" / "state" / "quinn-ops-state.json"
+            qpath.write_text(json.dumps(LEGACY_QUINN_OPS))
+            first = ist.parse_file(qpath)
+            # Write back in unified shape.
+            unified = {"incidents": {e["_slug"]: {k: v for k, v in e.items() if k != "_slug"} for e in first}}
+            qpath.write_text(json.dumps(unified))
+            second = ist.parse_file(qpath)
+            # Sort by slug for comparison.
+            first.sort(key=lambda e: e["_slug"])
+            second.sort(key=lambda e: e["_slug"])
+            self.assertEqual(len(first), len(second))
+            for a, b in zip(first, second):
+                # All non-_slug fields should match.
+                a_clean = {k: v for k, v in a.items() if k != "_slug"}
+                b_clean = {k: v for k, v in b.items() if k != "_slug"}
+                self.assertEqual(a_clean, b_clean)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/schemas/agent-incident-state.schema.json
+++ b/agents/schemas/agent-incident-state.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sindustries.co.nz/schemas/agent-incident-state.schema.json",
+  "title": "Agent incident state",
+  "description": "Unified incident state file written by Quinn (workflow/pipeline anomalies) and Lox (infra/host reliability). Each agent owns its own file; this schema is the superset both must conform to after migration.",
+  "type": "object",
+  "required": ["incidents"],
+  "additionalProperties": false,
+  "properties": {
+    "incidents": {
+      "type": "object",
+      "description": "Slug-keyed map of incidents. Keys are stable, kebab-cased identifiers derived from the failure pattern (e.g. 'tasks-api-dev-down', 'bookmark-acpx-openai-401-no-scopes').",
+      "additionalProperties": { "$ref": "#/$defs/incident" }
+    },
+    "_meta": {
+      "type": "object",
+      "description": "Optional operator-only metadata. Not part of the incident contract; never required. Use for last-write bookkeeping.",
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "incident": {
+      "type": "object",
+      "required": ["owner", "status"],
+      "description": "Single incident record. The schema marks only `owner` and `status` as required; other fields default to safe values on read so legacy entries still validate.",
+      "additionalProperties": true,
+      "properties": {
+        "owner": {
+          "type": "string",
+          "enum": ["lox", "quinn"],
+          "description": "Which agent owns this entry. Set explicitly when writing; legacy entries default to filename-derived owner during read-time normalization."
+        },
+        "firstSeen": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 UTC timestamp when the incident was first observed."
+        },
+        "lastCheckedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 UTC timestamp of the most recent check or write."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["watching", "escalated", "resolved", "false_positive"],
+          "description": "Current state of the incident. `watching` = under observation, `escalated` = needs human attention, `resolved` = fixed, `false_positive` = turned out not to be a real issue."
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["low", "medium", "high", "critical"],
+          "description": "How serious the incident is. `high` and `critical` are surfaced to Tom automatically by Quinn's heartbeat roll-up."
+        },
+        "needsTom": {
+          "type": "boolean",
+          "description": "Set true once the incident has been escalated to Tom (or `severity` is `high`/`critical`). Quinn's heartbeat surfaces these."
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of times the owning agent has attempted to investigate/auto-recover."
+        },
+        "escalatedAt": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "ISO-8601 UTC timestamp when the incident was first escalated. Null if never escalated."
+        },
+        "resolvedAt": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "ISO-8601 UTC timestamp when the incident was resolved. Null if still open."
+        },
+        "nextRetryAt": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "ISO-8601 UTC timestamp of the earliest time the next retry is allowed. Used to back off auto-recovery attempts."
+        },
+        "recurrenceCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of times the same slug has re-appeared after resolution. Used for trending and runbook effectiveness."
+        },
+        "lastAction": {
+          "type": "string",
+          "description": "Free-form description of the most recent action taken (investigation, repair attempt, escalation, resolution)."
+        },
+        "details": {
+          "type": "object",
+          "description": "Operator-defined structured context (links to PRs, runbooks, blast radius, follow-up tasks, etc.). Schema is intentionally open.",
+          "additionalProperties": true
+        },
+        "linkedPr": {
+          "type": ["string", "array"],
+          "items": { "type": "string" },
+          "description": "Optional shortcut for the remediation PR(s). Single string for one PR; array when multiple PRs share the root cause. Mirrors `details.linkedPr` for agents that prefer a top-level field."
+        },
+        "linkedRunbook": {
+          "type": ["string", "array"],
+          "items": { "type": "string" },
+          "description": "Optional shortcut for the runbook path(s). Mirrors `details.linkedRunbook`."
+        },
+        "followUp": {
+          "type": "array",
+          "description": "Optional list of follow-up items. Each entry is a short string (a task, PR, or note).",
+          "items": { "type": "string" }
+        },
+        "dailyReviewDate": {
+          "type": "string",
+          "description": "Lox-specific: the daily review date that produced this entry. Format YYYY-MM-DD."
+        }
+      }
+    }
+  }
+}

--- a/docs/systems/agent-incidents.md
+++ b/docs/systems/agent-incidents.md
@@ -1,0 +1,139 @@
+---
+title: Agent Incidents
+type: System reference
+last_updated: 2026-07-11
+owner: Rowan
+repos: Stoffer-Industries/sindustries
+related_pr: null
+shipped_date: null
+---
+
+# Agent Incidents
+
+**Type:** System reference (keep updated as the unified schema evolves)
+**Last updated:** 2026-07-11
+**Owner:** Rowan
+**Repos:** `Stoffer-Industries/sindustries` (parser, schema, migration script)
+**Related PR:** TBD — task 75ec1c8c
+**Shipped date:** TBD
+
+## Purpose
+
+Quinn (workflow/pipeline anomalies) and Lox (infra/host reliability) both maintain operational incident state files in the workspace. Before task 75ec1c8c, the two files used divergent shapes — Quinn's `brain/state/quinn-ops-state.json` used an `ops` key and lacked `recurrenceCount`/`nextRetryAt`/`details`; Lox's `brain/state/lox-incident-state.json` already used an `incidents` key but lacked `firstSeen`/`attempts`/`needsTom`/`severity`. Quinn's heartbeat had to branch on the two formats to roll up cross-agent incidents. This system doc is the durable record of the unified schema and the shared parser.
+
+Related systems: `docs/systems/agent-orchestration.md` (agent map), `docs/systems/feature-task-workflow.md` (feature-task gates; unrelated but co-located).
+
+## Architecture and ownership
+
+- **Quinn writes** `brain/state/quinn-ops-state.json` (top-level key `incidents`).
+- **Lox writes** `brain/state/lox-incident-state.json` (top-level key `incidents`).
+- Each agent owns its own file. There is no shared network state file and no IPC. The two files are read-only from the perspective of the *other* agent.
+- The unified schema (`agents/schemas/agent-incident-state.schema.json`, JSON Schema 2020-12) is the superset both files must conform to. The schema marks only `owner` and `status` as required; the rest default to safe values on read so legacy entries still validate.
+- The shared parser (`agents/lib/incident_state.py`) reads both files, normalizes legacy shapes on the fly, and returns a flat list of unified incident records. Quinn's heartbeat calls this on every tick.
+
+## Runtime behaviour
+
+1. When an agent detects an incident (failed cron, blocked workflow, stale pipeline item), it appends a slug-keyed entry to its `incidents` map.
+2. Each entry carries enough context (`lastAction`, `details`, `linkedPr`, `linkedRunbook`) for Tom to triage without opening the agent's logs.
+3. On every heartbeat tick, Quinn calls `agents.lib.incident_state.load_all_incidents()` and surfaces anything matching `needs_tom()` (entries where `needsTom` is True OR `severity` is `high`/`critical`).
+4. Lox's daily-review script is the source of most Lox entries; Lox's heartbeat updates existing entries (increments `attempts`, refreshes `lastCheckedAt`, sets `nextRetryAt`, marks resolved) but does not create new entries outside of the daily review.
+5. Quinn's heartbeat updates existing Quinn entries in place and never mutates Lox entries (read-only on Lox's file).
+6. Quinn escalates to Tom via Telegram the first time a `needsTom` entry has `escalatedAt == null`, then sets `escalatedAt`. Quinn does not re-escalate already-escalated items unless they are updated.
+
+## Data contract
+
+The unified entry shape (top-level `incidents` map, slug keys → entry dict):
+
+| Field | Type | Required | Default on read | Description |
+|---|---|---|---|---|
+| `owner` | `"lox"` \| `"quinn"` | yes | (filename-derived) | Which agent owns this entry. |
+| `status` | `"watching"` \| `"escalated"` \| `"resolved"` \| `"false_positive"` | yes | `"watching"` | Current state. Legacy Lox `"repair_attempted"` → `"watching"`; legacy `"blocked"` → `"escalated"`. |
+| `severity` | `"low"` \| `"medium"` \| `"high"` \| `"critical"` | no | `"medium"` | `high` and `critical` are auto-surfaced to Tom. |
+| `firstSeen` | ISO-8601 UTC | no | `now()` | When first observed. |
+| `lastCheckedAt` | ISO-8601 UTC | no | `now()` | Most recent check. |
+| `attempts` | int ≥ 0 | no | `0` | Recovery attempts. |
+| `recurrenceCount` | int ≥ 0 | no | `0` | Times re-appeared after resolution. |
+| `needsTom` | bool | no | `false` | Set true once escalated or severity is high/critical. |
+| `escalatedAt` | ISO-8601 UTC \| null | no | `null` | First escalation time. |
+| `resolvedAt` | ISO-8601 UTC \| null | no | `null` | Resolution time. |
+| `nextRetryAt` | ISO-8601 UTC \| null | no | `null` | Earliest allowed next retry. |
+| `lastAction` | string | no | `""` | Most recent action description. |
+| `details` | object | no | `{}` | Operator-defined structured context. Open shape. |
+| `linkedPr` | string | no | — | Shortcut for primary remediation PR. Mirrors `details.linkedPr`. |
+| `linkedRunbook` | string | no | — | Shortcut for runbook path. |
+| `followUp` | string[] | no | — | Follow-up items (tasks, PRs, notes). |
+| `dailyReviewDate` | `"YYYY-MM-DD"` | no | — | Lox-specific: the daily review date that produced the entry. |
+
+The top-level object **must** have an `incidents` key (object). An optional `_meta` key holds operator-only bookkeeping (e.g. `lastHeartbeatAt`); it is not part of the incident contract and never required.
+
+**Legacy normalization (safety net):**
+- Quinn's pre-migration files used an `ops` key and lacked `owner`, `recurrenceCount`, `nextRetryAt`, `details`. The parser reads either key and applies `_normalize_quinn_entry`.
+- Lox's pre-migration files lacked `firstSeen`, `attempts`, `needsTom`, `severity`. The parser applies `_normalize_lox_entry`. If a Lox entry has `dailyReviewDate` but no `firstSeen`, `firstSeen` is derived from the daily review date at midnight UTC.
+- These normalizers exist so agents can roll forward without breaking each other; they are not an excuse to leave files in legacy shape forever. The migration script (see below) brings both files to the canonical shape in one shot.
+
+## API surface
+
+`agents/lib/incident_state.py` exposes:
+
+- `load_all_incidents(workspace: Path | None = None) -> list[dict]` — read both state files, return a flat list. `workspace` defaults to the `OPENCLAW_WORKSPACE` env var, falling back to `/Users/quinnstoffer/.openclaw/workspace`.
+- `parse_file(path: Path, owner: str | None = None) -> list[dict]` — read one file with the legacy normalizer for that file's known shape.
+- `needs_tom(incidents: list[dict]) -> list[dict]` — filter to entries where `needsTom is True` or `severity in {"high", "critical"}`.
+- `validate_with_schema(state, schema_path: Path | None = None) -> None` — validate a state dict against the JSON Schema. Raises `jsonschema.ValidationError`. The `jsonschema` package is imported lazily so the hot `parse_file()` path does not need it installed.
+
+`agents/lib/incident_migrate.py` is a one-shot CLI used by Quinn after this PR merges:
+
+```bash
+python3 agents/lib/incident_migrate.py --dry-run                  # safe inspection
+python3 agents/lib/incident_migrate.py --in-place                 # migrate live state
+python3 agents/lib/incident_migrate.py --in-place --reset         # drop all entries
+```
+
+The migration script writes a `.bak.<UTC timestamp>` next to each file before replacing it, validates the migrated result against the JSON Schema, and is idempotent (running twice on the same file produces no further changes).
+
+## Runbook notes and common failure modes
+
+**Adding a new incident slug:** choose a stable kebab-case identifier derived from the failure pattern (e.g. `tasks-api-prod-down`, `firewall`, `bookmark-acpx-openai-401-no-scopes`). Slugs must be stable — they are how cross-recurrence is detected.
+
+**Marking an incident resolved:** set `status: "resolved"` and `resolvedAt: <now>`. Do not delete the entry — keep it for `recurrenceCount` trending. If the same failure reappears, increment `recurrenceCount` rather than creating a new entry.
+
+**Escalation policy:** Quinn auto-escalates the first time a `needs_tom` entry has `escalatedAt == null`. Quinn does not re-escalate already-escalated items unless they are updated with new evidence.
+
+**`recurrenceCount`:** the number of times the same slug has re-appeared after resolution. Use it to drive runbook improvements — a recurring slug with a runbook that keeps failing means the runbook is wrong, not the agent.
+
+**Common failure modes:**
+- *Malformed JSON:* the parser logs a warning and treats the file as empty (so heartbeat does not crash).
+- *Missing owner field on a legacy entry:* defaults to the filename-derived owner (`quinn-ops-state.json → "quinn"`, `lox-incident-state.json → "lox"`).
+- *Legacy status `"repair_attempted"` (Lox):* mapped to `"watching"` so the entry stays open and visible.
+- *Legacy status `"blocked"` (Lox):* mapped to `"escalated"` so it auto-surfaces to Tom.
+- *Schema drift:* if either agent writes a shape that doesn't normalize, the parser logs a warning and emits a best-effort entry. The schema validator catches drift at write-time when `jsonschema` is installed.
+- *Cross-agent correlation:* out of scope for this task. A future task can join entries by slug to detect incidents affecting both agents at once.
+
+## Migration and `.openclaw` boundary
+
+The state files live in `brain/state/` in the workspace, NOT in this repo. The PR that ships this system does NOT commit them and does NOT execute the migration against live state. Quinn (or whoever runs ops migrations) executes the migration script after the PR merges, via the `[openclaw-needed]` task comment workflow:
+
+```bash
+python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/lib/incident_migrate.py \
+    --workspace /Users/quinnstoffer/.openclaw/workspace \
+    --in-place
+```
+
+The script writes a `.bak.<timestamp>` next to each file before replacing it, so the migration is reversible. To roll back: stop the agents, restore the `.bak` files, restart.
+
+The HEARTBEAT.md files (`agents/definitions/quinn/HEARTBEAT.md`, `agents/definitions/lox/HEARTBEAT.md`) are doc/instruction files in this repo and ARE modified by this PR. They are agent instruction files, not runtime state.
+
+## Related specs, tasks, and PRs
+
+- **Task:** 75ec1c8c — Unify agent incident schema across Quinn and Lox
+- **Tech design:** `docs/specs/unify-agent-incident-schema-tech-design.md`
+- **Idea doc:** `brain/ideas/unified-agent-incident-schema.md`
+- **JSON Schema:** `agents/schemas/agent-incident-state.schema.json`
+- **Parser:** `agents/lib/incident_state.py` + `agents/lib/test_incident_state.py`
+- **Migration script:** `agents/lib/incident_migrate.py` + `agents/lib/test_incident_migrate.py`
+- **Heartbeat docs:** `agents/definitions/quinn/HEARTBEAT.md`, `agents/definitions/lox/HEARTBEAT.md`
+
+## Lifecycle / update rules
+
+- When an agent adds a new top-level field to an incident entry, update this doc first, then update the JSON Schema, then update the normalizer in `incident_state.py`, then update the tests, then update the agent's HEARTBEAT.md so it writes the new field.
+- When an agent adds a new top-level file (e.g. Ivy starts tracking incidents), add the file path to `load_all_incidents()`, update the parser, update this doc.
+- Schema changes that break backwards compat (dropping a required field, renaming a key) require bumping the JSON Schema `$id` and adding a `v2` normalizer. Out of scope for now.


### PR DESCRIPTION
## Summary

Unify the two agents' incident state file schemas onto a single superset so heartbeat can roll up across Quinn and Lox with one parser. Quinn's `brain/state/quinn-ops-state.json` used an `ops` key and lacked `recurrenceCount`/`nextRetryAt`/`details`/`owner`; Lox's `brain/state/lox-incident-state.json` used `incidents` but lacked `firstSeen`/`attempts`/`needsTom`/`severity`.

## Changes

### New
- `agents/schemas/agent-incident-state.schema.json` — JSON Schema 2020-12 for the unified entry shape. Only `owner` and `status` are required so legacy entries still validate.
- `agents/lib/incident_state.py` — shared parser (`load_all_incidents`, `parse_file`, `needs_tom`, `validate_with_schema`). Legacy shapes are normalized on the fly; Lox's `repair_attempted` → `watching` and `blocked` → `escalated` legacy statuses are mapped to the canonical four.
- `agents/lib/incident_migrate.py` — one-shot migration CLI. Validates against the schema, writes `.bak.<ts>` before replacing, idempotent, supports `--dry-run` / `--in-place` / `--reset`. **Not** executed by this PR.
- `agents/lib/test_incident_state.py` + `test_incident_migrate.py` — 29 unit tests.
- `docs/systems/agent-incidents.md` — durable system reference for the unified schema, parser API, migration, `.openclaw` boundary, and failure modes.

### Modified
- `agents/definitions/quinn/HEARTBEAT.md` — OPS STATE MANAGEMENT documents the unified schema; read/write helpers switched from `ops` to `incidents` and import the shared parser when available.
- `agents/definitions/lox/HEARTBEAT.md` — incident recording guidance updated to emit canonical statuses and the four newly-required fields.

## Acceptance criteria

- [x] **AC1** Shared schema defined — `docs/systems/agent-incidents.md` defines the canonical schema and `agents/schemas/agent-incident-state.schema.json` is the JSON Schema 2020-12 document both state files validate against. *(file: docs/systems/agent-incidents.md:7, agents/schemas/agent-incident-state.schema.json:1)*
- [x] **AC2** Quinn file migrated (script shipped) — `quinn-ops-state.json` keys migrate from `ops` → `incidents`; each entry gains `owner: "quinn"`, `recurrenceCount`, `nextRetryAt`, `details`. *(file: agents/lib/incident_migrate.py:62, agents/lib/incident_state.py:147)*
- [x] **AC3** Lox file migrated (script shipped) — `lox-incident-state.json` entries gain `firstSeen` (derived from `dailyReviewDate` if missing), `attempts`, `needsTom`, `severity`. *(file: agents/lib/incident_state.py:178)*
- [x] **AC4** Quinn HEARTBEAT.md OPS STATE section updated — now writes the unified schema (`incidents` key, `owner: "quinn"`), imports the shared parser. *(file: agents/definitions/quinn/HEARTBEAT.md:118)*
- [x] **AC5** Lox daily health-check scripts guidance updated — heartbeat documents the four newly-required fields and canonical statuses (`watching`/`escalated`/`resolved`/`false_positive`). *(file: agents/definitions/lox/HEARTBEAT.md:67)*
- [x] **AC6** Quinn heartbeat roll-up reads both files with shared parser — `agents/lib/incident_state.py` exposes `load_all_incidents()`, `parse_file()`, `needs_tom()`. *(file: agents/lib/incident_state.py:233)*
- [x] **AC7** Both state files valid against new schema after migration — dry-run of migration against real live state (207 Quinn + 52 Lox entries) validates against the JSON Schema. *(file: agents/lib/test_incident_state.py:138, agents/lib/test_incident_migrate.py:113)*

## Validation

- `python3 -m unittest agents.lib.test_incident_state agents.lib.test_incident_migrate` → **29 passed, 0 failed**.
- Real-data smoke against the live state files: 207 Quinn + 52 Lox entries all validate against the JSON Schema after the normalizer runs.

## `.openclaw` boundary

- The state files (`brain/state/quinn-ops-state.json`, `brain/state/lox-incident-state.json`) live in the workspace, NOT in this repo. This PR does **not** commit them and does **not** run the migration against live state.
- Quinn runs the migration once after merge via the `[openclaw-needed]` task comment workflow:
  ```
  python3 agents/lib/incident_migrate.py --in-place
  ```
  The script writes a `.bak.<UTC timestamp>` next to each file before replacing it.

## Tech design

`docs/specs/unify-agent-incident-schema-tech-design.md` (already on main, status: approved).