### PR TITLE
docs: mark tech designs shipped for tasks 205d7615 + b179c0e3

### DIFF
--- a/docs/specs/bookmark-pipeline-analytics-postgres-transition-log-tech-design.md
+++ b/docs/specs/bookmark-pipeline-analytics-postgres-transition-log-tech-design.md
@@ -1,9 +1,9 @@
 ---
-status: draft
+status: shipped
 task_id: b179c0e3-c6b0-4c9d-97dc-982d3b841783
 product_spec: brain/tasks/specs/bookmark-analytics-postgres.md
-shipped_pr: null
-shipped_date: null
+shipped_pr: 216
+shipped_date: 2026-07-12
 ---
 
 # Bookmark pipeline analytics — Postgres transition log — tech design

--- a/docs/specs/bookmarks-tab-sankey-and-retire-tools-2026-07-16-tech-design.md
+++ b/docs/specs/bookmarks-tab-sankey-and-retire-tools-2026-07-16-tech-design.md
@@ -1,9 +1,9 @@
 ---
-status: draft
+status: shipped
 task_id: b179c0e3-c6b0-4c9d-97dc-982d3b841783
 product_spec: brain/tasks/specs/bookmark-analytics-postgres.md
-shipped_pr: null
-shipped_date: null
+shipped_pr: 238
+shipped_date: 2026-07-16
 ---
 
 # Bookmarks tab — Sankey + states-over-time + retire tools dashboard — Tech Design

--- a/docs/specs/mc-design-system-tab-tech-design.md
+++ b/docs/specs/mc-design-system-tab-tech-design.md
@@ -1,9 +1,9 @@
 ---
-status: draft
+status: shipped
 task_id: 205d7615-3756-4b4f-9685-d08fd6381634
 product_spec: brain/tasks/specs/mc-design-system-tab-2026-07-07.md
-shipped_pr: null
-shipped_date: null
+shipped_pr: 234
+shipped_date: 2026-07-16
 ---
 
 # Design System tab in Mission Control — Tech Design


### PR DESCRIPTION
Per docs/CONVENTIONS.md, tech design frontmatter should be flipped to `status: shipped` with the merge PR + date once the feature ships. This was missed in the original merge PRs:

- `docs/specs/mc-design-system-tab-tech-design.md` — shipped via #234 (AC5/AC6). AC1-AC4 already shipped via #201.
- `docs/specs/bookmark-pipeline-analytics-postgres-transition-log-tech-design.md` — shipped via #216 (AC1-AC7).
- `docs/specs/bookmarks-tab-sankey-and-retire-tools-2026-07-16-tech-design.md` — shipped via #238 (AC8-AC10).

Refs:
- Task 205d7615-3756-4b4f-9685-d08fd6381634 (Design System tab in Mission Control)
- Task b179c0e3-c6b0-4c9d-97dc-982d3b841783 (Bookmark pipeline analytics — Postgres transition log)

Docs-only, 3 files, 9 lines changed.