### PR TITLE
feat: sync spec folder lifecycle

### DIFF
--- a/agents/skills/ops/tasks-create/SKILL.md
+++ b/agents/skills/ops/tasks-create/SKILL.md
@@ -59,7 +59,7 @@ tasks_api_client.py create \
   --priority <low|medium|high> \
   --assignee Rowan \
   --tags feature-factory rowan <topic> \
-  --description "**Spec:** brain/tasks/specs/<slug>-YYYY-MM-DD.md
+  --description "**Spec:** brain/tasks/specs/open/<slug>-YYYY-MM-DD.md
 
 - [ ] **Approved by Tom**
 
@@ -83,7 +83,7 @@ tasks_api_client.py create \
 ```
 
 **Rules:**
-- The `**Spec:**` line must point to a real file in `brain/tasks/specs/` (write it first)
+- The `**Spec:**` line for new chat-created feature specs must point to a real file in `brain/tasks/specs/open/` (write it first)
 - The `- [ ] **Approved by Tom**` line must be unchecked — never pre-tick it
 - ACs must be unchecked — never pre-tick them; Tom/QA ticks after testing
 - Workstreams section must be present with `Branch: (pending)` and `PR: (pending)` placeholders

--- a/agents/skills/product/feature-task-create/SKILL.md
+++ b/agents/skills/product/feature-task-create/SKILL.md
@@ -33,13 +33,13 @@ For direct work: hand it to Rowan with a clear instruction and let him open a PR
 
 | Situation | Spec location |
 |---|---|
-| New spec for this feature | `brain/tasks/specs/<slug>-YYYY-MM-DD.md` |
+| New spec for this feature | `brain/tasks/specs/open/<slug>-YYYY-MM-DD.md` |
 | Bookmark pipeline produced a spec | `brain/bookmarks/specs/<slug>-<key>.md` |
 | An existing sindustries spec covers this | `docs/specs/<filename>.md` |
 
 Do **not** amend an existing approved spec unless the task is explicitly an amendment. Do **not** create a new spec inside `docs/specs/` — that dir is for committed, reviewed specs only.
 
-### Spec format (brain/tasks/specs/)
+### Spec format (brain/tasks/specs/open/)
 
 ```markdown
 # Spec — <Title>
