### PR TITLE
feat(mission-control): SIndustries brand site tab

### DIFF
--- a/apps/mission-control/SPEC.md
+++ b/apps/mission-control/SPEC.md
@@ -9,7 +9,7 @@ surface.
 
 - **Audience:** internal Sindustries operators (Tom and the agent team).
 - **Route:** `apps/mission-control` is deployed at the `/` surface.
-- **Tabs in MVP:** Tasks, Bookmarks, Flow metrics, Design System.
+- **Tabs in MVP:** Tasks, Bookmarks, Flow metrics, Design System, Content, SIndustries.
 - **Non-goal:** mobile/responsive (desktop ≥ 1280px only).
 
 ## Flows
@@ -84,6 +84,8 @@ surface.
 | Bookmarks | `/bookmarks` | `Tabs/BookmarksTab.jsx` | Bookmark pipeline dashboard (KPIs, curations, funnel, topics, recent transitions); toolbar filters by time window + topic |
 | Flow metrics | `/flow-metrics` | `Tabs/FlowMetricsTab.jsx` | Filter row (assignee, tag), metric cards, throughput chart, WIP chart |
 | Design System | `/design-system` | `Tabs/DesignSystemTab.jsx` | Shared `DesignSystemPage` specimen (Tokens / Pulse / Brand) with back link to Tasks |
+| Content | `/content-scheduler` | `Tabs/ContentSchedulerTab.jsx` | Content scheduler queue: list + create/approve/publish/remove/reorder; embeds content via iframe + Tasks-API proxy |
+| SIndustries | `/sindustries` | `Tabs/SIndustriesTab.jsx` | Embedded `sindustries.co.nz` via iframe; falls back to an external-link card if the upstream `X-Frame-Options`/`CSP` blocks embedding (timeout-based detection, ~8s) |
 | 404 / unknown path | `/<anything>` | falls back to Tasks tab | The default tab renders; no error surface |
 
 ## E2e Coverage
@@ -113,6 +115,7 @@ specimen mount.
 | Recent transitions | Vitest: `bookmarkPipeline.test.js` covers `recentTransitions` scope + ordering |
 | State source fetch | Vitest: `bookmarkStateSource.test.js` covers parallel fetch + 404 → empty defaults |
 | BookmarksTab render | Vitest: `tabs/BookmarksTab.test.jsx` covers loading/data/error/refresh paths |
+| SIndustries tab iframe + fallback | Vitest: `tabs/SIndustriesTab.test.jsx` covers initial iframe render, fallback after timeout, and success-path load event |
 
 ## Data Sources
 

