### PR TITLE
fix(tasks-api): add x-actor to CORS Allow-Headers

### DIFF
--- a/services/tasks-api/src/app.ts
+++ b/services/tasks-api/src/app.ts
@@ -35,7 +35,7 @@ export function createApp() {
     }
 
     res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-actor');
 
     if (req.method === 'OPTIONS') {
       return res.sendStatus(204);


### PR DESCRIPTION
## Summary
- `x-actor` was missing from `Access-Control-Allow-Headers` in `app.ts`. All content scheduler write operations (publish, approve, remove, update) include this header, triggering a CORS preflight that the browser blocks silently — surfacing as "Failed to fetch".
- Read operations (list items, today-status) don't include `x-actor` so they worked fine. Only writes were broken.

## Test plan
- [ ] On prodlike, open content scheduler tab — items list should load as before
- [ ] Approve an item and click Publish — should succeed (fake client returns deterministic URL)
- [ ] Check browser network tab: OPTIONS preflight for `/publish` should return 204 with `x-actor` in allowed headers

🤖 Generated with Claude Code