### PR TITLE
chore(heartbeat): restore silence-rule and per-section output gates

### DIFF
--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -60,6 +60,17 @@ I am a heartbeat agent. I check the Tasks API on a regular interval for content 
 
 ---
 
+## Escalate on Failure
+
+If any step fails due to an external dependency (API key invalid, auth error, quota exceeded, service unavailable, unexpected empty output from an external call):
+
+1. Do NOT silently fall back or generate a placeholder
+2. Note which step failed and what the error was
+3. Read and follow `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/notify-soft-fail/SKILL.md` — escalate to Lox's main session
+4. Skip the remainder of that task — do not ship partial or degraded output
+
+---
+
 ## HEARTBEAT.md Maintenance
 
 Heartbeat is for discovery and authoring rhythm. Workflow changes go in WORKFLOW.md. Voice/identity changes go in SOUL.md. Quality bar changes go in DoD.md. This file is just the heartbeat cadence and procedures.

--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -175,12 +175,15 @@ for inc in needs_tom(all_incidents):
 4. If an entry has `attempts >= 3` and is still unresolved: set `needsTom: true`, `severity` to at least `high`
 5. Always increment `attempts` and update `lastCheckedAt` when re-checking an existing entry
 
-**Escalation — announce count and new items:**
+**Escalation — always surface the top unblock:**
 After completing all sections, check both `quinn-ops-state.json` and `brain/state/lox-incident-state.json`:
