### PR TITLE
docs: add service boundary guardrails

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ For non-trivial code tasks:
 - record the spec doc path in the task
 - task notes are not a substitute for a spec doc
 
-See [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) for the full doc taxonomy: tech designs, system docs, app specs, and their lifecycle.
+See [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) for the full doc taxonomy: tech designs, system docs, app specs, and their lifecycle. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for repo-level architecture principles, service boundaries, and ownership rules.
 
 ## Environment rules
 
@@ -52,6 +52,8 @@ Use prodlike for final verification, smoke checks, and automation that should ta
 ## Non-trivial work
 
 A change is non-trivial if it changes architecture, introduces/refactors modules, crosses service/app boundaries, materially changes behavior, or is more than a tiny isolated edit.
+
+Before changing backend ownership, adding persistence, or wiring a new service/API boundary, check [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). Architecture principles belong there; task notes, PR comments, and agent workflow docs may reference them but are not the canonical source.
 
 For non-trivial work:
 
@@ -137,4 +139,4 @@ Avoid vague messages like `wip`, `misc`, `fix`, or `stuff`.
 - `services/` for backend APIs, workers, and processes
 - `packages/` for shared libraries, types, and config
 - `infra/` for deployment/runtime/infrastructure config
-- `docs/` for architecture, specs, and decision records
+- `docs/` for architecture principles, system docs, specs, and decision records

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -69,16 +69,9 @@ Rowan must pass the clarification gate from `TASK_TEMPLATE.md` before implementa
 
 ## Service Boundary Guardrail
 
-Sindustries is a micro-service architecture. Mission Control is a multi-service client, not a reason to centralize unrelated backend state behind `services/tasks-api`.
+Canonical architecture principles live in `docs/ARCHITECTURE.md`. Rowan must read and apply that file before adding any API route, database table/model, queue, cron, worker, external integration, or cross-service dependency.
 
-Before adding any API route, database table/model, queue, cron, or external integration, Rowan must answer in the design/PR:
-- Which service owns this domain and why?
-- Is the data about tasks, task comments, tags, task dependencies, task lifecycle, or task workflow metadata?
-- If not, why is it being added to an existing service instead of a dedicated service?
-- Which apps/services consume this API directly?
-- What migration or extraction path exists if this is intentionally temporary?
-
-Default rule: `services/tasks-api` only owns task/workflow state. Content scheduling/publishing, bookmarks, finance, analytics, agent incidents, and other product domains need their own service boundary unless Tom explicitly approves an exception.
+At minimum, designs/PRs must identify service ownership, data ownership, direct consumers, why existing services are or are not appropriate, and the extraction/migration plan for any temporary placement. `services/tasks-api` remains task/workflow-only unless Tom explicitly approves an exception.
 
 ---
 

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -61,10 +61,24 @@ Before coding, Rowan must:
   - assumptions
   - in-scope / out-of-scope
   - architecture approach
+  - service boundary and data ownership
   - milestones
   - risks/questions
 
 Rowan must pass the clarification gate from `TASK_TEMPLATE.md` before implementation.
+
+## Service Boundary Guardrail
+
+Sindustries is a micro-service architecture. Mission Control is a multi-service client, not a reason to centralize unrelated backend state behind `services/tasks-api`.
+
+Before adding any API route, database table/model, queue, cron, or external integration, Rowan must answer in the design/PR:
+- Which service owns this domain and why?
+- Is the data about tasks, task comments, tags, task dependencies, task lifecycle, or task workflow metadata?
+- If not, why is it being added to an existing service instead of a dedicated service?
+- Which apps/services consume this API directly?
+- What migration or extraction path exists if this is intentionally temporary?
+
+Default rule: `services/tasks-api` only owns task/workflow state. Content scheduling/publishing, bookmarks, finance, analytics, agent incidents, and other product domains need their own service boundary unless Tom explicitly approves an exception.
 
 ---
 

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -71,7 +71,7 @@ Rowan must pass the clarification gate from `TASK_TEMPLATE.md` before implementa
 
 Canonical architecture principles live in `docs/ARCHITECTURE.md`. Rowan must read and apply that file before adding any API route, database table/model, queue, cron, worker, external integration, or cross-service dependency.
 
-At minimum, designs/PRs must identify service ownership, data ownership, direct consumers, why existing services are or are not appropriate, and the extraction/migration plan for any temporary placement. `services/tasks-api` remains task/workflow-only unless Tom explicitly approves an exception.
+At minimum, designs/PRs must identify service ownership, data ownership, direct consumers, why existing services are or are not appropriate, and the extraction/migration plan for any temporary placement.
 
 ---
 

