### PR TITLE
fix(feature-task-lobster): auto-assign Rowan when promoting open → ready

### DIFF
--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -58,6 +58,8 @@ Run:
 `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/feature-task/run.py`
 Report only failures, newly blocked tasks, or meaningful transitions. **Do not report tasks already in ops state with `escalatedAt` set — Tom has already been notified. Do not summarise routine doing/acceptance counts.**
 
+**Ops-state logging rule for blocked tasks:** When the lobster reports any `*_blocked` action on a task, check ops-state for an entry whose slug includes both the task ID AND the current gate (e.g. `verify_delivery`, `ready_checks`, `qa_ac_verified`). A task-level entry from a *different* gate does NOT count — create a new entry. Slug format: `feature-task-<task-id-prefix>-<gate>-<YYYY-MM-DD>`. This prevents a resolved blockage from masking a new one on the same task.
+
 **When the lobster reports `ready_checks_blocked` due to missing `[tech-design]`:**
 - Check if Rowan is free (no tasks in `doing` assigned to Rowan)
 - If Rowan is free: spawn Rowan as a background subagent to write the tech design (see tech-design skill)

--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -24,7 +24,11 @@ Check for active feature tasks assigned to you:
 Follow WORKFLOW.md for full per-state instructions (tech design, implementation, system spec, acceptance):
 `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/definitions/rowan/WORKFLOW.md`
 
-**Ready-task tech design priority:** If any assigned feature task is in `ready` and does not yet have a posted/approved tech design, prioritize writing and posting that tech design before continuing implementation on `doing` tasks. Tech design prep is not considered parallel implementation WIP; it is the unblocker for the next task. After posting the tech design, return to the active `doing`/`acceptance` work unless Tom says otherwise.
+**State boundaries — do not cross them:**
+- `ready` = **tech design only**. Your only job on a `ready` task is to write the tech design, commit it to the implementation branch, and post `[tech-design] <blob-url>`. Do NOT write any feature code. Do NOT open a feature PR. Wait for Quinn to post `[tech-design-approved] true` and for the lobster to move the task to `doing` before touching implementation.
+- `doing` / `acceptance` = implementation. Only pick up implementation work on tasks the lobster has already moved to `doing`.
+
+**Ready-task tech design priority:** If any assigned feature task is in `ready` and does not yet have a posted tech design, prioritize writing and posting that tech design before continuing implementation on `doing` tasks. After posting the tech design comment, return to the active `doing`/`acceptance` work — do not start implementing the `ready` task.
 
 **Note on `[feature-task-progress-checklist]` comments:** Lobster posts this to list what's still outstanding. It is not a signal that work is blocked or waiting on someone else — it means you need to produce those items. Keep working.
 

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -910,6 +910,9 @@ fn transition_or_block(
             let mut patch = json!({"status": next_status});
             if next_status == "ready" {
                 patch["specChecksum"] = Value::String(spec_checksum(&env.task));
+                if env.task.assignee.is_none() {
+                    patch["assignee"] = Value::String("Rowan".to_string());
+                }
             }
             if let Err(err) = api_patch::<Task>(&args.base_url, &env.task.id, patch) {
                 if let Some(message) = spec_checksum_mismatch_message(&err) {


### PR DESCRIPTION
## Summary
- Lobster now sets `assignee: Rowan` in the same PATCH that promotes a task from `open` → `ready` (when no assignee is already set). Tasks no longer arrive in `ready` unassigned, so `ready_checks` can advance them to `doing` without a manual fix.
- Tightened Rowan's HEARTBEAT to make the `ready`/`doing` boundary explicit: `ready` = tech design only, `doing` = implementation. Prevents Rowan from starting feature code before the lobster promotes the task.

## Test plan
- [ ] Create a feature task, approve the spec — confirm it lands in `ready` with `assignee: Rowan` set automatically
- [ ] Confirm existing tasks already in `ready` with an assignee are unaffected (assignee is not overwritten)
- [ ] Rowan's HEARTBEAT state-boundary block is visible and clear

🤖 Generated with Claude Code