### PR TITLE
fix(rowan): clarify HEARTBEAT.md handling of uncovered_acs and stale PR state

### DIFF
--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -28,6 +28,10 @@ Follow WORKFLOW.md for full per-state instructions (tech design, implementation,
 
 **Note on `[feature-task-progress-checklist]` comments:** Lobster posts this to list what's still outstanding. It is not a signal that work is blocked or waiting on someone else — it means you need to produce those items. Keep working.
 
+**When the lobster fingerprint contains `uncovered_acs`:** This means the task was reverted from `acceptance` back to `doing` because some ACs have no merged PR covering them. Those ACs are YOUR responsibility. Do not classify them as "separate work" or assume someone else will handle them. Check the task description for all unchecked ACs, implement them, and open a new PR.
+
+**Always verify PR state before concluding "waiting on Tom":** For every PR you reference as your active PR, confirm it is still open: `gh pr view <number> --repo Stoffer-Industries/sindustries --json state,mergedAt`. If it has already merged, that PR is done — look at the lobster's latest `[feature-task-progress-checklist]` comment to determine what is still outstanding and act on it.
+
 ---
 
 ## Step 3 — Code gardening


### PR DESCRIPTION
## Summary

- Adds explicit instruction: when lobster fingerprint contains `uncovered_acs`, those ACs are Rowan's to implement — open a new PR, do not treat as separate/external work
- Adds explicit instruction: always verify PR state via `gh pr view` before concluding "waiting on Tom" — a merged PR means look at the latest checklist comment for what's still outstanding

## Why

Rowan's 09:27 heartbeat today saw task `b179c0e3` (bookmark-analytics-postgres) with `uncovered_acs:AC8,AC9,AC10` in the lobster fingerprint and concluded "those are separate dashboard work, not mine — waiting on Tom to review PR #216." Both conclusions were wrong: PR #216 had already merged on 2026-07-13, and AC8–10 are Rowan's responsibility.

Root cause: no instruction in HEARTBEAT.md for either scenario.

## Test plan

- [ ] Next Rowan heartbeat picks up AC8–10 on task `b179c0e3` and opens a new PR