--- a/agents/skills/ops/tasks-create/SKILL.md
+++ b/agents/skills/ops/tasks-create/SKILL.md
@@ -110,7 +110,8 @@ tasks_api_client.py create \
 ```
 
 **Rules:**
-- No spec file required, but ACs are still required and observable
+- No spec file required by default, but ACs are still required and observable
+- Attach a `docs/specs/<slug>-tech-design.md` when a code task changes service boundaries, moves data ownership, splits/merges services, adds migrations, or touches cross-service API contracts
 - Use a 🐛 emoji in the title for bug fixes (`🔧 🐛 <short description>`) so they stand out in lists
 - Pure chores (typos, renames, dep bumps) are fine with a single AC; bugs and refactors need ACs that describe the fix
 

--- a/agents/skills/ops/tasks-create/SKILL.md
+++ b/agents/skills/ops/tasks-create/SKILL.md
@@ -94,7 +94,7 @@ Code covers both bug fixes and chores — anything that touches existing code wi
 
 ```
 tasks_api_client.py create \
-  --title "🔧 <short description>" \
+  --title "<short description>" \
   --type code \
   --priority <low|medium|high> \
   --assignee Rowan \
@@ -112,7 +112,7 @@ tasks_api_client.py create \
 **Rules:**
 - No spec file required by default, but ACs are still required and observable
 - Attach a `docs/specs/<slug>-tech-design.md` when a code task changes service boundaries, moves data ownership, splits/merges services, adds migrations, or touches cross-service API contracts
-- Use a 🐛 emoji in the title for bug fixes (`🔧 🐛 <short description>`) so they stand out in lists
+- Do not add prefix emoji manually; the Tasks UI renders type icons in the browser
 - Pure chores (typos, renames, dep bumps) are fine with a single AC; bugs and refactors need ACs that describe the fix
 
 ### Content task

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,14 @@ Use an existing service only when the new state or behavior is part of that serv
 - task lifecycle metadata
 - workflow metadata/comments consumed by agents and lobsters
 
-It must not become the default backend for Mission Control or other apps. Product domains such as content scheduling/publishing, bookmarks, finance, analytics, agent incidents, or website content operations need their own service boundary unless Tom explicitly approves an exception.
+It must not become the default backend for Mission Control or other apps. Product domains such as content scheduling/publishing, bookmarks, budget/finance, analytics, agent incidents, or website content operations need their own service boundary unless Tom explicitly approves an exception.
+
+### Existing domain service examples
+
+- `services/tasks-api` owns task/workflow state.
+- `services/budget-api` owns budget/finance data and Akahu integration boundaries.
+
+New work should extend the matching domain service when one exists, or create a new domain service when it does not. Do not route unrelated domains through `tasks-api` for convenience.
 
 ### Required service-boundary questions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,6 +60,51 @@ If a service split or data move is needed:
 - verify row counts and representative records before removing old ownership;
 - avoid coupling rollback to destructive drops.
 
+## Technology choices
+
+Default to the repo's existing stack unless there is a clear reason not to. New languages/runtimes add operational and review cost, so the tech design must justify them.
+
+### TypeScript / JavaScript
+
+Use TypeScript/JavaScript for:
+
+- user-facing apps in `apps/`;
+- backend product APIs in `services/` unless a different runtime is explicitly justified;
+- shared packages, UI, domain types, and config in `packages/`;
+- code that benefits from sharing types and validation with frontend clients.
+
+This is the default product-surface choice because most of the repo, test tooling, and app/service conventions already live here.
+
+### Python
+
+Use Python for:
+
+- agent workflow glue and operational automation;
+- scripts that primarily orchestrate files, subprocesses, HTTP calls, or LLM/tooling workflows;
+- quick data migration/backfill helpers where the logic is small, auditable, and one-shot;
+- research/prototype code that is not on a product request path.
+
+Do not let Python scripts become hidden product services. If Python starts owning durable APIs, long-running workers, or core domain state, promote the boundary into an explicit service design first.
+
+### Rust
+
+Use Rust for:
+
+- durable workflow engines, validators, and state-machine-heavy automation where correctness and explicit types matter;
+- CLIs or workers where a single static binary, predictable performance, or stronger compile-time guarantees are valuable;
+- code that benefits from making invalid states hard to represent.
+
+Do not choose Rust just because code is important. Prefer it when the problem is correctness-sensitive, concurrent, performance-sensitive, or a stable tool/engine that will be maintained for a while. Small glue scripts should usually stay Python; product APIs should usually stay TypeScript unless there is a documented reason.
+
+### Language decision rule
+
+A tech design that introduces a new runtime for a domain must state:
+
+1. why the existing TypeScript/Python/Rust precedent is insufficient;
+2. who will maintain and review it;
+3. how it is built, tested, deployed, and observed;
+4. what API/data boundary keeps it from leaking into unrelated domains.
+
 ## Documentation expectations
 
 - Architecture principles and best practices: `docs/ARCHITECTURE.md`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,70 @@