-1. Count all entries where `needsTom: true` AND `status` is not `resolved` or `false_positive`. Call this N.
-2. For any entry where `needsTom: true` AND `escalatedAt` is null (newly escalated this pass): set `escalatedAt: <now>` and include a one-line summary of the new item in the output.
-3. **Always output a single closing line:** `N items need your attention` (where N is the open count). If N = 0: output nothing and reply HEARTBEAT_OK instead.
-4. Do not re-list items that were already escalated in previous heartbeats — just the count covers them.
+1. Collect all entries where `needsTom: true` AND `status` is not `resolved` or `false_positive`. Call this N.
+2. For any entry where `needsTom: true` AND `escalatedAt` is null: set `escalatedAt: <now>`.
+3. **Always end the heartbeat with the single most important thing Tom can unblock right now:**
+   - Sort candidates by severity (critical → high → medium → low), then by `firstSeen` (oldest first).
+   - Pick the top candidate and output one line: `🔴 Top unblock: <what it is and exactly what Tom needs to do>` (or 🟠/🟡 for high/medium).
+   - If N = 0: output nothing and reply HEARTBEAT_OK instead.
+4. This line appears every heartbeat while the item is open — even if previously escalated. Tom seeing it repeatedly is the point.
 
 **State file read/write pattern (unified schema, task 75ec1c8c):**
 ```python

--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -1,26 +1,25 @@
 # HEARTBEAT
 
+**SILENCE RULE: Default to HEARTBEAT_OK. Only produce output when there is a new, actionable item that Tom or Quinn needs to act on RIGHT NOW. Do not narrate zero-counts, unchanged state, chronic items already escalated, sections with nothing to do, or items already tracked in ops state with `escalatedAt` set. Each section below should contribute nothing to output unless it has a genuine new finding. When in doubt, stay silent.**
+
+---
+
 BOOKMARK STATE OBSERVABILITY
 
 Heartbeat does not curate bookmarks, write specs, validate spec artifacts, or
 advance bookmark review state. Production bookmark curation and spec generation
 now run from the bookmark review cron.
 
-Heartbeat only reports bookmark pipeline health:
-
 1. Read the state analyzer skill:
    `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/bookmarks/state/SKILL.md`
 2. Run the compact analyzer:
    `python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/bookmarks/state/scripts/run_bookmark_state_analyzer.py --json`
-3. Report counts by `reviewStatus`, topic, and approval status.
-4. Flag blocked or stale states across heartbeats:
-   - approvals pending for Tom
-   - specs requested but not created
-   - specs created but no approval requested
-   - tasks requested or task creation follow-up needed
-   - repeated likely-follow-up buckets that have not changed since the last heartbeat
-5. Track repeated stalls in `brain/state/quinn-ops-state.json` under OPS STATE MANAGEMENT.
-6. Do not mutate bookmark state from heartbeat.
+3. **Only output if at least one of these is true:**
+   - `approvalPendingCount > 0` (new approvals waiting for Tom — report which items)
+   - A stall appeared that is NOT already in ops state (specs requested but missing, tasks blocked)
+   - **Otherwise: skip this section entirely. Do not report counts, stale items, or unchanged state.**
+4. Track new stalls in `brain/state/quinn-ops-state.json` under OPS STATE MANAGEMENT.
+5. Do not mutate bookmark state from heartbeat.
 
 ---
 
@@ -33,12 +32,13 @@ Each heartbeat:
 2. Find feature tasks with a `[tech-design]` comment but no proper `[tech-design-approved] true` comment:
    `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py --json`
    The script mirrors the lobster's parser (`tagged_values` + `tech_design_approved` in `agents/workflows/feature-task/src/main.rs`): a comment counts as approval only if its trimmed text STARTS WITH the tag and the first whitespace-separated token after the tag is `true` (case-insensitive). Substring matches in the lobster's progress-checklist complaints (e.g. `Missing task comment [tech-design-approved] true`) are intentionally NOT counted.
-3. For each pending task:
+3. **If 0 pending: skip this section entirely. No output.**
+4. For each pending task:
    - Read the design at the linked path.
    - Check: all required sections present, aligned with spec, no unbounded scope, `.openclaw` boundary notes where relevant.
    - If it looks good: post task comment `[tech-design-approved] true`
    - If something looks wrong or risky: flag to Tom via Telegram instead of approving.
-4. Do not approve a design that was written in the same heartbeat pass (let Rowan write it, Quinn approves next pass).
+5. Do not approve a design that was written in the same heartbeat pass (let Rowan write it, Quinn approves next pass).
 
 ---
 
@@ -47,7 +47,7 @@ CONTENT TASK LOBSTER CHECK
 Quinn dispatches content task workflow passes from heartbeat; Lobster owns all status transitions.
 Run:
 `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/content-tasks/run.py --json`
-Report only failures, blocked closed-unmerged PRs, or meaningful transitions.
+Report only failures, blocked closed-unmerged PRs, or meaningful transitions. If nothing actionable: no output.
 
 ---
 
@@ -55,8 +55,8 @@ FEATURE TASK LOBSTER CHECK
 
 Quinn dispatches feature task workflow passes from heartbeat; Lobster owns all status transitions.
 Run:
-`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/feature-task/run.py --json`
-Report only failures, blocked tasks, or meaningful transitions.
+`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/feature-task/run.py`
+Report only failures, newly blocked tasks, or meaningful transitions. **Do not report tasks already in ops state with `escalatedAt` set — Tom has already been notified. Do not summarise routine doing/acceptance counts.**
 
 **When the lobster reports `ready_checks_blocked` due to missing `[tech-design]`:**
 - Check if Rowan is free (no tasks in `doing` assigned to Rowan)
@@ -81,6 +81,7 @@ Each heartbeat:
    - Validate using the command in the comment.
    - Post a task comment: `[openclaw-done] <changed paths> | validated: <command output summary> | <any follow-up notes>`
 4. If `[openclaw-needed]` comments exist but are unclear or unsafe, mark the task blocked and post a comment explaining what is missing.
+5. **If no unresolved handoffs: skip this section entirely. No output.**
 
 Do not apply `.openclaw` changes speculatively. Only act on explicit `[openclaw-needed]` comments from Rowan.
 
@@ -90,6 +91,8 @@ Process any PRs that need your attention.
 
 Read and follow the reviewer section of:
 `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/dev/pr-process/SKILL.md`
+
+**Only output if you took a review action (submitted a review, requested changes, approved). Do not report PRs already reviewed or awaiting Tom.**
 
 ---
 
@@ -110,7 +113,7 @@ Run this check every heartbeat. Write at most 1 ops note per run.
 - Use the content-notes skill: `codebases/sindustries/agents/skills/content-notes/SKILL.md`
 - The `why:` field must be specific ("first time the pipeline ran end-to-end without manual intervention") not vague ("shows how we're hardening the system")
 
-**If nothing passes the tweet test:** do not write a note. Silence is correct.
+**If nothing passes the tweet test:** do not write a note. Silence is correct. Do not report that you checked.
 
 ---
 
@@ -148,7 +151,7 @@ from agents.lib.incident_state import load_all_incidents, needs_tom
 
 all_incidents = load_all_incidents()
 for inc in needs_tom(all_incidents):
-    # Telegram Tom, set escalatedAt, etc.
+    # include in heartbeat output, set escalatedAt, etc.
     ...
 ```
 