@@ -74,7 +74,7 @@ Key constraints or non-obvious integration points. One paragraph max.
 **Critical:** Copy the full AC text from the spec into the task description. Do NOT use placeholder labels like `AC1: ...` — write out the actual acceptance criterion text. The task description must be self-contained; the spec is the source of truth for detail, but the task must show the real ACs.
 
 ```
-**Spec:** <relative path from workspace root, e.g. brain/tasks/specs/my-spec-2026-06-29.md>
+**Spec:** <relative path from workspace root, e.g. brain/tasks/specs/open/my-spec-2026-06-29.md>
 - [ ] **Approved by Tom**
 
 <One paragraph describing what the feature does and why it matters>
@@ -127,7 +127,7 @@ YAML
 TASKS_API_BASE_URL=${TASKS_API_BASE_URL:-http://localhost:4001/api/v1} \
   python3 agents/skills/ops/tasks-api/tasks_api_client.py create \
     --title '<Title>' \
-    --spec 'brain/tasks/specs/<slug>-YYYY-MM-DD.md' \
+    --spec 'brain/tasks/specs/open/<slug>-YYYY-MM-DD.md' \
     --workstreams /tmp/task-ws.yaml \
     --description '<body text from Step 3, minus Spec/Workstreams>' \
     --priority high \
@@ -153,7 +153,7 @@ Direct `urllib` POSTs remain valid as a fallback if the CLI is unavailable, but 
 
 ## Checklist before declaring done
 
-- [ ] Spec written at `brain/tasks/specs/` (or existing spec identified)
+- [ ] Spec written at `brain/tasks/specs/open/` for new chat-created specs (or existing spec identified)
 - [ ] `**Spec:**` line is exact path, no trailing text
 - [ ] `- [ ] **Approved by Tom**` marker line is present in the task description template
 - [ ] ACs are copied verbatim from the spec — not placeholder labels like "AC1: ..."

--- a/agents/workflows/bookmarks/scripts/handle_approval_reply.py
+++ b/agents/workflows/bookmarks/scripts/handle_approval_reply.py
@@ -169,6 +169,35 @@ def run_lobster_resume(token: str, approve: bool) -> tuple[dict | None, str | No
 
 
 
+def _workspace_rel_path(path: str) -> Path:
+    rel = Path(str(path).strip())
+    if rel.is_absolute() or '..' in rel.parts:
+        raise ValueError(f"unsafe spec path: {path}")
+    return WORKSPACE / rel
+
+
+def set_spec_approval_checkbox(spec_doc: str, approved: bool) -> bool:
+    """Set the Tom approval checkbox in a bookmark spec without moving the file."""
+    if not approved:
+        return False
+    rel = str(spec_doc).strip()
+    if not rel.startswith('brain/bookmarks/specs/'):
+        raise ValueError(f"approval checkbox toggle only applies to bookmark specs: {spec_doc}")
+    path = _workspace_rel_path(rel)
+    text = path.read_text(encoding='utf-8')
+    checked_re = re.compile(r'^\s*-\s*\[[xX]\]\s+\*\*Approved by Tom\*\*\s*$', re.MULTILINE)
+    unchecked_re = re.compile(r'^(\s*-\s*)\[\s\](\s+\*\*Approved by Tom\*\*\s*)$', re.MULTILINE)
+    if checked_re.search(text):
+        return False
+    if not unchecked_re.search(text):
+        raise ValueError(f"missing unchecked Approved by Tom marker in {spec_doc}")
+    updated = unchecked_re.sub(r'\1[x]\2', text, count=1)
+    tmp = path.with_name(f'.{path.name}.tmp')
+    tmp.write_text(updated, encoding='utf-8')
+    os.replace(tmp, path)
+    return True
+
+
 def force_clear_approval_lock(state: dict, approval_id: str, approved: bool) -> int:
     cleared = 0
     for key, item in (state.get("items") or {}).items():
@@ -647,6 +676,24 @@ def main() -> int:
             continue
 
         if token:
+            toggled_specs = 0
+            toggle_error = None
+            if decision == "approve":
+                try:
+                    for summary in approval_items:
+                        for spec_doc in summary.get("specDocs") or []:
+                            if set_spec_approval_checkbox(str(spec_doc), True):
+                                toggled_specs += 1
+                except Exception as exc:  # noqa: BLE001
+                    toggle_error = str(exc)
+            if toggle_error:
+                results.append({
+                    "status": "error",
+                    "decision": decision,
+                    "approvalId": matched_id,
+                    "reason": f"approval checkbox toggle failed: {toggle_error}",
+                })
+                continue
             resumed, err = run_lobster_resume(token, decision == "approve")
             cleared = 0
             if not err:
@@ -700,7 +747,7 @@ def main() -> int:
                 pending_ids="|".join(sorted(pending.keys())),
                 result_status=status,
                 error=err,
-                details=f"token={token};cleared={cleared}",
+                details=f"token={token};cleared={cleared};toggledSpecs={toggled_specs}",
             )
             results.append({
                 "status": status,

--- a/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py
+++ b/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py
@@ -18,6 +18,58 @@ if str(SCRIPT_ROOT) not in sys.path:
 from tasks_api_client import api_request, list_tasks  # noqa: E402
 
 
+TASK_SPECS_IN_PROGRESS = 'brain/tasks/specs/in-progress'
+BOOKMARK_SPECS_PREFIX = 'brain/bookmarks/specs/'
+
+
+def task_spec_destination(spec_doc: str) -> str:
+    rel = str(spec_doc).strip()
+    if rel.startswith(f'{TASK_SPECS_IN_PROGRESS}/'):
+        return rel
+    if not rel.startswith(BOOKMARK_SPECS_PREFIX):
+        return rel
+    return f'{TASK_SPECS_IN_PROGRESS}/{Path(rel).name}'
+
+
+def rewrite_spec_line(description: str, old_path: str, new_path: str) -> str:
+    pattern = re.compile(r'(?m)^(\s*\*\*Spec:\*\*\s+)([^\s].*?)\s*$')
+    return pattern.sub(
+        lambda match: f'{match.group(1)}{new_path}' if match.group(2).strip() == old_path else match.group(0),
+        description,
+        count=1,
+    )
+
+
+def move_bookmark_spec_to_task_in_progress(spec_doc: str) -> tuple[str, bool]:
+    dest_doc = task_spec_destination(spec_doc)
+    if dest_doc == spec_doc:
+        return dest_doc, False
+    source = WORKSPACE / spec_doc
+    dest = WORKSPACE / dest_doc
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        if source.exists() and source.read_bytes() != dest.read_bytes():
+            raise RuntimeError(f'destination already exists with different content: {dest_doc}')
+        return dest_doc, False
+    if not source.exists():
+        raise FileNotFoundError(f'spec file not found: {spec_doc}')
+    source.rename(dest)
+    return dest_doc, True
+
+
+def patch_task_spec_line(base_url: str, task_id: str, old_path: str, new_path: str, task: dict | None = None) -> None:
+    task_data = task or {}
+    if not task_data.get('description'):
+        resp = api_request('GET', base_url, f'/tasks/{task_id}')
+        task_data = resp.get('data') if isinstance(resp, dict) else resp
+        if not isinstance(task_data, dict):
+            return
+    desc = str(task_data.get('description') or '')
+    new_desc = rewrite_spec_line(desc, old_path, new_path)
+    if new_desc != desc:
+        api_request('PATCH', base_url, f'/tasks/{task_id}', {'description': new_desc})
+
+
 def proposal_marker(bookmark_key: str, spec_docs: list[str], proposal: dict) -> str:
     """Legacy marker for per-proposedTask dedup. Kept for backward compat with existing tasks."""
     payload = {
@@ -83,7 +135,7 @@ def _extract_section(text: str, heading: str) -> str:
     return (section[:next_h.start()] if next_h else section).strip()
 
 
-def build_task_from_spec(spec_doc: str, bookmark_key: str, topic: str) -> dict | None:
+def build_task_from_spec(spec_doc: str, task_spec_doc: str, bookmark_key: str, topic: str) -> dict | None:
     """Read a spec markdown file and build a task dict (title + description)."""
     spec_path = WORKSPACE / spec_doc
     if not spec_path.exists():
@@ -100,7 +152,7 @@ def build_task_from_spec(spec_doc: str, bookmark_key: str, topic: str) -> dict |
     outcome = _extract_section(text, 'Outcome')
 
     parts = [
-        f'**Spec:** {spec_doc}',
+        f'**Spec:** {task_spec_doc}',
         f'**Topic:** {topic}',
         f'**Bookmark:** {bookmark_key}',
     ]
@@ -126,19 +178,34 @@ def create_task_for_spec(
     spec_docs: list[str],
     existing_by_marker: dict[str, dict],
 ) -> tuple[dict | None, dict | None]:
-    marker = spec_marker(spec_doc)
-    existing = existing_by_marker.get(marker)
+    task_spec_doc = task_spec_destination(spec_doc)
+    marker = spec_marker(task_spec_doc)
+    legacy_marker = spec_marker(spec_doc)
+    existing = existing_by_marker.get(marker) or existing_by_marker.get(legacy_marker)
     if existing and existing.get('id'):
+        try:
+            moved_doc, moved = move_bookmark_spec_to_task_in_progress(spec_doc)
+            patch_task_spec_line(base_url, str(existing['id']), spec_doc, moved_doc, existing)
+        except Exception as exc:  # noqa: BLE001
+            return None, {
+                'bookmarkKey': bookmark_key,
+                'topic': topic,
+                'specDoc': spec_doc,
+                'marker': marker,
+                'error': str(exc),
+            }
         return {
             'bookmarkKey': bookmark_key,
             'topic': topic,
-            'specDoc': spec_doc,
+            'specDoc': moved_doc,
+            'sourceSpecDoc': spec_doc,
             'taskId': str(existing['id']),
             'reused': True,
+            'moved': moved,
             'marker': marker,
         }, None
 
-    task_def = build_task_from_spec(spec_doc, bookmark_key, topic)
+    task_def = build_task_from_spec(spec_doc, task_spec_doc, bookmark_key, topic)
     if not task_def:
         return None, {
             'bookmarkKey': bookmark_key,
@@ -153,7 +220,7 @@ def create_task_for_spec(
         'description': task_def['description'],
         'priority': task_def['priority'],
         'status': 'open',
-        'tags': task_tags(topic, bookmark_key, spec_docs, marker),
+        'tags': task_tags(topic, bookmark_key, [task_spec_destination(d) for d in spec_docs], marker),
     }
     response = api_request('POST', base_url, '/tasks', payload)
     task = response.get('data') if isinstance(response, dict) else None
@@ -168,13 +235,29 @@ def create_task_for_spec(
             'response': response,
         }
 
+    try:
+        moved_doc, moved = move_bookmark_spec_to_task_in_progress(spec_doc)
+        if moved_doc != task_spec_doc:
+            patch_task_spec_line(base_url, str(task_id), task_spec_doc, moved_doc, task if isinstance(task, dict) else None)
+    except Exception as exc:  # noqa: BLE001
+        return None, {
+            'bookmarkKey': bookmark_key,
+            'topic': topic,
+            'specDoc': spec_doc,
+            'marker': marker,
+            'taskId': str(task_id),
+            'error': str(exc),
+        }
+
     created = {
         'bookmarkKey': bookmark_key,
         'topic': topic,
-        'specDoc': spec_doc,
+        'specDoc': moved_doc,
+        'sourceSpecDoc': spec_doc,
         'title': task_def['title'],
         'taskId': str(task_id),
         'reused': False,
+        'moved': moved,
         'marker': marker,
     }
     existing_by_marker[marker] = task if isinstance(task, dict) else {'id': task_id, 'tags': payload['tags']}
@@ -208,6 +291,8 @@ def main() -> int:
                 )
                 if result:
                     created.append(result)
+                    if result.get('sourceSpecDoc') and result.get('specDoc'):
+                        item['specDocs'] = [result['specDoc'] if d == result['sourceSpecDoc'] else d for d in spec_docs]
                 if error:
                     errors.append(error)
 

--- a/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py
+++ b/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py
@@ -186,6 +186,11 @@ def create_task_for_spec(
         try:
             moved_doc, moved = move_bookmark_spec_to_task_in_progress(spec_doc)
             patch_task_spec_line(base_url, str(existing['id']), spec_doc, moved_doc, existing)
+        except FileNotFoundError:
+            # Backward-compatible reuse path for legacy tasks/tests where the
+            # dedupe marker already exists but the source spec is absent. New
+            # task creation still requires a movable source file.
+            moved_doc, moved = spec_doc, False
         except Exception as exc:  # noqa: BLE001
             return None, {
                 'bookmarkKey': bookmark_key,

--- a/agents/workflows/bookmarks/tests/test_spec_lifecycle.py
+++ b/agents/workflows/bookmarks/tests/test_spec_lifecycle.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parents[4]
+SCRIPTS = REPO / 'agents' / 'workflows' / 'bookmarks' / 'scripts'
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+TASKS_API = REPO / 'agents' / 'skills' / 'ops' / 'tasks-api'
+if str(TASKS_API) not in sys.path:
+    sys.path.insert(0, str(TASKS_API))
+
+
+def load_module(name: str, file_name: str, workspace: Path):
+    os.environ['OPENCLAW_WORKSPACE'] = str(workspace)
+    sys.modules.pop('common', None)
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / file_name)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class BookmarkSpecLifecycleTests(unittest.TestCase):
+    def test_approval_toggle_checks_marker_without_moving_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            workspace = Path(td)
+            mod = load_module('handle_approval_reply_toggle_test', 'handle_approval_reply.py', workspace)
+            spec = workspace / 'brain/bookmarks/specs/example-abcd1234.md'
+            spec.parent.mkdir(parents=True)
+            spec.write_text('# Spec\n\n- [ ] **Approved by Tom**\n', encoding='utf-8')
+
+            changed = mod.set_spec_approval_checkbox('brain/bookmarks/specs/example-abcd1234.md', True)
+            self.assertTrue(changed)
+            self.assertTrue(spec.exists())
+            self.assertIn('- [x] **Approved by Tom**', spec.read_text(encoding='utf-8'))
+            self.assertFalse(mod.set_spec_approval_checkbox('brain/bookmarks/specs/example-abcd1234.md', True))
+
+    def test_declined_toggle_does_not_check_marker(self):
+        with tempfile.TemporaryDirectory() as td:
+            workspace = Path(td)
+            mod = load_module('handle_approval_reply_decline_test', 'handle_approval_reply.py', workspace)
+            spec = workspace / 'brain/bookmarks/specs/example-abcd1234.md'
+            spec.parent.mkdir(parents=True)
+            spec.write_text('- [ ] **Approved by Tom**\n', encoding='utf-8')
+
+            self.assertFalse(mod.set_spec_approval_checkbox('brain/bookmarks/specs/example-abcd1234.md', False))
+            self.assertIn('- [ ] **Approved by Tom**', spec.read_text(encoding='utf-8'))
+
+    def test_bookmark_task_creation_moves_spec_and_uses_destination_spec_line(self):
+        with tempfile.TemporaryDirectory() as td:
+            workspace = Path(td)
+            mod = load_module('lobster_create_tasks_lifecycle_test', 'lobster_create_tasks_from_proposals.py', workspace)
+            source_rel = 'brain/bookmarks/specs/example-abcd1234.md'
+            source = workspace / source_rel
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                '# Spec — Example\n\n- [x] **Approved by Tom**\n\n## Outcome\nShip it.\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n',
+                encoding='utf-8',
+            )
+            seen_payloads = []
+
+            def fake_api(method, base_url, path, payload=None):
+                seen_payloads.append((method, path, payload))
+                if method == 'POST':
+                    return {'data': {'id': 'task-1', 'description': payload['description'], 'tags': payload['tags']}}
+                if method == 'PATCH':
+                    return {'data': {'id': 'task-1'}}
+                return {'data': {'id': 'task-1', 'description': ''}}
+
+            with mock.patch.object(mod, 'api_request', side_effect=fake_api):
+                result, error = mod.create_task_for_spec('http://tasks', 'agent-tools', 'abcd1234', source_rel, [source_rel], {})
+
+            self.assertIsNone(error)
+            self.assertIsNotNone(result)
+            dest_rel = 'brain/tasks/specs/in-progress/example-abcd1234.md'
+            self.assertEqual(result['specDoc'], dest_rel)
+            self.assertFalse(source.exists())
+            self.assertTrue((workspace / dest_rel).exists())
+            post_payload = seen_payloads[0][2]
+            self.assertIn(f'**Spec:** {dest_rel}', post_payload['description'])
+
+    def test_bookmark_move_is_idempotent_and_repairs_stale_spec_line_for_existing_task(self):
+        with tempfile.TemporaryDirectory() as td:
+            workspace = Path(td)
+            mod = load_module('lobster_create_tasks_idempotent_test', 'lobster_create_tasks_from_proposals.py', workspace)
+            source_rel = 'brain/bookmarks/specs/example-abcd1234.md'
+            dest_rel = 'brain/tasks/specs/in-progress/example-abcd1234.md'
+            dest = workspace / dest_rel
+            dest.parent.mkdir(parents=True)
+            dest.write_text('# Spec — Example\n', encoding='utf-8')
+            patched = []
+
+            def fake_api(method, base_url, path, payload=None):
+                if method == 'GET':
+                    return {'data': {'id': 'task-1', 'description': f'**Spec:** {source_rel}\n'}}
+                if method == 'PATCH':
+                    patched.append(payload['description'])
+                    return {'data': {'id': 'task-1'}}
+                raise AssertionError(method)
+
+            existing = {mod.spec_marker(source_rel): {'id': 'task-1', 'description': f'**Spec:** {source_rel}\n', 'tags': []}}
+            with mock.patch.object(mod, 'api_request', side_effect=fake_api):
+                result, error = mod.create_task_for_spec('http://tasks', 'agent-tools', 'abcd1234', source_rel, [source_rel], existing)
+
+            self.assertIsNone(error)
+            self.assertEqual(result['specDoc'], dest_rel)
+            self.assertEqual(patched, [f'**Spec:** {dest_rel}'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -202,12 +202,16 @@ fn load_task(base_url: &str, task_id: &str) -> Result<Envelope> {
 
 fn spec_check(args: StageArgs) -> Result<Envelope> {
     let mut env = read_envelope()?;
+    bootstrap_task_spec_layout(workspace_root(&args))?;
     if let Some(blocked) = block_on_spec_drift_fluid(&args, env.clone(), "spec_check")? {
         return Ok(blocked);
     }
     let manual_failures = manual_block_failures(&env.task);
     if !manual_failures.is_empty() {
         return block_with_manual_block(&args, env, "spec_check", manual_failures);
+    }
+    if !args.dry_run {
+        env = move_approved_chat_spec_if_needed(&args, env)?;
     }
     if is_past(&env.task, "open") {
         let failures = missing_spec_checksum_failures(&env.task, &args.repo, workspace_root(&args));
@@ -464,8 +468,7 @@ fn task_ac_vs_open_pr_failures(
     // the 8-char branch-name short prefix in `### Task <id>` headings. Match
     // either form so a single `### Task 513b3b02 — …` or `### Task 513b3b02-uuid — …`
     // heading can identify the subsection.
-    let subsection_re =
-        Regex::new(r"(?m)^\s*#{3,}\s+Task\s+(\S+)").unwrap();
+    let subsection_re = Regex::new(r"(?m)^\s*#{3,}\s+Task\s+(\S+)").unwrap();
     let ac_re = Regex::new(r"(?m)^\s*-\s*\[([xX ])\]\s+(AC\d+):\s*(.+)$").unwrap();
     let task_short_id = task_id.split('-').next().unwrap_or(task_id);
     let mut pr_ac_map: HashMap<String, (String, Option<Evidence>)> = HashMap::new();
@@ -529,7 +532,10 @@ fn parse_git_worktree_porcelain(output: &str) -> Vec<WorktreeEntry> {
                 path = Some(PathBuf::from(rest.trim()));
             } else if let Some(rest) = line.strip_prefix("branch ") {
                 // Strip the `refs/heads/` prefix to match typical branch names.
-                let name = rest.trim().strip_prefix("refs/heads/").unwrap_or(rest.trim());
+                let name = rest
+                    .trim()
+                    .strip_prefix("refs/heads/")
+                    .unwrap_or(rest.trim());
                 branch = Some(name.to_string());
             }
         }
@@ -586,7 +592,10 @@ fn select_matching_rowan_worktrees<'a>(
 /// paths are reported as `AlreadyAbsent` so re-runs stay idempotent.
 /// All other failures are captured as `Failed(<message>)` and surfaced as
 /// non-fatal warnings; this function never returns Err.
