### PR TITLE
docs: require AC verification planning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,8 @@ For non-trivial work:
    - Ask questions if needed, or explicitly note why no clarification is needed.
    - Record assumptions.
 2. Write or update a tech design in `docs/specs/` before implementation (see [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md)).
+   - The tech design must map each acceptance criterion to planned verification before coding starts.
+   - User-visible/app-flow ACs should plan E2E coverage where possible; if not possible, record why and name the fallback test layer.
 3. Implement in small, mergeable slices.
 4. Validate with the right tests/checks and note any manual verification.
 5. Capture rollback, mitigation, or follow-up notes if risk remains.

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -101,6 +101,8 @@ Rowan breaks large work into milestones that are:
 Before writing any code on a feature task, write the tech design:
 - Location: `docs/specs/<task-slug>-tech-design.md` in the primary implementation repo
 - Must cover: product spec link, task link, repos involved, branch names, worktree paths, `.openclaw` changes needed, implementation plan, test plan, open questions
+- Must map each acceptance criterion to planned verification before implementation starts
+- For every user-visible/app-flow AC, plan an E2E test where possible; if not possible or disproportionate, record the reason and the lower-level fallback test
 - Post `[tech-design] <GitHub URL>` as a task comment when done
 - Wait for Quinn to set `tech_design_approved: true` before starting implementation
 

--- a/agents/skills/dev/tech-design/SKILL.md
+++ b/agents/skills/dev/tech-design/SKILL.md
@@ -19,7 +19,9 @@ Include:
 - Implementation plan with file/module scope
 - Data model or API contract changes
 - Workflow, cron, and skill changes
-- Test plan
+- Test plan with an AC-by-AC verification matrix
+  - User-visible/app-flow ACs should plan E2E coverage where possible
+  - If E2E is not possible or is disproportionate, record why and name the fallback test layer (`file`, unit, component, integration, or manual)
 - Open questions and risks
 
 After writing the design, post the durable task comment:

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -32,7 +32,9 @@ Tech designs are historical record. Do not delete them. When a feature ships, up
 - `.openclaw` boundary notes for work outside this repo
 - Implementation plan with file/module scope
 - Data model or API contract changes
-- Test plan
+- Test plan with an acceptance-criterion verification matrix
+  - Prefer E2E coverage for user-visible/app-flow ACs
+  - If E2E is not possible or is disproportionate, record the reason and fallback layer before implementation starts
 - Open questions and risks
 
 ### 2. System docs — `docs/systems/<system>.md`


### PR DESCRIPTION
## Summary
- Requires tech designs to map each acceptance criterion to planned verification before implementation starts.
- Makes E2E the preferred planned coverage for user-visible/app-flow ACs, with an explicit reason + fallback layer required when E2E is not possible or proportionate.
- Adds the rule to contributing guidance, doc conventions, the tech-design skill, and Rowan workflow so it is enforced during planning rather than only in PR evidence.

## Test plan
- [x] `git diff --check`
- [x] Direct inspection of changed markdown docs

🤖 Generated with Claude Code