@@ -172,12 +175,12 @@ for inc in needs_tom(all_incidents):
 4. If an entry has `attempts >= 3` and is still unresolved: set `needsTom: true`, `severity` to at least `high`
 5. Always increment `attempts` and update `lastCheckedAt` when re-checking an existing entry
 
-**Escape early — direct Tom ping:**
+**Escalation — announce count and new items:**
 After completing all sections, check both `quinn-ops-state.json` and `brain/state/lox-incident-state.json`:
-- For any entry where `needsTom: true` AND `escalatedAt` is null (not yet escalated):
-  - Send a direct Telegram message to Tom (session key: `telegram:6435140143` or via main session) with a concise summary of what needs him
-  - Set `escalatedAt: <now>` on the entry so it only fires once per incident
-  - Do not re-escalate already-escalated items unless they've been updated
+1. Count all entries where `needsTom: true` AND `status` is not `resolved` or `false_positive`. Call this N.
+2. For any entry where `needsTom: true` AND `escalatedAt` is null (newly escalated this pass): set `escalatedAt: <now>` and include a one-line summary of the new item in the output.
+3. **Always output a single closing line:** `N items need your attention` (where N is the open count). If N = 0: output nothing and reply HEARTBEAT_OK instead.
+4. Do not re-list items that were already escalated in previous heartbeats — just the count covers them.
 
 **State file read/write pattern (unified schema, task 75ec1c8c):**
 ```python

--- a/agents/skills/ops/tasks-create/SKILL.md
+++ b/agents/skills/ops/tasks-create/SKILL.md
@@ -116,17 +116,40 @@ tasks_api_client.py create \
 
 ### Content task
 
-Content tasks are created by the weekly content review workflow, not manually. Only create one manually if explicitly asked.
+Content tasks are created after Tom approves a weekly content review. Only create one manually if explicitly asked.
+
+The description **must** follow this exact format — the content task lobster validates it:
 
 ```
 tasks_api_client.py create \
-  --title "✍️ <description>" \
+  --title "✍️ SIndustries website content — YYYY-MM-DD weekly review (Tom approved)" \
   --type content \
   --priority high \
   --assignee Ivy \
-  --description "**Source:** brain/content/sindustries-weekly-content/<date>.md
-..."
+  --description "**Source:** brain/content/sindustries-weekly-content/YYYY-MM-DD.md
+
+**Review window:** YYYY-MM-DD to YYYY-MM-DD
+
+---
+
+## Quinn can execute
+
+- [ ] EDIT experiment/slug — description of change
+- [ ] ADD release — ...
+
+## Needs Tom approval
+
+- [ ] ADD system/slug — description of change
+- [ ] EDIT story/slug — ..."
 ```
+
+**Format rules (enforced by the content task lobster):**
+- The `**Source:**` line must point to a real file at `brain/content/sindustries-weekly-content/YYYY-MM-DD.md`
+- The heading names must be exactly `## Quinn can execute` and `## Needs Tom approval` — these mirror the sections in the review file and the lobster validates that each heading contains "Tom" or "Quinn"
+- Each heading must have at least one checkbox line (`- [ ] ...`) beneath it — the lobster rejects tasks where a heading has no checkboxes
+- Copy items verbatim from the review file into the relevant section; do not paraphrase or reword
+- If a section has no approved items, omit that heading rather than leaving it empty
+- The `**Review window:**` line is informational; include it but it is not validated
 
 ---
 