--- a/apps/mission-control/src/App.test.jsx
+++ b/apps/mission-control/src/App.test.jsx
@@ -10,13 +10,24 @@ beforeEach(() => {
 });
 
 describe('Pulse shell', () => {
-  it('renders the sidebar with four tabs', () => {
+  it('renders the sidebar with the registered tabs', () => {
     render(<App />);
     expect(screen.getByTestId('pulse-sidebar')).toBeTruthy();
     expect(screen.getByTestId('pulse-sidebar-tab-tasks')).toBeTruthy();
     expect(screen.getByTestId('pulse-sidebar-tab-bookmarks')).toBeTruthy();
     expect(screen.getByTestId('pulse-sidebar-tab-flow-metrics')).toBeTruthy();
     expect(screen.getByTestId('pulse-sidebar-tab-design-system')).toBeTruthy();
+    expect(screen.getByTestId('pulse-sidebar-tab-content-scheduler')).toBeTruthy();
+    expect(screen.getByTestId('pulse-sidebar-tab-sindustries')).toBeTruthy();
+  });
+
+  it('routes /sindustries to the SIndustries tab', () => {
+    window.history.pushState({}, '', '/sindustries');
+    render(<App />);
+    const active = screen.getByTestId('pulse-sidebar-tab-sindustries');
+    expect(active.getAttribute('aria-current')).toBe('page');
+    // The SIndustries iframe is in the active content area.
+    expect(screen.getByTestId('pulse-sindustries')).toBeTruthy();
   });
 
   it('routes to a tab matching the URL path on first render', () => {

--- a/apps/mission-control/src/pulseTabs.jsx
+++ b/apps/mission-control/src/pulseTabs.jsx
@@ -18,6 +18,7 @@ import { TasksTab } from './tabs/TasksTab.jsx';
 import { BookmarksTab } from './tabs/BookmarksTab.jsx';
 import { DesignSystemTab } from './tabs/DesignSystemTab.jsx';
 import { ContentSchedulerTab } from './tabs/ContentSchedulerTab.jsx';
+import { SIndustriesTab } from './tabs/SIndustriesTab.jsx';
 
 function IconClipboard() {
   return (
@@ -69,6 +70,17 @@ function IconContent() {
   );
 }
 
+function IconSindustries() {
+  // Globe-with-S glyph: simple brand-style mark for sindustries.co.nz.
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M3 12h18" strokeLinecap="round" />
+      <path d="M12 3c2.5 3 2.5 15 0 18M12 3c-2.5 3-2.5 15 0 18" />
+    </svg>
+  );
+}
+
 export const PULSE_TABS = [
   {
     id: 'tasks',
@@ -104,6 +116,13 @@ export const PULSE_TABS = [
     path: '/content-scheduler',
     icon: <IconContent />,
     component: ContentSchedulerTab
+  },
+  {
+    id: 'sindustries',
+    label: 'SIndustries',
+    path: '/sindustries',
+    icon: <IconSindustries />,
+    component: SIndustriesTab
   }
 ];
 

--- a/apps/mission-control/src/styles/components.css
+++ b/apps/mission-control/src/styles/components.css
@@ -454,3 +454,70 @@
     grid-template-columns: 1fr;
   }
 }
+/* SIndustries tab — iframe + fallback styles */
+.sindustries-tab {
+  padding: 24px 32px;
+  display: grid;
+  gap: 16px;
+  height: 100%;
+  grid-template-rows: auto 1fr;
+}
+
+.sindustries-tab__header {
+  display: grid;
+  gap: 4px;
+}
+
+.sindustries-tab__title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.sindustries-tab__subtitle {
+  margin: 0;
+  color: var(--si-color-text-muted, #666);
+  font-size: 13px;
+}
+
+.sindustries-tab__iframe {
+  border: 0;
+  width: 100%;
+  height: 100%;
+  min-height: 480px;
+  background: var(--si-color-bg-canvas, #fff);
+  border-radius: 8px;
+}
+
+.sindustries-tab__fallback-title {
+  margin: 0 0 8px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.sindustries-tab__fallback-detail {
+  margin: 0 0 12px;
+  color: var(--si-color-text-muted, #666);
+  font-size: 13px;
+}
+
+.sindustries-tab__fallback-detail code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  background: var(--si-color-bg-subtle, #f1f1f4);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+.sindustries-tab__fallback-link {
+  display: inline-block;
+  color: var(--si-color-accent, #4c8bf5);
+  font-weight: 500;
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.sindustries-tab__fallback-link:hover,
+.sindustries-tab__fallback-link:focus-visible {
+  text-decoration: underline;
+}

--- a/apps/mission-control/src/tabs/SIndustriesTab.jsx
+++ b/apps/mission-control/src/tabs/SIndustriesTab.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Card } from '@sindustries/ui/react';
+
+const SINDUSTRIES_URL = 'https://sindustries.co.nz';
+// How long we wait for the iframe load event before showing the fallback.
+// sindustries.co.nz is typically fast, but X-Frame-Options/CSP blocks
+// never fire load events at all, so a timeout-based fallback is the
+// only reliable detection in jsdom-free environments.
+const IFRAME_LOAD_TIMEOUT_MS = 8000;
+
+/**
+ * SIndustriesTab embeds sindustries.co.nz as a Mission Control tab for
+ * quick internal access alongside the existing tools. When embedding is
+ * blocked by the upstream site's X-Frame-Options or CSP header (a real
+ * possibility for marketing sites), the tab degrades gracefully to a
+ * card with an external link that opens sindustries.co.nz in a new tab.
+ *
+ * The embedding contract is intentionally conservative: we never attempt
+ * to bypass upstream framing headers, only detect the failure and
+ * present the fallback path the AC explicitly allows.
+ */
+export function SIndustriesTab() {
+  const [loadFailed, setLoadFailed] = useState(false);
+  const loadedRef = useRef(false);
+
+  useEffect(() => {
+    loadedRef.current = false;
+    setLoadFailed(false);
+    const timer = setTimeout(() => {
+      // If onload hasn't fired by now the iframe is almost certainly
+      // being blocked upstream. Switch to the fallback path.
+      if (!loadedRef.current) {
+        setLoadFailed(true);
+      }
+    }, IFRAME_LOAD_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const handleLoad = () => {
+    loadedRef.current = true;
+    setLoadFailed(false);
+  };
+
+  return (
+    <section className="sindustries-tab" data-testid="pulse-sindustries">
+      <header className="sindustries-tab__header">
+        <h1 className="sindustries-tab__title">SIndustries</h1>
+        <p className="sindustries-tab__subtitle">
+          sindustries.co.nz embedded for quick access alongside internal tools.
+        </p>
+      </header>
+      {loadFailed ? (
+        <Card data-testid="pulse-sindustries-fallback">
+          <h2 className="sindustries-tab__fallback-title">Embedding blocked</h2>
+          <p className="sindustries-tab__fallback-detail">
+            sindustries.co.nz refused to embed (likely{' '}
+            <code>X-Frame-Options</code> or <code>CSP</code>). Open it in a new
+            tab instead:
+          </p>
+          <a
+            href={SINDUSTRIES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="sindustries-tab__fallback-link"
+            data-testid="pulse-sindustries-fallback-link"
+          >
+            {SINDUSTRIES_URL}
+          </a>
+        </Card>
+      ) : (
+        <iframe
+          title="SIndustries"
+          src={SINDUSTRIES_URL}
+          onLoad={handleLoad}
+          data-testid="pulse-sindustries-iframe"
+          aria-label="SIndustries brand site"
+          className="sindustries-tab__iframe"
+        />
+      )}
+    </section>
+  );
+}

--- a/apps/mission-control/src/tabs/SIndustriesTab.test.jsx
+++ b/apps/mission-control/src/tabs/SIndustriesTab.test.jsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+import { SIndustriesTab } from './SIndustriesTab.jsx';
+
+const SINDUSTRIES_URL = 'https://sindustries.co.nz';
+const IFRAME_LOAD_TIMEOUT_MS = 8000;
+
+describe('SIndustriesTab', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the iframe with correct title, src, and aria-label', () => {
+    render(<SIndustriesTab />);
+    const iframe = screen.getByTestId('pulse-sindustries-iframe');
+    expect(iframe.tagName).toBe('IFRAME');
+    expect(iframe.getAttribute('title')).toBe('SIndustries');
+    expect(iframe.getAttribute('src')).toBe(SINDUSTRIES_URL);
+    expect(iframe.getAttribute('aria-label')).toBe('SIndustries brand site');
+    expect(screen.queryByTestId('pulse-sindustries-fallback')).toBeNull();
+  });
+
+  it('shows the fallback card after the iframe load timeout fires', () => {
+    render(<SIndustriesTab />);
+    expect(screen.getByTestId('pulse-sindustries-iframe')).toBeTruthy();
+    expect(screen.queryByTestId('pulse-sindustries-fallback')).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(IFRAME_LOAD_TIMEOUT_MS);
+    });
+
+    expect(screen.queryByTestId('pulse-sindustries-iframe')).toBeNull();
+    const fallback = screen.getByTestId('pulse-sindustries-fallback');
+    expect(fallback).toBeTruthy();
+    const link = screen.getByTestId('pulse-sindustries-fallback-link');
+    expect(link.getAttribute('href')).toBe(SINDUSTRIES_URL);
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toContain('noopener');
+    expect(link.getAttribute('rel')).toContain('noreferrer');
+  });
+
+  it('does not show the fallback before the timeout fires', () => {
+    render(<SIndustriesTab />);
+    act(() => {
+      vi.advanceTimersByTime(IFRAME_LOAD_TIMEOUT_MS - 100);
+    });
+    expect(screen.getByTestId('pulse-sindustries-iframe')).toBeTruthy();
+    expect(screen.queryByTestId('pulse-sindustries-fallback')).toBeNull();
+  });
+
+  it('clears the fallback once the iframe load event fires before the timeout', () => {
+    render(<SIndustriesTab />);
+
+    // Simulate the upstream site firing its load event (succeeds).
+    const iframe = screen.getByTestId('pulse-sindustries-iframe');
+    act(() => {
+      fireEvent.load(iframe);
+      vi.advanceTimersByTime(IFRAME_LOAD_TIMEOUT_MS + 1000);
+    });
+
+    // Iframe is still rendered; fallback never appeared.
+    expect(screen.getByTestId('pulse-sindustries-iframe')).toBeTruthy();
+    expect(screen.queryByTestId('pulse-sindustries-fallback')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a new SIndustries tab at `/sindustries` per task 77a28087, embedding sindustries.co.nz for quick internal access alongside the existing Pulse tools.
- Embedding contract is conservative: if the upstream `X-Frame-Options`/`CSP` blocks framing, the tab degrades gracefully to a Card with an external-link in a new tab rather than attempting to bypass headers (per the AC's explicit fallback allowance).
- New `SIndustriesTab.jsx` + test pair (4 cases: initial iframe render, fallback after 8s timeout, no fallback before timeout, success-path onLoad clears the timer); updated `App.test.jsx` to cover 4-tab sidebar + `/sindustries` routing. SPEC.md updated to document the new tab and the iframe fallback flow.

## Test plan
- [x] `npm test` in `apps/mission-control` — 80/80 pass (4 new + 76 existing, including the updated 5-case App test)
- [x] `npm run build` in `apps/mission-control` — clean, ~54 KB gzipped JS
- [ ] Manual: load `/sindustries` in a dev browser, confirm iframe renders sindustries.co.nz
- [ ] Manual: if upstream blocks framing, confirm the fallback Card appears with the external link

## Acceptance Criteria
- [x] AC1: SIndustries tab registered in Mission Control at its own route. (file: apps/mission-control/src/pulseTabs.jsx: SIndustries entry — id 'sindustries', path '/sindustries', SIndustriesTab component)
- [x] AC2: Site renders in an iframe; graceful fallback link if embedding is blocked. (file: apps/mission-control/src/tabs/SIndustriesTab.test.jsx: shows the fallback card after the iframe load timeout fires)
- [x] AC3: Tab accessible from tab bar. (file: apps/mission-control/src/App.test.jsx: routes /sindustries to the SIndustries tab)

🤖 Generated with Claude Code