### PR TITLE
feat(mission-control): design system tab ac5/ac6 — remove in-page chrome, follow shell theme

### DIFF
--- a/apps/mission-control/SPEC.md
+++ b/apps/mission-control/SPEC.md
@@ -108,7 +108,7 @@ surface.
 | Tasks | `/tasks` | `Tabs/TasksTab.jsx` (iframe) | Embedded tasks app — all existing flows remain available |
 | Bookmarks | `/bookmarks` | `Tabs/BookmarksTab.jsx` | Bookmark pipeline dashboard (KPIs, curations, funnel, topics, recent transitions); toolbar filters by time window + topic |
 | Flow metrics | `/flow-metrics` | `Tabs/FlowMetricsTab.jsx` | Filter row (assignee, tag), metric cards, throughput chart, WIP chart |
-| Design System | `/design-system` | `Tabs/DesignSystemTab.jsx` | Shared `DesignSystemPage` specimen (Tokens / Pulse / Brand) with back link to Tasks |
+| Design System | `/design-system` | `Tabs/DesignSystemTab.jsx` | Shared `DesignSystemPage` specimen (Tokens / Pulse / Brand); follows the shell's `data-si-theme` (the Mission Control tab bar is the canonical navigation — no in-page back link, no in-page theme toggle) |
 | Content | `/content-scheduler` | `Tabs/ContentSchedulerTab.jsx` | Content scheduler queue: list + create/approve/publish/remove/reorder; embeds content via iframe + Tasks-API proxy |
 | SIndustries | `/sindustries` | `Tabs/SIndustriesTab.jsx` | Embedded `sindustries.co.nz` via iframe; falls back to an external-link card if the upstream `X-Frame-Options`/`CSP` blocks embedding (timeout-based detection, ~8s) |
 | 404 / unknown path | `/<anything>` | falls back to Tasks tab | The default tab renders; no error surface |
@@ -136,7 +136,7 @@ specimen mount.
 | WIP by status | Vitest: `flowMetrics.test.js` covers status grouping |
 | Bookmark pipeline counts (KPIs, funnel, topics) | Vitest: `bookmarkPipeline.test.js` covers `kpiCounts`, `funnelRows`, `topicCounts` |
 | Curation bucketing | Vitest: `bookmarkPipeline.test.js` covers `curationGroups` threshold + sort |
-| Design System specimen mount | Vitest: `tabs/DesignSystemTab.test.jsx` covers kit nav, back link, default active kit tab |
+| Design System specimen mount | Vitest: `tabs/DesignSystemTab.test.jsx` covers kit nav, default active kit tab, no in-page back link, no in-page theme toggle, mirror of `data-si-theme` on first render and on shell theme flip |
 | Recent transitions | Vitest: `bookmarkPipeline.test.js` covers `recentTransitions` scope + ordering |
 | State source fetch | Vitest: `bookmarkStateSource.test.js` covers parallel fetch + 404 → empty defaults |
 | BookmarksTab render | Vitest: `tabs/BookmarksTab.test.jsx` covers loading/data/error/refresh paths |

--- a/apps/mission-control/src/tabs/DesignSystemTab.jsx
+++ b/apps/mission-control/src/tabs/DesignSystemTab.jsx
@@ -2,14 +2,13 @@ import React from 'react';
 import { DesignSystemPage } from '@sindustries/ui/specimen';
 
 // Design System tab — hosts the shared DesignSystemPage specimen inside
-// Mission Control. The specimen renders the design-kit navigation, theme
-// toggle, and the kit pages (Tokens / Pulse / Brand) from
-// packages/ui/src/specimen. The Mission Control tab bar IS the navigation;
-// the back link is preserved to match the prior Tasks-app UX.
+// Mission Control.
 //
-// This tab is intentionally simple: it has no data fetching, no toolbar,
-// and no local state. The DesignSystemPage owns its own theme + kit-tab
-// state.
+// The Mission Control tab bar IS the navigation, so the page no longer
+// renders an in-page back link (AC5). The shell's Day/Night sidebar
+// toggle owns `data-si-theme`; the specimen follows that attribute via
+// its own MutationObserver, so the design system tab picks up shell
+// theme flips without a remount (AC6).
 export function DesignSystemTab() {
-  return <DesignSystemPage backHref="/tasks" backLabel="← Tasks" />;
+  return <DesignSystemPage />;
 }