@@ -150,3 +173,5 @@ tasks_api_client.py create \
 | Putting `feature-factory` tag on a code/content/research task | Only feature tasks get the `feature-factory` tag |
 | Using `--type bug` or `--type chore` | Those don't exist. Use `--type code` (covers both) |
 | Leaving `--type` unset because you're unsure | Ask Tom — don't ship a typeless task |
+| Content task headings like `## Tom` / `## Quinn` | Use exact names `## Quinn can execute` and `## Needs Tom approval` — mirrors review file sections |
+| Content task has no checkbox lines under a heading | Each Tom/Quinn heading must have `- [ ] ...` lines beneath it or the lobster rejects it |

--- a/docs/specs/unify-agent-incident-schema-tech-design.md
+++ b/docs/specs/unify-agent-incident-schema-tech-design.md
@@ -230,79 +230,10 @@ None. This is a backend / Python / docs change.
 - **Q8 — Backwards-compat window.** After the migration runs, both files are unified. But if either agent writes a legacy-shaped entry by mistake, the parser still handles it. We don't break anything by introducing the schema; we just add the superset.
 - **Q9 — AC count discrepancy.** The task description's "Acceptance Criteria" lists 7 bullets; the "Workstreams" block says AC1–AC5. This design addresses all 7 (they're the real list). If Tom confirms only AC1–AC5 are in scope, drop AC6 and AC7 — but the design recommends keeping them since they're cheap and complete the picture.
 
-## Phase 2 — Active resolution + cross-agent handoff (not yet tasked)
+## Phase 2
 
-Tom's post-ship feedback surfaced two new capabilities that extend the unified schema into runtime behaviour. These are not part of the original AC1–AC7 scope but are the natural next step once the unified schema is live.
+See task 326d4520 — Incident actioning system. Active resolution and cross-agent handoff are designed there.
 
