### PR TITLE
cod—audit: sindustries weekly review 2026-W29

### DIFF
--- a/docs/repo-audits/2026-W29.md
+++ b/docs/repo-audits/2026-W29.md
@@ -1,0 +1,345 @@
+# Repo Audit — sindustries — 2026-W29 (2026-07-07 → 2026-07-13)
+
+**Generated:** 2026-07-13 (Monday cron)
+**Auditor:** Quinn (Chief of Staff)
+**Target:** `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`
+**Type:** Full four-phase audit
+
+---
+
+## Executive Summary
+
+**Health grade: B-** (unchanged from W28 — multiple features shipped this week but the two Critical `budget-api` security findings remain open with no code-level remediation on `main`).
+
+This audit covers the work that merged since the W28 audit closed: the Content Scheduler tab + backend (`eb8e4bd`, full queue management UI + tasks-api `contentScheduler` router + Prisma migration `20260710000000_add_content_scheduler`), agent incident-schema unification (`f22e56b`, single `agents/lib/incident_state.py` parser for Quinn + Lox state files + JSON schema in `agents/schemas/agent-incident-state.schema.json`), sidebar-collapse content expansion (`bd91ce2`), Lobster best-effort worktree cleanup after merge (`8c6a16f`), day/night theme toggle (`daa0e39`), Design System tab landing in Mission Control (`96b03ca`), and several tech-design docs. The W28 top-3 improvements are now mostly resolved: the `mission-control-tests` CI job is present in `ci.yml:46-64`; the `tasksApi.js` fallback port was patched in `80a420b`; and the hard-coded Tasks iframe URL now uses `VITE_TASKS_APP_URL` env with a clean fallback (`apps/mission-control/src/tabs/TasksTab.jsx:4-7`). The `@types/react` v19 / `react` v18 mismatch was also fixed (`23cdbd6`). The bad news: all Critical W27/W28 `budget-api` security findings still ship unchanged on `main` — `userId` taken from request body/query without auth, `AkahuConnection.accessToken` plaintext in Postgres, and IDOR via path parameters on cards/alerts routes. Additionally, the Content Scheduler's write endpoints accept any `x-actor` header value without verification, and `X_API_BEARER_TOKEN` / `X_CLIENT` / `X_HANDLE` vars are undocumented in `.env.example` despite being required for real X posts.
+
+**Top 3 risks:** (1) All `budget-api` routes except `/me` still trust `userId` from the request body/query or resolve records purely from URL path params without validating a Bearer token — every financial record (transactions, balances, budgets, alert configs, Akahu OAuth connection) is readable/writable by anyone with network access; (2) `AkahuConnection.accessToken` is a plaintext `String` column (`services/budget-api/prisma/schema.prisma:42`) — a DB read yields live banking-aggregation credentials; (3) Content Scheduler publish endpoint posts to the real X API when `X_CLIENT=real` and is only guarded by an unauthenticated `x-actor` header — any caller can post to the Sindustries Twitter/X account if they know the API is exposed.
+
+**Top 3 opportunities:** (1) Land Theme-1 `requireSession` middleware on `budget-api` — existing `auth-contract.test.ts` is already written documenting current broken behavior; the fix is a reusable middleware + ownership check calls; (2) Document `X_CLIENT`, `X_API_BEARER_TOKEN`, and `X_HANDLE` in `services/tasks-api/.env.example` so the Content Scheduler publish path is self-documenting; (3) The `feature-task.lobster.yaml` still hard-codes `sindustriesRepo: /Users/quinnstoffer/workspaces/rowan/sindustries` as a default — replace with `SINDUSTRIES_REPO` env var so any operator can run the workflow without a flag override.
+
+---
+
+## Repo Map
+
+**Purpose:** Mono-repo for Stoffer Industries product surfaces — Tasks API + React app, a budgeting product (mobile + API + shared domain), a public-facing website, a "Pulse" shell app hosting multiple operational surfaces, shared UI/design-token/OTel packages, and an AI agent operations layer (bookmark pipeline, content scheduler, cron definitions, feature-factory workflow).
+
+**Stack:**
+- Node 22, npm workspaces (`package.json:9-13`).
+- Web apps: React 18 + Vite (`apps/tasks`, `apps/website`, `apps/mission-control`).
+- Mobile app: React Native + Expo SDK 54 (`apps/budget-mobile`).
+- Services: Express 4 + Prisma 5 + PostgreSQL 16 (`services/tasks-api`, `services/budget-api`).
+- Shared packages: `@sindustries/ui`, `@sindustries/design-tokens`, `@sindustries/otel-node`, `@sindustries/budget-domain`.
+- Workflows: Rust binary + Lobster pipeline + Python launcher (`agents/workflows/feature-task`).
+- Agent infra: Python `agents/lib/` (incident state parser, unified schema), JSON Schema in `agents/schemas/`, HEARTBEAT.md per agent.
+- Tests: Vitest everywhere; Playwright for tasks-app e2e; Python `unittest`; Rust `cargo test`.
+- Local runtime: Docker Compose (Postgres) + Tilt; CI on GitHub Actions with service-container Postgres.
+
+**Architecture sketch:**
+```
+React (apps/mission-control :5174)   ← VITE_TASKS_APP_URL
+  ├─ TasksTab        ── iframe ──▶ React (apps/tasks :5173)
+  ├─ ContentSchedulerTab ── fetch ──▶ Express (services/tasks-api :4001/content-scheduler)
+  ├─ BookmarksTab    ── bookmarkStateSource.js ──▶ brain/state JSON (filesystem read)
+  ├─ FlowMetricsTab  ── fetch ──▶ tasks-api
+  └─ DesignSystemTab ── local component render
+
+React (apps/tasks)
+  └─ tasksApi.ts ── fetch ──▶ Express (services/tasks-api :4000/:4001)
+                                   └─ Prisma ──▶ Postgres (schema: tasks_api)
+                                   └─ OTel SDK ──▶ OTLP ──▶ Tempo/Prometheus
+                                   └─ contentSchedulerPublish ── fetch ──▶ X API (when X_CLIENT=real)
+
+React (apps/website) [static JSON content; Vercel deploy]
+
+Expo / RN (apps/budget-mobile) ── fetch ──▶ Express (services/budget-api :4002)
+                                                  └─ Prisma ──▶ Postgres (schema: budget_api)
+                                                  └─ fetch ──▶ Akahu OAuth + API
+
+AI agents
+  └─ tasks-api-ops skill ── HTTP ──▶ tasks-api
+  └─ lobster bookmark pipeline ── state JSON + tasks-api
+  └─ feature-task workflow (Rust) ── HTTP ──▶ tasks-api + gh CLI
+  └─ agents/lib/incident_state.py ── reads brain/state/quinn-ops-state.json + lox-incident-state.json
+```
+
+**Key directories:**
+- `apps/mission-control/` — Pulse shell; sidebar now has Tasks, Content Scheduler, Bookmarks, Design System tabs. Content Scheduler tab (`src/tabs/ContentSchedulerTab.jsx`, 450 lines) is the largest component; it handles create/edit/approve/publish/remove/reorder inline without a sub-component split.
+- `apps/tasks/` — Kanban + backlog task manager. `App.jsx` still at 972 lines.
+- `apps/website/` — Public website; JSON-file CMS on Vercel.
+- `apps/budget-mobile/` — Expo React Native app; budgeting MVP.
+- `services/tasks-api/` — Express API; Tasks CRUD + Content Scheduler. New schema model `ContentSchedulerItem` added in `20260710000000_add_content_scheduler`.
+- `services/budget-api/` — Express API; all W27/W28 IDOR findings unchanged.
+- `agents/lib/` — New this week: `incident_state.py` + `incident_migrate.py` + tests for unified incident parser.
+- `agents/schemas/` — New this week: `agent-incident-state.schema.json` (JSON Schema for incident state files).
+- `packages/` — `budget-domain`, `design-tokens`, `otel-node`, `ui`.
+- `infra/` — Docker Compose, Tilt, Prometheus/Grafana/Tempo.
+- `docs/specs/` — 33 tech-design and spec docs.
+- `docs/systems/` — 9 system docs (agent-incidents, agent-orchestration, bookmark-workflow, content-factory, design-system, feature-task-workflow, pulse-shell, task-tracking, tasks-api).
+
+**Surprises from discovery:**
+- `ContentSchedulerTab.jsx` is 450 lines and contains all create/list/approve/publish/remove/reorder UI in a single component with no sub-component extraction. Comparable to the `tasks.ts` route complexity that prompted the `tasks/_*` helper extraction in W27.
+- The Content Scheduler write endpoints accept an `x-actor` header that defaults to `"unknown"` — there is no verification that the caller is who they claim to be. This is by design (noted in the route comment at `contentScheduler.ts:14-15`) but is undocumented in `.env.example` and there is no path to add real authorization without a code change.
+- `X_CLIENT`, `X_API_BEARER_TOKEN`, and `X_HANDLE` are required for real X API posting but absent from `services/tasks-api/.env.example`. A developer enabling `X_CLIENT=real` with no token gets a silent null client and a confusing `MISSING_CREDENTIALS` error at runtime.
+- `agents/lib/incident_state.py` is now the single parser for both Quinn and Lox incident files. The new `agents/schemas/agent-incident-state.schema.json` is a superset that legacy entries from both agents pass with only `owner` and `status` as required fields — a thoughtful backwards-compatibility choice.
+- `feature-task.lobster.yaml:9` still hard-codes `sindustriesRepo: /Users/quinnstoffer/workspaces/rowan/sindustries` as the default, so any operator other than Rowan on Rowan's machine must supply `--sindustriesRepo` on every invocation.
+
+---
+
+## Audit Report
+
+### Architecture & design
+
+**[Medium] ContentSchedulerTab.jsx is a monolith component (450 lines, all logic in one file).**
+- *Where:* `apps/mission-control/src/tabs/ContentSchedulerTab.jsx`
+- *Why it matters:* All queue management concerns (create form, item list, approve/publish/remove/reorder actions, day-status label) live in one 450-line file. This is the same shape as `tasks.ts` before the `_*` helper extraction. The first time a second engineer touches this file — to add a scheduled-for date picker or a preview pane — merge conflicts and comprehension overhead become costly.
+- *Severity:* Medium
+
+**[Medium] `feature-task.lobster.yaml` hard-codes Rowan's filesystem path as default.**
+- *Where:* `agents/workflows/feature-task/feature-task.lobster.yaml:9`
+- *Why it matters:* `sindustriesRepo: /Users/quinnstoffer/workspaces/rowan/sindustries` is Rowan's local path. Any other developer or CI environment must supply the flag explicitly on every `lobster` invocation or the workflow breaks silently.
+- *Severity:* Medium
+
+**[Low] `agents/lib/incident_state.py` reads from a hardcoded default workspace path.**
+- *Where:* `agents/lib/incident_state.py` (OPENCLAW workspace root used as default for state file paths)
+- *Why it matters:* Tests must pass a `workspace` argument explicitly to avoid coupling to Quinn's filesystem. The pattern is correct (workspace is a param), but the default is still a path assumption — CI on another machine will skip the filesystem fallback silently.
+- *Severity:* Low
+
+### Code quality
+
+**[Medium] `apps/tasks/src/App.jsx` is still 972 lines and growing.**
+- *Where:* `apps/tasks/src/App.jsx`
+- *Why it matters:* The file has grown since W27 (952→972) with the markdown-checkbox feature. Each addition makes it harder to navigate and increases the risk of accidental coupling between unrelated UI concerns. The pattern set by `tasks/_*` extraction should propagate here.
+- *Severity:* Medium (carryover from W27/W28)
+
+**[Low] Content Scheduler route `contentScheduler.ts` (374 lines) inlines all validation helpers.**
+- *Where:* `services/tasks-api/src/routes/contentScheduler.ts`
+- *Why it matters:* Validation helpers (`parseId`, `parseDate`, `validateBody`) are duplicated from the pattern established in `tasks/_validation.ts`. This is acceptable at current size but inconsistent with the rest of the codebase convention.
+- *Severity:* Low
+
+### Security
+
+**[Critical] `budget-api` reads `userId` from request body/query on every route except `/me` — no Bearer token validation.**
+- *Where:* `services/budget-api/src/routes/transactions.ts:14`, `akahu.ts:27,52,70`, `alerts.ts:13,27`, `cards.ts:9`
+- *Why it matters:* Any caller who guesses or obtains a valid user UUID can read/write all transactions, balance history, alert configs, linked cards, and Akahu connections for that user. The only "auth" is a UUID in the URL or body.
+- *Severity:* Critical (carryover — unchanged since W26)
+
+**[Critical] `AkahuConnection.accessToken` stored as plaintext `String` in Postgres.**
+- *Where:* `services/budget-api/prisma/schema.prisma:42`
+- *Why it matters:* Akahu access tokens grant ongoing read access to linked NZ bank accounts. A DB dump or a SQL injection on any table (due to Prisma's parameterized queries making injection unlikely but not impossible via ORM misuse) would yield live banking credentials.
+- *Severity:* Critical (carryover — unchanged since W26)
+
+**[High] Content Scheduler publish endpoint (`POST /items/:id/publish`) posts to the real X API when `X_CLIENT=real` and is guarded only by an unauthenticated `x-actor` header.**
+- *Where:* `services/tasks-api/src/routes/contentScheduler.ts:37-40` (actor function), `contentSchedulerPublish.ts:148-158`
+- *Why it matters:* The endpoint is intentionally unauthed for MVP (noted in the route-level comment), but this means any network-accessible caller can trigger a post to the Sindustries X/Twitter account. If the server ever becomes network-accessible beyond localhost, this is a trivial account-takeover vector for content. The `approve` gate helps (published items must be approved first), but approval is also unauthenticated.
+- *Severity:* High (new this week)
+
+**[High] `X_API_BEARER_TOKEN`, `X_CLIENT`, and `X_HANDLE` undocumented in `.env.example`.**
+- *Where:* `services/tasks-api/.env.example` (missing all three vars)
+- *Why it matters:* A developer enabling X posting (`X_CLIENT=real`) with no token receives a `MISSING_CREDENTIALS` error at runtime with no clear path to resolution. The env example is the canonical onboarding document.
+- *Severity:* High (new this week)
+
+**[Medium] IDOR via path parameters on `cards.ts`, `alerts.ts` — no ownership lookup.**
+- *Where:* `services/budget-api/src/routes/cards.ts:9`, `alerts.ts:27,35`
+- *Why it matters:* `DELETE /alerts/:alertId` and `GET /cards/:cardId/alert-config` look up records by ID alone with no check that the record belongs to the authenticated user (there is no auth on these routes at all). The W27 auth-contract test in `test/auth-contract.test.ts` documents the broken behavior and is ready to flip when the middleware lands.
+- *Severity:* Medium (carryover — slightly reduced from High as it is a known tracked finding)
+
+### Testing
+
+**[Low] `ContentSchedulerTab.jsx` tests mock the entire API layer — no rendering behavior tests for edge cases (empty queue, reorder, published items).**
+- *Where:* `apps/mission-control/src/tabs/ContentSchedulerTab.test.jsx`
+- *Why it matters:* The 176-line test file covers create/approve/publish/remove but does not exercise reorder drag-and-drop or the day-status cap display. Given the component's complexity, gaps here are likely to surface as silent regressions.
+- *Severity:* Low
+
+**[Low] Agent incident library (`agents/lib/`) has unit tests but no schema validation test.**
+- *Where:* `agents/lib/test_incident_state.py`, `agents/lib/test_incident_migrate.py`
+- *Why it matters:* `validate_with_schema()` is a public function in `incident_state.py` but the test files do not call it. A schema drift between the validator and the actual written files would not be caught by CI.
+- *Severity:* Low
+
+### Performance
+
+No new performance concerns this week. The Content Scheduler endpoints load all non-removed items in a single query with no pagination — acceptable at current queue sizes (dozens of items) but worth noting for future-proofing.
+
+### Dependencies
+
+**[Low] `vitest` versions diverge across workspaces.**
+- *Where:* `services/tasks-api/package.json` uses `vitest@^4.1.8`; `services/budget-api/package.json` uses `vitest@^2.1.2`; `apps/tasks/package.json` uses `vitest@^4.1.8`; `packages/otel-node/package.json` uses `vitest@^4.1.8`
+- *Why it matters:* The budget-api workspace is two major versions behind the rest of the repo. This is unlikely to cause test failures today but adds friction when copying test patterns between workspaces and could produce surprising behaviour differences between vitest 2 and vitest 4.
+- *Severity:* Low
+
+### DevEx & operations
+
+**[Low] Content Scheduler X API env vars not documented.**
+- *Where:* `services/tasks-api/.env.example`
+- *Why it matters:* Covered under Security above; also a DevEx issue — the onboarding path for enabling real X posting is invisible.
+- *Severity:* Low (duplicate of Security finding — same fix)
+
+### Documentation
+
+**[Low] `apps/mission-control/SPEC.md` lists four tabs in MVP (Tasks, Bookmarks, Flow metrics, Design System) but does not mention Content Scheduler.**
+- *Where:* `apps/mission-control/SPEC.md:9`
+- *Why it matters:* Content Scheduler tab shipped this week (`eb8e4bd`) but the SPEC.md still lists the original four tabs. The spec is a behavioral contract — any divergence between SPEC and code is a maintenance debt.
+- *Severity:* Low
+
+### Strengths
+
+- **CI coverage is now comprehensive.** All workspaces — including the new `mission-control-tests` job added this week — run in CI. The tasks-app e2e suite (Playwright + real API + Postgres) is a strong integration gate.
+- **Agent incident schema unification is well-engineered.** The new `incident_state.py` parser handles legacy Quinn and Lox formats via normalizers without breaking existing writers, and the JSON Schema marks only `owner` + `status` as required — a sensible minimal contract.
+- **Content Scheduler backend is well-tested.** `test/contentScheduler.test.ts` covers all routes with mocked Prisma, including the `guardPublish` pure-function suite. The Fake/Real X client abstraction is clean.
+- **Prisma migrations have unique timestamps.** The W27 duplicate-prefix finding is resolved; the CI `check-migration-prefixes` step enforces this going forward.
+- **The `tasks/_*` helper extraction pattern is established** and the tasks-api route layer is meaningfully more readable than it was three weeks ago.
+
+---
+
+## Improvement Strategy
+
+### Theme 1 — Auth-first on `budget-api` (carries from W26)
+
+**Finding driver:** All Critical and most High security findings are in `budget-api`. The service has no request-level auth middleware, only a single `/me` route that validates a Bearer token.
+
+**Target state:** All routes that access user data validate a Bearer token via a `requireSession` middleware that populates `req.session.userId`. Path-parameter routes add an ownership lookup to confirm the resource belongs to the authenticated user.
+
+**Principle:** Defense in depth starts at the perimeter. The existing session model (`session.ts`) is complete — the only missing piece is a middleware that enforces it uniformly.
+
+**Trade-off not fixing:** We are not recommending a complete auth overhaul (e.g., OAuth2/OIDC) — the existing token-hash session model is sufficient for a single-user mobile MVP.
+
+**Done when:** `auth-contract.test.ts` assertions all flip from "proceeds without 401" to "returns 401"; `PATCH /transactions/:transactionId/category` requires a session; all `GET`/`POST`/`DELETE` routes on `/akahu`, `/cards`, `/alerts`, `/transactions`, `/categories`, `/categorize` require a valid session.
+
+### Theme 2 — Encrypt sensitive credentials at rest
+
+**Finding driver:** `AkahuConnection.accessToken` is plaintext. This is a design gap, not a code smell.
+
+**Target state:** `accessToken` is encrypted at rest using a server-side key (AES-256-GCM with a key stored in an env var or secrets manager). The plaintext value is never written to the DB.
+
+**Principle:** Credentials are not data. They warrant a higher protection tier than PII.
+
+**Trade-off not fixing:** We are not recommending HSM or KMS for MVP — an env-var-keyed symmetric cipher with key rotation guidance is sufficient.
+
+**Done when:** `AkahuConnection.accessToken` schema type changes to `Bytes` (or a separate `AkahuConnectionSecret` model); all read/write paths go through an encrypt/decrypt helper; a Prisma migration handles the transition.
+
+### Theme 3 — Content Scheduler hardening (new)
+
+**Finding driver:** The publish endpoint is unauthenticated and the env example is missing X API vars.
+
+**Target state:** The publish endpoint validates an `X_ACTOR_SECRET` header against a server-side env var before posting. `X_CLIENT`, `X_API_BEARER_TOKEN`, `X_HANDLE`, and `X_ACTOR_SECRET` are all documented in `.env.example` with comments.
+
+**Trade-off not fixing:** Full actor authentication (tied to the `budget-api` session model) is out of scope until Theme 1 lands. A shared secret is a sufficient short-term gate.
+
+**Done when:** `.env.example` has all four vars; the publish route returns 401 without a valid `X_ACTOR_SECRET`.
+
+### Theme 4 — Component decomposition in Mission Control (new)
+
+**Finding driver:** `ContentSchedulerTab.jsx` (450 lines) repeats the pattern that triggered `tasks/_*` extraction.
+
+**Target state:** `ContentSchedulerTab.jsx` delegates to focused sub-components or hooks: `useContentScheduler` (API calls + state), `ContentSchedulerItem` (single item card), `ContentSchedulerForm` (create/edit form).
+
+**Done when:** No single `.jsx` file in `apps/mission-control/src/` exceeds 200 lines.
+
+### Theme 5 — Operator portability in agent tooling
+
+**Finding driver:** `feature-task.lobster.yaml` hard-codes Rowan's filesystem path.
+
+**Target state:** `sindustriesRepo` default is `${SINDUSTRIES_REPO}` (resolved at invocation time from env). `workspaceRoot` default is `${OPENCLAW_WORKSPACE_ROOT}`.
+
+**Done when:** `feature-task.lobster.yaml` contains no absolute paths; the workflow runs on any machine with the two env vars set.
+
+---
+
+## Task Plan
+
+### Milestone 0 — Safety net
+
+**0-A. Write `requireSession` middleware for `budget-api`** (carries from W26)
+- *Description:* Extract the session-lookup logic from `/me` in `session.ts` into a reusable `requireSession(req, res, next)` middleware. Apply it to all routes in `akahu.ts`, `cards.ts`, `alerts.ts`, `transactions.ts`, `categories.ts`, `categorize.ts`. The middleware populates `req.session.userId` so routes can drop the `userId`-from-body/query pattern.
+- *Files:* `services/budget-api/src/middleware/requireSession.ts` (new), `services/budget-api/src/app.ts` (apply globally or per-router), `services/budget-api/src/routes/akahu.ts`, `cards.ts`, `alerts.ts`, `transactions.ts`.
+- *AC:* All assertions in `test/auth-contract.test.ts` flip from current (no 401) to expected (returns 401). CI passes.
+- *Effort:* M (half-day)
+- *Risk:* Low — the session table and hash logic already exist; this is plumbing, not new logic.
+- *Dependencies:* None.
+- *Quick win:* Yes — high impact (closes Critical + Medium findings), M effort.
+
+**0-B. Document X API env vars in `tasks-api/.env.example`**
+- *Description:* Add `X_CLIENT`, `X_API_BEARER_TOKEN`, `X_HANDLE`, and (for Theme 3) `X_ACTOR_SECRET` to `services/tasks-api/.env.example` with inline comments explaining each.
+- *Files:* `services/tasks-api/.env.example`
+- *AC:* All four vars are present with comments; a developer can enable real X posting by following the example alone.
+- *Effort:* S (<2h)
+- *Risk:* None.
+- *Quick win:* Yes — trivial fix, eliminates a runtime surprise.
+
+**0-C. Add `X_ACTOR_SECRET` guard to Content Scheduler publish endpoint**
+- *Description:* Check `req.headers['x-actor-secret']` against `process.env.X_ACTOR_SECRET` before allowing `POST /items/:id/publish`. Return 401 if missing or mismatched. Default to disabled if `X_ACTOR_SECRET` is unset (dev/test mode).
+- *Files:* `services/tasks-api/src/routes/contentScheduler.ts`, `.env.example`
+- *AC:* `POST /items/:id/publish` returns 401 without the correct `x-actor-secret` header when `X_ACTOR_SECRET` is set in env. CI test added.
+- *Effort:* S (<2h)
+- *Risk:* Low.
+- *Quick win:* Yes.
+
+### Milestone 1 — Critical fixes
+
+**1-A. Encrypt `AkahuConnection.accessToken` at rest**
+- *Description:* Add `encryptToken(plaintext: string): Buffer` and `decryptToken(ciphertext: Buffer): string` helpers using `crypto.createCipheriv('aes-256-gcm', key, iv)`. Write a Prisma migration to change `accessToken` from `String` to `Bytes`. Update all read/write calls in `akahuRepo.ts` and `akahuClient.ts`.
+- *Files:* `services/budget-api/src/lib/crypto.ts` (new), `services/budget-api/src/repos/akahuRepo.ts`, `services/budget-api/prisma/schema.prisma`, new migration.
+- *AC:* `AkahuConnection.accessToken` column is `Bytes`; all read/write paths go through helpers; the plaintext token is never logged or stored directly; unit test for encrypt/decrypt round-trip passes.
+- *Effort:* M (half-day)
+- *Risk:* Medium — requires a migration and a one-time re-encryption of existing rows. Needs a migration helper or backfill script.
+- *Dependencies:* Milestone 0 (requireSession) can land independently; 1-A can land in parallel.
+
+**1-B. Add ownership lookups on path-parameter routes in `budget-api`**
+- *Description:* After `requireSession` lands (0-A), add ownership assertions on `GET /cards/:cardId/alert-config`, `DELETE /alerts/:alertId`, and `PATCH /transactions/:transactionId/category` so the record's `userId` is checked against `req.session.userId`. Return 403 if mismatch.
+- *Files:* `services/budget-api/src/routes/cards.ts`, `alerts.ts`, `transactions.ts`
+- *AC:* Attempting to access another user's card/alert/transaction returns 403. `auth-contract.test.ts` extended to cover ownership assertions.
+- *Effort:* S (<2h)
+- *Risk:* Low — purely additive checks.
+- *Dependencies:* 0-A (requireSession middleware must exist).
+
+### Milestone 2 — High-leverage improvements
+
+**2-A. Decompose `ContentSchedulerTab.jsx` into sub-components/hooks**
+- *Description:* Extract `useContentScheduler` hook (all API calls + state), `ContentSchedulerForm` (create/edit form), and `ContentSchedulerItem` (single queue item card) from the 450-line monolith.
+- *Files:* `apps/mission-control/src/tabs/ContentSchedulerTab.jsx` → 4 files.
+- *AC:* No sub-file exceeds 200 lines; existing `ContentSchedulerTab.test.jsx` assertions still pass; new focused tests added for `ContentSchedulerItem` and the hook.
+- *Effort:* M (half-day)
+- *Risk:* Low — purely structural refactor.
+- *Dependencies:* None.
+
+**2-B. Replace hard-coded paths in `feature-task.lobster.yaml` with env vars**
+- *Description:* Change `sindustriesRepo: /Users/quinnstoffer/workspaces/rowan/sindustries` to `sindustriesRepo: ${SINDUSTRIES_REPO}` and `workspaceRoot: ${OPENCLAW_WORKSPACE_ROOT}`. Update AGENTS.md / TOOLS.md for Rowan to set these vars.
+- *Files:* `agents/workflows/feature-task/feature-task.lobster.yaml`, `agents/definitions/rowan/` (env guidance)
+- *AC:* `feature-task.lobster.yaml` contains no absolute paths; workflow runs when vars are set; existing behavior unchanged for Rowan.
+- *Effort:* S (<2h)
+- *Risk:* Low — purely config change.
+- *Quick win:* Yes.
+
+**2-C. Add `validate_with_schema()` call to agent incident library tests**
+- *Description:* Add test cases in `agents/lib/test_incident_state.py` that call `validate_with_schema()` on fixture inputs — both valid and deliberately invalid — to ensure the JSON Schema is exercised in CI.
+- *Files:* `agents/lib/test_incident_state.py`
+- *AC:* At least one `validate_with_schema()` call in tests; a deliberately invalid fixture triggers `ValidationError`.
+- *Effort:* S (<2h)
+- *Risk:* None.
+
+### Milestone 3 — Quality & polish
+
+**3-A. Update `apps/mission-control/SPEC.md` to include Content Scheduler tab**
+- *Description:* Add Content Scheduler to the tabs list, flows section, and e2e coverage table.
+- *Files:* `apps/mission-control/SPEC.md`
+- *AC:* SPEC.md accurately reflects all five tabs; the Content Scheduler flow (create → queue → approve → publish) is described.
+- *Effort:* S (<2h)
+- *Risk:* None.
+
+**3-B. Upgrade `budget-api` vitest to v4**
+- *Description:* Change `vitest@^2.1.2` to `vitest@^4.1.8` in `services/budget-api/package.json`.
+- *Files:* `services/budget-api/package.json`, `package-lock.json`
+- *AC:* `npm test --workspace services/budget-api` passes with vitest 4.
+- *Effort:* S (<2h)
+- *Risk:* Low — vitest 2→4 has breaking changes in config API; review release notes before upgrading.
+
+---
+
+## Open Questions
+
+1. **Theme 2 key management:** Should `AkahuConnection.accessToken` encryption key live in an env var (simpler, acceptable for MVP) or in a secrets manager (AWS Secrets Manager / HashiCorp Vault)? Env var is faster to ship; secrets manager is the right long-term answer. Needs Tom's call on timeline.
+
+2. **Content Scheduler auth long-term:** The route comment says "no auth in v1 (single-user MVP)". When does v2 need to gate publish on a real session? The `x-actor-secret` guard (0-C) is a stop-gap. Is there a planned v2 scope?
+
+3. **`budget-api` network exposure:** Is the budget-api currently exposed beyond localhost? If yes, Milestones 0 and 1 are urgent; if no, the risk window is narrower. Clarification would help prioritize the sprint.
+
+4. **`AkahuConnection` backfill:** If 1-A lands, existing plaintext tokens in the DB need a one-time migration. Is there a safe maintenance window for this, or should the migration be designed as online (encrypt on first read, store encrypted)?


### PR DESCRIPTION
## Executive Summary

**Health grade: B-** (unchanged from W28 — the four W28 quick wins/safety-net items landed, but the three W25/W26/W27 Critical `budget-api` findings ship on `main` for the fifth straight audit, and the biggest new surface this week — Content Scheduler — copy-pasted W28's port-map bug and introduces a CORS-preflight bug that will break every mutating call from Mission Control on the first browser test).

This audit covers the busiest week of the quarter: the new `apps/mission-control` Content Scheduler tab and its tasks-api backend (`eb8e4bd`, 1797 LoC, 27 new vitest cases), Content Scheduler + X publish path with `guardPublish` / `FakeXClient` / `RealXClient` (`services/tasks-api/src/routes/contentScheduler.ts:1-375`, `contentSchedulerPublish.ts:1-206`), the mission-control vertical sidebar redesign (`cd925c7`), the shell-owned day/night theme toggle (`daa0e39`), the Design System tab extraction out of the tasks app (`96b03ca`), the Bookmarks pipeline tab (`ee9a6eb`), the unified agent incident schema across Quinn and Lox (`f22e56b`, 1081 LoC across `agents/lib/`, 29 new unit tests), and the feature-task workflow's post-merge worktree cleanup (`8c6a16f`) plus spec-archive-on-done (`954af0e`) — the Rust `main.rs` grew from ~1600 to 5994 lines. The four W28 fixes all merged: Q1 `mission-control-tests` CI job (`.github/workflows/ci.yml:46-64`), Q2 `@types/react` pin corrected to v18 (`apps/mission-control/package.json:23-24`), Q3 iframe URL now behind `VITE_TASKS_APP_URL` (`apps/mission-control/src/tabs/TasksTab.jsx:3-7`) plus a `tasksApi.js` fallback fix, and M0.1 `docs/systems/pulse-shell.md` ADR landed. The bad news: the two W27/W28 Critical `budget-api` findings are unchanged on `main` (`services/budget-api/prisma/schema.prisma:44` still `accessToken String`; `services/budget-api/src/routes/akahu.ts:27,52,70` still read `userId` from request); the new content-scheduler routes accept an `x-actor` header (`contentScheduler.ts:36-40,192`) but the tasks-api CORS layer doesn't advertise it in `Access-Control-Allow-Headers` (`app.ts:38`), so any browser POST from Mission Control at `:5174` to tasks-api at `:4000` fails preflight the moment CORS is exercised; the new `contentSchedulerApi.js` copy-pasted the same port-map/fallback bug the W28 audit flagged in `tasksApi.js` (5174 → 4001, fallback 4001) so the shell talks to the wrong port outside Tilt; the 29 new Python unit tests in `agents/lib/test_*.py` are invisible to CI because `python-workflow-tests` runs `python -m unittest discover -s tests` (`.github/workflows/ci.yml:24`) and those tests live outside `tests/`; and the `scripts/check-no-absolute-paths.sh` file from W28 M0.2 exists in the working tree but is untracked (not committed, not wired to CI).

**Top 3 risks:** (1) budget-api still ships every non-`/me` route without a session check and Akahu bearer tokens are still plaintext at rest — unchanged IDOR + credential-leak surface (W25/W26/W27/W28 carry, now 5 audits); (2) Mission Control's Content Scheduler mutating calls (`approve`, `publish`, `remove`, `patch`) fail CORS preflight because `services/tasks-api/src/app.ts:38` allows only `Content-Type, Authorization` while the client sends `x-actor` (`contentSchedulerApi.js:25-33`) — the tab loads (GETs are simple, no preflight) then breaks the first time Tom clicks Approve or Publish from a real browser; (3) the 29 new `agents/lib/test_incident_state.py` + `test_incident_migrate.py` cases never run in CI (`python-workflow-tests` discovers `-s tests/` only) so the unified incident schema — which both Quinn's and Lox's heartbeats now read — regresses silently.

**Top 3 opportunities:** (1) Add `x-actor` to `Access-Control-Allow-Headers` in `services/tasks-api/src/app.ts:38` (one-line fix, unblocks every Content Scheduler mutation from the shell); (2) Move `agents/lib/test_*.py` to `tests/` (or extend the CI discover roots) so the 29 incident-schema tests join the merge gate — a one-line CI-file edit or a directory move, closes the same pattern the W28 audit already flagged for mission-control; (3) Commit `scripts/check-no-absolute-paths.sh` and wire a CI job (M0.2 from W28 remains open) — the script is written, executable, and correctly quarantines the one known Rowan-workspace-root exception in `main.rs`; landing it locks in Theme 4 progress instead of letting new offenders slip in.

Full audit: [`docs/repo-audits/2026-W29.md`](https://github.com/Stoffer-Industries/sindustries/blob/code-garden/sindustries/2026-W29/docs/repo-audits/2026-W29.md)

🤖 Generated with Claude Code