+# Architecture Principles
+
+This document is the repo-level home for Sindustries architecture principles and best practices. It applies to humans and agents. System docs in `docs/systems/` describe shipped systems; tech designs in `docs/specs/` describe proposed changes. When a tech design makes an architecture decision, check it against this file first.
+
+## Service boundaries
+
+Sindustries is a micro-service-oriented monorepo:
+
+- `apps/` are clients and user-facing surfaces.
+- `services/` own backend domains, APIs, workers, integrations, and persistence.
+- `packages/` hold shared libraries, UI, types, config, and utilities.
+- `infra/` wires runtime/deployment concerns.
+
+A service owns a domain, not a frontend tab. Mission Control is a multi-service client: adding a Mission Control screen does not imply adding routes or tables to an existing service.
+
+### Domain ownership rule
+
+Before adding an API route, database model/table, migration, queue, cron, worker, or external integration, identify the owning domain and service.
+
+Use an existing service only when the new state or behavior is part of that service's domain. Otherwise, create or extend the appropriate domain service.
+
+### `tasks-api` boundary
+
+`services/tasks-api` owns task/workflow state only:
+
+- tasks
+- task comments
+- tags
+- task dependencies
+- task lifecycle metadata
+- workflow metadata/comments consumed by agents and lobsters
+
+It must not become the default backend for Mission Control or other apps. Product domains such as content scheduling/publishing, bookmarks, finance, analytics, agent incidents, or website content operations need their own service boundary unless Tom explicitly approves an exception.
+
+### Required service-boundary questions
+
+Every non-trivial tech design or PR that changes backend ownership must answer:
+
+1. Which service owns this domain and why?
+2. What data does the service own?
+3. Which apps/services consume this API directly?
+4. Why is this not being added to an existing service?
+5. If the placement is temporary, what is the extraction/migration plan?
+6. What runtime config, ports, credentials, or `.openclaw` changes are required?
+
+## App-to-service communication
+
+Apps may call multiple services directly when they render multiple domains. Prefer explicit app-to-domain-service clients over a catch-all app backend or accidental aggregation through `tasks-api`.
+
+Add an aggregation/orchestration service only when the aggregation itself is a domain with durable behavior, not just because a frontend needs data from more than one place.
+
+## Persistence and migrations
+
+A service that owns a domain owns that domain's schema and migrations. Do not add tables to another service's Prisma schema for convenience.
+
+If a service split or data move is needed:
+
+- preserve existing data until the destination is verified;
+- document the backfill/cutover/rollback path;
+- verify row counts and representative records before removing old ownership;
+- avoid coupling rollback to destructive drops.
+
+## Documentation expectations
+
+- Architecture principles and best practices: `docs/ARCHITECTURE.md`.
+- Durable shipped-system behavior: `docs/systems/<system>.md`.
+- Proposed implementation decisions: `docs/specs/<slug>-tech-design.md`.
+- User-facing app behavior: `apps/<app>/SPEC.md`.
+
+When architecture principles change, update this file. When a system changes, update the relevant `docs/systems/` file. Agent-local workflow docs may reference these rules, but should not be the only source of truth.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -26,6 +26,7 @@ Tech designs are historical record. Do not delete them. When a feature ships, up
 **What to include:**
 - Product intent summary (quote key goals from the brain spec — Rowan may not have direct access to brain)
 - Task ID, branch, worktree, and repo names
+- Service boundary and data ownership: which service owns the domain, why existing services are/are not appropriate, direct app/service consumers, and extraction/migration plan for temporary placements
 - `.openclaw` boundary notes for work outside this repo
 - Implementation plan with file/module scope
 - Data model or API contract changes

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -2,6 +2,8 @@
 
 This file is the single source of truth for how spec and system documentation is structured, maintained, and linked across the Sindustries repo. All agents must read this before writing or updating any spec or system doc.
 
+For architecture principles and service-boundary best practices, read [`docs/ARCHITECTURE.md`](ARCHITECTURE.md). This file defines documentation taxonomy; `docs/ARCHITECTURE.md` defines architectural direction.
+
 ---
 
 ## Document taxonomy

