### PR TITLE
chore(agents): tighten heartbeat reporting contract + Rowan code-garden rule

### DIFF
--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -66,6 +66,11 @@ Report only failures, newly blocked tasks, or meaningful transitions. **Do not r
 - If Rowan is busy: log to quinn-ops-state.json as a watching entry; do not re-spawn
 - Do NOT just report the stall without acting — dispatching Rowan is Quinn's job here
 
+**Heartbeat/subagent reporting contract:**
+- Heartbeat progress that matters to Tom should be announced here by Quinn's heartbeat output.
+- Rowan subagent completions are worker results: collect them back into the spawning Quinn heartbeat/session, then summarize the meaningful progress in Quinn's own heartbeat output.
+- Do not let Rowan subagent completion text become a standalone Tom-facing progress announcement; Tom should see the heartbeat summary, not raw worker handoff output.
+
 ---
 
 QUINN OPS TASKS

--- a/agents/definitions/quinn/SOUL.md
+++ b/agents/definitions/quinn/SOUL.md
@@ -32,6 +32,8 @@ _I am the Chief of Staff of Stoffer Industries. I serve Tom Stoffer, the CEO, in
 
 Each session I wake up fresh. These files are my memory. Read them. Update them. They're how I persist.
 
+**Daily memory note — non-negotiable:** At the end of every session (or before any significant silence), append at least one bullet to `memory/YYYY-MM-DD.md` (today's date). Create the file if it doesn't exist. Even if nothing happened, write `- Quiet day.` A gap in these files means a gap in memory for every downstream system that depends on them (content review, morning brief, dreaming).
+
 ---
 
 _This file is mine to evolve. As I learn who I am, I update it._

--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -45,4 +45,4 @@ Read and follow:
 
 **Limit:** Open at most 1 code-garden PR at a time. Check for open PRs first — if one exists, skip this step.
 
-**Skip code gardening entirely** if you have any assigned feature task in `ready` waiting for tech design, or any active unblocked feature task in `doing` or `acceptance`.
+**Skip code gardening entirely** if you have any assigned feature task in `ready` waiting for tech design, or any active feature task in `doing`/`acceptance` that you can materially progress in this pass (implementation, review feedback, merge/post-merge work, required comments/specs, or validation). If all active feature tasks are waiting on Quinn/Tom/reviewer action and you have already sent any needed nudge, code garden is on the table.


### PR DESCRIPTION
## Summary

Bundles two heartbeat rule changes Tom flagged, plus a small Quinn SOUL.md note that lives in the same family.

- **`agents/definitions/quinn/HEARTBEAT.md`** — adds a heartbeat/subagent reporting contract:
  - heartbeat progress for Tom is announced here by Quinn's heartbeat output
  - Rowan subagent completions return to the spawning Quinn heartbeat/session
  - Tom sees the heartbeat summary, not raw worker handoff output
- **`agents/definitions/rowan/HEARTBEAT.md`** — clarifies code-garden gating: skip when an active feature task can be materially progressed in this pass; code garden is on the table only when all active tasks are waiting on Quinn/Tom/reviewer action.
- **`agents/definitions/quinn/SOUL.md`** — adds a non-negotiable daily memory note rule so `memory/YYYY-MM-DD.md` is appended every session (creates the file if missing). A gap in these files breaks content review, morning brief, and dreaming.

## Why now

These rules came out of two real investigations:

1. **Subagent reporting contract (Quinn HEARTBEAT)** — Rowan subagent runs spawned from Quinn's heartbeat were delivering raw worker output to this DM instead of returning to the spawning session. Tom confirmed the desired contract on 2026-07-18: heartbeats announce progress here; subagent completions go back to the spawner.
2. **Rowan code-garden gating** — Tom flagged that a recent heartbeat skipped code garden even though no doing/acceptance task had been materially progressed. The rule now spells out "materially progressed" so it's not a blanket skip.
3. **Quinn SOUL daily memory note** — prevents future gaps in `memory/YYYY-MM-DD.md` that downstream systems (content review, morning brief, dreaming) depend on.

## Test plan

- [x] Diff reviewed — all three files are doc-only, no code paths change
- [x] No CI impact — no test files, no workflow files touched
- [x] Reviewer: skim the three edits and confirm the contract wording

🤖 Generated with Claude Code