### PR TITLE
chore(rowan): route heartbeat soft failures to Lox

### DIFF
--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -46,3 +46,14 @@ Read and follow:
 **Limit:** Open at most 1 code-garden PR at a time. Check for open PRs first — if one exists, skip this step.
 
 **Skip code gardening entirely** if you have any assigned feature task in `ready` waiting for tech design, or any active feature task in `doing`/`acceptance` that you can materially progress in this pass (implementation, review feedback, merge/post-merge work, required comments/specs, or validation). If all active feature tasks are waiting on Quinn/Tom/reviewer action and you have already sent any needed nudge, code garden is on the table.
+
+---
+
+## Escalate on Failure
+
+If any step fails due to an external dependency or operational issue (GitHub auth/scope error, Tasks API error, service unavailable, command traceback, unexpected empty output, or a brittle diagnostic command failure):
+
+1. Do NOT silently fall back, spam Tom with raw command failure output, or treat the failure as ordinary heartbeat progress
+2. Note which step failed and what the error was
+3. Read and follow `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/notify-soft-fail/SKILL.md` — escalate to Lox's main session
+4. Continue only if the remaining heartbeat steps are safe and independent; otherwise stop after the Lox escalation


### PR DESCRIPTION
## Summary
- Adds Ivy-style `Escalate on Failure` guidance to Rowan's heartbeat.
- Routes GitHub auth/scope errors, Tasks API errors, tracebacks, unexpected empty output, and brittle diagnostic command failures through `notify-soft-fail` to Lox instead of surfacing raw command output to Tom.
- Keeps remaining heartbeat work allowed only when it is safe and independent after escalation.

## Why now
Tom pointed out that Lox can help with this class of issue and Ivy already has this pattern. Rowan's HEARTBEAT.md did not, so raw soft failures like the `===isDraft?===` diagnostic failure were being surfaced directly.

## Test plan
- [x] Doc-only change; compared against Ivy's heartbeat escalation pattern
- [x] References existing `agents/skills/ops/notify-soft-fail/SKILL.md`

🤖 Generated with Claude Code