-fn remove_worktrees_best_effort(repo: &Path, candidates: &[WorktreeEntry]) -> Vec<WorktreeCleanupResult> {
+fn remove_worktrees_best_effort(
+    repo: &Path,
+    candidates: &[WorktreeEntry],
+) -> Vec<WorktreeCleanupResult> {
     let mut results = Vec::with_capacity(candidates.len());
     for entry in candidates {
         let path = &entry.path;
@@ -599,7 +608,13 @@ fn remove_worktrees_best_effort(repo: &Path, candidates: &[WorktreeEntry]) -> Ve
             continue;
         }
         let output = Command::new("git")
-            .args(["-C", repo.to_string_lossy().as_ref(), "worktree", "remove", "--force"])
+            .args([
+                "-C",
+                repo.to_string_lossy().as_ref(),
+                "worktree",
+                "remove",
+                "--force",
+            ])
             .arg(path)
             .output();
         let outcome = match output {
@@ -609,7 +624,10 @@ fn remove_worktrees_best_effort(repo: &Path, candidates: &[WorktreeEntry]) -> Ve
                 let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
                 let combined = if stderr.is_empty() { stdout } else { stderr };
                 WorktreeCleanupOutcome::Failed(if combined.is_empty() {
-                    format!("git worktree remove exited with status {:?}", out.status.code())
+                    format!(
+                        "git worktree remove exited with status {:?}",
+                        out.status.code()
+                    )
                 } else {
                     combined
                 })
@@ -629,7 +647,13 @@ fn remove_worktrees_best_effort(repo: &Path, candidates: &[WorktreeEntry]) -> Ve
 /// results (empty when nothing matched). Failures are non-fatal by design.
 fn cleanup_rowan_worktree_for_task(repo: &Path, task_id: &str) -> Vec<WorktreeCleanupResult> {
     let list_output = Command::new("git")
-        .args(["-C", repo.to_string_lossy().as_ref(), "worktree", "list", "--porcelain"])
+        .args([
+            "-C",
+            repo.to_string_lossy().as_ref(),
+            "worktree",
+            "list",
+            "--porcelain",
+        ])
         .output();
     let stdout = match list_output {
         Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).into_owned(),
@@ -641,7 +665,10 @@ fn cleanup_rowan_worktree_for_task(repo: &Path, task_id: &str) -> Vec<WorktreeCl
                 path: PathBuf::from("<git-worktree-list>"),
                 branch: None,
                 outcome: WorktreeCleanupOutcome::Failed(if stderr.is_empty() {
-                    format!("git worktree list exited with status {:?}", out.status.code())
+                    format!(
+                        "git worktree list exited with status {:?}",
+                        out.status.code()
+                    )
                 } else {
                     stderr
                 }),
@@ -886,16 +913,19 @@ const BRAIN_DIR: &str = "brain";
 // When a feature task transitions to `done`, the spec referenced in the task's
 // `**Spec:**` line should move from `brain/tasks/specs/` into
 // `brain/tasks/specs/done/`. The boundary is intentionally narrow:
-//   1. Only specs under `brain/tasks/specs/<slug>.md` are eligible.
+//   1. Only specs under `brain/tasks/specs/in-progress/<slug>.md` are eligible.
 //   2. Specs already under `brain/tasks/specs/done/` are a no-op (idempotent).
-//   3. `brain/bookmarks/specs/`, `docs/specs/`, and other paths are out of scope.
+//   3. `brain/tasks/specs/open/`, `brain/bookmarks/specs/`, `docs/specs/`, and other paths are out of scope.
 //
 // These helpers intentionally differ from `safe_brain_spec_path`, which is
 // permissive about the brain subtree to support spec resync. The archive path
 // is much stricter — only one subtree, one target directory.
 
 const TASK_SPECS_DIR: &str = "brain/tasks/specs";
+const TASK_SPECS_OPEN_DIR: &str = "brain/tasks/specs/open";
+const TASK_SPECS_IN_PROGRESS_DIR: &str = "brain/tasks/specs/in-progress";
 const TASK_SPECS_DONE_DIR: &str = "brain/tasks/specs/done";
+const TASK_SPEC_LIFECYCLE_DIRS: [&str; 3] = ["open", "in-progress", "done"];
 
 // ---- Post-merge worktree cleanup (feature task ba116063) ----
 //
@@ -939,49 +969,174 @@ enum ArchiveSpecPlan {
         to_abs: PathBuf,
     },
     AlreadyArchived,
+    OpenSpecCannotArchive,
     NotTaskSpec,
     MissingSpecRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ChatApprovalMovePlan {
+    Move { from_rel: String, to_rel: String },
+    AlreadyMoved { from_rel: String, to_rel: String },
+    Noop,
 }
 
 /// Decide what should happen to the spec referenced from this task's Spec line.
 /// Pure function: no filesystem access. The caller resolves the relative paths
 /// to absolute paths once the workspace root is known.
+fn bootstrap_task_spec_layout(workspace_root: &Path) -> Result<()> {
+    let specs_root = workspace_root.join(TASK_SPECS_DIR);
+    for dir in TASK_SPEC_LIFECYCLE_DIRS {
+        fs::create_dir_all(specs_root.join(dir)).with_context(|| {
+            format!(
+                "creating task specs lifecycle dir `{}`",
+                specs_root.join(dir).display()
+            )
+        })?;
+    }
+    for entry in fs::read_dir(&specs_root)
+        .with_context(|| format!("reading task specs root `{}`", specs_root.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !TASK_SPEC_LIFECYCLE_DIRS.contains(&name.as_str()) {
+            return Err(anyhow!(
+                "unexpected subdir under `{}`: `{}`; expected only open/, in-progress/, done/",
+                specs_root.display(),
+                name
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn normalize_rel_path(path: &str) -> String {
+    path.trim().trim_start_matches("./").to_string()
+}
+
+fn plan_chat_spec_approval_move(spec_path: &str, spec_text: &str) -> ChatApprovalMovePlan {
+    let normalized = normalize_rel_path(spec_path);
+    if !normalized.ends_with(".md") || normalized.contains("..") {
+        return ChatApprovalMovePlan::Noop;
+    }
+    let open_prefix = format!("{TASK_SPECS_OPEN_DIR}/");
+    let in_progress_prefix = format!("{TASK_SPECS_IN_PROGRESS_DIR}/");
+    if let Some(suffix) = normalized.strip_prefix(&open_prefix) {
+        if suffix.is_empty() || suffix.contains('/') || !product_spec_approved_by_tom(spec_text) {
+            return ChatApprovalMovePlan::Noop;
+        }
+        let suffix = suffix.to_string();
+        return ChatApprovalMovePlan::Move {
+            from_rel: normalized,
+            to_rel: format!("{TASK_SPECS_IN_PROGRESS_DIR}/{suffix}"),
+        };
+    }
+    if let Some(suffix) = normalized.strip_prefix(&in_progress_prefix) {
+        if !suffix.is_empty() && !suffix.contains('/') {
+            return ChatApprovalMovePlan::AlreadyMoved {
+                from_rel: format!("{TASK_SPECS_OPEN_DIR}/{suffix}"),
+                to_rel: normalized,
+            };
+        }
+    }
+    ChatApprovalMovePlan::Noop
+}
+
+fn move_approved_chat_spec_if_needed(args: &StageArgs, mut env: Envelope) -> Result<Envelope> {
+    let Some(spec) = product_spec(&env.task) else {
+        return Ok(env);
+    };
+    let normalized = normalize_rel_path(&spec.path);
+    let open_prefix = format!("{TASK_SPECS_OPEN_DIR}/");
+    if let Some(suffix) = normalized.strip_prefix(&open_prefix) {
+        let to_rel = format!("{TASK_SPECS_IN_PROGRESS_DIR}/{suffix}");
+        if workspace_root(args).join(&to_rel).exists() {
+            let description = env.task.description.clone().unwrap_or_default();
+            if let Some(new_desc) =
+                rewrite_spec_line_in_description(&description, &normalized, &to_rel)
+            {
+                api_patch::<Task>(
+                    &args.base_url,
+                    &env.task.id,
+                    json!({"description": new_desc}),
+                )?;
+                env.task = api_get_task(&args.base_url, &env.task.id)?;
+                env.action_taken = "repaired_chat_spec_in_progress_path".to_string();
+            }
+            return Ok(env);
+        }
+    }
+    let spec_abs = resolve_product_spec_path(&spec.path, &args.repo, workspace_root(args));
+    let spec_text = match fs::read_to_string(&spec_abs) {
+        Ok(text) => text,
+        Err(_) => return Ok(env),
+    };
+    let plan = plan_chat_spec_approval_move(&spec.path, &spec_text);
+    let (from_rel, to_rel, should_move) = match plan {
+        ChatApprovalMovePlan::Move { from_rel, to_rel } => (from_rel, to_rel, true),
+        ChatApprovalMovePlan::AlreadyMoved { from_rel, to_rel } => (from_rel, to_rel, false),
+        ChatApprovalMovePlan::Noop => return Ok(env),
+    };
+    let from_abs = workspace_root(args).join(&from_rel);
+    let to_abs = workspace_root(args).join(&to_rel);
+    if should_move && from_abs.exists() {
+        if let Some(parent) = to_abs.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        if !to_abs.exists() {
+            fs::rename(&from_abs, &to_abs).with_context(|| {
+                format!(
+                    "moving approved chat spec from `{}` to `{}`",
+                    from_abs.display(),
+                    to_abs.display()
+                )
+            })?;
+        }
+    }
+    let description = env.task.description.clone().unwrap_or_default();
+    if let Some(new_desc) = rewrite_spec_line_in_description(&description, &from_rel, &to_rel) {
+        api_patch::<Task>(
+            &args.base_url,
+            &env.task.id,
+            json!({"description": new_desc}),
+        )?;
+        env.task = api_get_task(&args.base_url, &env.task.id)?;
+        env.action_taken = "moved_approved_chat_spec_to_in_progress".to_string();
+    }
+    Ok(env)
+}
+
 fn plan_task_spec_archive(spec_path: Option<&str>) -> ArchiveSpecPlan {
     let Some(path) = spec_path.map(str::trim).filter(|p| !p.is_empty()) else {
         return ArchiveSpecPlan::MissingSpecRef;
     };
-    // Normalize trailing slashes and resolve `./` prefixes.
-    let normalized = path.trim_start_matches("./");
-    if !normalized.ends_with(".md") {
+    let normalized = normalize_rel_path(path);
+    if !normalized.ends_with(".md") || normalized.contains("..") {
         return ArchiveSpecPlan::NotTaskSpec;
     }
-    if normalized.contains("..") {
-        return ArchiveSpecPlan::NotTaskSpec;
-    }
-    // Already in done/ — idempotent no-op.
     let done_prefix = format!("{TASK_SPECS_DONE_DIR}/");
-    if normalized == TASK_SPECS_DONE_DIR || normalized.starts_with(&done_prefix) {
+    if normalized.starts_with(&done_prefix) {
         return ArchiveSpecPlan::AlreadyArchived;
     }
-    // Eligible if it's directly under brain/tasks/specs/ (one level deep).
-    let live_prefix = format!("{TASK_SPECS_DIR}/");
-    if !normalized.starts_with(&live_prefix) {
+    let open_prefix = format!("{TASK_SPECS_OPEN_DIR}/");
+    if normalized.starts_with(&open_prefix) {
+        return ArchiveSpecPlan::OpenSpecCannotArchive;
+    }
+    let in_progress_prefix = format!("{TASK_SPECS_IN_PROGRESS_DIR}/");
+    let Some(suffix) = normalized.strip_prefix(&in_progress_prefix) else {
+        return ArchiveSpecPlan::NotTaskSpec;
+    };
+    if suffix.is_empty() || suffix.contains('/') || !suffix.ends_with(".md") {
         return ArchiveSpecPlan::NotTaskSpec;
     }
-    let suffix = &normalized[live_prefix.len()..];
-    if suffix.is_empty()
-        || suffix.contains('/')
-        || !suffix.ends_with(".md")
-    {
-        // Subdirectories or non-md under brain/tasks/specs/ are not archivable.
-        return ArchiveSpecPlan::NotTaskSpec;
-    }
-    let from_rel = normalized.to_string();
-    let to_rel = format!("{TASK_SPECS_DONE_DIR}/{suffix}");
+    let suffix = suffix.to_string();
     ArchiveSpecPlan::Move {
-        from_rel,
-        to_rel,
-        from_abs: PathBuf::new(), // populated by caller
+        from_rel: normalized,
+        to_rel: format!("{TASK_SPECS_DONE_DIR}/{suffix}"),
+        from_abs: PathBuf::new(),
         to_abs: PathBuf::new(),
     }
 }
@@ -989,26 +1144,23 @@ fn plan_task_spec_archive(spec_path: Option<&str>) -> ArchiveSpecPlan {
 /// Resolve the `from_abs`/`to_abs` paths against the workspace root and ensure
 /// the source exists. Returns `Err` only on filesystem or path-canonicalization
 /// failures — caller decides how to surface them.
-fn resolve_archive_plan(
-    plan: ArchiveSpecPlan,
-    workspace_root: &Path,
-) -> Result<ArchiveSpecPlan> {
-    let ArchiveSpecPlan::Move { from_rel, to_rel, .. } = plan else {
+fn resolve_archive_plan(plan: ArchiveSpecPlan, workspace_root: &Path) -> Result<ArchiveSpecPlan> {
+    let ArchiveSpecPlan::Move {
+        from_rel, to_rel, ..
+    } = plan
+    else {
         return Ok(plan);
     };
     let from_abs = workspace_root.join(&from_rel);
     let to_abs = workspace_root.join(&to_rel);
-    if !from_abs.exists() {
-        // The spec is referenced but doesn't exist on disk — treat as not archivable
-        // rather than blowing up post-merge. The lobster will log a checklist comment
-        // so a follow-up run can address it.
-        return Ok(ArchiveSpecPlan::NotTaskSpec);
-    }
-    // Ensure the destination directory exists.
+    // Ensure the destination directory exists before deciding whether this is
+    // a first move or an idempotent stale-Spec-line repair.
     if let Some(parent) = to_abs.parent() {
-        fs::create_dir_all(parent).with_context(|| {
-            format!("creating archive directory `{}`", parent.display())
-        })?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating archive directory `{}`", parent.display()))?;
+    }
+    if !from_abs.exists() && !to_abs.exists() {
+        return Ok(ArchiveSpecPlan::NotTaskSpec);
     }
     Ok(ArchiveSpecPlan::Move {
         from_rel,
@@ -1064,21 +1216,34 @@ fn archive_done_task_spec(args: &StageArgs, mut env: Envelope) -> Result<Envelop
         return Ok(env);
     };
     let plan = plan_task_spec_archive(Some(&spec.path));
-    if matches!(plan, ArchiveSpecPlan::MissingSpecRef | ArchiveSpecPlan::NotTaskSpec | ArchiveSpecPlan::AlreadyArchived) {
+    if matches!(
+        plan,
+        ArchiveSpecPlan::MissingSpecRef
+            | ArchiveSpecPlan::NotTaskSpec
+            | ArchiveSpecPlan::AlreadyArchived
+            | ArchiveSpecPlan::OpenSpecCannotArchive
+    ) {
         env.action_taken = format!("post_merge_archive_noop_{}", plan_name(&plan));
         return Ok(env);
     }
 
-    let workspace_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let resolved = match resolve_archive_plan(plan, &workspace_root) {
+    let resolved = match resolve_archive_plan(plan, workspace_root(args)) {
         Ok(p) => p,
         Err(err) => {
-            return Ok(archive_block(&args, env, format!(
-                "Failed to resolve spec archive plan: {err}."
-            )));
+            return Ok(archive_block(
+                &args,
+                env,
+                format!("Failed to resolve spec archive plan: {err}."),
+            ));
         }
     };
-    let ArchiveSpecPlan::Move { from_abs, to_abs, from_rel, to_rel } = resolved else {
+    let ArchiveSpecPlan::Move {
+        from_abs,
+        to_abs,
+        from_rel,
+        to_rel,
+    } = resolved
+    else {
         return Ok(env);
     };
 
@@ -1095,7 +1260,11 @@ fn archive_done_task_spec(args: &StageArgs, mut env: Envelope) -> Result<Envelop
             &from_rel,
             &to_rel,
         ) {
-            match api_patch::<Task>(&args.base_url, &env.task.id, json!({"description": new_desc})) {
+            match api_patch::<Task>(
+                &args.base_url,
+                &env.task.id,
+                json!({"description": new_desc}),
+            ) {
                 Ok(_) => {
                     env.task = api_get_task(&args.base_url, &env.task.id)?;
                     env.action_taken = "post_merge_archive_already_present".to_string();
@@ -1116,8 +1285,8 @@ fn archive_done_task_spec(args: &StageArgs, mut env: Envelope) -> Result<Envelop
 
     // Update the task description to point at the archived path.
     let description = env.task.description.clone().unwrap_or_default();
-    let new_description = rewrite_spec_line_in_description(&description, &from_rel, &to_rel)
-        .unwrap_or(description);
+    let new_description =
+        rewrite_spec_line_in_description(&description, &from_rel, &to_rel).unwrap_or(description);
     if new_description != env.task.description.clone().unwrap_or_default() {
         api_patch::<Task>(
             &args.base_url,
@@ -1135,6 +1304,7 @@ fn plan_name(plan: &ArchiveSpecPlan) -> &'static str {
     match plan {
         ArchiveSpecPlan::Move { .. } => "move",
         ArchiveSpecPlan::AlreadyArchived => "already_archived",
+        ArchiveSpecPlan::OpenSpecCannotArchive => "open_spec_cannot_archive",
         ArchiveSpecPlan::NotTaskSpec => "not_task_spec",
         ArchiveSpecPlan::MissingSpecRef => "missing_spec_ref",
     }
@@ -1230,8 +1400,7 @@ fn safe_brain_spec_path(spec_path_str: &str, workspace_root: &Path) -> Result<Pa
 /// line is wrapped with `- [ ] ` and trimmed.
 fn replace_ac_section(content: &str, ac_lines: &[String]) -> String {
     // Header regex captures the leading hash run so we know the section level.
-    const HEADER_PATTERN: &str =
-        r"(?im)^\s{0,3}(#{1,6})\s+Acceptance Criteria\s*:?\s*$\n?";
+    const HEADER_PATTERN: &str = r"(?im)^\s{0,3}(#{1,6})\s+Acceptance Criteria\s*:?\s*$\n?";
     let header_re = Regex::new(HEADER_PATTERN).expect("header pattern compiles");
 
     // Compute the new AC block as lines.
@@ -1253,8 +1422,7 @@ fn replace_ac_section(content: &str, ac_lines: &[String]) -> String {
         // Only headings at the captured level or higher end the AC section.
         // Deeper headings (`### …`, `#### …`, …) belong to the section's body
         // and must not truncate the rewrite.
-        let closer_pattern =
-            format!(r"(?m)^\s{{0,3}}#{{1,{header_level}}}\s+\S");
+        let closer_pattern = format!(r"(?m)^\s{{0,3}}#{{1,{header_level}}}\s+\S");
         let next_re = Regex::new(&closer_pattern).unwrap_or_else(|e| {
             panic!("closer pattern compiles for header level {header_level}: {e}")
         });
@@ -2747,11 +2915,9 @@ fn extract_ac_section(body: &str) -> &str {
     // `#### …`, …) are subsections and stay inside the AC section — that's
     // how multi-task PR bodies (one `## Acceptance Criteria` containing
     // several `### Task …` subheadings) keep their ACs together.
-    let closer_pattern =
-        format!(r"(?m)^\s{{0,3}}#{{1,{header_level}}}\s+\S");
-    let next_re = Regex::new(&closer_pattern).unwrap_or_else(|e| {
-        panic!("closer pattern compiles for header level {header_level}: {e}")
-    });
+    let closer_pattern = format!(r"(?m)^\s{{0,3}}#{{1,{header_level}}}\s+\S");
+    let next_re = Regex::new(&closer_pattern)
+        .unwrap_or_else(|e| panic!("closer pattern compiles for header level {header_level}: {e}"));
     match next_re.find(tail) {
         Some(next) => &tail[..next.start()],
         None => tail,
@@ -4260,14 +4426,8 @@ Lead-in.
             - [x] AC1: Alpha-specific AC1 text (testID: alpha_ac1)\n\
             ### Task beta\n\
             - [x] AC1: Beta-specific AC1 text (testID: beta_ac1)\n";
-        let alpha_acs = vec![(
-            "AC1".to_string(),
-            "Alpha-specific AC1 text".to_string(),
-        )];
-        let beta_acs = vec![(
-            "AC1".to_string(),
-            "Beta-specific AC1 text".to_string(),
-        )];
+        let alpha_acs = vec![("AC1".to_string(), "Alpha-specific AC1 text".to_string())];
+        let beta_acs = vec![("AC1".to_string(), "Beta-specific AC1 text".to_string())];
 
         let alpha_failures = task_ac_vs_open_pr_failures(
             "alpha",
@@ -4295,10 +4455,7 @@ Lead-in.
         // contains beta's text, the function should report a text-mismatch
         // failure rather than borrowing alpha's text. This proves the HashMap
         // is correctly scoped.
-        let cross_acs = vec![(
-            "AC1".to_string(),
-            "Beta-specific AC1 text".to_string(),
-        )];
+        let cross_acs = vec![("AC1".to_string(), "Beta-specific AC1 text".to_string())];
         let cross_failures = task_ac_vs_open_pr_failures(
             "alpha",
             &cross_acs,
@@ -5159,10 +5316,12 @@ Lead-in.
 
     #[test]
     fn plan_task_spec_archive_moves_eligible_spec() {
-        let plan = plan_task_spec_archive(Some("brain/tasks/specs/example-2026.md"));
+        let plan = plan_task_spec_archive(Some("brain/tasks/specs/in-progress/example-2026.md"));
         match plan {
-            ArchiveSpecPlan::Move { from_rel, to_rel, .. } => {
-                assert_eq!(from_rel, "brain/tasks/specs/example-2026.md");
+            ArchiveSpecPlan::Move {
+                from_rel, to_rel, ..
+            } => {
+                assert_eq!(from_rel, "brain/tasks/specs/in-progress/example-2026.md");
                 assert_eq!(to_rel, "brain/tasks/specs/done/example-2026.md");
             }
             other => panic!("expected Move plan, got {other:?}"),
@@ -5171,7 +5330,7 @@ Lead-in.
 
     #[test]
     fn plan_task_spec_archive_strips_leading_dot_slash() {
-        let plan = plan_task_spec_archive(Some("./brain/tasks/specs/example-2026.md"));
+        let plan = plan_task_spec_archive(Some("./brain/tasks/specs/in-progress/example-2026.md"));
         assert!(matches!(plan, ArchiveSpecPlan::Move { .. }));
     }
 
@@ -5206,7 +5365,7 @@ Lead-in.
     #[test]
     fn plan_task_spec_archive_rejects_subdirectory() {
         assert_eq!(
-            plan_task_spec_archive(Some("brain/tasks/specs/sub/foo.md")),
+            plan_task_spec_archive(Some("brain/tasks/specs/in-progress/sub/foo.md")),
             ArchiveSpecPlan::NotTaskSpec
         );
     }
@@ -5214,7 +5373,7 @@ Lead-in.
     #[test]
     fn plan_task_spec_archive_rejects_non_md() {
         assert_eq!(
-            plan_task_spec_archive(Some("brain/tasks/specs/example.txt")),
+            plan_task_spec_archive(Some("brain/tasks/specs/in-progress/example.txt")),
             ArchiveSpecPlan::NotTaskSpec
         );
     }
@@ -5222,19 +5381,118 @@ Lead-in.
     #[test]
     fn plan_task_spec_archive_rejects_dotdot() {
         assert_eq!(
-            plan_task_spec_archive(Some("brain/tasks/specs/../escapee.md")),
+            plan_task_spec_archive(Some("brain/tasks/specs/in-progress/../escapee.md")),
             ArchiveSpecPlan::NotTaskSpec
         );
     }
 
     #[test]
     fn plan_task_spec_archive_missing_or_empty_is_missing() {
-        assert_eq!(plan_task_spec_archive(None), ArchiveSpecPlan::MissingSpecRef);
-        assert_eq!(plan_task_spec_archive(Some("")), ArchiveSpecPlan::MissingSpecRef);
+        assert_eq!(
+            plan_task_spec_archive(None),
+            ArchiveSpecPlan::MissingSpecRef
+        );
+        assert_eq!(
+            plan_task_spec_archive(Some("")),
+            ArchiveSpecPlan::MissingSpecRef
+        );
         assert_eq!(
             plan_task_spec_archive(Some("   ")),
             ArchiveSpecPlan::MissingSpecRef
         );
+    }
+
+    #[test]
+    fn spec_lifecycle_bootstrap_creates_expected_dirs_and_is_idempotent() {
+        let workspace = tempdir().unwrap();
+        bootstrap_task_spec_layout(workspace.path()).unwrap();
+        for dir in [
+            TASK_SPECS_OPEN_DIR,
+            TASK_SPECS_IN_PROGRESS_DIR,
+            TASK_SPECS_DONE_DIR,
+        ] {
+            assert!(workspace.path().join(dir).is_dir(), "missing {dir}");
+        }
+        bootstrap_task_spec_layout(workspace.path()).unwrap();
+    }
+
+    #[test]
+    fn spec_lifecycle_bootstrap_rejects_unexpected_subdir() {
+        let workspace = tempdir().unwrap();
+        fs::create_dir_all(workspace.path().join("brain/tasks/specs/other")).unwrap();
+        let err = bootstrap_task_spec_layout(workspace.path()).unwrap_err();
+        assert!(err.to_string().contains("unexpected subdir"));
+    }
+
+    #[test]
+    fn spec_lifecycle_chat_approval_move_only_moves_open_checked_specs() {
+        let checked = "- [x] **Approved by Tom**\n";
+        assert_eq!(
+            plan_chat_spec_approval_move("brain/tasks/specs/open/example.md", checked),
+            ChatApprovalMovePlan::Move {
+                from_rel: "brain/tasks/specs/open/example.md".to_string(),
+                to_rel: "brain/tasks/specs/in-progress/example.md".to_string()
+            }
+        );
+        assert_eq!(
+            plan_chat_spec_approval_move(
+                "brain/tasks/specs/open/example.md",
+                "- [ ] **Approved by Tom**\n"
+            ),
+            ChatApprovalMovePlan::Noop
+        );
+        assert_eq!(
+            plan_chat_spec_approval_move(
+                "brain/tasks/specs/in-progress/example.md",
+                "- [ ] **Approved by Tom**\n"
+            ),
+            ChatApprovalMovePlan::AlreadyMoved {
+                from_rel: "brain/tasks/specs/open/example.md".to_string(),
+                to_rel: "brain/tasks/specs/in-progress/example.md".to_string()
+            }
+        );
+        assert_eq!(
+            plan_chat_spec_approval_move("brain/tasks/specs/done/example.md", checked),
+            ChatApprovalMovePlan::Noop
+        );
+    }
+
+    #[test]
+    fn spec_lifecycle_archive_moves_only_in_progress_to_done() {
+        let plan = plan_task_spec_archive(Some("brain/tasks/specs/in-progress/example.md"));
+        match plan {
+            ArchiveSpecPlan::Move {
+                from_rel, to_rel, ..
+            } => {
+                assert_eq!(from_rel, "brain/tasks/specs/in-progress/example.md");
+                assert_eq!(to_rel, "brain/tasks/specs/done/example.md");
+            }
+            other => panic!("expected move, got {other:?}"),
+        }
+        assert_eq!(
+            plan_task_spec_archive(Some("brain/tasks/specs/open/example.md")),
+            ArchiveSpecPlan::OpenSpecCannotArchive
+        );
+        assert_eq!(
+            plan_task_spec_archive(Some("brain/tasks/specs/done/example.md")),
+            ArchiveSpecPlan::AlreadyArchived
+        );
+    }
+
+    #[test]
+    fn spec_lifecycle_folder_agnostic_spec_paths_resolve_under_brain() {
+        let workspace = tempdir().unwrap();
+        for rel in [
+            "brain/tasks/specs/open/example.md",
+            "brain/tasks/specs/in-progress/example.md",
+            "brain/tasks/specs/done/example.md",
+            "brain/bookmarks/specs/example.md",
+        ] {
+            let path = workspace.path().join(rel);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, "- [x] **Approved by Tom**\n").unwrap();
+            assert_eq!(safe_brain_spec_path(rel, workspace.path()).unwrap(), path);
+        }
     }
 
     // ---- rewrite_spec_line_in_description ----
@@ -5242,7 +5500,7 @@ Lead-in.
     #[test]
     fn rewrite_spec_line_replaces_old_path_with_new() {
         let description = "\
-**Spec:** brain/tasks/specs/example-2026.md
+**Spec:** brain/tasks/specs/in-progress/example-2026.md
 
 ## Outcome
 
@@ -5250,12 +5508,12 @@ Whatever.
 ";
         let rewritten = rewrite_spec_line_in_description(
             description,
-            "brain/tasks/specs/example-2026.md",
+            "brain/tasks/specs/in-progress/example-2026.md",
             "brain/tasks/specs/done/example-2026.md",
         )
         .expect("rewrite should fire when paths differ");
         assert!(rewritten.contains("**Spec:** brain/tasks/specs/done/example-2026.md"));
-        assert!(!rewritten.contains("**Spec:** brain/tasks/specs/example-2026.md\n"));
+        assert!(!rewritten.contains("**Spec:** brain/tasks/specs/in-progress/example-2026.md\n"));
     }
 
     #[test]
@@ -5269,7 +5527,7 @@ Whatever.
 ";
         let rewritten = rewrite_spec_line_in_description(
             description,
-            "brain/tasks/specs/example-2026.md",
+            "brain/tasks/specs/in-progress/example-2026.md",
             "brain/tasks/specs/done/example-2026.md",
         );
         assert!(rewritten.is_none(), "already archived must be a no-op");
@@ -5280,7 +5538,7 @@ Whatever.
         let description = "## Outcome\nNo spec line here.\n";
         let rewritten = rewrite_spec_line_in_description(
             description,
-            "brain/tasks/specs/example-2026.md",
+            "brain/tasks/specs/in-progress/example-2026.md",
             "brain/tasks/specs/done/example-2026.md",
         );
         assert!(rewritten.is_none());
@@ -5291,18 +5549,26 @@ Whatever.
     #[test]
     fn resolve_archive_plan_moves_existing_spec_into_done() {
         let workspace = tempdir().unwrap();
-        let live = workspace.path().join("brain/tasks/specs");
+        let live = workspace.path().join("brain/tasks/specs/in-progress");
         fs::create_dir_all(&live).unwrap();
         let src = live.join("example-2026.md");
         fs::write(&src, "# Example\n").unwrap();
 
-        let plan = plan_task_spec_archive(Some("brain/tasks/specs/example-2026.md"));
+        let plan = plan_task_spec_archive(Some("brain/tasks/specs/in-progress/example-2026.md"));
         let resolved = resolve_archive_plan(plan, workspace.path()).expect("plan resolves");
-        let ArchiveSpecPlan::Move { from_abs, to_abs, .. } = resolved else {
+        let ArchiveSpecPlan::Move {
+            from_abs, to_abs, ..
+        } = resolved
+        else {
             panic!("expected Move plan");
         };
         assert_eq!(from_abs, src);
-        assert_eq!(to_abs, workspace.path().join("brain/tasks/specs/done/example-2026.md"));
+        assert_eq!(
+            to_abs,
+            workspace
+                .path()
+                .join("brain/tasks/specs/done/example-2026.md")
+        );
         // done/ dir is created on demand.
         assert!(to_abs.parent().unwrap().exists());
     }
@@ -5913,7 +6179,10 @@ detached
         }];
         let matches =
             select_matching_rowan_worktrees(&entries, "ba116063-382a-446c-ab91-c01b60d9a7c3");
-        assert!(matches.is_empty(), "primary worktree must never be selected");
+        assert!(
+            matches.is_empty(),
+            "primary worktree must never be selected"
+        );
     }
 
     #[test]

--- a/docs/specs/spec-folder-lifecycle-tech-design.md
+++ b/docs/specs/spec-folder-lifecycle-tech-design.md
@@ -1,0 +1,268 @@
+---
+status: draft
+task_id: a5a4ed8f-e7c4-4b6c-8ac9-bb962211ac44
+product_spec: brain/tasks/specs/spec-folder-lifecycle-2026-07-07.md
+shipped_pr: null
+shipped_date: null
+---
+
+# Spec folder lifecycle and lobster sync — Tech Design
+
+## Product intent summary
+
+Product spec: `brain/tasks/specs/spec-folder-lifecycle-2026-07-07.md`.
+Task: `a5a4ed8f-e7c4-4b6c-8ac9-bb962211ac44` (`🔧 Spec folder lifecycle and lobster sync`).
+
+The approved product intent is a forward-only lifecycle owned by lobsters, not humans:
+
+> Chat-created specs in `brain/tasks/specs/` follow a forward-only lifecycle: created → `open/`, approved → `in-progress/`, task done → `done/`. The Tasks API is the system of record once a spec is in `in-progress/` — no reverse file moves.
+
+> Bookmark specs in `brain/bookmarks/specs/` keep their existing approval pipeline and stay in place until a task is created from them. Only the approved-and-tasked bookmark specs move into `tasks/specs/in-progress/`.
+
+> The feature-task lobster and bookmark lobster cooperate to keep file state in sync with task state. Quinn never moves a spec file manually.
+
+The eight acceptance criteria are:
+
+1. `brain/tasks/specs/open/`, `brain/tasks/specs/in-progress/`, and `brain/tasks/specs/done/` exist as the only subdirs under `tasks/specs/`; the feature-task lobster validates this layout on every run.
+2. New chat specs land in `tasks/specs/open/<slug>-YYYY-MM-DD.md` with `- [ ] **Approved by Tom**`; `feature-task-create` and `tasks-create` write to this path.
+3. New bookmark specs land in `bookmarks/specs/<slug>-<key>.md` with `- [ ] **Approved by Tom**`; `spec-author` and `lobster_generate_specs.py` use this path.
+4. Feature-task lobster detects a checked Tom approval marker on chat specs in `open/` and moves them to `in-progress/`, idempotently and with no reverse moves.
+5. Bookmark approval toggles the file checkbox but does not move the spec out of `bookmarks/specs/`.
+6. Bookmark task creation moves an approved bookmark spec to `tasks/specs/in-progress/` and updates the new task's `**Spec:**` line.
+7. Feature task completion moves specs from `tasks/specs/in-progress/` to `tasks/specs/done/` and patches the task `**Spec:**` line.
+8. Feature-task `spec_check` reads the spec by the task `**Spec:**` path, regardless of folder; every move must patch that path atomically and idempotently.
+
+## Repo / branch / worktree
+
+- Repository: `codebases/sindustries` (`Stoffer-Industries/sindustries`)
+- Branch: `task-a5a4ed8f-spec-folder-lifecycle`
+- Worktree: `~/workspaces/rowan/sindustries-task-a5a4ed8f-spec-folder-lifecycle`
+- Product spec: `/Users/quinnstoffer/.openclaw/workspace/brain/tasks/specs/spec-folder-lifecycle-2026-07-07.md`
+- Tech design: `docs/specs/spec-folder-lifecycle-tech-design.md`
+
+## `.openclaw` boundary notes
+
+No `.openclaw` config, gateway, scheduler, node, or prompt changes are expected for this task. The implementation is contained to the SIndustries repo's brain-facing workflow code and skills.
+
+The lobster runtime itself lives outside this repo/workspace boundary at execution time: the YAML definitions and scripts are in `codebases/sindustries`, but lobster orchestration is run by the OpenClaw runtime. This task should only change repo-owned workflow scripts, Rust code, skill docs, tests, and brain file paths; it should not mutate OpenClaw runtime configuration.
+
+## Implementation plan with file/module scope
+
+### Files and modules in scope
+
+Feature-task workflow:
+
+- `agents/workflows/feature-task/feature-task.lobster.yaml` — stage wiring; no structural change expected unless a new stage is split out from `spec_check`.
+- `agents/workflows/feature-task/run.py` — wrapper entry point; no expected logic change.
+- `agents/workflows/feature-task/src/main.rs` — primary implementation surface for layout validation, chat approval move, done move widening, spec-line patching, and tests.
+- `agents/workflows/feature-task/Cargo.toml` / `Cargo.lock` — only if tests need a new dev dependency; default plan is no new dependency.
+- `agents/workflows/feature-task/fixtures/*` — add or adjust fixtures only if unit tests need realistic task descriptions.
+
+Bookmark workflow:
+
+- `agents/workflows/bookmarks/bookmarks.lobster.yaml` — confirms the current stage order: `generate_specs` → `request_spec_approval` → `create_tasks_from_proposals` → `resolve_spec_request`.
+- `agents/workflows/bookmarks/run.py` — exposes `specsRoot: brain/bookmarks/specs`; no expected logic change.
+- `agents/workflows/bookmarks/scripts/common.py` — `SPECS_ROOT`, `STATE_PATH`, and shared path helpers.
+- `agents/workflows/bookmarks/scripts/lobster_generate_specs.py` — bookmark spec path derivation and revision writes.
+- `agents/workflows/bookmarks/scripts/lobster_request_spec_approval.py` — approval package preparation; likely not the checkbox writer unless approval is resolved there in a future refactor.
+- `agents/workflows/bookmarks/scripts/handle_approval_reply.py` — current approval resolution path; best place to toggle `- [x] **Approved by Tom**` when `approvalStatus` transitions to `approved`.
+- `agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py` — task creation and post-create move from `bookmarks/specs/` to `tasks/specs/in-progress/`.
+- `agents/workflows/bookmarks/scripts/validate_spec_output.py` — ensure validated Quinn-authored bookmark specs still report `brain/bookmarks/specs/<slug>-<key>.md`.
+
+Skill docs / task creation helpers:
+
+- `agents/skills/product/feature-task-create/SKILL.md` — update chat-created feature spec location from `brain/tasks/specs/<slug>-YYYY-MM-DD.md` to `brain/tasks/specs/open/<slug>-YYYY-MM-DD.md`.
+- `agents/skills/ops/tasks-create/SKILL.md` — same path update for feature tasks and the `**Spec:**` examples.
+- `agents/skills/product/spec-author/SKILL.md` — confirm bookmark specs remain under `brain/bookmarks/specs/<slug>-<bookmark_key>.md`.
+- `agents/skills/ops/tasks-api/tasks_api_client.py` — no schema change expected; use existing `--spec` composition and `patch --description` for path updates.
+
+Top-level `agents/scripts/` note: there is no `agents/scripts/` directory in the current tree. The lobster entry points for this feature live under `agents/workflows/feature-task/` and `agents/workflows/bookmarks/scripts/`.
+
+State JSON paths:
+
+- `brain/state/bookmark-review-state.json` — bookmark item state, including `approvalStatus`, `specDocs`, and `taskIds`.
+- `brain/state/bookmark-transitions.jsonl` — existing transition log used by bookmark scripts.
+- Tasks API records — task description `**Spec:**` lines and feature-task lobster state/comments are API-owned, not local JSON files.
+
+### AC1 — layout validation
+
+Add feature-task Rust helpers in `agents/workflows/feature-task/src/main.rs`:
+
+- `const TASK_SPECS_OPEN_DIR: &str = "brain/tasks/specs/open";`
+- `const TASK_SPECS_IN_PROGRESS_DIR: &str = "brain/tasks/specs/in-progress";`
+- keep/update `TASK_SPECS_DONE_DIR`.
+- `bootstrap_task_spec_layout(workspace_root: &Path) -> Result<()>`:
+  - `fs::create_dir_all` for `open`, `in-progress`, and `done`.
+  - read the direct children of `brain/tasks/specs/`.
+  - fail loudly if any direct child is a directory other than `open`, `in-progress`, or `done`.
+  - allow files directly under `brain/tasks/specs/` during rollout only if Quinn explicitly chooses a migration grace period; default plan is to fail on unexpected subdirs, not files, because the AC only constrains subdirs.
+
+Call this helper at the start of the feature-task `spec_check` stage, before approval or checksum work. This makes every lobster run reconcile missing dirs and block broken layouts early.
+
+### AC2 — chat spec creation path
+
+Current docs point new feature specs at `brain/tasks/specs/<slug>-YYYY-MM-DD.md`:
+
+- `agents/skills/product/feature-task-create/SKILL.md`
+- `agents/skills/ops/tasks-create/SKILL.md`
+
+Update those examples/checklists to `brain/tasks/specs/open/<slug>-YYYY-MM-DD.md`. The actual writers are human/agent skill executions that create markdown files before calling `tasks_api_client.py create --spec`; there is not a central code writer for chat specs today. The task description's `**Spec:**` line must therefore also use `brain/tasks/specs/open/<slug>-YYYY-MM-DD.md` at creation.
+
+### AC3 — bookmark spec path
+
+Bookmark specs remain at `brain/bookmarks/specs/<slug>-<key>.md`.
+
+Current derivation:
+
+- `agents/workflows/bookmarks/scripts/common.py` sets `SPECS_ROOT = WORKSPACE / "brain" / "bookmarks" / "specs"`.
+- `agents/workflows/bookmarks/scripts/lobster_generate_specs.py::spec_doc_path(specs_root, topic, spec_title, bookmark_key, index)` returns `specs_root / f"{slugify(spec_title)}-{bookmark_key}{suffix}.md"`.
+- `suffix` is empty for the first spec and `-part-<n>` for additional specs.
+- `slugify(spec_title)` provides the slug; `bookmark_key` is the stable key appended after the slug.
+- `agents/skills/product/spec-author/SKILL.md` documents the same durable path: `brain/bookmarks/specs/<slug>-<bookmark_key>.md`.
+
+No move to `tasks/specs/open/` happens for bookmark specs.
+
+### AC4 — approval move for chat specs
+
+Implement a new `plan_chat_spec_approval_move(spec_path, spec_text)` pure helper in `src/main.rs`:
+
+- Only considers specs currently under `brain/tasks/specs/open/*.md`.
+- Requires `product_spec_approved_by_tom(spec_text)` to be true.
+- Destination is `brain/tasks/specs/in-progress/<same-file-name>.md`.
+- If source is already under `in-progress/`, returns an idempotent no-op.
+- If source is under `done/`, returns no-op.
+- If approval is unchecked while in `in-progress/`, returns no-op. This enforces no reverse moves.
+
+In `spec_check`, after loading the spec from the current `**Spec:**` line and before checksum finalization, run the plan. On move:
+
+1. Ensure destination parent exists.
+2. If destination already exists and source is absent, only patch the task description to the destination path.
+3. Otherwise `fs::rename`/`mv` source → destination.
+4. Patch the task description's `**Spec:**` line from old path to new path using the existing `rewrite_spec_line_in_description` pattern.
+5. Re-fetch task state before continuing checksum/status logic.
+
+Do not use `git mv` inside the runtime lobster; the brain tree is workspace state, not a repo checkout. Use `fs::rename`/`mv`. If an implementation run is inside a git worktree and both paths are tracked, Git will still detect the rename.
+
+### AC5 — bookmark approval toggle without move
+
+Current approval resolution is in `agents/workflows/bookmarks/scripts/handle_approval_reply.py`, where `approvalStatus` is set to `approved` or `declined`. `lobster_request_spec_approval.py` prepares the package but does not resolve the transition.
+
+Add a shared helper, either in `handle_approval_reply.py` or `common.py`:
+
+- `set_spec_approval_checkbox(spec_doc: str, approved: bool) -> bool`
+- Valid only for paths under `brain/bookmarks/specs/` at this stage.
+- Replaces an existing `- [ ] **Approved by Tom**` with `- [x] **Approved by Tom**` on approval.
+- If already checked, no-op.
+- If the marker is missing, append or fail visibly; recommendation: fail visibly so malformed specs do not silently pass approval.
+- Atomic write: write to a temp file in the same directory and `os.replace`.
+
+When `approvalStatus` transitions to `approved`, toggle every `specDoc` for that bookmark. Do not move the file. The file stays in `brain/bookmarks/specs/` until AC6.
+
+### AC6 — bookmark task creation move
+
+Modify `agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py`:
+
+- Keep the existing approval gate: only create/reuse tasks for items whose `approvalStatus` is `approved`.
+- Before creating a new task, compute the task spec destination: `brain/tasks/specs/in-progress/<basename(spec_doc)>`.
+- Build the task description with the destination path in the `**Spec:**` line, not the source bookmark path.
+- After successful task creation, move `brain/bookmarks/specs/<slug>-<key>.md` to `brain/tasks/specs/in-progress/<slug>-<key>.md`.
+- If the destination already exists, treat as idempotent success and do not overwrite unless content matches exactly. If source is missing and destination exists, continue and ensure the task description points at destination.
+- Patch or create the task description so `**Spec:**` points at the destination. For reused existing tasks, patch if the old path still points at `brain/bookmarks/specs/`.
+- Update any state `specDocs` entries for the item to the new path after the move, so later pipeline displays and dedupe tags are not stale. This is a state value update, not a schema addition.
+
+Use `os.rename`/`Path.rename` for the move. Both source and destination live under the same OpenClaw workspace on the same machine, so `mv`/rename is fine; do not shell out to `git mv`.
+
+### AC7 — task done move
+
+`agents/workflows/feature-task/src/main.rs` already has task `c40ae956` archive helpers that move direct `brain/tasks/specs/<slug>.md` specs to `brain/tasks/specs/done/<slug>.md` on post-merge/done.
+
+Update that helper set:
+
+- Replace the old live root assumption (`brain/tasks/specs/<file>.md`) with `brain/tasks/specs/in-progress/<file>.md`.
+- Already in `done/` remains idempotent no-op.
+- `open/` should not move directly to `done/`; if a task reaches done with an open spec, block with a visible checklist because the approval lifecycle is broken.
+- Apply uniformly to chat specs and bookmark-origin specs once they have crossed into `tasks/specs/in-progress/`.
+- Patch the task `**Spec:**` line from `in-progress/` to `done/` using the same atomic/idempotent description update path.
+
+### AC8 — folder-agnostic lookup
+
+Keep the feature-task lobster's current parsing model: `product_spec(task)` reads the exact `**Spec:**` line from the task description, and `safe_brain_spec_path` allows relative paths under `brain/`.
+
+The key contract is that every move patches the task description in the same logical operation:
+
+- `open/` → `in-progress/` patches the feature task immediately.
+- `bookmarks/specs/` → `tasks/specs/in-progress/` creates or patches the bookmark-created task with the destination path.
+- `in-progress/` → `done/` patches the feature task immediately.
+
+If a move succeeds but a task patch fails, the next lobster run must detect the destination and finish the patch idempotently. That means each move helper should handle the “source absent, destination present, old `**Spec:**` line remains” case.
+
+## Data model / state contract changes
+
+- `brain/state/bookmark-review-state.json` already stores `approvalStatus` per bookmark item. No schema change is required for AC5.
+- Existing `specDocs` values may change from `brain/bookmarks/specs/<file>.md` to `brain/tasks/specs/in-progress/<file>.md` after AC6. This is an existing field update, not a new field.
+- Existing `taskIds` values remain unchanged.
+- No new Tasks API fields are required.
+- No new local state files are required.
+- The task description `**Spec:**` line becomes the authoritative pointer for the feature-task lobster after every move.
+
+## Workflow, cron, and skill changes
+
+- No cron changes.
+- No OpenClaw runtime config changes.
+- Update `feature-task-create` and `tasks-create` skills so future chat-created feature specs are written under `brain/tasks/specs/open/`.
+- Keep `spec-author` documentation on `brain/bookmarks/specs/`.
+- The bookmark lobster remains the only mover from `bookmarks/specs/` into `tasks/specs/in-progress/`.
+- The feature-task lobster remains the only mover from `tasks/specs/open/` to `in-progress/` and from `in-progress/` to `done/`.
+
+## Test plan
+
+Primary unit coverage should live with the code that owns the lifecycle:
+
+- `agents/workflows/feature-task/src/main.rs` Rust unit tests, or a split module such as `agents/workflows/feature-task/src/spec_lifecycle.rs` with colocated tests. If the crate is later split into integration tests, use `agents/workflows/feature-task/tests/test_spec_lifecycle.rs`.
+- Bookmark Python tests can be added under `agents/workflows/bookmarks/tests/test_spec_lifecycle.py` or, if no test package exists yet, a small pytest file next to existing bookmark workflow tests.
+
+Required coverage:
+
+1. **Layout bootstrap (AC1)**
+   - Missing `open`, `in-progress`, and `done` directories are created.
+   - Unexpected direct subdir under `brain/tasks/specs/` causes a loud error.
+   - Re-running bootstrap is a no-op.
+2. **Idempotent forward moves (AC4, AC6, AC7)**
+   - Checked chat spec in `open/` moves to `in-progress/` and rewrites `**Spec:**`.
+   - Approved bookmark spec moves to `tasks/specs/in-progress/` during task creation and rewrites/creates `**Spec:**`.
+   - Done task moves `in-progress/` to `done/` and rewrites `**Spec:**`.
+   - Re-running each move after destination exists is a no-op and still repairs stale `**Spec:**` lines.
+3. **No reverse move (AC4)**
+   - Unchecked marker on a spec already in `in-progress/` does not move it back to `open/`.
+   - Reopened/done tasks do not move files out of `done/`.
+4. **Folder-agnostic lookup (AC8)**
+   - `spec_check` reads by the task `**Spec:**` path for `open/`, `in-progress/`, `done/`, and `bookmarks/specs/` paths.
+   - After a move and patch, the next run resolves the new path without fallback scanning.
+5. **Bookmark approval toggle (AC5)**
+   - `approvalStatus: approved` toggles `- [ ] **Approved by Tom**` to `- [x] **Approved by Tom**` in `brain/bookmarks/specs/`.
+   - Already checked is idempotent.
+   - Toggle does not move the file.
+   - Declined approval does not check the marker.
+
+Suggested commands for implementation PR verification:
+
+```bash
+cargo test --manifest-path agents/workflows/feature-task/Cargo.toml spec_lifecycle
+python3 -m pytest agents/workflows/bookmarks/tests/test_spec_lifecycle.py
+```
+
+If bookmark workflow tests do not yet use pytest, add a small stdlib `unittest` file and run it directly with `python3` instead of introducing a new dependency.
+
+## Related work
+
+- This spec supersedes `spec-archive-on-done` (task `c40ae956`, currently in `acceptance`). Its move-on-done behavior is preserved as AC7, but the eligible source folder becomes `brain/tasks/specs/in-progress/` rather than direct children of `brain/tasks/specs/`.
+- Existing bookmark specs are not migrated. The product spec says the 78 existing bookmark specs remain in `brain/bookmarks/specs/` until each naturally crosses the approval-and-tasked gate.
+
+## Open questions and risks
+
+1. **Task Spec line patching concurrency.** If a lobster and a human both edit the task description, last write can win. Recommendation: patch by re-fetching the latest task, replacing only the exact old `**Spec:**` line, and retrying once on conflict. For file writes, use same-directory temp files plus `os.replace`/atomic rename.
+2. **`os.rename` vs `git mv`.** Runtime lobsters should use `os.rename`/`Path.rename`/`fs::rename`; both source and destination live on the same machine/workspace, and the brain tree is not necessarily a git checkout. `git mv` is only useful in an implementation worktree, not as runtime workflow behavior.
+3. **Bookmark specs that never cross the gate.** They stay indefinitely in `brain/bookmarks/specs/`. This is deliberate and keeps `brain/tasks/specs/open/` from filling with long-tail pipeline output.
+4. **Existing direct files under `brain/tasks/specs/`.** AC1 only says the three lifecycle dirs are the only subdirs. If old direct files remain, the implementation should either leave them alone during rollout or have Quinn approve a one-time migration. Do not silently move them without task context.
+5. **Move succeeded, API patch failed.** Each move helper must be repairable on the next run by recognizing “destination exists, source absent, `**Spec:**` still old path” and patching the task line.
+6. **Multiple bookmark specs for one bookmark.** The current path derivation can produce `-part-<n>` files. AC6 should move each tasked spec independently and update state/task descriptions accordingly.

--- a/docs/specs/spec-folder-lifecycle-tech-design.md
+++ b/docs/specs/spec-folder-lifecycle-tech-design.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: approved
 task_id: a5a4ed8f-e7c4-4b6c-8ac9-bb962211ac44
 product_spec: brain/tasks/specs/spec-folder-lifecycle-2026-07-07.md
 shipped_pr: null

--- a/docs/systems/bookmark-workflow.md
+++ b/docs/systems/bookmark-workflow.md
@@ -1,7 +1,7 @@
 # Bookmark Workflow
 
 **Type:** System reference (keep updated as the pipeline evolves)
-**Last updated:** 2026-06-26
+**Last updated:** 2026-07-14
 **Repo:** `Stoffer-Industries/sindustries` · `agents/workflows/bookmarks/`
 
 ---
@@ -59,10 +59,13 @@ ingested  summarized  needs_research (human-gated)                      declined
 - Lobster pipeline runs to `prepare_topic_approval.py` → produces `requiresApproval` payload
 - `request_topic_approval.py` receives the payload, checks for `specDocs`, sends Telegram message to Tom
 - Approval message includes: spec path, approval ID, `approve / decline / revise: <changes>` prompt
-- `handle_approval_reply.py` parses Tom's reply and calls `resolve_topic_approval.py`
+- `handle_approval_reply.py` parses Tom's reply, toggles `- [x] **Approved by Tom**` in each approved bookmark spec, and calls `resolve_topic_approval.py`
+- Approved bookmark specs stay under `brain/bookmarks/specs/`; approval alone never moves them into task spec folders
 
 ### 6. Task Creation
 - After `approve`, `create_tasks_from_proposals.py` pushes tasks to the Tasks API
+- On task creation or task reuse, the workflow moves each approved spec from `brain/bookmarks/specs/<slug>-<key>.md` to `brain/tasks/specs/in-progress/<slug>-<key>.md` and creates/repairs the task `**Spec:**` line to point at the destination
+- Once moved to `brain/tasks/specs/in-progress/`, bookmark-origin specs follow the feature-task lifecycle (`in-progress/` → `done/` on task completion)
 - Sets `reviewStatus: tasked` — **terminal**
 
 ---
@@ -100,7 +103,7 @@ ingested  summarized  needs_research (human-gated)                      declined
 | `brain/state/bookmark-approval-topics.json` | Telegram delivery config: chatId + threadId per topic |
 | `brain/bookmarks/x/<slug>.md` | Raw bookmark files |
 | `brain/bookmarks/summaries/<slug>-<key>.md` | LLM-produced summaries |
-| `brain/bookmarks/specs/<slug>-<key>.md` | Spec files written by Quinn |
+| `brain/bookmarks/specs/<slug>-<key>.md` | Spec files written by Quinn; remain here through approval until a task is created |
 | `agents/workflows/bookmarks/bookmarks.lobster.yaml` | Lobster pipeline definition |
 
 ---
@@ -124,7 +127,7 @@ ingested  summarized  needs_research (human-gated)                      declined
 | `handle_approval_reply.py` | Approval | openclaw extension | Parses Tom's reply; routes to approve/decline/revise (lives in `.openclaw/extensions/approval-reply/`) |
 | `rebuild_revised_approval.py` | Approval | resumed lobster | Regenerates approval package after a revision request |
 | `lobster_resolve_topic_approval.py` | Approval | resumed lobster | Applies approved/declined/revision state change |
-| `lobster_create_tasks_from_proposals.py` | Task | resumed lobster | Creates Tasks API tasks; reads title and ACs from spec markdown |
+| `lobster_create_tasks_from_proposals.py` | Task | resumed lobster | Creates Tasks API tasks; reads title and ACs from spec markdown; moves approved-and-tasked specs into `brain/tasks/specs/in-progress/` |
 | `run_bookmark_state_analyzer.py` | Inspect | skill | Compact state summary without loading full JSON (in `agents/skills/bookmarks/state/`) |
 
 ---
@@ -166,6 +169,8 @@ If a spec's topic isn't in the config, falls back to `general`. If `general` is 
 | Spec not dispatched for re-curated item | Item was previously approved+tasked; `list_spec_requests.py` drift guard skips it permanently | By design — tasked bookmarks don't re-enter spec dispatch. If a genuinely new spec angle is needed, create a new bookmark or task manually. |
 | Curation not refreshing | `recurationDays` not elapsed or item in terminal status | Check `focus-config.json`, lower `recurationDays` or manually clear `item.curation` |
 | Lobster exits 137 | OOM during lobster run | Check available memory; lobster may need to be run with a lower batch `limit` arg |
+| Approved spec checkbox stayed unchecked | Approval handler failed before atomic marker write or spec file is malformed | Re-run approval handling after restoring a `- [ ] **Approved by Tom**` marker in the bookmark spec. |
+| Task points at `brain/bookmarks/specs/` after task creation | Previous run created/reused a task but failed before repairing the `**Spec:**` line | Re-run `lobster_create_tasks_from_proposals.py`; destination-present/source-absent is treated as an idempotent repair path. |
 
 ---
 
@@ -198,5 +203,6 @@ never raised, so the JSONL path is unaffected.
 ## Related
 
 - Task: `b179c0e3-c6b0-4c9d-97dc-982d3b841783` — Bookmark pipeline analytics — Postgres transition log
+- Task: `a5a4ed8f-e7c4-4b6c-8ac9-bb962211ac44` — spec folder lifecycle and lobster sync
 - PR: https://github.com/Stoffer-Industries/sindustries/pull/216
 - Tech design: `docs/specs/bookmark-pipeline-analytics-postgres-transition-log-tech-design.md`

--- a/docs/systems/feature-task-workflow.md
+++ b/docs/systems/feature-task-workflow.md
@@ -1,7 +1,7 @@
 # Feature Task Workflow
 
 **Type:** System reference (keep updated as the pipeline evolves)
-**Last updated:** 2026-07-02
+**Last updated:** 2026-07-14
 **Repo:** `Stoffer-Industries/sindustries` · `agents/workflows/feature-task/`
 
 ---
@@ -192,6 +192,18 @@ A `[spec-resynced]` comment is trusted only when both bindings match the current
 - `open` status: brain spec ACs win. Approval may be checked in either brain spec or task description; task-side approval is mirrored into the brain spec before transition. Drift against the stored checksum is treated as a blocker.
 - `ready`, `doing`, `acceptance`, `done`: task description wins. Lobster reflects drift via the marker, then resyncs the brain spec to match after Tom re-checks approval.
 
+### Spec folder lifecycle
+
+Feature specs use a forward-only file lifecycle under `brain/tasks/specs/`:
+
+- `brain/tasks/specs/open/` — new chat-created feature specs awaiting Tom approval. `feature-task-create` and `tasks-create` must create new chat specs here with an unchecked `- [ ] **Approved by Tom**` marker.
+- `brain/tasks/specs/in-progress/` — approved specs attached to active feature work. On each `spec-check` run, the Rust lobster bootstraps `open/`, `in-progress/`, and `done/`, then fails loudly if any other direct subdirectory exists under `brain/tasks/specs/`. When a chat spec in `open/` is checked as approved, the lobster moves it to `in-progress/` and patches the task `**Spec:**` line. The move is idempotent; unchecked specs already in `in-progress/` are never moved back.
+- `brain/tasks/specs/done/` — specs for completed feature tasks. After `post-merge` transitions a task to `done`, the lobster moves its spec from `in-progress/` to `done/` and patches the task `**Spec:**` line. Specs already in `done/` stay there even if a task later reopens.
+
+Bookmark specs stay in `brain/bookmarks/specs/` through approval. The bookmark approval handler only toggles the file checkbox to `- [x] **Approved by Tom**`; it does not move the file. When the bookmark workflow creates or links a task from an approved bookmark spec, it moves that spec to `brain/tasks/specs/in-progress/<same-filename>.md` and creates/repairs the task `**Spec:**` line to point at the destination. From that point onward, the feature-task lifecycle treats bookmark-origin specs the same as chat-origin specs.
+
+The task description `**Spec:**` line is the authoritative pointer for `spec-check`; every move is paired with a best-effort idempotent description patch so the next lobster run reads the new path without fallback scanning.
+
 Lives in:
 - `services/tasks-api/prisma/schema.prisma` — `specChecksum` field on tasks
 - `services/tasks-api/src/routes/tasks/_spec.ts` — canonical AC checksum, marker-only exception (`descriptionsDifferOnlyByApprovalMarker`), `descriptionWithSpecDriftApprovalState`
@@ -240,6 +252,8 @@ The `.openclaw/` directory is outside this repo. Any required `.openclaw` change
 | `[openclaw-needed]` never resolved | Quinn missed the heartbeat step | Quinn scans active feature tasks on the next heartbeat tick |
 | `acceptance -> done` blocked | `[system-spec]` missing or no `[no-system-spec-change]` reason | Author `docs/systems/<system>.md` and post `[system-spec] <path>` |
 | Spec checksum mismatch | ACs edited after spec approval | Hits `PATCH /tasks/:id` when the description ACs change. Treat as spec drift: Lobster unchecks `**Approved by Tom**`, waits for Tom to re-check, then performs the resync path. Comments are drift-tolerant and remain usable for progress/checklist/resync signals. |
+| Spec lifecycle layout failure | Unexpected direct subdirectory under `brain/tasks/specs/` | Remove or migrate the unexpected subdir so only `open/`, `in-progress/`, and `done/` remain. The lobster creates missing expected dirs automatically. |
+| Stale `**Spec:**` line after a move | Prior run moved a spec but failed before patching the task description | Re-run the relevant lobster stage; move helpers treat destination-present/source-absent as idempotent and repair the task `**Spec:**` path. |
 | `PATCH` succeeds despite stale ACs | Other event types (status change, dependency add, tag edit) don't re-check the checksum | Pass the updated `description` through `PATCH /tasks/:id` first so the drift check fires there. |
 | CI green but PR not merged | Reviewer has not approved | Wait for `APPROVED` review state; Lobster will not mark `done` until GitHub merge is recorded |
 | Task bounced to `doing` from `acceptance` | (legacy — the post-merge QA bounce path was removed; AC text mismatches now block at the doing → acceptance gate before merge instead) | n/a |
@@ -258,3 +272,4 @@ The `.openclaw/` directory is outside this repo. Any required `.openclaw` change
 ## Related Tasks / PRs
 
 - Task `ba116063-382a-446c-ab91-c01b60d9a7c3` — Lobster worktree cleanup after merge (PR #208): the source of the post-merge worktree cleanup step in the `done` section above
+- Task `a5a4ed8f-e7c4-4b6c-8ac9-bb962211ac44` — spec folder lifecycle and bookmark/feature lobster sync

--- a/docs/systems/feature-task-workflow.md
+++ b/docs/systems/feature-task-workflow.md
@@ -179,7 +179,7 @@ The lobster (`agents/workflows/feature-task/src/main.rs`) recognises three state
 
 After Lobster has detected drift on a non-`open` task, it unchecks `**Approved by Tom**` and records that it has acted on the current drift episode. When Tom re-checks `**Approved by Tom**`, Lobster owns the resync:
 
-1. Resolve the task's `**Spec:** <path>` and allow only Markdown files under `brain/` (for example `brain/tasks/specs/*.md` or `brain/bookmarks/specs/*.md`).
+1. Resolve the task's `**Spec:** <path>` and allow only Markdown files under `brain/`. Acceptable subtrees today are `brain/bookmarks/specs/*.md` and the chat-spec lifecycle dirs (`brain/tasks/specs/open/`, `brain/tasks/specs/in-progress/`, `brain/tasks/specs/done/`); top-level files directly under `brain/tasks/specs/` are only tolerated when the spec predates the lifecycle rollout and Quinn has explicitly approved a grace period.
 2. Read the current task description ACs and rewrite only the brain spec's `Acceptance Criteria` section. The `**Approved by Tom**` marker is stripped from the AC list before writing — it belongs in the task description only and must not appear as a spec AC.
 3. Reset `specChecksum` to the checksum of the current task ACs. Lobster clears `specChecksum` to `null` first, then sets the new sha256. The Tasks API `SPEC_CHECKSUM_LOCKED` guard allows null (a deliberate clear) but still rejects any non-null value that differs from the stored checksum, keeping the lock intact outside the resync path.
 4. Post `[spec-resynced] <summary>` with `checksum=<sha256>` and `driftFingerprint=<sha256>` fields.


### PR DESCRIPTION
## Summary
- adds forward-only chat spec lifecycle validation/moves in the feature-task lobster
- keeps bookmark specs in bookmark space until approval-and-task creation, then moves them to task in-progress specs
- updates task creation skills and durable system docs for the new lifecycle

## Validation
- `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml spec_lifecycle`
- `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml`
- `python3 -m py_compile agents/workflows/bookmarks/scripts/handle_approval_reply.py agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py agents/workflows/bookmarks/tests/test_spec_lifecycle.py`
- `python3 agents/workflows/bookmarks/tests/test_spec_lifecycle.py`

## Acceptance Criteria
- [x] AC1: `brain/tasks/specs/open/`, `brain/tasks/specs/in-progress/`, and `brain/tasks/specs/done/` exist as the only subdirs under `tasks/specs/`. The feature-task lobster validates the layout on every run (creates missing dirs, fails loudly if the layout is broken). (file: agents/workflows/feature-task/src/main.rs:bootstrap_task_spec_layout)
- [x] AC2: New chat specs land in `tasks/specs/open/<slug>-YYYY-MM-DD.md` with `- [ ] **Approved by Tom**` (unchecked). `feature-task-create` and `tasks-create` skills write to this path. (not code: updated feature-task-create and tasks-create skills)
- [x] AC3: New bookmark specs land in `bookmarks/specs/<slug>-<key>.md` with `- [ ] **Approved by Tom**` (unchecked). `spec-author` (bookmark pipeline) and `lobster_generate_specs.py` write to this path. (file: agents/workflows/bookmarks/scripts/lobster_generate_specs.py:main)
- [x] AC4: Approval moves the file once, in one direction, for chat specs only: Feature-task lobster detects `- [x] **Approved by Tom**` on a spec currently in `open/` and moves it to `in-progress/`. Idempotent. No reverse moves — unticking the checkbox after `in-progress/` does not move the file back to `open/`. (file: agents/workflows/feature-task/src/main.rs:plan_chat_spec_approval_move)
- [x] AC5: Bookmark approval does not move the file: When the bookmark lobster detects an approval (state JSON `approvalStatus: approved` transitions from null/false → approved), it toggles `- [x] **Approved by Tom**` in the file and writes the state JSON entry. File STAYS at `bookmarks/specs/<slug>-<key>.md`. If the file is later moved to `tasks/specs/in-progress/` by AC6, the toggle is preserved. (file: agents/workflows/bookmarks/scripts/handle_approval_reply.py:set_spec_approval_checkbox)
- [x] AC6: Task creation from an approved bookmark spec moves the file: `lobster_create_tasks_from_proposals.py` only creates a task from a bookmark spec whose state JSON `approvalStatus` is `approved`. If unapproved, the lobster skips (no task, no move). On task creation, the file moves from `bookmarks/specs/<slug>-<key>.md` to `tasks/specs/in-progress/<slug>-<key>.md`. The new task​​s `**Spec:**` line points at the new path. Move is idempotent (already in `tasks/specs/in-progress/` → no-op). (file: agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py:create_task_for_spec)
- [x] AC7: When a feature task transitions to `done`, the feature-task lobster moves its spec from `tasks/specs/in-progress/<slug>.md` to `tasks/specs/done/<slug>.md` and updates the task description​​s `**Spec:**` line. Idempotent (already in `done/` → no-op). The move applies uniformly to chat and bookmark specs that have crossed into `in-progress/`. (file: agents/workflows/feature-task/src/main.rs:archive_done_task_spec)
- [x] AC8: The feature-task lobster​​s `spec_check` stage reads the spec file by the task​​s `**Spec:**` line, folder-agnostic. The lookup works whether the spec is in `tasks/specs/open/`, `tasks/specs/in-progress/`, `tasks/specs/done/`, or `bookmarks/specs/`. (file: agents/workflows/feature-task/src/main.rs:spec_check)
