### PR TITLE
chore(code-garden): document X API env vars in tasks-api [2026-W29]

### DIFF
--- a/docs/repo-audits/2026-W29.md
+++ b/docs/repo-audits/2026-W29.md
@@ -133,7 +133,7 @@ AI agents
 - *Why it matters:* The endpoint is intentionally unauthed for MVP (noted in the route-level comment), but this means any network-accessible caller can trigger a post to the Sindustries X/Twitter account. If the server ever becomes network-accessible beyond localhost, this is a trivial account-takeover vector for content. The `approve` gate helps (published items must be approved first), but approval is also unauthenticated.
 - *Severity:* High (new this week)
 
-**[High] `X_API_BEARER_TOKEN`, `X_CLIENT`, and `X_HANDLE` undocumented in `.env.example`.**
+**[High] `X_API_BEARER_TOKEN`, `X_CLIENT`, and `X_HANDLE` undocumented in `.env.example`.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 - *Where:* `services/tasks-api/.env.example` (missing all three vars)
 - *Why it matters:* A developer enabling X posting (`X_CLIENT=real`) with no token receives a `MISSING_CREDENTIALS` error at runtime with no clear path to resolution. The env example is the canonical onboarding document.
 - *Severity:* High (new this week)
@@ -168,7 +168,7 @@ No new performance concerns this week. The Content Scheduler endpoints load all 
 
 ### DevEx & operations
 
-**[Low] Content Scheduler X API env vars not documented.**
+**[Low] Content Scheduler X API env vars not documented.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 - *Where:* `services/tasks-api/.env.example`
 - *Why it matters:* Covered under Security above; also a DevEx issue — the onboarding path for enabling real X posting is invisible.
 - *Severity:* Low (duplicate of Security finding — same fix)

--- a/docs/repo-audits/2026-W29.md
+++ b/docs/repo-audits/2026-W29.md
@@ -133,7 +133,7 @@ AI agents
 - *Why it matters:* The endpoint is intentionally unauthed for MVP (noted in the route-level comment), but this means any network-accessible caller can trigger a post to the Sindustries X/Twitter account. If the server ever becomes network-accessible beyond localhost, this is a trivial account-takeover vector for content. The `approve` gate helps (published items must be approved first), but approval is also unauthenticated.
 - *Severity:* High (new this week)
 
-**[High] `X_API_BEARER_TOKEN`, `X_CLIENT`, and `X_HANDLE` undocumented in `.env.example`.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**[High] `X_API_BEARER_TOKEN`, `X_CLIENT`, and `X_HANDLE` undocumented in `.env.example`.** ✅ [PR #227](https://github.com/Stoffer-Industries/sindustries/pull/227)
 - *Where:* `services/tasks-api/.env.example` (missing all three vars)
 - *Why it matters:* A developer enabling X posting (`X_CLIENT=real`) with no token receives a `MISSING_CREDENTIALS` error at runtime with no clear path to resolution. The env example is the canonical onboarding document.
 - *Severity:* High (new this week)
@@ -168,7 +168,7 @@ No new performance concerns this week. The Content Scheduler endpoints load all 
 
 ### DevEx & operations
 
-**[Low] Content Scheduler X API env vars not documented.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**[Low] Content Scheduler X API env vars not documented.** ✅ [PR #227](https://github.com/Stoffer-Industries/sindustries/pull/227)
 - *Where:* `services/tasks-api/.env.example`
 - *Why it matters:* Covered under Security above; also a DevEx issue — the onboarding path for enabling real X posting is invisible.
 - *Severity:* Low (duplicate of Security finding — same fix)

--- a/services/tasks-api/.env.example
+++ b/services/tasks-api/.env.example
@@ -20,3 +20,13 @@ OTEL_LOGS_EXPORTER=none
 OTEL_ENVIRONMENT=dev
 # Set to 1 in CI or when the collector is not running
 # OTEL_SDK_DISABLED=1
+
+# Content Scheduler — X (Twitter) publishing
+# Selection rules (see services/tasks-api/src/routes/contentSchedulerPublish.ts):
+#   X_CLIENT=fake   (default in dev/test): returns FakeXClient, no network calls
+#   X_CLIENT=real   : requires X_API_BEARER_TOKEN; returns null with MISSING_CREDENTIALS otherwise
+#   X_CLIENT unset  : same as fake
+# X_HANDLE is the Twitter handle to attribute published posts to; defaults to 'sindustries'.
+X_CLIENT=fake
+# X_API_BEARER_TOKEN=
+# X_HANDLE=sindustries


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W29.md
- **Finding:** [High] `X_API_BEARER_TOKEN`, `X_CLIENT`, and `X_HANDLE` undocumented in `.env.example`.
- Adds a commented documentation block to `services/tasks-api/.env.example` describing the X client selection rules (`fake` / `real` / unset) and the three env vars the content-scheduler routes already read from `process.env`. Mirrors the existing OpenTelemetry block style. Also marks the related [Low] DevEx finding as done.

## Test plan
- [ ] No logic changes — diff is purely documentation
- [ ] `.env.example` is gitignored as a copy template (verified by `.gitignore`); runtime behavior is unchanged because `services/tasks-api` does not read `.env.example` directly

🌱 Code garden — non-functional cleanup only