-### AC8 — Quinn active resolution via runbooks
-
-**Problem:** Quinn's current OPS STATE MANAGEMENT loop is passive. It detects incidents, increments `checkCount`, and escalates after N passes — but never *attempts remediation*. Lox already uses runbooks to attempt fixes before escalating; Quinn should follow the same pattern.
-
-**Design:**
-
-- Add remediation metadata fields to the schema (all optional, default null):
-  - `attemptCount` — how many remediation attempts have been made (distinct from detection `checkCount`)
-  - `lastAttemptAt` — ISO timestamp of most recent attempt
-  - `nextRetryAt` — backoff fence; Quinn skips re-attempt until this time passes
-  - `linkedRunbook` — path to the runbook Quinn should invoke for this incident type
-- Quinn's heartbeat OPS STATE MANAGEMENT section changes from passive-log to active-remediation loop:
-  1. Load all incidents where `owner == "quinn"` and status is not `resolved`/`false_positive`.
-  2. For each incident, skip if `nextRetryAt` is in the future.
-  3. Look up `linkedRunbook` (or fall back to deterministic default by incident type).
-  4. Attempt remediation per the runbook.
-  5. On success: mark `status: resolved`, set `resolvedAt`.
-  6. On failure: increment `attemptCount`, set `lastAttemptAt`, compute `nextRetryAt` (exponential backoff, e.g. 15m → 30m → 60m).
-  7. After N failed attempts (suggested N=3): set `needsTom: true`, `status: escalated`, `escalatedAt`, and ping Tom via Telegram.
-- Missing or invalid `linkedRunbook` → escalate immediately; don't silently skip.
-
-**Runbook stubs Quinn will need** (paths in `infra/runbooks/quinn/`):
-- `task-workflow-stall.md`
-- `agent-pipeline-stall.md`
-- `bookmark-pipeline-stall.md`
-- `feature-task-lobster-stall.md`
-
-**Schema additions (additive, backwards-compatible):**
-```json
-"attemptCount":     { "type": "integer", "default": 0 },
-"lastAttemptAt":    { "type": ["string", "null"], "format": "date-time" },
-"nextRetryAt":      { "type": ["string", "null"], "format": "date-time" },
-"linkedRunbook":    { "type": ["string", "null"] }
-```
-
-### AC9 — Lox → Quinn cross-agent handoff
-
-**Problem:** When Lox detects a problem in Quinn's domain (lobster workflow stall, bookmark pipeline issue), it currently either misses it or escalates directly to Tom. The unified schema's `owner` field enables a cleaner path: Lox writes an incident with `owner: "quinn"` and Quinn picks it up via `load_all_incidents()`.
-
-**Design:**
-
-- No shared file. Each agent keeps its own state file.
-- Lox writes an incident to `lox-incident-state.json` with `owner: "quinn"` and `linkedRunbook` pointing at the relevant Quinn runbook.
-- Quinn's `load_all_incidents()` already reads both files — so Quinn discovers Lox-assigned incidents automatically. No polling or queue needed.
-- Add optional `reportedBy` / `sourceAgent` field for provenance (so we know Lox created it, not Quinn).
-- Quinn updates the incident **in the source file** (Lox's state file) when it attempts remediation or resolves. This requires `load_all_incidents()` to tag each incident with its `sourceFile` at parse time so Quinn knows where to write back.
-- Lox escalates to Tom for Quinn-domain incidents **only if**:
-  - The handoff itself fails (e.g. Quinn's state file is unreadable)
-  - The incident is an infra/safety concern that can't wait for Quinn's next heartbeat
-  - Owner assignment is ambiguous
-
-**Domain boundary:**
-- **Lox owns:** infra, containers, hosts, network, process crashes, service availability
-- **Quinn owns:** task workflow stalls, agent pipeline state, bookmark pipeline, feature-task lobster stalls
-
-**Schema additions:**
-```json
-"reportedBy":   { "type": ["string", "null"] },
-"sourceFile":   { "type": ["string", "null"], "description": "Runtime-only: set by parser, not stored" }
-```
-Note: `sourceFile` is injected by the parser at load time, not persisted to disk.
-
-### Open questions for Phase 2
-
-- Exact retry threshold N and backoff schedule.
-- Whether `reportedBy` becomes required or stays optional.
-- Whether a Lox-assigned incident can be re-assigned back to Lox if Quinn can't fix it (one bounce allowed? immediate escalation?).
-- Whitelist/allowlist for runnable runbook paths (prevent arbitrary code execution).
-- Migration: add new fields to existing entries via a `--phase2` flag on `incident_migrate.py`, or let them default-null on first read.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary
- Restores WIP from stash `rowan-heartbeat-pre-stash-2026-07-13` that was lost during branch switching
- Adds top-level SILENCE RULE: default to HEARTBEAT_OK, only output when there is a new actionable finding
- Each heartbeat section now has an explicit output gate — no narrating zero-counts, unchanged state, or already-escalated items
- Ivy HEARTBEAT.md gets the same silence-rule treatment
- tasks-create skill and unify-agent-incident-schema tech design also updated (part of same stash)

## Test plan
- [ ] Run a heartbeat with nothing new — should return HEARTBEAT_OK with no prose
- [ ] Run a heartbeat with a pending tech-design approval — should output only that finding
- [ ] Confirm Ivy heartbeat also stays silent when nothing actionable

🤖 Generated with Claude Code