--- a/apps/mission-control/src/tabs/DesignSystemTab.test.jsx
+++ b/apps/mission-control/src/tabs/DesignSystemTab.test.jsx
@@ -1,22 +1,61 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import { DesignSystemTab } from './DesignSystemTab.jsx';
 
+// Helper: read the shell theme off documentElement (jsdom exposes it).
+function setShellTheme(value) {
+  document.documentElement.setAttribute('data-si-theme', value);
+}
+
 describe('DesignSystemTab', () => {
+  beforeEach(() => {
+    setShellTheme('dark');
+  });
+
   it('renders the design-kit navigation from DesignSystemPage', () => {
     render(<DesignSystemTab />);
     expect(screen.getByRole('navigation', { name: 'Design kit' })).toBeTruthy();
   });
 
-  it('renders the back link with href and label pointing at Tasks', () => {
+  // AC5 (task 205d7615): the in-page back link has been removed; the
+  // Mission Control tab bar is the canonical navigation.
+  it('does not render an in-page back link', () => {
     render(<DesignSystemTab />);
-    const backLink = screen.getByRole('link', { name: /Tasks/ });
-    expect(backLink.getAttribute('href')).toBe('/tasks');
+    expect(screen.queryByRole('link', { name: /Tasks/ })).toBeNull();
+    expect(screen.queryByRole('link', { name: /Back/ })).toBeNull();
+  });
+
+  // AC5 (task 205d7615): the in-page theme toggle has been removed; the
+  // shell's Day/Night sidebar toggle owns data-si-theme globally.
+  it('does not render an in-page theme toggle', () => {
+    render(<DesignSystemTab />);
+    expect(screen.queryByRole('button', { name: /Switch to .* theme/ })).toBeNull();
   });
 
   it('renders the Tokens kit tab as active by default', () => {
     render(<DesignSystemTab />);
     const tokensTab = screen.getByRole('button', { name: 'Tokens' });
     expect(tokensTab.getAttribute('aria-current')).toBe('page');
+  });
+
+  // AC6 (task 205d7615): the design system tab picks up the shell's
+  // current theme via the specimen's MutationObserver on
+  // <html data-si-theme>.
+  it('mirrors the shell data-si-theme on first render', () => {
+    setShellTheme('light');
+    render(<DesignSystemTab />);
+    expect(screen.getByRole('main')).toHaveAttribute('data-si-theme', 'light');
+  });
+
+  // AC6 (task 205d7615): the tab follows shell theme flips without a
+  // remount — the specimen observes <html data-si-theme>.
+  it('follows shell theme flips without a remount', async () => {
+    setShellTheme('dark');
+    render(<DesignSystemTab />);
+    const shell = screen.getByRole('main');
+    expect(shell).toHaveAttribute('data-si-theme', 'dark');
+
+    setShellTheme('light');
+    await waitFor(() => expect(shell).toHaveAttribute('data-si-theme', 'light'));
   });
 });

--- a/packages/ui/src/specimen/DesignSystemPage.jsx
+++ b/packages/ui/src/specimen/DesignSystemPage.jsx
@@ -1,5 +1,4 @@
-import React, { useState } from 'react';
-import { Button } from '../react/index.jsx';
+import React, { useEffect, useState } from 'react';
 import { SPECIMEN_PAGES } from './generated/pages.js';
 import { SpecimenSection } from './SpecimenSections.jsx';
 import './styles.css';
@@ -22,29 +21,64 @@ function shellPackForPage(page) {
   return page?.pack ?? 'pulse';
 }
 
-export function DesignSystemPage({ backHref = '/', backLabel = '← Back' }) {
+// Read the shell's current data-si-theme attribute (Mission Control
+// owns it on <html>; tests can simulate by setting it on documentElement).
+// Falls back to 'dark' so SSR / no-DOM callers get a deterministic value.
+function readShellTheme() {
+  if (typeof document === 'undefined') return 'dark';
+  const value = document.documentElement.getAttribute('data-si-theme');
+  return value === 'light' ? 'light' : 'dark';
+}
+
+/**
+ * DesignSystemPage — design-kit specimen viewer used by Mission Control's
+ * Design System tab and (historically) the Tasks app.
+ *
+ * Per AC5/AC6 of task 205d7615 (Design System tab in Mission Control),
+ * the page no longer owns its own in-page theme toggle or back link:
+ *   - The shell's Day/Night sidebar toggle is the single source of truth
+ *     for `data-si-theme`. We track <html data-si-theme> via a
+ *     MutationObserver so theme flips propagate without a remount.
+ *   - Navigation lives in the Mission Control tab bar; the in-page back
+ *     link to "/tasks" is redundant and has been removed.
+ *
+ * Per-kit-page overrides (`SPECIMEN_PAGES[*].theme`) still apply to the
+ * individual section element (e.g. the Brand kit renders `data-si-theme="light"`
+ * on its own section so its pale palette survives the shell being dark).
+ */
+export function DesignSystemPage() {
   const [activePageId, setActivePageId] = useState(SPECIMEN_PAGES[0]?.id ?? 'tokens');
-  const [theme, setTheme] = useState(SPECIMEN_PAGES[0]?.theme ?? 'dark');
+  const [shellTheme, setShellTheme] = useState(readShellTheme);
+
+  // Mirror the shell's data-si-theme attribute. Mission Control sets it
+  // on <html> via the sidebar ThemeToggle; this observer keeps the
+  // specimen shell in sync without a reload or remount.
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+    setShellTheme(readShellTheme());
+    const target = document.documentElement;
+    const observer = new MutationObserver(() => {
+      const next = readShellTheme();
+      setShellTheme((current) => (current === next ? current : next));
+    });
+    observer.observe(target, { attributes: true, attributeFilter: ['data-si-theme'] });
+    return () => observer.disconnect();
+  }, []);
+
   const activePage = SPECIMEN_PAGES.find((page) => page.id === activePageId) ?? SPECIMEN_PAGES[0];
-  const nextTheme = theme === 'dark' ? 'light' : 'dark';
 
   function selectPage(pageId) {
-    const page = SPECIMEN_PAGES.find((entry) => entry.id === pageId);
     setActivePageId(pageId);
-    if (page?.theme) setTheme(page.theme);
   }
 
   return (
     <main
       className="si-specimen-shell"
-      data-si-theme={theme}
+      data-si-theme={shellTheme}
       data-si-pack={shellPackForPage(activePage)}
       data-si-surface="bgCanvas"
     >
       <header className="si-specimen-header">
-        <a href={backHref} className="si-specimen-back">
-          {backLabel}
-        </a>
         <nav className="si-specimen-kit-tabs" aria-label="Design kit">
           {KIT_TABS.map((tab) => (
             <button
@@ -58,17 +92,6 @@ export function DesignSystemPage({ backHref = '/', backLabel = '← Back' }) {
             </button>
           ))}
         </nav>
-        <div className="si-specimen-header-actions">
-          <p className="si-specimen-eyebrow">Design system</p>
-          <Button
-            type="button"
-            variant="outline"
-            aria-label={`Switch to ${nextTheme} theme`}
-            onClick={() => setTheme(nextTheme)}
-          >
-            {theme === 'dark' ? 'Dark' : 'Light'}
-          </Button>
-        </div>
       </header>
 
       <div className="si-specimen-page">

--- a/packages/ui/src/specimen/DesignSystemPage.test.jsx
+++ b/packages/ui/src/specimen/DesignSystemPage.test.jsx
@@ -1,14 +1,23 @@
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach } from 'vitest';
 import { DesignSystemPage } from './DesignSystemPage.jsx';
 
+// Helper: read the shell theme off documentElement (jsdom exposes it).
+function setShellTheme(value) {
+  document.documentElement.setAttribute('data-si-theme', value);
+}
+
 describe('DesignSystemPage', () => {
+  beforeEach(() => {
+    setShellTheme('dark');
+  });
+
   it('renders the design system specimen', async () => {
     const user = userEvent.setup();
-    render(<DesignSystemPage backHref="/" backLabel="← Tasks" />);
+    render(<DesignSystemPage />);
 
     expect(screen.getByRole('navigation', { name: 'Design kit' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Tokens' })).toHaveAttribute('aria-current', 'page');
@@ -79,15 +88,59 @@ describe('DesignSystemPage', () => {
     expect(within(brandPage).getByText('Ink card — dark industrial panel')).toBeInTheDocument();
     expect(within(brandPage).getByText('Button/Brand/Primary')).toBeInTheDocument();
     expect(within(brandPage).getByText('Card/Brand/Ink')).toBeInTheDocument();
+  });
 
-    expect(screen.getByRole('link', { name: '← Tasks' })).toHaveAttribute('href', '/');
+  // AC5 (task 205d7615): the in-page back link has been removed; the
+  // Mission Control tab bar is the canonical navigation.
+  it('does not render an in-page back link', () => {
+    render(<DesignSystemPage />);
+    expect(screen.queryByRole('link', { name: /Tasks/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Back/i })).not.toBeInTheDocument();
+  });
 
+  // AC5 (task 205d7615): the in-page theme toggle has been removed; the
+  // shell's Day/Night sidebar toggle is the single source of truth.
+  it('does not render an in-page theme toggle', () => {
+    render(<DesignSystemPage />);
+    expect(screen.queryByRole('button', { name: /Switch to .* theme/ })).not.toBeInTheDocument();
+  });
+
+  // AC6 (task 205d7615): the specimen shell mirrors the shell's
+  // data-si-theme attribute on first render so the design system tab
+  // renders in the active theme without a flash of wrong palette.
+  it('mirrors the shell data-si-theme attribute on first render', () => {
+    setShellTheme('light');
+    render(<DesignSystemPage />);
     const shell = screen.getByRole('main');
     expect(shell).toHaveAttribute('data-si-theme', 'light');
+  });
 
-    const toggle = screen.getByRole('button', { name: 'Switch to dark theme' });
-    await user.click(toggle);
+  // AC6 (task 205d7615): when the shell flips theme, the specimen
+  // shell follows without a remount — the MutationObserver on
+  // <html data-si-theme> drives a re-render.
+  it('follows shell theme flips without a remount', async () => {
+    setShellTheme('dark');
+    render(<DesignSystemPage />);
+    const shell = screen.getByRole('main');
     expect(shell).toHaveAttribute('data-si-theme', 'dark');
-    expect(screen.getByRole('button', { name: 'Switch to light theme' })).toBeInTheDocument();
+
+    setShellTheme('light');
+    await waitFor(() => expect(shell).toHaveAttribute('data-si-theme', 'light'));
+
+    setShellTheme('dark');
+    await waitFor(() => expect(shell).toHaveAttribute('data-si-theme', 'dark'));
+  });
+
+  // Per-kit-page theme overrides (e.g. Brand forces light) must survive
+  // the shell being in dark mode — the override is per-section, not on
+  // the page shell, so the inner section still renders light.
+  it('keeps per-page theme overrides intact when shell is dark', async () => {
+    setShellTheme('dark');
+    const user = userEvent.setup();
+    render(<DesignSystemPage />);
+    await user.click(screen.getByRole('button', { name: 'Brand' }));
+    const brandPage = screen.getByRole('heading', { name: 'Brand / React' }).closest('section');
+    expect(brandPage).toHaveAttribute('data-si-theme', 'light');
+    expect(screen.getByRole('main')).toHaveAttribute('data-si-theme', 'dark');
   });
 });

--- a/packages/ui/src/specimen/styles.css
+++ b/packages/ui/src/specimen/styles.css
@@ -9,14 +9,14 @@
   align-items: center;
   background: var(--si-color-bg-section);
   border-bottom: 1px solid var(--si-color-border-subtle);
-  display: grid;
-  gap: 16px;
-  grid-template-columns: auto 1fr auto;
+  display: flex;
+  justify-content: center;
   padding: 16px 20px;
 }
 
 .si-specimen-kit-tabs {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   justify-content: center;
 }

--- a/packages/ui/test/setup.js
+++ b/packages/ui/test/setup.js
@@ -1,0 +1,10 @@
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// Unmount any React trees rendered during the test so the next test
+// starts from a clean DOM. Matches the pattern used by
+// apps/mission-control/test/setup.js.
+afterEach(() => {
+  cleanup();
+});

--- a/packages/ui/vitest.config.js
+++ b/packages/ui/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./test/setup.js'],
+    include: ['src/**/*.test.{js,jsx,ts,tsx}']
+  }
+});


### PR DESCRIPTION
## Summary
- **AC5**: remove the in-page day/night toggle and the `<- Tasks` back link from the design system header. The Mission Control tab bar is the canonical navigation; the shell's Day/Night sidebar toggle owns `data-si-theme` globally.
- **AC6**: the design system tab now follows the shell's `data-si-theme` via a `MutationObserver` on `<html>`, so flipping the shell's sidebar toggle re-themes the tab without a remount. Per-kit-page overrides (Brand forces `light`) are preserved on the inner section element.

## Test plan
- [x] `npm test --workspace=@sindustries/ui` — 15/15 pass (9 existing + 6 in `DesignSystemPage.test.jsx`)
- [x] `npm test --workspace=@sindustries/mission-control` — 104/104 pass (3 existing + 3 new in `DesignSystemTab.test.jsx`)
- [x] `npm test --workspace=@sindustries/tasks` — 143/143 pass (no source impact)
- [x] `npm run build --workspace=@sindustries/mission-control` — clean, 210.90 kB JS / 46.46 kB CSS

## Companion
- `packages/ui/vitest.config.js` + `test/setup.js` — adds jsdom environment + RTL cleanup so the `MutationObserver`-driven tests flush correctly.
- `packages/ui/src/specimen/styles.css` — header switches from a 3-column grid (back / tabs / actions) to a single flex row centred on the kit tabs.
- `apps/mission-control/SPEC.md` — Screens table + E2e coverage row updated to reflect the new contract.

## Acceptance Criteria

- [x] AC1: Design System removed from Tasks app UI (file: apps/tasks/src/main.jsx:removes DesignSystemPage import and Root wrapper)
- [x] AC2: Design System tab registered in Mission Control at its own route (file: apps/mission-control/src/pulseTabs.js:design-system tab registered in tab registry)
- [x] AC3: Tab accessible from tab bar, renders in light and dark mode (file: apps/mission-control/src/tabs/DesignSystemTab.test.jsx:renders the design-kit navigation from DesignSystemPage)
- [x] AC4: No design system functionality lost in migration (file: apps/mission-control/src/tabs/DesignSystemTab.test.jsx:renders the Tokens kit tab as active by default)
- [x] AC5: Remove day/night toggle and <- Tasks from design system header (file: apps/mission-control/src/tabs/DesignSystemTab.test.jsx:does not render an in-page back link)
- [x] AC5: Remove day/night toggle and <- Tasks from design system header (file: apps/mission-control/src/tabs/DesignSystemTab.test.jsx:does not render an in-page theme toggle)
- [x] AC6: Mission control Day/Night mode applied applying across Tasks and Design system tabs (file: apps/mission-control/src/tabs/DesignSystemTab.test.jsx:mirrors the shell data-si-theme on first render)
- [x] AC6: Mission control Day/Night mode applied applying across Tasks and Design system tabs (file: apps/mission-control/src/tabs/DesignSystemTab.test.jsx:follows shell theme flips without a remount)
- [x] AC6: Mission control Day/Night mode applied applying across Tasks and Design system tabs (file: packages/ui/src/specimen/DesignSystemPage.test.jsx:keeps per-page theme overrides intact when shell is dark)

🤖 Generated with Claude Code