--- a/docs/specs/content-scheduler-service-extraction-tech-design.md
+++ b/docs/specs/content-scheduler-service-extraction-tech-design.md
@@ -1,0 +1,108 @@
+---
+status: draft
+task_id: 94d5e4fc-1b31-4d04-a13b-4f69a7ec297a
+product_spec: n/a
+shipped_pr: null
+shipped_date: null
+---
+
+# Content Scheduler service extraction — tech design
+
+## Context
+
+PR #213 shipped the Content Scheduler tab with backend routes, Prisma model, migration, and X publishing integration under `services/tasks-api`. That placement was expedient but weakens the intended Sindustries micro-service architecture: Mission Control should be a multi-service client, and `tasks-api` should not become the default backend for unrelated product domains.
+
+This design defines the follow-up code task to move Content Scheduler backend ownership out of `tasks-api` into a dedicated service boundary.
+
+## Service boundary and data ownership
+
+- **New owner:** `services/content-scheduler-api` owns content scheduling queue state, approval metadata, publishing guard rules, X publishing integration, and scheduler-specific migrations.
+- **Existing owner retained:** `services/tasks-api` continues to own tasks, task comments, tags, task dependencies, task lifecycle state, and workflow metadata only.
+- **Consumer:** `apps/mission-control` calls Content Scheduler API directly for `/content-scheduler` tab behavior, while continuing to call Tasks API directly for task/workflow screens.
+- **No aggregate Mission Control backend:** Mission Control should not get a monolithic backend service just because multiple tabs exist. Each domain service exposes its own API.
+- **Temporary state:** Content Scheduler tables/routes currently live in `tasks-api` because PR #213 has already merged. This task removes that temporary coupling.
+
+## Scope
+
+In scope:
+- Create `services/content-scheduler-api` using the repo's existing Express/TypeScript/Prisma conventions.
+- Move Content Scheduler routes, publish guard/client logic, tests, Prisma schema model/enums, and migration ownership out of `services/tasks-api`.
+- Update Mission Control's content scheduler API client/config to target the new service directly.
+- Remove Content Scheduler route mounting and scheduler-specific tests/docs from `services/tasks-api`.
+- Preserve existing data where possible via migration/backfill plan for prodlike/dev databases.
+- Update docs/system references so the Tasks API boundary is explicit and Content Scheduler has its own system reference.
+
+Out of scope:
+- Changing Content Scheduler product behavior or UI flows.
+- Adding cron-driven auto-publishing.
+- Adding multi-account X support, media attachments, or thread composition.
+- Reworking the task workflow itself.
+
+## Proposed implementation
+
+### 1. Service scaffold
+
+- Add `services/content-scheduler-api/package.json`, `tsconfig.json`, source entrypoint, tests, and Prisma config matching existing service conventions.
+- Expose health endpoint and Content Scheduler routes under `/api/v1/content-scheduler`.
+- Assign a separate local/prodlike port in infra/dev config rather than reusing `tasks-api` ports.
+
+### 2. API and publish logic move
+
+Move from `services/tasks-api`:
+- `src/routes/contentScheduler.ts`
+- `src/routes/contentSchedulerPublish.ts`
+- related route tests
+
+Keep the public route contract stable so Mission Control only changes base URL, not behavior.
+
+### 3. Database ownership
+
+- Move `ContentSchedulerItem` and scheduler enums to the new service Prisma schema.
+- Create migrations owned by `services/content-scheduler-api`.
+- Decide the production-safe migration path before implementation:
+  - if the same Postgres database is shared by services, transfer migration ownership carefully without dropping data;
+  - if a new database/schema is introduced, backfill existing rows and verify counts before removing old tables.
+- Do not drop existing scheduler data until the new service is verified.
+
+### 4. Mission Control integration
+
+- Update `apps/mission-control/src/contentSchedulerApi.js` to use a dedicated Content Scheduler base URL/env var.
+- Keep Tasks API client usage separate for task-related screens.
+- Document Mission Control as a multi-service client in `apps/mission-control/README.md` or `SPEC.md`.
+
+### 5. Tasks API cleanup
+
+- Remove Content Scheduler route registration from `services/tasks-api/src/app.ts`.
+- Remove scheduler-specific env docs from `services/tasks-api/README.md`.
+- Ensure `tasks-api` tests prove no scheduler routes are mounted there.
+
+### 6. Documentation
+
+- Create `docs/systems/content-scheduler.md` with architecture, API contract, runtime behavior, X credential boundary, runbook notes, and related PRs/tasks.
+- Update `docs/systems/task-tracking.md` / `docs/systems/tasks-api.md` to state that Tasks API does not own Content Scheduler.
+- Mark this tech design shipped when the extraction PR merges.
+
+## Acceptance criteria for the code task
+
+- AC1: Content Scheduler backend routes run from a dedicated `services/content-scheduler-api` service, not `services/tasks-api`.
+- AC2: Mission Control calls the new Content Scheduler service directly while continuing to call Tasks API only for task/workflow data.
+- AC3: Existing scheduler behavior is preserved: create, edit, reorder, approve/unapprove, publish guard, soft remove, today status, and published metadata.
+- AC4: Migration/backfill path preserves existing Content Scheduler rows; no scheduler data is dropped without verification.
+- AC5: Tasks API has no Content Scheduler route mount, model ownership, tests, or service docs beyond boundary references.
+- AC6: System docs describe Content Scheduler as its own service and Tasks API as task/workflow-only.
+
+## Test plan
+
+- `npm --workspace @sindustries/content-scheduler-api test`
+- `npm --workspace @sindustries/tasks-api test`
+- `npm --workspace @sindustries/mission-control test`
+- Prisma validate/migrate dry-run for both affected services.
+- Manual smoke: run local stack, open Mission Control `/content-scheduler`, add/approve/publish with fake X client, verify daily cap and published URL behavior.
+- Data migration verification: compare source/destination scheduler row counts and sample IDs before cutover.
+
+## Risks and open questions
+
+- **Migration ownership:** need to inspect current deployment DB layout before deciding whether the new service shares the existing Postgres database or gets a separate database/schema.
+- **Local dev infra:** adding a service means assigning ports and updating Tilt/make/dev env. Keep changes minimal and documented.
+- **Cutover safety:** avoid deleting old tables/routes in the same step that first introduces the new service unless rollback is clear.
+- **X credentials:** credentials remain outside the repo. The new service should use env vars and return clear 503 errors when missing, matching current behavior.

