### PR TITLE
fix(tasks-api): update contentScheduler tests to use OAuth 1.0a env vars

### DIFF
--- a/services/tasks-api/test/contentScheduler.test.ts
+++ b/services/tasks-api/test/contentScheduler.test.ts
@@ -139,7 +139,10 @@ describe('FakeXClient', () => {
 describe('getXClient', () => {
   it('returns FakeXClient by default', () => {
     delete process.env.X_CLIENT;
-    delete process.env.X_API_BEARER_TOKEN;
+    delete process.env.X_API_KEY;
+    delete process.env.X_API_SECRET;
+    delete process.env.X_ACCESS_TOKEN;
+    delete process.env.X_ACCESS_TOKEN_SECRET;
     const client = getXClient();
     expect(client).toBeInstanceOf(FakeXClient);
   });
@@ -150,18 +153,37 @@ describe('getXClient', () => {
     expect(client).toBeInstanceOf(FakeXClient);
   });
 
-  it('returns null when X_CLIENT=real without bearer token', () => {
+  it('returns null when X_CLIENT=real and any OAuth 1.0a credential is missing', () => {
     process.env.X_CLIENT = 'real';
-    delete process.env.X_API_BEARER_TOKEN;
+    delete process.env.X_API_KEY;
+    delete process.env.X_API_SECRET;
+    delete process.env.X_ACCESS_TOKEN;
+    delete process.env.X_ACCESS_TOKEN_SECRET;
     expect(getXClient()).toBeNull();
   });
 
-  it('returns RealXClient when X_CLIENT=real and bearer token is set', () => {
+  it('returns null when X_CLIENT=real and only some OAuth 1.0a credentials are set', () => {
     process.env.X_CLIENT = 'real';
-    process.env.X_API_BEARER_TOKEN = 'test-token';
+    process.env.X_API_KEY = 'k';
+    delete process.env.X_API_SECRET;
+    delete process.env.X_ACCESS_TOKEN;
+    delete process.env.X_ACCESS_TOKEN_SECRET;
+    expect(getXClient()).toBeNull();
+    delete process.env.X_API_KEY;
+  });
+
+  it('returns RealXClient when X_CLIENT=real and all OAuth 1.0a creds are set', () => {
+    process.env.X_CLIENT = 'real';
+    process.env.X_API_KEY = 'k';
+    process.env.X_API_SECRET = 's';
+    process.env.X_ACCESS_TOKEN = 't';
+    process.env.X_ACCESS_TOKEN_SECRET = 'ts';
     const client = getXClient();
     expect(client).toBeInstanceOf(RealXClient);
-    delete process.env.X_API_BEARER_TOKEN;
+    delete process.env.X_API_KEY;
+    delete process.env.X_API_SECRET;
+    delete process.env.X_ACCESS_TOKEN;
+    delete process.env.X_ACCESS_TOKEN_SECRET;
   });
 });
 
@@ -280,7 +302,10 @@ describe('contentScheduler routes', () => {
 
   it('POST /content-scheduler/items/:id/publish returns 503 when credentials missing', async () => {
     process.env.X_CLIENT = 'real';
-    delete process.env.X_API_BEARER_TOKEN;
+    delete process.env.X_API_KEY;
+    delete process.env.X_API_SECRET;
+    delete process.env.X_ACCESS_TOKEN;
+    delete process.env.X_ACCESS_TOKEN_SECRET;
     const item = itemFixture({
       id: 'dddd1111-1111-1111-1111-111111111111',
       status: 'approved',


### PR DESCRIPTION
## Summary
- Test setup was deleting `X_API_BEARER_TOKEN` (OAuth 2.0) but the implementation now uses OAuth 1.0a (`X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`). Updates the test teardown to match.

## Test plan
- [ ] `npm test --workspace @sindustries/tasks-api` passes with no env-var-related test pollution

🤖 Generated with Claude Code