### PR TITLE
chore(code-garden): extract content scheduler validation

### DIFF
--- a/docs/repo-audits/2026-W29.md
+++ b/docs/repo-audits/2026-W29.md
@@ -111,7 +111,7 @@ AI agents
 - *Why it matters:* The file has grown since W27 (952→972) with the markdown-checkbox feature. Each addition makes it harder to navigate and increases the risk of accidental coupling between unrelated UI concerns. The pattern set by `tasks/_*` extraction should propagate here.
 - *Severity:* Medium (carryover from W27/W28)
 
-**[Low] Content Scheduler route `contentScheduler.ts` (374 lines) inlines all validation helpers.**
+**[Low] Content Scheduler route `contentScheduler.ts` (374 lines) inlines all validation helpers.** ✅ [PR #251](https://github.com/Stoffer-Industries/sindustries/pull/251)
 - *Where:* `services/tasks-api/src/routes/contentScheduler.ts`
 - *Why it matters:* Validation helpers (`parseId`, `parseDate`, `validateBody`) are duplicated from the pattern established in `tasks/_validation.ts`. This is acceptable at current size but inconsistent with the rest of the codebase convention.
 - *Severity:* Low

--- a/services/tasks-api/src/routes/contentScheduler.ts
+++ b/services/tasks-api/src/routes/contentScheduler.ts
@@ -25,36 +25,20 @@ import {
   getXClient,
   TERMINAL_STATUSES
 } from './contentSchedulerPublish.ts';
+import {
+  parseDate,
+  parseId,
+  uuidPattern,
+  validateBody,
+  validSources,
+  validStatuses
+} from './contentSchedulerValidation.ts';
 
-const MAX_BODY = 1000;
-
-const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-const validSources = new Set(['ops_notes', 'cto_craft', 'manual', 'other']);
-const validStatuses = new Set(['draft', 'queued', 'approved', 'published', 'removed']);
 
 function actor(req: any): string {
   const header = req.headers['x-actor'];
   if (typeof header === 'string' && header.trim().length > 0) return header.trim();
   return 'unknown';
-}
-
-function parseId(raw: string): string | null {
-  return uuidPattern.test(raw) ? raw : null;
-}
-
-function parseDate(value: unknown): Date | null | 'invalid' {
-  if (value === undefined || value === null || value === '') return null;
-  const d = new Date(value as string);
-  return Number.isNaN(d.valueOf()) ? 'invalid' : d;
-}
-
-function validateBody(body: unknown): string | null {
-  if (typeof body !== 'string') return 'body must be a string';
-  const trimmed = body.trim();
-  if (trimmed.length === 0) return 'body must not be empty';
-  if (body.length > MAX_BODY) return `body must be <= ${MAX_BODY} characters`;
-  return null;
 }
 
 export const contentSchedulerRouter = Router();

--- a/services/tasks-api/src/routes/contentSchedulerValidation.ts
+++ b/services/tasks-api/src/routes/contentSchedulerValidation.ts
@@ -1,0 +1,24 @@
+const MAX_BODY = 1000;
+
+export const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const validSources = new Set(['ops_notes', 'cto_craft', 'manual', 'other']);
+export const validStatuses = new Set(['draft', 'queued', 'approved', 'published', 'removed']);
+
+export function parseId(raw: string): string | null {
+  return uuidPattern.test(raw) ? raw : null;
+}
+
+export function parseDate(value: unknown): Date | null | 'invalid' {
+  if (value === undefined || value === null || value === '') return null;
+  const d = new Date(value as string);
+  return Number.isNaN(d.valueOf()) ? 'invalid' : d;
+}
+
+export function validateBody(body: unknown): string | null {
+  if (typeof body !== 'string') return 'body must be a string';
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return 'body must not be empty';
+  if (body.length > MAX_BODY) return `body must be <= ${MAX_BODY} characters`;
+  return null;
+}


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W29.md
- **Finding:** [Low] Content Scheduler route `contentScheduler.ts` inlines all validation helpers
- Extracts the existing Content Scheduler validation constants/helpers into a focused route-adjacent module with no logic changes.

## Test plan
- [x] `npm test --workspace @sindustries/tasks-api -- contentScheduler`
- [x] No logic changes — diff is purely structural

🌱 Code garden — non-functional cleanup only