### PR TITLE
fix(dev): correct WORKSPACE_ROOT path and dev/prodlike port clash

### DIFF
--- a/apps/mission-control/vite.config.js
+++ b/apps/mission-control/vite.config.js
@@ -21,8 +21,8 @@ function brainStateApi() {
   function resolveBrainRoot() {
     const explicit = process.env.WORKSPACE_ROOT;
     if (explicit) return path.resolve(explicit, 'brain');
-    // apps/mission-control/vite.config.js -> ../../.. = workspace root
-    return path.resolve(fileURLToPath(new URL('.', import.meta.url)), '../../..', 'brain');
+    // apps/mission-control/vite.config.js -> ../../../.. = workspace root (codebases/sindustries/apps/mission-control -> workspace)
+    return path.resolve(fileURLToPath(new URL('.', import.meta.url)), '../../../..', 'brain');
   }
 
   return {

--- a/docs/repo-audits/2026-W29.md
+++ b/docs/repo-audits/2026-W29.md
@@ -133,7 +133,7 @@ AI agents
 - *Why it matters:* The endpoint is intentionally unauthed for MVP (noted in the route-level comment), but this means any network-accessible caller can trigger a post to the Sindustries X/Twitter account. If the server ever becomes network-accessible beyond localhost, this is a trivial account-takeover vector for content. The `approve` gate helps (published items must be approved first), but approval is also unauthenticated.
 - *Severity:* High (new this week)
 
-**[High] `X_API_BEARER_TOKEN`, `X_CLIENT`, and `X_HANDLE` undocumented in `.env.example`.**
+**[High] `X_API_BEARER_TOKEN`, `X_CLIENT`, and `X_HANDLE` undocumented in `.env.example`.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 - *Where:* `services/tasks-api/.env.example` (missing all three vars)
 - *Why it matters:* A developer enabling X posting (`X_CLIENT=real`) with no token receives a `MISSING_CREDENTIALS` error at runtime with no clear path to resolution. The env example is the canonical onboarding document.
 - *Severity:* High (new this week)
@@ -168,7 +168,7 @@ No new performance concerns this week. The Content Scheduler endpoints load all 
 
 ### DevEx & operations
 
-**[Low] Content Scheduler X API env vars not documented.**
+**[Low] Content Scheduler X API env vars not documented.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 - *Where:* `services/tasks-api/.env.example`
 - *Why it matters:* Covered under Security above; also a DevEx issue — the onboarding path for enabling real X posting is invisible.
 - *Severity:* Low (duplicate of Security finding — same fix)

--- a/docs/repo-audits/2026-W29.md
+++ b/docs/repo-audits/2026-W29.md
@@ -133,7 +133,7 @@ AI agents
 - *Why it matters:* The endpoint is intentionally unauthed for MVP (noted in the route-level comment), but this means any network-accessible caller can trigger a post to the Sindustries X/Twitter account. If the server ever becomes network-accessible beyond localhost, this is a trivial account-takeover vector for content. The `approve` gate helps (published items must be approved first), but approval is also unauthenticated.
 - *Severity:* High (new this week)
 
-**[High] `X_API_BEARER_TOKEN`, `X_CLIENT`, and `X_HANDLE` undocumented in `.env.example`.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**[High] `X_API_BEARER_TOKEN`, `X_CLIENT`, and `X_HANDLE` undocumented in `.env.example`.** ✅ [PR #227](https://github.com/Stoffer-Industries/sindustries/pull/227)
 - *Where:* `services/tasks-api/.env.example` (missing all three vars)
 - *Why it matters:* A developer enabling X posting (`X_CLIENT=real`) with no token receives a `MISSING_CREDENTIALS` error at runtime with no clear path to resolution. The env example is the canonical onboarding document.
 - *Severity:* High (new this week)
@@ -168,7 +168,7 @@ No new performance concerns this week. The Content Scheduler endpoints load all 
 
 ### DevEx & operations
 
-**[Low] Content Scheduler X API env vars not documented.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**[Low] Content Scheduler X API env vars not documented.** ✅ [PR #227](https://github.com/Stoffer-Industries/sindustries/pull/227)
 - *Where:* `services/tasks-api/.env.example`
 - *Why it matters:* Covered under Security above; also a DevEx issue — the onboarding path for enabling real X posting is invisible.
 - *Severity:* Low (duplicate of Security finding — same fix)

--- a/infra/tilt/Tiltfile
+++ b/infra/tilt/Tiltfile
@@ -5,7 +5,7 @@ mode = os.getenv('MODE', 'dev')
 tasks_api_port = os.getenv('TASKS_API_PORT', '4000')
 budget_api_port = os.getenv('BUDGET_API_PORT', '4002')
 tasks_app_port = os.getenv('TASKS_APP_PORT', '5173')
-mission_control_port = os.getenv('MISSION_CONTROL_PORT', '5174')  # dev default; prodlike uses 5175 via mode-env.sh
+mission_control_port = os.getenv('MISSION_CONTROL_PORT', '5176')  # dev default; prodlike uses 5175 via mode-env.sh
 tasks_api_base_url = os.getenv('TASKS_API_BASE_URL', 'http://localhost:4000/api/v1')
 tasks_api_env_file = os.getenv('TASKS_API_ENV_FILE', 'services/tasks-api/.env.dev')
 compose_project = os.getenv('COMPOSE_PROJECT_NAME', 'sindustries-' + mode)
@@ -95,7 +95,7 @@ tasks_app_base_url = 'http://localhost:{}'.format(tasks_app_port)
 local_resource(
   'mission-control',
   serve_cmd='cd ../../apps/mission-control && WORKSPACE_ROOT={} VITE_TASKS_API_BASE_URL={} VITE_TASKS_APP_URL={} npm run dev -- --host 0.0.0.0 --port {}'.format(
-    '../../..',
+    '../../../..',
     tasks_api_base_url,
     tasks_app_base_url,
     mission_control_port,

--- a/scripts/dev/mode-env.sh
+++ b/scripts/dev/mode-env.sh
@@ -12,7 +12,7 @@ case "$MODE" in
     export TASKS_API_PORT="4000"
     export BUDGET_API_PORT="4002"
     export TASKS_APP_PORT="5173"
-    export MISSION_CONTROL_PORT="5174"
+    export MISSION_CONTROL_PORT="5176"
     export TILT_PORT="10350"
     export POSTGRES_DB="sindustries_dev"
     export POSTGRES_CONTAINER_NAME="sindustries-postgres-dev"

--- a/services/tasks-api/.env.example
+++ b/services/tasks-api/.env.example
@@ -20,3 +20,13 @@ OTEL_LOGS_EXPORTER=none
 OTEL_ENVIRONMENT=dev
 # Set to 1 in CI or when the collector is not running
 # OTEL_SDK_DISABLED=1
+
+# Content Scheduler — X (Twitter) publishing
+# Selection rules (see services/tasks-api/src/routes/contentSchedulerPublish.ts):
+#   X_CLIENT=fake   (default in dev/test): returns FakeXClient, no network calls
+#   X_CLIENT=real   : requires X_API_BEARER_TOKEN; returns null with MISSING_CREDENTIALS otherwise
+#   X_CLIENT unset  : same as fake
+# X_HANDLE is the Twitter handle to attribute published posts to; defaults to 'sindustries'.
+X_CLIENT=fake
+# X_API_BEARER_TOKEN=
+# X_HANDLE=sindustries


### PR DESCRIPTION
## Summary
- Fixed WORKSPACE_ROOT in Tiltfile and vite.config.js fallback: was 3 levels up from apps/mission-control (landing on codebases/), should be 4 levels (landing on workspace/). The Vite plugin uses this to locate brain/state/ — wrong path silently served empty state every time.
- Fixed port clash: dev mission-control was on 5174, same as prodlike tasks-app. Both stacks are designed to run simultaneously on the same machine. Moved dev mission-control to 5176 (mode-env.sh + Tiltfile default).

## Test plan
- [ ] Both dev (localhost:5176) and prodlike (localhost:5175) mission-control Bookmarks tabs show pipeline data after stack restart
- [ ] No port conflicts when both dev and prodlike stacks run simultaneously

🤖 Generated with Claude Code