### PR TITLE
fix(workflow): consolidate to one PR per task — tech design on impl branch

### DIFF
--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -99,22 +99,27 @@ Rowan breaks large work into milestones that are:
 
 ### Tech design first
 Before writing any code on a feature task, write the tech design:
-- Location: `docs/specs/<task-slug>-tech-design.md` in the primary implementation repo
+- Create the implementation branch first: `task-<id>-<slug>`
+- Location: `docs/specs/<task-slug>-tech-design.md` committed to the **implementation branch** — not a separate branch or PR
 - Must cover: product spec link, task link, repos involved, branch names, worktree paths, `.openclaw` changes needed, implementation plan, test plan, open questions
-- Must map each acceptance criterion to planned verification before implementation starts
+- Must map each acceptance criterion to planned verification before implementation starts — this matrix belongs inside the tech design doc only, never in a PR body
 - For every user-visible/app-flow AC, plan an E2E test where possible; if not possible or disproportionate, record the reason and the lower-level fallback test
-- Post `[tech-design] <GitHub URL>` as a task comment when done
-- Wait for Quinn to set `tech_design_approved: true` before starting implementation
+- Post `[tech-design] <GitHub blob URL on the branch>` as a task comment — e.g. `https://github.com/Stoffer-Industries/sindustries/blob/<branch>/docs/specs/<slug>-tech-design.md`
+- No separate tech design PR is needed; Quinn reads the design from the branch blob URL
+- Wait for Quinn to set `[tech-design-approved] true` before starting implementation
 
 ### Implementation
-- Work on dedicated worktree branches; all changes come via PRs — no direct pushes to main
+- Work on the same branch as the tech design; all changes come via PRs — no direct pushes to main
+- Open a **DRAFT PR** after the tech design is approved and implementation begins; this keeps the branch reviewable but signals work is in progress
 - Capacity: 1 unblocked feature task per implementation state at a time. `ready` tech design work is the exception: if an assigned `ready` task lacks a posted/approved tech design, write and post that tech design ASAP even when another task is already in `doing`; then return to the active implementation task.
 - When `.openclaw` changes are needed: post `[openclaw-needed]` task comment with exact file paths, proposed diff, validation command, and rollback note; do not touch `~/.openclaw/` yourself
-- When all implementation PRs are open: post `[rowan-prs] <url1>, <url2>` as a task comment
+- **Do not post `[rowan-prs]`** until all task ACs are implemented and the PR is converted from draft to ready-for-review
+- When the PR is ready: convert draft → ready-for-review, then post `[rowan-prs] <url>` as a task comment
 
 ### PR requirements
-- PR body must include all parent task ACs, with `- [x]` for done and `- [ ]` for not yet done
+- The implementation PR body must include all parent task ACs, with `- [x]` for done and evidence annotation, or `- [ ]` for not yet done
 - Each PR body must list which parent ACs its sub-ACs contribute to
+- Do not include the AC checklist in tech design docs or any other non-implementation PR body — ACs in a merged PR body are treated by the lobster as "covered"; only include them when the code is actually done
 
 ### AC checkboxes on the task — hands off
 **Never tick or untick AC checkboxes in the task description.** That is Tom/QA's gate, applied only once the task reaches `acceptance`. Rowan's evidence belongs in the PR body only.

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -158,8 +158,10 @@ When Rowan opens a PR:
 
 When all ACs are implemented and the PR is ready for review:
 - convert draft → ready-for-review
-- assign **Tom** (`Stoff81`) and add **Quinn** (`quinnstoffer`) as a reviewer — Quinn does the code review, Tom does final QA/product approval
+- assign **Tom** (`Stoff81`) as product owner; add **Quinn** (`quinnstoffer`) as the code reviewer
 - post `[rowan-prs] <url>` as a task comment
+- merge after Quinn approves and CI is green — do not wait for Tom's PR approval
+- Tom tests post-merge in main; his sign-off is `[qa-ac-verified] true` on the task, not a PR review
 
 ---
 

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -158,7 +158,7 @@ When Rowan opens a PR:
 
 When all ACs are implemented and the PR is ready for review:
 - convert draft → ready-for-review
