### PR TITLE
docs: define audit follow-up code task workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,10 @@
 This repo uses a **spec-first** workflow for any non-trivial change, plus a strict **dev vs prodlike** split for local work.
 
 For non-trivial code tasks:
-- create or update a tech design in `docs/specs/` before implementation starts
-- record the spec doc path in the task
-- task notes are not a substitute for a spec doc
+- no product spec is required
+- create or update a tech design in `docs/specs/` before implementation starts when the task changes security posture, service boundaries, data ownership, migrations, cross-service APIs, or significant internal architecture
+- record the tech design path in the task
+- task notes are not a substitute for a needed tech design
 
 See [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) for the full doc taxonomy: tech designs, system docs, app specs, and their lifecycle. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for repo-level architecture principles, service boundaries, and ownership rules.
 
@@ -66,6 +67,19 @@ For non-trivial work:
 3. Implement in small, mergeable slices.
 4. Validate with the right tests/checks and note any manual verification.
 5. Capture rollback, mitigation, or follow-up notes if risk remains.
+
+## Audit findings and follow-up tasks
+
+Weekly repo audits are the ledger for technical findings.
+
+- Code-garden-safe findings stay in the code-garden lane and are marked done by the code-garden PR link.
+- Important findings that are not code-garden-safe should become tracked tasks during the audit when the follow-up is clear.
+- Use `code` tasks for non-functional/security/refactor/migration/service-boundary work with no new product capability.
+- Use `feature` tasks for new product/user capability or behavior requiring product scope.
+- Use `research` tasks when the right implementation path is not known yet.
+- The audit finding line should link the task while work is pending, then the implementation PR when fixed.
+
+This keeps traceability as: `audit finding → task → tech design when needed → PR → audit marked done`.
 
 ## Validation expectations
 

--- a/agents/skills/dev/repo-audit/SKILL.md
+++ b/agents/skills/dev/repo-audit/SKILL.md
@@ -76,7 +76,38 @@ Constraints:
 - Do not modify any source files while auditing. Analysis only.
 - Do not pad the report. If a dimension is healthy, say so in one sentence.
 - Calibrate to the project's maturity.
-- Do not create Tasks API tasks, code-garden tags, `Resolved:` lines, or `Closes:` lines.
+- Do not add `Resolved:` lines or `Closes:` lines.
+- Do not create code-garden tags from the audit PR.
+- You may create/link Tasks API tasks for important findings that are not code-garden-safe, following the audit follow-up workflow below.
+
+## Audit follow-up task workflow
+
+Code garden remains a narrow, behavior-preserving cleanup lane. Do not loosen it to pick up security, product, behavior, data migration, or architecture work.
+
+During the weekly audit, classify actionable findings:
+
+| Classification | Meaning | Follow-up |
+|---|---|---|
+| `garden-safe` | Functionally equivalent cleanup that fits code-garden guardrails | Leave for normal code-garden PR selection |
+| `tracked-code-task` | Non-functional or corrective code work that is too risky for code-garden, including security hardening, architecture refactors, service-boundary fixes, migrations, or behavior-sensitive bug fixes | Create a `code` task and link it from the audit finding |
+| `tracked-feature-task` | New user/product capability or product behavior that needs product scope | Create a `feature` task/spec and link it from the audit finding |
+| `tracked-research-task` | Needs investigation before implementation is clear | Create a `research` task and link it from the audit finding |
+| `needs-human-decision` | Needs Tom/Quinn judgement before tasking | List in Open Questions; do not create a task yet |
+
+When creating a task during the audit:
+
+1. Create the task with the correct `taskType`.
+2. Include the source audit file and exact finding title in the task description.
+3. Explain why the finding is not code-garden-safe.
+4. Add observable ACs.
+5. For code tasks with security implications, data migrations, service boundaries, cross-service APIs, or non-trivial refactors, include a linked tech design in `docs/specs/<slug>-tech-design.md`.
+6. Update the audit finding line with `➡️ Tracked by task <short-id> (<full-id>)` or a task URL if available.
+
+When the implementation lands, its PR updates the same audit finding line with `✅ [PR #<n>](https://github.com/Stoffer-Industries/sindustries/pull/<n>)`. The ledger is therefore:
+
+`audit finding → task → tech design when needed → implementation PR → audit marked done`
+
+If a task is created after the audit PR has already merged, open a tiny docs-only audit-ledger PR to add the task link. If the task is created before the audit PR merges, include the task link directly in the audit PR.
 
 ## Runbook
 

