### PR TITLE
fix(agents): remove file: evidence option, enforce testID: as default

### DIFF
--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -123,6 +123,14 @@ Before writing any code on a feature task, write the tech design:
 - Each PR body must list which parent ACs its sub-ACs contribute to
 - Do not include the AC checklist in tech design docs or any other non-implementation PR body — ACs in a merged PR body are treated by the lobster as "covered"; only include them when the code is actually done
 
+**Evidence annotation — default to `testID:`:**
+- `(testID: <id>)` — **use this whenever the AC is testable**. Write a Playwright E2E test and reference its ID.
+- `(not tested: <reason>)` — only when Playwright coverage is genuinely not possible; reason must be specific (e.g. `pure algorithm, covered by unit test at src/foo.test.ts:myTest`). Do not use this as a shortcut.
+- `(not code: <reason>)` — AC fulfilled outside the codebase (brain file, spec doc, etc.)
+- `(pr: #<n>)` — covered by a separate already-merged PR
+
+Do not use `(file: ...)` — it is not an accepted evidence form.
+
 ### AC checkboxes on the task — hands off
 **Never tick or untick AC checkboxes in the task description.** That is Tom/QA's gate, applied only once the task reaches `acceptance`. Rowan's evidence belongs in the PR body only.
 

--- a/agents/skills/dev/pr-open/SKILL.md
+++ b/agents/skills/dev/pr-open/SKILL.md
@@ -55,10 +55,10 @@ Co-Authored-By: <Your Name> <your-email>
 
 **Acceptance Criteria (feature-task PRs only):** the lobster enforces a per-AC evidence rule at the `doing → acceptance` gate. Every checked `- [x]` AC line must end with one of:
 
-- `(testID: <id>)` — Playwright test ID reference
-- `(file: <path>:<test-name>)` — file plus test name reference
-- `(not tested: <reason>)` — implemented in code but not testable
+- `(testID: <id>)` — **default choice**: Playwright test ID. If the AC is testable, write an E2E test and use this.
+- `(not tested: <reason>)` — implemented in code but not testable via Playwright; reason must be specific (e.g. `pure algorithm, covered by unit test at src/foo.test.ts:myTest`)
 - `(not code: <reason>)` — AC fulfilled outside the codebase (brain file, spec doc, etc.)
+- `(pr: #<n>)` — covered by another already-merged PR
 
 **Every task AC must appear in the PR body** — checked with evidence. Fix PRs must re-list all task ACs, not just the ones being addressed.
 
@@ -67,7 +67,7 @@ Example:
 ```markdown
 ## Acceptance Criteria
 - [x] AC1: Task detail shows dependency links. (testID: 4)
-- [x] AC2: Card click-to-copy affordance. (file: apps/tasks/src/components/TaskCardSummary.test.jsx: click-to-copy affordance)
+- [x] AC2: Card click-to-copy affordance. (testID: 7)
 - [x] AC3: Reduced opacity for archived tasks. (not tested: design tokens supply color; visual review only)
 - [x] AC4: Feature factory v2 spec updated. (not code: updated brain/bookmarks/specs/feature-factory-v2-2026-06-04.md)
 ```
@@ -83,7 +83,7 @@ PRs without the required annotations are blocked from acceptance with a clear co
 - [x] AC2: Tab bar shows Tasks, Bookmarks, and Flow metrics tabs. (not tested: design tokens; visual review only)
 ### Task e2e647b1 — Flow metrics dashboard
 - [x] AC1: Dashboard shows cycle time (median and p90) for tasks completed. (testID: 5)
-- [x] AC2: Dashboard is reachable from the Flow metrics tab. (file: apps/mission-control/src/dashboard.test.jsx: flow metrics reachable)
+- [x] AC2: Dashboard is reachable from the Flow metrics tab. (testID: 6)
 ```
 
 The lobster walks the AC section line-by-line and tracks the current `### Task <id>` heading. ACs in a sibling task's subsection are not considered for the current task's text/evidence comparison. PR bodies without any `### Task <id>` heading fall back to the pre-#183 behavior (the whole AC section is implicitly one subsection).

--- a/agents/skills/dev/tech-design/SKILL.md
+++ b/agents/skills/dev/tech-design/SKILL.md
@@ -20,8 +20,8 @@ Include:
 - Data model or API contract changes
 - Workflow, cron, and skill changes
 - Test plan with an AC-by-AC verification matrix
-  - User-visible/app-flow ACs should plan E2E coverage where possible
-  - If E2E is not possible or is disproportionate, record why and name the fallback test layer (`file`, unit, component, integration, or manual)
+  - Default: plan a Playwright E2E test for every user-visible/app-flow AC; note the planned test description so it becomes the `(testID: <id>)` evidence in the PR
+  - If E2E is genuinely not possible or disproportionate, state why explicitly and name the fallback (unit, component, integration, or manual) — this becomes `(not tested: <reason>)` evidence; do not use `(file: ...)` as evidence in PR bodies
 - Open questions and risks
 
 **The AC verification matrix belongs inside this doc only.** Do not include the AC checklist (`- [x] AC1: ...`) in the PR body of the tech design or any other non-implementation PR — the lobster treats ACs appearing in a merged PR body as "covered by implementation", so listing them in a docs-only commit creates a false signal.


### PR DESCRIPTION
## Summary
- Removes `(file: <path>:<test-name>)` from all Rowan-facing docs (pr-open SKILL.md, WORKFLOW.md, tech-design SKILL.md). Rowan was defaulting to this option because it appeared second in every list and in examples — making it the lazy path over writing an actual Playwright test.
- New hierarchy: `(testID: <id>)` is the default for anything testable; `(not tested: <reason>)` requires an explicit reason; `(not code: <reason>)` for out-of-codebase ACs.
- The lobster parser is unchanged so any in-flight PRs that already used `file:` still pass the verify-delivery gate.

## Test plan
- [ ] Check that Rowan's next tech design plans `(testID: ...)` evidence for testable ACs rather than `(file: ...)`
- [ ] Confirm the lobster still accepts `file:` evidence on an existing PR (parser unchanged)

🤖 Generated with Claude Code