-- set yourself (`rowanstoffer`) as PR assignee and **Quinn** (`quinnstoffer`) as reviewer
+- set yourself (`rowanstoffer`) as PR assignee; add **Quinn** (`quinnstoffer`) and **Tom** (`Stoff81`) as reviewers — Quinn is the blocking code reviewer, Tom is non-blocking (visibility only)
 - post `[rowan-prs] <url>` as a task comment
 - merge after Quinn approves and CI is green — do not wait for Tom's PR approval
 - Tom tests post-merge in main; his sign-off is `[qa-ac-verified] true` on the task, not a PR review

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -158,7 +158,7 @@ When Rowan opens a PR:
 
 When all ACs are implemented and the PR is ready for review:
 - convert draft → ready-for-review
-- assign **Tom** (`Stoff81`) as product owner; add **Quinn** (`quinnstoffer`) as the code reviewer
+- set yourself (`rowanstoffer`) as PR assignee and **Quinn** (`quinnstoffer`) as reviewer
 - post `[rowan-prs] <url>` as a task comment
 - merge after Quinn approves and CI is green — do not wait for Tom's PR approval
 - Tom tests post-merge in main; his sign-off is `[qa-ac-verified] true` on the task, not a PR review

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -98,6 +98,8 @@ Rowan breaks large work into milestones that are:
 ## Feature Factory v2 — Task Requirements
 
 ### Tech design first
+Use the tech-design skill: `agents/skills/dev/tech-design/SKILL.md`
+
 Before writing any code on a feature task, write the tech design:
 - Create the implementation branch first: `task-<id>-<slug>`
 - Location: `docs/specs/<task-slug>-tech-design.md` committed to the **implementation branch** — not a separate branch or PR
@@ -132,6 +134,8 @@ Before the task can move from `doing` to `acceptance`, use the system-spec skill
 The skill covers when to create vs update an existing spec. Post the resulting task comment (`[system-spec]` or `[no-system-spec-change]`) — Lobster verify-delivery blocks until one is present.
 
 ### Acceptance
+Use the pr-address-feedback skill when handling review comments: `agents/skills/dev/pr-address-feedback/SKILL.md`
+
 - Stay in `acceptance` while addressing PR review feedback — do not regress to `doing`
 - Address valid feedback on the same branch and push; do not open new PRs for review iterations
 - Mark task blocked when waiting on Tom to approve a PR
@@ -142,6 +146,9 @@ Rowan cannot write to `~/.openclaw/`. Post `[openclaw-needed]` and wait for Quin
 ---
 
 ## PR Standards
+Use the pr-open skill for branch setup and PR creation: `agents/skills/dev/pr-open/SKILL.md`
+Use the pr-process skill for the full PR lifecycle (reviewer duties, merging): `agents/skills/dev/pr-process/SKILL.md`
+
 When Rowan opens a PR:
 - open as **draft** with **no assignee** — this signals the PR is not yet ready for Tom's attention
 - include clear description of changes and full AC checklist (with `- [ ]` placeholders until each AC is done)

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -158,7 +158,7 @@ When Rowan opens a PR:
 
 When all ACs are implemented and the PR is ready for review:
 - convert draft → ready-for-review
-- assign **Tom** (`Stoff81`)
+- assign **Tom** (`Stoff81`) and add **Quinn** (`quinnstoffer`) as a reviewer — Quinn does the code review, Tom does final QA/product approval
 - post `[rowan-prs] <url>` as a task comment
 
 ---

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -143,11 +143,16 @@ Rowan cannot write to `~/.openclaw/`. Post `[openclaw-needed]` and wait for Quin
 
 ## PR Standards
 When Rowan opens a PR:
-- assign to **Tom** (`Stoff81`)
-- include clear description of changes and full AC checklist
+- open as **draft** with **no assignee** — this signals the PR is not yet ready for Tom's attention
+- include clear description of changes and full AC checklist (with `- [ ]` placeholders until each AC is done)
 - include validation evidence
 - include screenshots/GIFs for UI work where useful
 - reference the task in the PR body