--- a/docs/systems/task-tracking.md
+++ b/docs/systems/task-tracking.md
@@ -33,7 +33,13 @@ PostgreSQL
   sindustries_prodlike (port 7432)
 ```
 
-The API is the single source of truth. The frontend is a thin client — no local task state beyond a session's in-memory view.
+The API is the single source of truth for task tracking. The frontend is a thin client — no local task state beyond a session's in-memory view.
+
+### Service boundary
+
+`services/tasks-api` owns task/workflow state only: tasks, comments, tags, dependencies, task lifecycle metadata, and workflow comments consumed by agents/lobsters.
+
+It must not become the default backend for Mission Control or other apps. New product domains such as content scheduling/publishing, bookmarks, finance, analytics, or agent incident reporting should expose their own service APIs and be called directly by the consuming apps/services. Exceptions need an explicit service-boundary note in the tech design/PR explaining why the placement is temporary or domain-correct, plus an extraction path if temporary.
 
 ---
 

--- a/docs/systems/task-tracking.md
+++ b/docs/systems/task-tracking.md
@@ -39,7 +39,7 @@ The API is the single source of truth for task tracking. The frontend is a thin 
 
 `services/tasks-api` owns task/workflow state only: tasks, comments, tags, dependencies, task lifecycle metadata, and workflow comments consumed by agents/lobsters.
 
-It must not become the default backend for Mission Control or other apps. New product domains such as content scheduling/publishing, bookmarks, finance, analytics, or agent incident reporting should expose their own service APIs and be called directly by the consuming apps/services. Exceptions need an explicit service-boundary note in the tech design/PR explaining why the placement is temporary or domain-correct, plus an extraction path if temporary.
+It must not become the default backend for Mission Control or other apps. New product domains such as content scheduling/publishing, bookmarks, budget/finance, analytics, or agent incident reporting should expose their own service APIs and be called directly by the consuming apps/services. Budget/finance already has a separate service boundary in `services/budget-api`; related work should extend that service or justify a new finance-domain service, not land in `tasks-api`. Exceptions need an explicit service-boundary note in the tech design/PR explaining why the placement is temporary or domain-correct, plus an extraction path if temporary.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `docs/ARCHITECTURE.md` as the repo-level home for architecture principles, service boundaries, and ownership rules.
- Updates Rowan workflow, contributing guidance, and doc conventions to reference the canonical architecture doc rather than keeping service-boundary rules agent-local.
- Clarifies `tasks-api` as task/workflow-only and adds the Content Scheduler extraction tech design for code task `94d5e4fc-1b31-4d04-a13b-4f69a7ec297a`.

## Test plan
- [x] `git diff --check`
- [x] Direct inspection of changed markdown docs

## Related task
- Code task: `94d5e4fc-1b31-4d04-a13b-4f69a7ec297a` — Extract Content Scheduler from Tasks API

🤖 Generated with Claude Code
