### PR TITLE
chore(heartbeat): re-validate ops state entries before escalating

### DIFF
--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -175,8 +175,15 @@ for inc in needs_tom(all_incidents):
 4. If an entry has `attempts >= 3` and is still unresolved: set `needsTom: true`, `severity` to at least `high`
 5. Always increment `attempts` and update `lastCheckedAt` when re-checking an existing entry
 
-**Escalation — always surface the top unblock:**
+**Escalation — validate before escalating, then surface the top unblock:**
 After completing all sections, check both `quinn-ops-state.json` and `brain/state/lox-incident-state.json`:
+
+**Before escalating any `needsTom` entry, re-validate it is still a real problem:**
+- For bookmark pipeline stalls: re-run the bookmark state analyzer. If `approvalPendingCount == 0` and no genuine stall exists (no `spec_created` items without a `specPath`, no items stuck in the same status for multiple heartbeats), mark the entry `resolved` with `resolvedAt: <now>` and do NOT escalate.
+- For feature task stalls: re-check the lobster output. If the task is no longer in the reported state, mark resolved.
+- For any other stall: if the original condition is no longer detectable in live state, mark `false_positive` rather than escalating.
+- Only escalate if the condition is confirmed present in live state this pass.
+
 1. Collect all entries where `needsTom: true` AND `status` is not `resolved` or `false_positive`. Call this N.
 2. For any entry where `needsTom: true` AND `escalatedAt` is null: set `escalatedAt: <now>`.
 3. **Always end the heartbeat with a count + the top unblock:**

--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -179,11 +179,12 @@ for inc in needs_tom(all_incidents):
 After completing all sections, check both `quinn-ops-state.json` and `brain/state/lox-incident-state.json`:
 1. Collect all entries where `needsTom: true` AND `status` is not `resolved` or `false_positive`. Call this N.
 2. For any entry where `needsTom: true` AND `escalatedAt` is null: set `escalatedAt: <now>`.
-3. **Always end the heartbeat with the single most important thing Tom can unblock right now:**
-   - Sort candidates by severity (critical → high → medium → low), then by `firstSeen` (oldest first).
-   - Pick the top candidate and output one line: `🔴 Top unblock: <what it is and exactly what Tom needs to do>` (or 🟠/🟡 for high/medium).
+3. **Always end the heartbeat with a count + the top unblock:**
    - If N = 0: output nothing and reply HEARTBEAT_OK instead.
-4. This line appears every heartbeat while the item is open — even if previously escalated. Tom seeing it repeatedly is the point.
+   - If N > 0: output two lines:
+     - `N incident(s) waiting on you.`
+     - Sort candidates by severity (critical → high → medium → low), then by `firstSeen` (oldest first). Pick the top candidate and output: `🔴 Top unblock: <what it is and exactly what Tom needs to do>` (or 🟠/🟡 for high/medium).
+4. Both lines appear every heartbeat while items are open — even if previously escalated. Tom seeing it repeatedly is the point.
 
 **State file read/write pattern (unified schema, task 75ec1c8c):**
 ```python


### PR DESCRIPTION
## Summary

- Before surfacing any `needsTom` entry to Tom, Quinn now re-checks that the underlying condition still exists in live state
- Bookmark stalls: re-runs the bookmark state analyzer — if `approvalPendingCount == 0` and no spec_created items without specPath, marks entry resolved
- Feature task stalls: re-checks lobster output before escalating
- Any stall where the original condition is gone: marks `false_positive` instead of escalating

Fixes the pattern where stale ops state entries kept re-escalating after the problem was already fixed (e.g. 5 bookmark spec_created items that were reset to summarized but kept firing in subsequent heartbeats).

Interim fix while the Rust `incident-actioning` worker (task 326d4520) gets the `agent_validate` handler type added.

## Test plan
- [ ] After fixing a bookmark stall, next heartbeat should not re-escalate it
- [ ] Genuine open stalls should still be surfaced

🤖 Generated with Claude Code