+
+When all ACs are implemented and the PR is ready for review:
+- convert draft → ready-for-review
+- assign **Tom** (`Stoff81`)
+- post `[rowan-prs] <url>` as a task comment
 
 ---
 

--- a/agents/skills/dev/pr-process/SKILL.md
+++ b/agents/skills/dev/pr-process/SKILL.md
@@ -65,7 +65,7 @@ This skill is role-based, not agent-based. Any agent can play any role on a give
 
 Concrete patterns in our workflows:
 
-- **Feature tasks:** Rowan opens (`--assignee rowanstoffer --reviewer quinnstoffer`). Quinn does the code review. Rowan merges after Quinn approves and CI is green. Tom tests post-merge in main — his sign-off is the `[qa-ac-verified] true` task comment, not a PR review approval.
+- **Feature tasks:** Rowan opens (`--assignee rowanstoffer --reviewer quinnstoffer,Stoff81`). Quinn does the blocking code review; Tom is an optional/non-blocking reviewer for GitHub inbox visibility. Rowan merges after Quinn approves and CI is green — do not wait for Tom's PR approval. Tom tests post-merge in main; his sign-off is the `[qa-ac-verified] true` task comment.
 - **Content tasks:** opener opens (`--assignee <self>`, `--reviewer quinn,tomstoffer`). Quinn and Tom review. Opener merges after both approvals.
 - **Code-garden tasks:** opener opens with `--label code-garden`, reviewer reviews against the code-garden guardrail (no behavior change). Opener merges after approval.
 - **Cross-repo PRs (workspace repo, infra scripts):** same pattern — opener opens, reviewer reviews, opener merges.

--- a/agents/skills/dev/pr-process/SKILL.md
+++ b/agents/skills/dev/pr-process/SKILL.md
@@ -65,7 +65,7 @@ This skill is role-based, not agent-based. Any agent can play any role on a give
 
 Concrete patterns in our workflows:
 
-- **Feature tasks:** Rowan opens (`--assignee Stoff81 --reviewer quinnstoffer`). Quinn does the code review. Rowan merges after Quinn approves and CI is green. Tom is the assignee (product owner) and tests post-merge in main — his sign-off is the `[qa-ac-verified] true` task comment, not a PR review approval.
+- **Feature tasks:** Rowan opens (`--assignee rowanstoffer --reviewer quinnstoffer`). Quinn does the code review. Rowan merges after Quinn approves and CI is green. Tom tests post-merge in main — his sign-off is the `[qa-ac-verified] true` task comment, not a PR review approval.
 - **Content tasks:** opener opens (`--assignee <self>`, `--reviewer quinn,tomstoffer`). Quinn and Tom review. Opener merges after both approvals.
 - **Code-garden tasks:** opener opens with `--label code-garden`, reviewer reviews against the code-garden guardrail (no behavior change). Opener merges after approval.
 - **Cross-repo PRs (workspace repo, infra scripts):** same pattern — opener opens, reviewer reviews, opener merges.

--- a/agents/skills/dev/pr-process/SKILL.md
+++ b/agents/skills/dev/pr-process/SKILL.md
@@ -65,7 +65,7 @@ This skill is role-based, not agent-based. Any agent can play any role on a give
 
 Concrete patterns in our workflows:
 
-- **Feature tasks:** Rowan opens (`--assignee Stoff81 --reviewer quinnstoffer,Stoff81`). Quinn does the code review; Tom does final QA/product approval. Rowan merges after both approve and CI is green.
+- **Feature tasks:** Rowan opens (`--assignee Stoff81 --reviewer quinnstoffer`). Quinn does the code review. Rowan merges after Quinn approves and CI is green. Tom is the assignee (product owner) and tests post-merge in main — his sign-off is the `[qa-ac-verified] true` task comment, not a PR review approval.
 - **Content tasks:** opener opens (`--assignee <self>`, `--reviewer quinn,tomstoffer`). Quinn and Tom review. Opener merges after both approvals.
 - **Code-garden tasks:** opener opens with `--label code-garden`, reviewer reviews against the code-garden guardrail (no behavior change). Opener merges after approval.
 - **Cross-repo PRs (workspace repo, infra scripts):** same pattern — opener opens, reviewer reviews, opener merges.