--- a/agents/skills/ops/tasks-create/SKILL.md
+++ b/agents/skills/ops/tasks-create/SKILL.md
@@ -34,7 +34,7 @@ The API accepts these `taskType` values (nullable string; leave unset and you lo
 | Type | Use when | `--type` flag |
 |---|---|---|
 | `feature` | New capability. Requires spec + Tom approval before Rowan starts. Goes through the feature factory. | `feature` |
-| `code` | Bug fixes, maintenance, cleanup, dependency bumps, refactors, chores — anything that's a PR to fix or change existing code with no new capability. | `code` |
+| `code` | Bug fixes, maintenance, cleanup, dependency bumps, refactors, security hardening, migrations, chores — anything that's a PR to fix or change existing code with no new product capability. | `code` |
 | `content` | SIndustries website content updates (Ivy workflow). | `content` |
 | `research` | Spikes, investigation, feasibility checks. Output is a doc/decision, not a code PR. | `research` |
 
@@ -90,7 +90,7 @@ tasks_api_client.py create \
 
 ### Code task
 
-Code covers both bug fixes and chores — anything that touches existing code without adding new capability. No spec file required, but still needs a description and ACs.
+Code covers bug fixes, maintenance, cleanup, dependency bumps, refactors, security hardening, migrations, and architecture/service-boundary corrections that do not add a new product capability. Code tasks do **not** need a product spec. They still need a description, observable ACs, and sometimes a tech design.
 
 ```
 tasks_api_client.py create \
@@ -110,10 +110,12 @@ tasks_api_client.py create \
 ```
 
 **Rules:**
-- No spec file required by default, but ACs are still required and observable
-- Attach a `docs/specs/<slug>-tech-design.md` when a code task changes service boundaries, moves data ownership, splits/merges services, adds migrations, or touches cross-service API contracts
+- Product spec is not required for code tasks
+- ACs are still required and observable
+- Attach a `docs/specs/<slug>-tech-design.md` when a code task changes service boundaries, moves data ownership, splits/merges services, adds migrations, touches cross-service API contracts, changes security posture, or is a non-trivial refactor
+- Tech designs for code tasks do not require Tom product sign-off by default; they require review/sign-off only when they introduce security risk, data-loss/migration risk, user-visible behavior changes, new external credentials, or architecture decisions that need Tom/Quinn judgement
 - Do not add prefix emoji manually; the Tasks UI renders type icons in the browser
-- Pure chores (typos, renames, dep bumps) are fine with a single AC; bugs and refactors need ACs that describe the fix
+- Pure chores (typos, renames, dep bumps) are fine with a single AC; bugs, security hardening, migrations, and refactors need ACs that describe the fix and verification
 
 ### Content task
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,6 +112,17 @@ A tech design that introduces a new runtime for a domain must state:
 3. how it is built, tested, deployed, and observed;
 4. what API/data boundary keeps it from leaking into unrelated domains.
 
+## Work classification
+
+Use the lightest workflow that preserves traceability and safety:
+
+- Code garden: behavior-preserving cleanup only.
+- Code tasks: fixes, hardening, migrations, refactors, and architecture corrections with no new product capability.
+- Feature tasks: new user/product capability or product behavior requiring scope approval.
+- Research tasks: investigation before an implementation path is known.
+
+Repo audit findings that are important but not code-garden-safe should become tracked tasks rather than staying indefinitely skipped.
+
 ## Documentation expectations
 
 - Architecture principles and best practices: `docs/ARCHITECTURE.md`.

--- a/docs/systems/code-task-workflow.md
+++ b/docs/systems/code-task-workflow.md
@@ -1,0 +1,118 @@
+# Code Task Workflow
+
+**Type:** System reference
+**Last updated:** 2026-07-15
+**Owner:** Rowan
+**Repos:** `Stoffer-Industries/sindustries`
+
+---
+
+## Purpose
+
+Code tasks track implementation work that changes existing code without adding a new product capability. They cover bug fixes, security hardening, maintenance, refactors, migrations, dependency work, and architecture/service-boundary corrections.
+
+They are lighter than feature tasks: no product spec is required. They still need enough design and review to keep risky code changes visible.
+
+---
+
+## When to use a code task
+
+Use `taskType: code` when the work:
+
+- produces a PR that should be tracked;
+- fixes or changes existing code with no new product capability;
+- is too large/risky for direct assignment or code-garden;
+- comes from a repo audit finding that is important but not code-garden-safe.
+
+Examples:
+
+- security hardening in an existing service;
+- extracting misplaced backend code into the right service;
+- database migration/backfill refactors;
+- dependency upgrades with behavior or security implications;
+- correctness fixes that change observable behavior but do not add a new capability.
+
+Do not use a code task for:
+
+- net-new user/product capability — use `feature`;
+- investigation with no implementation PR yet — use `research`;
+- tiny one-turn chores that do not need tracking;
+- behavior-preserving cleanup that fits code-garden.
+
+---
+
+## Required task shape
+
+A code task must include:
+
+- short problem statement;
+- source link if created from an audit finding;
+- why it is not code-garden-safe, when applicable;
+- observable acceptance criteria;
+- assignee and relevant tags.
+
+A product spec is not required.
+
+---
+
+## Tech design requirement
+
+A tech design is required for a code task when the work touches any of these:
+
+- service boundaries or ownership;
+- data ownership, migrations, backfills, or deletion risk;
+- security posture, auth/authz, secrets, credentials, or external integrations;
+- cross-service API contracts;
+- substantial internal architecture/refactor decisions;
+- runtime/language choices.
+
+The tech design lives at `docs/specs/<slug>-tech-design.md` and is linked from the task via `[tech-design] <path-or-url>`.
+
+Tech designs for code tasks do not require Tom product sign-off by default. Escalate for Tom/Quinn sign-off when the design involves security risk, data-loss risk, user-visible behavior changes, new external credentials, or architecture decisions that need human judgement.
+
+---
+
+## Audit follow-up ledger
+
+Repo audit findings should remain traceable in the audit document.
+
+When an audit finding is important but not code-garden-safe:
+
+1. Create the correct task type (`code`, `feature`, or `research`).
+2. Link the task from the audit finding line.
+3. Add a tech design if required.
+4. When the implementation PR lands, update the same audit line with the PR link.
+
+Ledger format:
+
+```md
+### [High] Example finding title ➡️ Tracked by task `abcd1234` (`abcd1234-...`)
+```
+
+After implementation:
+
+```md
+### [High] Example finding title ➡️ Tracked by task `abcd1234` (`abcd1234-...`) ✅ [PR #234](https://github.com/Stoffer-Industries/sindustries/pull/234)
+```
+
+If the task is created during the weekly audit, include the task link in the audit PR. If the task is created later, open a tiny docs-only audit-ledger PR to add the task link.
+
+---
+
+## Relationship to code garden
+
+Code garden is intentionally narrow: functionally equivalent cleanup only. Do not relax code-garden to pick up security, behavior, migration, data ownership, or architecture work.
+
+Use a code task when a finding is valuable but not garden-safe.
+
+---
+
+## Completion
+
+A code task implementation PR should:
+
+- reference the task ID;
+- list the task ACs and evidence;
+- include validation results;
+- update relevant `docs/systems/` docs, or include `[no-system-spec-change] <reason>`;
+- update the source audit ledger line if the task came from an audit.


### PR DESCRIPTION
## Summary
- Defines a code-task workflow for non-feature implementation work: no product spec required, tech design required for security/data/service-boundary/API/architecture risk, and Tom sign-off only for risk/judgement cases.
- Updates repo-audit guidance so important findings that are not code-garden-safe become linked tasks during the weekly audit instead of staying indefinitely skipped.
- Adds a durable `docs/systems/code-task-workflow.md` ledger model: audit finding → task → tech design when needed → implementation PR → audit marked done.

## Test plan
- [x] `git diff --check`
- [x] Direct inspection of changed markdown docs

🤖 Generated with Claude Code