--- a/agents/skills/dev/pr-process/SKILL.md
+++ b/agents/skills/dev/pr-process/SKILL.md
@@ -65,6 +65,7 @@ This skill is role-based, not agent-based. Any agent can play any role on a give
 
 Concrete patterns in our workflows:
 
+- **Feature tasks:** Rowan opens (`--assignee Stoff81 --reviewer quinnstoffer,Stoff81`). Quinn does the code review; Tom does final QA/product approval. Rowan merges after both approve and CI is green.
 - **Content tasks:** opener opens (`--assignee <self>`, `--reviewer quinn,tomstoffer`). Quinn and Tom review. Opener merges after both approvals.
 - **Code-garden tasks:** opener opens with `--label code-garden`, reviewer reviews against the code-garden guardrail (no behavior change). Opener merges after approval.
 - **Cross-repo PRs (workspace repo, infra scripts):** same pattern — opener opens, reviewer reviews, opener merges.

--- a/agents/skills/dev/tech-design/SKILL.md
+++ b/agents/skills/dev/tech-design/SKILL.md
@@ -9,7 +9,7 @@ Use this skill when a feature task needs a design before Rowan starts implementa
 
 Read [`docs/CONVENTIONS.md`](../../../../docs/CONVENTIONS.md) for the full doc taxonomy and required frontmatter before writing.
 
-Write the design to `docs/specs/<task-slug>-tech-design.md`.
+Write the design to `docs/specs/<task-slug>-tech-design.md` **on the implementation branch** — no separate branch or PR is needed for the tech design.
 
 Include:
 
@@ -24,9 +24,11 @@ Include:
   - If E2E is not possible or is disproportionate, record why and name the fallback test layer (`file`, unit, component, integration, or manual)
 - Open questions and risks
 
-After writing the design, post the durable task comment:
+**The AC verification matrix belongs inside this doc only.** Do not include the AC checklist (`- [x] AC1: ...`) in the PR body of the tech design or any other non-implementation PR — the lobster treats ACs appearing in a merged PR body as "covered by implementation", so listing them in a docs-only commit creates a false signal.
 
-`[tech-design] <repo URL or local path>`
+After committing the design to the branch, post the durable task comment pointing to the branch blob URL:
+
+`[tech-design] https://github.com/Stoffer-Industries/sindustries/blob/<branch>/docs/specs/<slug>-tech-design.md`
 
 Quinn approves tech designs as part of heartbeat. After reading the design at the linked path, post the durable task comment:
 


### PR DESCRIPTION
## Summary

- Tech design is now written on the implementation branch, not a separate docs PR
- Rowan posts `[tech-design] <branch blob URL>` — Quinn reads from the branch URL, no separate PR needed
- Rowan opens a DRAFT PR after tech design approval; converts to ready-for-review only when all ACs are implemented
- `[rowan-prs]` is posted only when the PR is out of draft and all ACs are done
- AC checklist (`- [x] AC1:`) must only appear in implementation PR bodies — the lobster treats ACs in any merged PR body as "covered", so listing them in docs-only commits creates a false signal

## Why

Two issues triggered this:
1. PR #236 (tech design for bookmark-analytics AC8-10) included ACs marked `[x]` in the PR body with `(not code: this is the tech design)` evidence — this would have made the lobster count AC8-10 as covered before any code was written
2. The two-PR-per-task pattern doubled PR overhead with no benefit — Quinn reviews designs from the blob URL, not from a GitHub PR review

Closes #236 (superseded by this new pattern — Rowan will restart AC8-10 on the impl branch directly).

## Test plan

- [ ] Rowan's next feature task uses one branch: tech design committed first, then implementation, single PR
- [ ] `[tech-design]` task comment points to a branch blob URL (not a PR URL)
- [ ] `[rowan-prs]` is only posted when the PR is ready-for-review and all ACs are implemented