### PR TITLE
feat(content-scheduler): 10-day calendar view (task 95e65d06)

### DIFF
--- a/apps/mission-control/src/styles/components.css
+++ b/apps/mission-control/src/styles/components.css
@@ -646,3 +646,138 @@
 .sindustries-tab__fallback-link:focus-visible {
   text-decoration: underline;
 }
+
+/* =========================================================================
+ * Content Scheduler: 10-day calendar view
+ * Task 95e65d06-e529-466e-a6b0-d8dfb1e2eb87
+ * Replaces the prior three-status-group listing as the primary view.
+ * ======================================================================= */
+
+.content-scheduler-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.content-scheduler-calendar {
+  display: grid;
+  grid-template-columns: repeat(10, minmax(220px, 1fr));
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+}
+
+.content-scheduler-day-column {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 180px;
+  border: 1px dashed transparent;
+  border-radius: 8px;
+  padding: 8px;
+  background: var(--si-color-bg-elevated, #fff);
+  transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+.content-scheduler-day-column--drag-over {
+  border-color: var(--si-color-brand-500, #b46a00);
+  background: var(--si-color-bg-subtle, #f7f4ee);
+}
+
+.content-scheduler-day-column--drop-error {
+  border-color: var(--si-color-danger-500, #a3312b);
+  background: var(--si-color-danger-bg, #fbeceb);
+}
+
+.content-scheduler-day-column__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--si-color-border, #e5e5e5);
+}
+
+.content-scheduler-day-column__header--published {
+  background: var(--si-color-success-bg, #e8f4ec);
+}
+
+.content-scheduler-day-column__label {
+  font-weight: 600;
+  font-size: 13px;
+  flex: 1 1 auto;
+}
+
+.content-scheduler-day-column__count {
+  font-size: 11px;
+  color: var(--si-color-text-muted, #666);
+  background: var(--si-color-bg-subtle, #f1f1f4);
+  padding: 1px 6px;
+  border-radius: 999px;
+}
+
+.content-scheduler-day-column__drop-error {
+  margin: 0;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: var(--si-color-danger-bg, #fbeceb);
+  color: var(--si-color-danger-500, #a3312b);
+  font-size: 12px;
+}
+
+.content-scheduler-day-column__cards {
+  flex: 1 1 auto;
+}
+
+.content-scheduler-row--published {
+  opacity: 0.7;
+  background: var(--si-color-bg-subtle, #f7f4ee);
+  cursor: not-allowed;
+}
+
+.content-scheduler-row__published-day-hint {
+  color: var(--si-color-text-muted, #888);
+  font-size: 11px;
+  font-style: italic;
+}
+
+.content-scheduler-unscheduled {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px dashed var(--si-color-border, #e5e5e5);
+  border-radius: 8px;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.content-scheduler-unscheduled--drag-over {
+  border-color: var(--si-color-brand-500, #b46a00);
+  background: var(--si-color-bg-subtle, #f7f4ee);
+}
+
+.content-scheduler-unscheduled__header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0;
+}
+
+.content-scheduler-unscheduled__header h3 {
+  margin: 0;
+  font-size: 14px;
+}
+
+.content-scheduler-empty {
+  margin: 0;
+  padding: 12px;
+  font-size: 12px;
+  color: var(--si-color-text-muted, #888);
+  font-style: italic;
+  text-align: center;
+}
+
+@media (max-width: 1280px) {
+  .content-scheduler-calendar {
+    grid-template-columns: repeat(10, 220px);
+  }
+}

--- a/apps/mission-control/src/tabs/ContentSchedulerTab.jsx
+++ b/apps/mission-control/src/tabs/ContentSchedulerTab.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Button, Card, CardContainer, Field, Select, Textarea } from '@sindustries/ui/react';
+import { Badge, Button, Card, CardContainer, Field, Select, Textarea } from '@sindustries/ui/react';
 import {
   approveItem,
   createItem,
@@ -7,10 +7,18 @@ import {
   listItems,
   publishItem,
   removeItem,
-  reorderItems,
   unapproveItem,
   updateItem
 } from '../contentSchedulerApi.js';
+import {
+  SCHEDULER_TIME_ZONE,
+  buildCalendarDays,
+  dayDropBlocked,
+  getAucklandDayKey,
+  getAucklandTimeOfDay,
+  groupItemsForCalendar,
+  rescheduleIsoForDay
+} from './contentSchedulerCalendar.js';
 
 const ACTOR = 'Tom';
 
@@ -26,6 +34,14 @@ const STATUS_LABELS = {
   approved: 'Approved',
   published: 'Published'
 };
+
+const STATUS_BADGE_VARIANT = {
+  queued: 'neutral',
+  approved: 'info',
+  published: 'success'
+};
+
+const DROP_REFUSED_MESSAGE = 'Already has a published post — choose another day.';
 
 function defaultScheduledFor() {
   const d = new Date(Date.now() + 60_000);
@@ -75,7 +91,17 @@ function publishTooltip(item, today) {
   return '';
 }
 
-function ItemRow({ item, today, onApprove, onUnapprove, onPublish, onRemove, onSave, onDragStart, onDragOver, onDrop, isDragOver }) {
+function SchedulerItemCard({
+  item,
+  today,
+  onApprove,
+  onUnapprove,
+  onPublish,
+  onRemove,
+  onSave,
+  onDragStart,
+  isPublishedInCalendar
+}) {
   const [editing, setEditing] = useState(false);
   const [draftBody, setDraftBody] = useState(item.body);
   const [draftSchedule, setDraftSchedule] = useState(toDatetimeLocal(item.scheduledFor));
@@ -88,16 +114,24 @@ function ItemRow({ item, today, onApprove, onUnapprove, onPublish, onRemove, onS
   const disabled = isPublishDisabled(item, today);
   const tip = publishTooltip(item, today);
   const published = item.status === 'published';
+  const cardClass = `content-scheduler-row${published ? ' content-scheduler-row--published' : ''}`;
 
   return (
     <Card
-      className="content-scheduler-row"
+      className={cardClass}
       data-testid={`content-scheduler-row-${item.id}`}
+      data-item-id={item.id}
+      data-status={item.status}
       draggable={!published}
-      onDragStart={(e) => onDragStart(e, item.id)}
-      onDragOver={(e) => onDragOver(e, item.id)}
-      onDrop={(e) => onDrop(e, item.id)}
-      style={isDragOver ? { outline: '2px dashed var(--si-color-brand-500, #b46a00)' } : undefined}
+      onDragStart={(e) => {
+        if (published) {
+          e.preventDefault();
+          return;
+        }
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', item.id);
+        onDragStart(item.id);
+      }}
     >
       <div className="content-scheduler-row__body">
         {editing ? (
@@ -113,8 +147,18 @@ function ItemRow({ item, today, onApprove, onUnapprove, onPublish, onRemove, onS
           <p data-testid={`content-scheduler-body-${item.id}`}>{item.body}</p>
         )}
         <div className="content-scheduler-row__meta">
+          <Badge
+            variant={STATUS_BADGE_VARIANT[item.status] ?? 'neutral'}
+            data-testid={`content-scheduler-status-${item.id}`}
+          >
+            {STATUS_LABELS[item.status] ?? item.status}
+          </Badge>
           <span>Source: {item.source}</span>
-          {item.scheduledFor && <span>Scheduled: {new Date(item.scheduledFor).toLocaleString()}</span>}
+          {item.scheduledFor && (
+            <span data-testid={`content-scheduler-schedule-display-${item.id}`}>
+              Scheduled: {getAucklandTimeOfDay(item.scheduledFor, SCHEDULER_TIME_ZONE)} {SCHEDULER_TIME_ZONE}
+            </span>
+          )}
           {item.approvedAt && <span>Approved by {item.approvedBy ?? 'unknown'} at {new Date(item.approvedAt).toLocaleString()}</span>}
           {item.publishedAt && (
             <span>
@@ -131,6 +175,11 @@ function ItemRow({ item, today, onApprove, onUnapprove, onPublish, onRemove, onS
             </span>
           )}
           {item.publishError && <span style={{ color: 'var(--si-color-danger-500, #a3312b)' }}>Publish error: {item.publishError}</span>}
+          {isPublishedInCalendar && !published && (
+            <span className="content-scheduler-row__published-day-hint">
+              Published today — drop another day
+            </span>
+          )}
         </div>
         {editing && (
           <Field label="Scheduled for">
@@ -196,10 +245,10 @@ function ItemRow({ item, today, onApprove, onUnapprove, onPublish, onRemove, onS
                 Remove
               </Button>
             )}
-            {item.status === 'published' && (
-              <span className="content-scheduler-row__badge" data-testid={`content-scheduler-published-${item.id}`}>
+            {published && (
+              <Badge variant="success" data-testid={`content-scheduler-published-${item.id}`}>
                 Published
-              </span>
+              </Badge>
             )}
           </>
         )}
@@ -215,7 +264,9 @@ export function ContentSchedulerTab() {
   const [body, setBody] = useState('');
   const [source, setSource] = useState('manual');
   const [scheduledFor, setScheduledFor] = useState(defaultScheduledFor());
-  const [dragOverId, setDragOverId] = useState(null);
+  const [draggingItemId, setDraggingItemId] = useState(null);
+  const [dragOverZone, setDragOverZone] = useState(null);
+  const [dropError, setDropError] = useState(null); // { dayKey, message } | null
 
   const reload = useCallback(async () => {
     try {
@@ -243,16 +294,8 @@ export function ContentSchedulerTab() {
     return () => clearInterval(intervalId);
   }, [reload]);
 
-  const grouped = useMemo(() => {
-    const out = { queued: [], approved: [], published: [] };
-    for (const item of items ?? []) {
-      if (out[item.status]) out[item.status].push(item);
-    }
-    for (const status of Object.keys(out)) {
-      out[status].sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
-    }
-    return out;
-  }, [items]);
+  const days = useMemo(() => buildCalendarDays(new Date(), SCHEDULER_TIME_ZONE), [items]); // eslint-disable-line react-hooks/exhaustive-deps
+  const grouped = useMemo(() => groupItemsForCalendar(items, days, SCHEDULER_TIME_ZONE), [items, days]);
 
   const handleCreate = useCallback(async () => {
     if (!body.trim()) return;
@@ -331,24 +374,97 @@ export function ContentSchedulerTab() {
     [reload]
   );
 
-  const handleReorder = useCallback(
-    async (sourceId, targetId) => {
-      if (sourceId === targetId) return;
-      const current = (items ?? []).filter((i) => i.status === 'queued');
-      const fromIdx = current.findIndex((i) => i.id === sourceId);
-      const toIdx = current.findIndex((i) => i.id === targetId);
-      if (fromIdx < 0 || toIdx < 0) return;
-      const reordered = [...current];
-      const [moved] = reordered.splice(fromIdx, 1);
-      reordered.splice(toIdx, 0, moved);
+  const handleDragStart = useCallback((id) => {
+    setDraggingItemId(id);
+    setDropError(null);
+  }, []);
+
+  const handleDayDragOver = useCallback(
+    (e, dayKey) => {
+      if (!draggingItemId) return;
+      const item = (items ?? []).find((i) => i.id === draggingItemId);
+      if (!item || item.status === 'published') return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      setDragOverZone(`day:${dayKey}`);
+      const { blocked } = dayDropBlocked(grouped.publishedByDayKey, dayKey, draggingItemId);
+      if (blocked) {
+        setDropError({ dayKey, message: DROP_REFUSED_MESSAGE });
+      } else if (dropError?.dayKey === dayKey) {
+        setDropError(null);
+      }
+    },
+    [draggingItemId, items, grouped.publishedByDayKey, dropError]
+  );
+
+  const handleDayDrop = useCallback(
+    async (e, dayKey) => {
+      e.preventDefault();
+      setDragOverZone(null);
+      const sourceId = e.dataTransfer.getData('text/plain') || draggingItemId;
+      setDraggingItemId(null);
+      if (!sourceId) return;
+      const item = (items ?? []).find((i) => i.id === sourceId);
+      if (!item || item.status === 'published') {
+        setDropError(null);
+        return;
+      }
+      const { blocked } = dayDropBlocked(grouped.publishedByDayKey, dayKey, sourceId);
+      if (blocked) {
+        setDropError({ dayKey, message: DROP_REFUSED_MESSAGE });
+        return;
+      }
+      const currentDayKey = getAucklandDayKey(item.scheduledFor, SCHEDULER_TIME_ZONE);
+      if (currentDayKey === dayKey) {
+        // No-op drop on the same day; clear any stale error.
+        setDropError(null);
+        return;
+      }
+      const nextIso = rescheduleIsoForDay(item, dayKey, SCHEDULER_TIME_ZONE);
+      if (!nextIso) {
+        setError('Failed to compute new scheduled time.');
+        return;
+      }
       try {
-        await reorderItems(reordered.map((i) => i.id), ACTOR);
+        await updateItem(sourceId, { scheduledFor: nextIso }, { actor: ACTOR });
+        setDropError(null);
         await reload();
       } catch (err) {
         setError(err?.message ?? String(err));
       }
     },
-    [items, reload]
+    [draggingItemId, items, grouped.publishedByDayKey, reload]
+  );
+
+  const handleUnscheduledDragOver = useCallback((e) => {
+    if (!draggingItemId) return;
+    const item = (items ?? []).find((i) => i.id === draggingItemId);
+    if (!item || item.status === 'published') return;
+    e.preventDefault();
+    setDragOverZone('unscheduled');
+  }, [draggingItemId, items]);
+
+  const handleUnscheduledDrop = useCallback(
+    async (e) => {
+      e.preventDefault();
+      setDragOverZone(null);
+      const sourceId = e.dataTransfer.getData('text/plain') || draggingItemId;
+      setDraggingItemId(null);
+      if (!sourceId) return;
+      const item = (items ?? []).find((i) => i.id === sourceId);
+      if (!item || item.status === 'published') return;
+      if (!item.scheduledFor) {
+        // Already unscheduled — no-op.
+        return;
+      }
+      try {
+        await updateItem(sourceId, { scheduledFor: null }, { actor: ACTOR });
+        await reload();
+      } catch (err) {
+        setError(err?.message ?? String(err));
+      }
+    },
+    [draggingItemId, items, reload]
   );
 
   if (error && !items) {
@@ -414,45 +530,105 @@ export function ContentSchedulerTab() {
         {error && <p className="content-scheduler-error" data-testid="pulse-content-scheduler-error">{error}</p>}
       </Card>
 
-      {(['queued', 'approved', 'published']).map((status) => (
-        <section
-          key={status}
-          className={`content-scheduler-group content-scheduler-group--${status}`}
-          data-testid={`pulse-content-scheduler-group-${status}`}
-        >
-          <h3>{STATUS_LABELS[status]} ({grouped[status].length})</h3>
-          {grouped[status].length === 0 ? (
-            <p className="content-scheduler-empty">No {STATUS_LABELS[status].toLowerCase()} items.</p>
-          ) : (
-            <CardContainer>
-              {grouped[status].map((item) => (
-                <ItemRow
-                  key={item.id}
-                  item={item}
-                  today={today}
-                  onApprove={handleApprove}
-                  onUnapprove={handleUnapprove}
-                  onPublish={handlePublish}
-                  onRemove={handleRemove}
-                  onSave={handleSave}
-                  onDragStart={(e, id) => e.dataTransfer.setData('text/plain', id)}
-                  onDragOver={(e, id) => {
-                    e.preventDefault();
-                    setDragOverId(id);
-                  }}
-                  onDrop={async (e, id) => {
-                    e.preventDefault();
-                    const sourceId = e.dataTransfer.getData('text/plain');
-                    setDragOverId(null);
-                    await handleReorder(sourceId, id);
-                  }}
-                  isDragOver={dragOverId === item.id}
-                />
-              ))}
-            </CardContainer>
-          )}
-        </section>
-      ))}
+      <section
+        className="content-scheduler-calendar"
+        data-testid="pulse-content-scheduler-calendar"
+        aria-label="10-day publishing calendar (Pacific/Auckland)"
+      >
+        {days.map((day) => {
+          const dayItems = grouped.byDayKey[day.key] ?? [];
+          const publishedItem = grouped.publishedByDayKey[day.key] ?? null;
+          const isOver = dragOverZone === `day:${day.key}`;
+          const dayError = dropError?.dayKey === day.key ? dropError.message : null;
+          const headerClasses = ['content-scheduler-day-column__header'];
+          if (publishedItem) headerClasses.push('content-scheduler-day-column__header--published');
+          const columnClasses = ['content-scheduler-day-column'];
+          if (isOver) columnClasses.push('content-scheduler-day-column--drag-over');
+          if (dayError) columnClasses.push('content-scheduler-day-column--drop-error');
+          return (
+            <div
+              key={day.key}
+              className={columnClasses.join(' ')}
+              data-testid={`pulse-content-scheduler-day-${day.key}`}
+              data-day-key={day.key}
+              onDragOver={(e) => handleDayDragOver(e, day.key)}
+              onDrop={(e) => handleDayDrop(e, day.key)}
+            >
+              <header className={headerClasses.join(' ')} data-testid={`pulse-content-scheduler-day-header-${day.key}`}>
+                <span className="content-scheduler-day-column__label">{day.label}</span>
+                {publishedItem && (
+                  <Badge variant="success" data-testid={`pulse-content-scheduler-day-published-${day.key}`}>
+                    Published
+                  </Badge>
+                )}
+                <span className="content-scheduler-day-column__count" data-testid={`pulse-content-scheduler-day-count-${day.key}`}>
+                  {dayItems.length}
+                </span>
+              </header>
+              {dayError && (
+                <p
+                  className="content-scheduler-day-column__drop-error"
+                  data-testid={`pulse-content-scheduler-day-drop-error-${day.key}`}
+                  role="alert"
+                >
+                  {dayError}
+                </p>
+              )}
+              <CardContainer className="content-scheduler-day-column__cards">
+                {dayItems.length === 0 ? (
+                  <p className="content-scheduler-empty">No items.</p>
+                ) : (
+                  dayItems.map((item) => (
+                    <SchedulerItemCard
+                      key={item.id}
+                      item={item}
+                      today={today}
+                      onApprove={handleApprove}
+                      onUnapprove={handleUnapprove}
+                      onPublish={handlePublish}
+                      onRemove={handleRemove}
+                      onSave={handleSave}
+                      onDragStart={handleDragStart}
+                      isPublishedInCalendar={Boolean(publishedItem) && item.id !== publishedItem.id}
+                    />
+                  ))
+                )}
+              </CardContainer>
+            </div>
+          );
+        })}
+      </section>
+
+      <section
+        className={`content-scheduler-unscheduled${dragOverZone === 'unscheduled' ? ' content-scheduler-unscheduled--drag-over' : ''}`}
+        data-testid="pulse-content-scheduler-unscheduled"
+        onDragOver={handleUnscheduledDragOver}
+        onDrop={handleUnscheduledDrop}
+      >
+        <header className="content-scheduler-unscheduled__header">
+          <h3>Unscheduled</h3>
+          <span data-testid="pulse-content-scheduler-unscheduled-count">{grouped.unscheduled.length}</span>
+        </header>
+        {grouped.unscheduled.length === 0 ? (
+          <p className="content-scheduler-empty">No unscheduled items.</p>
+        ) : (
+          <CardContainer>
+            {grouped.unscheduled.map((item) => (
+              <SchedulerItemCard
+                key={item.id}
+                item={item}
+                today={today}
+                onApprove={handleApprove}
+                onUnapprove={handleUnapprove}
+                onPublish={handlePublish}
+                onRemove={handleRemove}
+                onSave={handleSave}
+                onDragStart={handleDragStart}
+              />
+            ))}
+          </CardContainer>
+        )}
+      </section>
 
       <div className="content-scheduler-day-strip" data-testid="pulse-content-scheduler-day-strip">
         {dayStatusLabel(today)}

--- a/apps/mission-control/src/tabs/ContentSchedulerTab.test.jsx
+++ b/apps/mission-control/src/tabs/ContentSchedulerTab.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 
 vi.mock('../contentSchedulerApi.js', () => ({
   listItems: vi.fn(),
@@ -16,10 +16,10 @@ vi.mock('../contentSchedulerApi.js', () => ({
 import {
   listItems,
   createItem,
+  updateItem,
   approveItem,
   publishItem,
   removeItem,
-  reorderItems,
   getTodayStatus
 } from '../contentSchedulerApi.js';
 import { ContentSchedulerTab } from './ContentSchedulerTab.jsx';
@@ -28,7 +28,12 @@ const QUEUED_ID = '11111111-1111-1111-1111-111111111111';
 const APPROVED_ID = '22222222-2222-2222-2222-222222222222';
 const PUBLISHED_ID = '33333333-3333-3333-3333-333333333333';
 
-function fixture() {
+function fixture({ now = '2026-07-18T15:00:00.000Z' } = {}) {
+  // Default fixture uses scheduledFor values that resolve to the same
+  // Pacific/Auckland day, regardless of the runtime clock.
+  // The frozen clock in beforeEach pins "now" to 2026-07-18T15:00:00Z,
+  // which is 2026-07-19 03:00 NZST, so the 10-day window starts at
+  // 2026-07-19 (Sun) and runs through 2026-07-28.
   return [
     {
       id: QUEUED_ID,
@@ -36,7 +41,8 @@ function fixture() {
       source: 'manual',
       sourceRef: null,
       status: 'queued',
-      scheduledFor: null,
+      // 2026-07-18T19:00:00Z = 2026-07-19 07:00 NZST → today (2026-07-19)
+      scheduledFor: '2026-07-18T19:00:00.000Z',
       position: 0,
       approvedAt: null,
       approvedBy: null,
@@ -53,7 +59,8 @@ function fixture() {
       source: 'ops_notes',
       sourceRef: null,
       status: 'approved',
-      scheduledFor: null,
+      // 2026-07-19T20:00:00Z = 2026-07-20 08:00 NZST → tomorrow (2026-07-20)
+      scheduledFor: '2026-07-19T20:00:00.000Z',
       position: 0,
       approvedAt: '2026-07-10T01:00:00.000Z',
       approvedBy: 'Tom',
@@ -70,46 +77,68 @@ function fixture() {
       source: 'cto_craft',
       sourceRef: null,
       status: 'published',
-      scheduledFor: null,
+      // 2026-07-20T21:00:00Z = 2026-07-21 09:00 NZST → today+2 (2026-07-21)
+      // Inside the 10-day window so the calendar shows it as a published day.
+      scheduledFor: '2026-07-20T21:00:00.000Z',
       position: 0,
       approvedAt: '2026-07-09T22:00:00.000Z',
       approvedBy: 'Tom',
-      publishedAt: '2026-07-10T03:00:00.000Z',
+      publishedAt: '2026-07-21T01:00:00.000Z',
       publishedUrl: 'https://x.com/sindustries/status/abc',
       publishError: null,
       createdAt: '2026-07-09T20:00:00.000Z',
-      updatedAt: '2026-07-10T03:00:00.000Z',
+      updatedAt: '2026-07-21T02:00:00.000Z',
       removedAt: null
     }
   ];
 }
 
-const TODAY_OK = { date: '2026-07-10', publishedCount: 0, publishedItemId: null, cap: 1 };
-const TODAY_FULL = { date: '2026-07-10', publishedCount: 1, publishedItemId: PUBLISHED_ID, cap: 1 };
+const TODAY_OK = { date: '2026-07-19', publishedCount: 0, publishedItemId: null, cap: 1 };
+const TODAY_FULL = { date: '2026-07-19', publishedCount: 1, publishedItemId: PUBLISHED_ID, cap: 1 };
+
+function dispatchDragStart(cardEl) {
+  const dt = {
+    effectAllowed: '',
+    dropEffect: '',
+    setData: vi.fn(),
+    getData: vi.fn().mockReturnValue(cardEl.getAttribute('data-item-id') ?? '')
+  };
+  fireEvent.dragStart(cardEl, { dataTransfer: dt });
+  return dt;
+}
 
 describe('ContentSchedulerTab', () => {
   beforeEach(() => {
+    // Freeze the runtime clock to 2026-07-19 03:00 NZST (= 2026-07-18T15:00:00Z)
+    // so the 10-day window is deterministic. We do NOT call useFakeTimers
+    // here because faking setInterval/setTimeout globally breaks the async
+    // reload() promise chain that the component relies on to populate
+    // items. The dedicated 10s-refresh test installs fake timers locally.
+    vi.setSystemTime(new Date('2026-07-18T15:00:00.000Z'));
     listItems.mockResolvedValue(fixture());
     getTodayStatus.mockResolvedValue(TODAY_OK);
     createItem.mockResolvedValue({ id: 'new-id', body: 'New tweet', status: 'queued', source: 'manual', position: 1 });
+    updateItem.mockResolvedValue({});
     approveItem.mockResolvedValue({});
     publishItem.mockResolvedValue({});
     removeItem.mockResolvedValue({});
-    reorderItems.mockResolvedValue({ ok: true, count: 3 });
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
-  it('renders loading state then the full tab on mount', async () => {
+  it('renders loading state then the calendar + unscheduled on mount', async () => {
     render(<ContentSchedulerTab />);
     expect(screen.getByTestId('pulse-content-scheduler-loading')).toBeTruthy();
     await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
-    expect(screen.getByTestId('pulse-content-scheduler-composer')).toBeTruthy();
-    expect(screen.getByTestId('pulse-content-scheduler-group-queued')).toBeTruthy();
-    expect(screen.getByTestId('pulse-content-scheduler-group-approved')).toBeTruthy();
-    expect(screen.getByTestId('pulse-content-scheduler-group-published')).toBeTruthy();
+    // AC1: 10 day columns exist.
+    const dayColumns = screen.getAllByTestId(/^pulse-content-scheduler-day-\d{4}-\d{2}-\d{2}$/);
+    expect(dayColumns).toHaveLength(10);
+    // Unscheduled overflow is present.
+    expect(screen.getByTestId('pulse-content-scheduler-unscheduled')).toBeTruthy();
+    // Day-strip footer still shows today-status.
     expect(screen.getByTestId('pulse-content-scheduler-day-strip').textContent).toContain('0 / 1');
   });
 
@@ -199,5 +228,150 @@ describe('ContentSchedulerTab', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // AC2 — in-window items appear in the correct Pacific/Auckland day column
+  // with status badges.
+  it('renders in-window items in the correct Pacific/Auckland day columns with status badges', async () => {
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    // Published item sits in 2026-07-18 (yesterday in NZ), queued in 2026-07-19 (today), approved in 2026-07-20 (tomorrow).
+    expect(within(screen.getByTestId('pulse-content-scheduler-day-2026-07-21')).getByTestId(`content-scheduler-row-${PUBLISHED_ID}`)).toBeTruthy();
+    expect(within(screen.getByTestId('pulse-content-scheduler-day-2026-07-19')).getByTestId(`content-scheduler-row-${QUEUED_ID}`)).toBeTruthy();
+    expect(within(screen.getByTestId('pulse-content-scheduler-day-2026-07-20')).getByTestId(`content-scheduler-row-${APPROVED_ID}`)).toBeTruthy();
+    // Status badges surface on every card.
+    expect(screen.getByTestId(`content-scheduler-status-${QUEUED_ID}`).textContent).toBe('Queued');
+    expect(screen.getByTestId(`content-scheduler-status-${APPROVED_ID}`).textContent).toBe('Approved');
+    expect(screen.getByTestId(`content-scheduler-status-${PUBLISHED_ID}`).textContent).toBe('Published');
+  });
+
+  // AC3 — items outside the 10-day window land in Unscheduled.
+  it('routes items with no scheduledFor or out-of-window dates to Unscheduled', async () => {
+    const items = fixture();
+    items.push({
+      id: 'unsched-1',
+      body: 'No schedule',
+      source: 'manual',
+      sourceRef: null,
+      status: 'queued',
+      scheduledFor: null,
+      position: 0,
+      approvedAt: null,
+      approvedBy: null,
+      publishedAt: null,
+      publishedUrl: null,
+      publishError: null,
+      createdAt: '2026-07-10T00:00:00.000Z',
+      updatedAt: '2026-07-10T00:00:00.000Z',
+      removedAt: null
+    });
+    items.push({
+      id: 'unsched-2',
+      body: 'Far future',
+      source: 'manual',
+      sourceRef: null,
+      status: 'queued',
+      // 2027-01-01 → way outside the 10-day window starting 2026-07-19.
+      scheduledFor: '2027-01-01T00:00:00.000Z',
+      position: 0,
+      approvedAt: null,
+      approvedBy: null,
+      publishedAt: null,
+      publishedUrl: null,
+      publishError: null,
+      createdAt: '2026-07-10T00:00:00.000Z',
+      updatedAt: '2026-07-10T00:00:00.000Z',
+      removedAt: null
+    });
+    listItems.mockResolvedValue(items);
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    const overflow = screen.getByTestId('pulse-content-scheduler-unscheduled');
+    expect(within(overflow).getByTestId('content-scheduler-row-unsched-1')).toBeTruthy();
+    expect(within(overflow).getByTestId('content-scheduler-row-unsched-2')).toBeTruthy();
+    // Neither overflow item appears inside any day column.
+    const dayColumns = screen.getAllByTestId(/^pulse-content-scheduler-day-\d{4}-\d{2}-\d{2}$/);
+    for (const col of dayColumns) {
+      expect(within(col).queryByTestId('content-scheduler-row-unsched-1')).toBeNull();
+      expect(within(col).queryByTestId('content-scheduler-row-unsched-2')).toBeNull();
+    }
+  });
+
+  // AC4 — drag from one day column to another calls updateItem with an ISO on
+  // the target date preserving HH:MM.
+  it('drag-drop to another day updates scheduledFor preserving HH:MM', async () => {
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    const card = screen.getByTestId(`content-scheduler-row-${QUEUED_ID}`);
+    const targetColumn = screen.getByTestId('pulse-content-scheduler-day-2026-07-22');
+    const dt = dispatchDragStart(card);
+    fireEvent.dragOver(targetColumn, { dataTransfer: dt });
+    fireEvent.drop(targetColumn, { dataTransfer: dt });
+    await waitFor(() => expect(updateItem).toHaveBeenCalled());
+    const call = updateItem.mock.calls[updateItem.mock.calls.length - 1];
+    expect(call[0]).toBe(QUEUED_ID);
+    // Queued item is at 07:00 NZST. Target day is 2026-07-22, so the new
+    // UTC instant is 2026-07-22 07:00 NZST = 2026-07-21 19:00 UTC.
+    expect(call[1].scheduledFor).toBe('2026-07-21T19:00:00.000Z');
+    expect(call[2]).toEqual({ actor: 'Tom' });
+  });
+
+  // AC4 — drag an item with no time defaults to 09:00.
+  it('drag-drop with no source time defaults scheduledFor to 09:00 local', async () => {
+    listItems.mockResolvedValue([
+      {
+        ...fixture()[0],
+        id: 'no-time',
+        scheduledFor: null
+      }
+    ]);
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    const card = screen.getByTestId('content-scheduler-row-no-time');
+    const target = screen.getByTestId('pulse-content-scheduler-day-2026-07-25');
+    const dt = dispatchDragStart(card);
+    fireEvent.dragOver(target, { dataTransfer: dt });
+    fireEvent.drop(target, { dataTransfer: dt });
+    await waitFor(() => expect(updateItem).toHaveBeenCalled());
+    const call = updateItem.mock.calls[updateItem.mock.calls.length - 1];
+    expect(call[1].scheduledFor).toBe('2026-07-24T21:00:00.000Z'); // 09:00 NZST
+  });
+
+  // AC5 — published cards are read-only with a published badge and no drag.
+  it('published cards render with the Published badge and cannot be dragged', async () => {
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    const publishedCard = screen.getByTestId(`content-scheduler-row-${PUBLISHED_ID}`);
+    expect(publishedCard.getAttribute('draggable')).toBe('false');
+    expect(within(publishedCard).getByTestId(`content-scheduler-published-${PUBLISHED_ID}`)).toBeTruthy();
+    // No edit, approve, unapprove, publish, remove buttons on a published card.
+    expect(within(publishedCard).queryByTestId(`content-scheduler-edit-${PUBLISHED_ID}`)).toBeNull();
+    expect(within(publishedCard).queryByTestId(`content-scheduler-approve-${PUBLISHED_ID}`)).toBeNull();
+    expect(within(publishedCard).queryByTestId(`content-scheduler-publish-${PUBLISHED_ID}`)).toBeNull();
+    expect(within(publishedCard).queryByTestId(`content-scheduler-remove-${PUBLISHED_ID}`)).toBeNull();
+    // Drag should be a no-op (no updateItem call).
+    const dt = { setData: vi.fn(), getData: vi.fn() };
+    fireEvent.dragStart(publishedCard, { dataTransfer: dt });
+    fireEvent.dragOver(screen.getByTestId('pulse-content-scheduler-day-2026-07-25'), { dataTransfer: dt });
+    fireEvent.drop(screen.getByTestId('pulse-content-scheduler-day-2026-07-25'), { dataTransfer: dt });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(updateItem).not.toHaveBeenCalled();
+  });
+
+  // AC6 — drag-drop onto a day with a published item is refused and shows an
+  // inline error.
+  it('refuses to drop onto a day with an existing published item and shows an inline error', async () => {
+    render(<ContentSchedulerTab />);
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler')).toBeTruthy());
+    // The published item sits in 2026-07-21 (today+2 in NZ). Drag the queued
+    // card onto that day.
+    const queuedCard = screen.getByTestId(`content-scheduler-row-${QUEUED_ID}`);
+    const publishedDay = screen.getByTestId('pulse-content-scheduler-day-2026-07-21');
+    const dt = dispatchDragStart(queuedCard);
+    fireEvent.dragOver(publishedDay, { dataTransfer: dt });
+    fireEvent.drop(publishedDay, { dataTransfer: dt });
+    await waitFor(() => expect(screen.getByTestId('pulse-content-scheduler-day-drop-error-2026-07-21')).toBeTruthy());
+    expect(screen.getByTestId('pulse-content-scheduler-day-drop-error-2026-07-21').textContent).toMatch(/already has a published/i);
+    expect(updateItem).not.toHaveBeenCalled();
   });
 });

--- a/apps/mission-control/src/tabs/contentSchedulerCalendar.js
+++ b/apps/mission-control/src/tabs/contentSchedulerCalendar.js
@@ -1,0 +1,277 @@
+// Pure helpers for the Content Scheduler 10-day calendar view.
+//
+// Task: 95e65d06-e529-466e-a6b0-d8dfb1e2eb87
+// Tech design: docs/specs/content-scheduler-calendar-view-2026-07-16-tech-design.md
+//
+// All functions here are deliberately framework-free so they can be
+// unit-tested under Node directly. The Component layer imports these
+// and renders them.
+
+export const SCHEDULER_TIME_ZONE = 'Pacific/Auckland';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const DAY_FORMATTER_CACHE = new Map();
+
+function dayFormatter(timeZone) {
+  let fmt = DAY_FORMATTER_CACHE.get(timeZone);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat('en-NZ', {
+      timeZone,
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit',
+      weekday: 'short'
+    });
+    DAY_FORMATTER_CACHE.set(timeZone, fmt);
+  }
+  return fmt;
+}
+
+function timeFormatter(timeZone) {
+  // One formatter per timeZone is sufficient — we only read hour/minute.
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false
+  });
+}
+
+/**
+ * Build the 10 calendar day descriptors starting from today in `timeZone`.
+ *
+ * Returns an array of length 10 (today through today + 9). Each entry has:
+ *   - key:    YYYY-MM-DD in `timeZone`
+ *   - label:  e.g. "Wed 16 Jul" (weekday short, day, month short)
+ *   - date:   the UTC instant of midnight in `timeZone` for that day (useful
+ *             for sorting/visual ordering, but NOT for comparisons across
+ *             DST boundaries — always compare `key` strings for equality)
+ *
+ * @param {Date} [now=new Date()]   anchor "now" instant
+ * @param {string} [timeZone=SCHEDULER_TIME_ZONE]
+ * @returns {Array<{key: string, label: string, date: Date}>}
+ */
+export function buildCalendarDays(now = new Date(), timeZone = SCHEDULER_TIME_ZONE) {
+  const todayKey = getAucklandDayKey(now, timeZone);
+  const fmt = dayFormatter(timeZone);
+  const out = [];
+  for (let i = 0; i < 10; i += 1) {
+    // Parse todayKey to get year/month/day as numbers.
+    const [yStr, mStr, dStr] = todayKey.split('-');
+    const y = Number(yStr);
+    const m = Number(mStr);
+    const d = Number(dStr);
+    // UTC midnight of today (in target tz) — we use UTC math as a stable
+    // anchor; the date Key/label is the source of truth for grouping.
+    const utcMidnight = new Date(Date.UTC(y, m - 1, d));
+    const offsetMs = i * DAY_MS;
+    const target = new Date(utcMidnight.getTime() + offsetMs);
+    const targetKey = getAucklandDayKey(target, timeZone);
+    // If the formatter shifted the key (DST edge cases where midnight in
+    // Pacific/Auckland doesn't map to UTC midnight the same day), advance
+    // until the formatter-produced key matches.
+    let safe = target;
+    while (getAucklandDayKey(safe, timeZone) !== targetKey && safe.getTime() < target.getTime() + DAY_MS * 2) {
+      safe = new Date(safe.getTime() + 60 * 60 * 1000);
+    }
+    const parts = fmt.formatToParts(safe);
+    const weekday = parts.find((p) => p.type === 'weekday')?.value ?? '';
+    const day = parts.find((p) => p.type === 'day')?.value ?? '';
+    const month = parts.find((p) => p.type === 'month')?.value ?? '';
+    const label = `${weekday} ${day} ${month}`;
+    out.push({ key: targetKey, label, date: safe });
+  }
+  return out;
+}
+
+/**
+ * Get the `YYYY-MM-DD` day key for an ISO timestamp / Date in `timeZone`.
+ *
+ * Used to bucket items into calendar day columns and to detect "today".
+ * The key is timezone-stable: the same Pacific/Auckland instant always
+ * produces the same key, regardless of the host system clock.
+ *
+ * @param {string|Date|null|undefined} value
+ * @param {string} [timeZone=SCHEDULER_TIME_ZONE]
+ * @returns {string|null} YYYY-MM-DD in the requested zone, or null if the
+ *   input is missing/invalid.
+ */
+export function getAucklandDayKey(value, timeZone = SCHEDULER_TIME_ZONE) {
+  if (!value) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.valueOf())) return null;
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  });
+  // en-CA formats as YYYY-MM-DD by default.
+  return fmt.format(d);
+}
+
+/**
+ * Group scheduler items for the calendar view.
+ *
+ * Buckets non-removed items by their Pacific/Auckland day key. Items with
+ * no `scheduledFor` or a day outside the calendar window land in the
+ * `unscheduled` array. Day columns without any items still appear in
+ * `byDayKey` (via the `days` argument) so the UI can render empty columns.
+ *
+ * @param {Array} items                scheduler items (any status)
+ * @param {Array<{key: string}>} days  output of `buildCalendarDays()`
+ * @param {string} [timeZone]
+ * @returns {{ byDayKey: Record<string, Array>, unscheduled: Array, publishedByDayKey: Record<string, object> }}
+ */
+export function groupItemsForCalendar(items, days, timeZone = SCHEDULER_TIME_ZONE) {
+  const dayKeys = new Set(days.map((d) => d.key));
+  const byDayKey = Object.fromEntries(days.map((d) => [d.key, []]));
+  const unscheduled = [];
+  const publishedByDayKey = {};
+
+  for (const item of items ?? []) {
+    if (!item) continue;
+    if (item.status === 'removed') continue;
+    const dayKey = getAucklandDayKey(item.scheduledFor, timeZone);
+    if (dayKey && dayKeys.has(dayKey)) {
+      byDayKey[dayKey].push(item);
+      if (item.status === 'published') {
+        publishedByDayKey[dayKey] = item;
+      }
+    } else {
+      unscheduled.push(item);
+    }
+  }
+
+  // Stable order within each day column: queued first by position, then
+  // approved by position, then published by publishedAt desc. Removed items
+  // are filtered above. Card metadata surface area stays small in 10-day
+  // windows so this is fine as a per-column sort.
+  const statusRank = { queued: 0, approved: 1, published: 2 };
+  for (const key of Object.keys(byDayKey)) {
+    byDayKey[key].sort((a, b) => {
+      const r = (statusRank[a.status] ?? 99) - (statusRank[b.status] ?? 99);
+      if (r !== 0) return r;
+      const ap = a.position ?? 0;
+      const bp = b.position ?? 0;
+      if (ap !== bp) return ap - bp;
+      return String(a.id).localeCompare(String(b.id));
+    });
+  }
+  unscheduled.sort((a, b) => {
+    const r = (statusRank[a.status] ?? 99) - (statusRank[b.status] ?? 99);
+    if (r !== 0) return r;
+    return String(a.id).localeCompare(String(b.id));
+  });
+
+  return { byDayKey, unscheduled, publishedByDayKey };
+}
+
+/**
+ * Extract HH:MM (24-hour) from an ISO timestamp in `timeZone`.
+ *
+ * Returns `null` if the input is missing/invalid. Hours/minutes are
+ * returned as zero-padded strings (e.g. "09:00", "23:05").
+ *
+ * @param {string|Date|null|undefined} value
+ * @param {string} [timeZone=SCHEDULER_TIME_ZONE]
+ * @returns {string|null}
+ */
+export function getAucklandTimeOfDay(value, timeZone = SCHEDULER_TIME_ZONE) {
+  if (!value) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.valueOf())) return null;
+  const parts = timeFormatter(timeZone).formatToParts(d);
+  const hour = parts.find((p) => p.type === 'hour')?.value ?? '00';
+  const minute = parts.find((p) => p.type === 'minute')?.value ?? '00';
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
+/**
+ * Compose a UTC ISO instant for the given dayKey + HH:MM in `timeZone`.
+ *
+ * Pacific/Auckland is UTC+12 standard / UTC+13 DST, so we cannot just
+ * `new Date('YYYY-MM-DDTHH:mm')` and call it done — the browser's local
+ * timezone would dominate the result. Instead we iterate the Intl-formatted
+ * parts and adjust a UTC guess until it matches the requested local time.
+ *
+ * @param {string} dayKey      YYYY-MM-DD in `timeZone`
+ * @param {string} hhmm        "HH:MM" (24h)
+ * @param {string} [timeZone]
+ * @returns {string|null} UTC ISO string, or null on bad input.
+ */
+export function zonedDateTimeToIso(dayKey, hhmm, timeZone = SCHEDULER_TIME_ZONE) {
+  if (!dayKey || typeof dayKey !== 'string') return null;
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dayKey.trim());
+  if (!m) return null;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+
+  const timeMatch = /^(\d{1,2}):(\d{2})$/.exec(String(hhmm ?? '').trim());
+  if (!timeMatch) return null;
+  const targetHour = Number(timeMatch[1]);
+  const targetMinute = Number(timeMatch[2]);
+  if (targetHour > 23 || targetMinute > 59) return null;
+
+  // First guess: treat the requested local clock as if it were UTC, then
+  // adjust by the zone offset we observe.
+  let utcGuess = Date.UTC(year, month - 1, day, targetHour, targetMinute, 0, 0);
+
+  // We allow up to 3 refinement passes. In practice 2 is always enough —
+  // the first adjustment handles the standard offset, the second handles
+  // a DST change within the loop.
+  for (let i = 0; i < 3; i += 1) {
+    const guess = new Date(utcGuess);
+    const parts = timeFormatter(timeZone).formatToParts(guess);
+    const hourPart = Number(parts.find((p) => p.type === 'hour')?.value ?? '0');
+    const minutePart = Number(parts.find((p) => p.type === 'minute')?.value ?? '0');
+    const deltaMinutes = (targetHour - hourPart) * 60 + (targetMinute - minutePart);
+    if (deltaMinutes === 0) {
+      return guess.toISOString();
+    }
+    utcGuess += deltaMinutes * 60 * 1000;
+  }
+  // If we couldn't converge, give up rather than ship a wrong value.
+  return null;
+}
+
+/**
+ * Compute the new scheduledFor ISO for dropping `item` onto `targetDayKey`.
+ *
+ * Preserves the source item's Pacific/Auckland HH:MM where present,
+ * defaulting to 09:00 when missing or invalid. Published items are not
+ * reschedulable — the caller should guard this before calling.
+ *
+ * @param {object} item         source item (must be non-published)
+ * @param {string} targetDayKey destination YYYY-MM-DD
+ * @param {string} [timeZone]
+ * @returns {string|null}       ISO string for updateItem, or null on bad input
+ */
+export function rescheduleIsoForDay(item, targetDayKey, timeZone = SCHEDULER_TIME_ZONE) {
+  const hhmm = getAucklandTimeOfDay(item?.scheduledFor, timeZone) ?? '09:00';
+  return zonedDateTimeToIso(targetDayKey, hhmm, timeZone);
+}
+
+/**
+ * Is `targetDayKey` blocked by an existing published item other than `itemId`?
+ *
+ * AC6: dragging a non-published card onto a day with a published item must
+ * be refused. The published item itself is not draggable (see `ItemRow`
+ * draggable prop), so the only "exception" we need to model is "the user
+ * somehow got the published card to be the dragged source", which we still
+ * allow to no-op cleanly by returning true (the caller should also refuse
+ * the drag on the published card up front).
+ *
+ * @param {Record<string, object>} publishedByDayKey
+ * @param {string} targetDayKey
+ * @param {string|null} itemId    dragged item id (so we don't self-block)
+ * @returns {{ blocked: boolean, publishedItem: object|null }}
+ */
+export function dayDropBlocked(publishedByDayKey, targetDayKey, itemId) {
+  const published = publishedByDayKey?.[targetDayKey] ?? null;
+  if (!published) return { blocked: false, publishedItem: null };
+  if (itemId && published.id === itemId) return { blocked: false, publishedItem: published };
+  return { blocked: true, publishedItem: published };
+}

--- a/apps/mission-control/src/tabs/contentSchedulerCalendar.test.js
+++ b/apps/mission-control/src/tabs/contentSchedulerCalendar.test.js
@@ -1,0 +1,243 @@
+// Unit tests for the Content Scheduler 10-day calendar helpers.
+// Task: 95e65d06-e529-466e-a6b0-d8dfb1e2eb87
+
+import { describe, it, expect } from 'vitest';
+import {
+  SCHEDULER_TIME_ZONE,
+  buildCalendarDays,
+  getAucklandDayKey,
+  getAucklandTimeOfDay,
+  groupItemsForCalendar,
+  zonedDateTimeToIso,
+  rescheduleIsoForDay,
+  dayDropBlocked
+} from './contentSchedulerCalendar.js';
+
+describe('buildCalendarDays', () => {
+  it('returns 10 day entries starting from today in Pacific/Auckland', () => {
+    // 2026-07-18 15:00 UTC = 2026-07-19 03:00 NZST (NZ is UTC+12 standard),
+    // so the anchor day in NZ is Sun 19 Jul.
+    const now = new Date('2026-07-18T15:00:00.000Z');
+    const days = buildCalendarDays(now);
+    expect(days).toHaveLength(10);
+    expect(days[0].key).toBe('2026-07-19');
+    expect(days[9].key).toBe('2026-07-28');
+    // First label should start with "Sun" and include the day number.
+    expect(days[0].label).toMatch(/^Sun 19 Jul$/);
+    expect(days[9].label).toMatch(/^Tue 28 Jul$/);
+    // en-NZ renders September as "Sept" (with t). Both forms should pass.
+  });
+
+  it('keeps keys sequential across the DST boundary (early-October NZ DST start)', () => {
+    // 2026-09-27 is one day before NZ DST starts (last Sunday of September).
+    // Daylight savings begins on 2026-09-27 in NZ, so this is the day the
+    // hour moves forward at 02:00 → 03:00. The calendar must still produce
+    // 10 sequential keys.
+    const now = new Date('2026-09-26T15:00:00.000Z'); // Sun 27 Sep in NZ
+    const days = buildCalendarDays(now);
+    expect(days).toHaveLength(10);
+    expect(days[0].key).toBe('2026-09-27');
+    expect(days[9].key).toBe('2026-10-06');
+    expect(days[0].label).toMatch(/^Sun 27 Sep(t)?$/);
+  });
+
+  it('uses the provided timezone instead of Pacific/Auckland when overridden', () => {
+    const now = new Date('2026-07-18T15:00:00.000Z');
+    const days = buildCalendarDays(now, 'UTC');
+    expect(days[0].key).toBe('2026-07-18');
+  });
+});
+
+describe('getAucklandDayKey', () => {
+  it('returns the YYYY-MM-DD key in Pacific/Auckland for a UTC instant', () => {
+    // 2026-07-18 23:30 UTC = 2026-07-19 11:30 NZST — next day in NZ.
+    expect(getAucklandDayKey('2026-07-18T23:30:00.000Z')).toBe('2026-07-19');
+    // 2026-07-18 13:00 UTC = 2026-07-19 01:00 NZST — next day in NZ.
+    expect(getAucklandDayKey('2026-07-18T13:00:00.000Z')).toBe('2026-07-19');
+    // 2026-07-18 11:00 UTC = 2026-07-18 23:00 NZST — same day in NZ.
+    expect(getAucklandDayKey('2026-07-18T11:00:00.000Z')).toBe('2026-07-18');
+  });
+
+  it('returns null for missing/invalid input', () => {
+    expect(getAucklandDayKey(null)).toBeNull();
+    expect(getAucklandDayKey(undefined)).toBeNull();
+    expect(getAucklandDayKey('not-a-date')).toBeNull();
+    expect(getAucklandDayKey('')).toBeNull();
+  });
+
+  it('accepts Date instances', () => {
+    expect(getAucklandDayKey(new Date('2026-07-18T11:00:00.000Z'))).toBe('2026-07-18');
+  });
+});
+
+describe('getAucklandTimeOfDay', () => {
+  it('extracts HH:MM in Pacific/Auckland', () => {
+    // 2026-07-18 22:00 UTC = 2026-07-19 10:00 NZST.
+    expect(getAucklandTimeOfDay('2026-07-18T22:00:00.000Z')).toBe('10:00');
+    // 2026-07-18 19:30 UTC = 2026-07-19 07:30 NZST.
+    expect(getAucklandTimeOfDay('2026-07-18T19:30:00.000Z')).toBe('07:30');
+    // Just before midnight NZ.
+    expect(getAucklandTimeOfDay('2026-07-18T11:55:00.000Z')).toBe('23:55');
+  });
+
+  it('returns null for invalid input', () => {
+    expect(getAucklandTimeOfDay(null)).toBeNull();
+    expect(getAucklandTimeOfDay('bad')).toBeNull();
+  });
+});
+
+describe('zonedDateTimeToIso', () => {
+  it('returns a UTC ISO for standard-time (NZST, UTC+12) target time', () => {
+    // 2026-07-19 09:00 NZST = 2026-07-18 21:00 UTC.
+    const iso = zonedDateTimeToIso('2026-07-19', '09:00');
+    expect(iso).not.toBeNull();
+    expect(new Date(iso).toISOString()).toBe('2026-07-18T21:00:00.000Z');
+    // Round-trip back to local HH:MM should land on 09:00.
+    expect(getAucklandTimeOfDay(iso)).toBe('09:00');
+  });
+
+  it('handles DST (NZDT, UTC+13) correctly', () => {
+    // 2026-09-30 09:00 NZDT (DST starts 2026-09-27) = 2026-09-29 20:00 UTC.
+    const iso = zonedDateTimeToIso('2026-09-30', '09:00');
+    expect(iso).not.toBeNull();
+    expect(new Date(iso).toISOString()).toBe('2026-09-29T20:00:00.000Z');
+    expect(getAucklandTimeOfDay(iso)).toBe('09:00');
+  });
+
+  it('crosses midnight correctly when local time would shift days', () => {
+    // 2026-07-19 00:30 NZST = 2026-07-18 12:30 UTC, but the day key must
+    // remain 2026-07-19.
+    const iso = zonedDateTimeToIso('2026-07-19', '00:30');
+    expect(iso).not.toBeNull();
+    expect(getAucklandDayKey(iso)).toBe('2026-07-19');
+    expect(getAucklandTimeOfDay(iso)).toBe('00:30');
+  });
+
+  it('returns null on bad input', () => {
+    expect(zonedDateTimeToIso('', '09:00')).toBeNull();
+    expect(zonedDateTimeToIso('2026/07/19', '09:00')).toBeNull();
+    expect(zonedDateTimeToIso('2026-07-19', '')).toBeNull();
+    expect(zonedDateTimeToIso('2026-07-19', '25:00')).toBeNull();
+    expect(zonedDateTimeToIso('2026-07-19', '9:99')).toBeNull();
+  });
+});
+
+describe('rescheduleIsoForDay', () => {
+  it('preserves the source item HH:MM when present', () => {
+    const item = { scheduledFor: '2026-07-18T19:30:00.000Z' }; // 07:30 NZST
+    const iso = rescheduleIsoForDay(item, '2026-07-22');
+    expect(iso).not.toBeNull();
+    expect(getAucklandTimeOfDay(iso)).toBe('07:30');
+    expect(getAucklandDayKey(iso)).toBe('2026-07-22');
+  });
+
+  it('defaults to 09:00 when the source has no scheduledFor', () => {
+    const item = { scheduledFor: null };
+    const iso = rescheduleIsoForDay(item, '2026-07-22');
+    expect(iso).not.toBeNull();
+    expect(getAucklandTimeOfDay(iso)).toBe('09:00');
+    expect(getAucklandDayKey(iso)).toBe('2026-07-22');
+  });
+
+  it('defaults to 09:00 when the source scheduledFor is invalid', () => {
+    const item = { scheduledFor: 'not-a-date' };
+    const iso = rescheduleIsoForDay(item, '2026-07-22');
+    expect(iso).not.toBeNull();
+    expect(getAucklandTimeOfDay(iso)).toBe('09:00');
+  });
+});
+
+describe('groupItemsForCalendar', () => {
+  const days = [
+    { key: '2026-07-18', label: 'Sat 18 Jul', date: new Date('2026-07-18T00:00:00Z') },
+    { key: '2026-07-19', label: 'Sun 19 Jul', date: new Date('2026-07-19T00:00:00Z') },
+    { key: '2026-07-20', label: 'Mon 20 Jul', date: new Date('2026-07-20T00:00:00Z') }
+  ];
+
+  function makeItem(overrides) {
+    return {
+      id: 'i-1',
+      body: 'b',
+      source: 'manual',
+      status: 'queued',
+      scheduledFor: null,
+      position: 0,
+      approvedAt: null,
+      approvedBy: null,
+      publishedAt: null,
+      publishedUrl: null,
+      publishError: null,
+      removedAt: null,
+      ...overrides
+    };
+  }
+
+  it('places in-window items into their Pacific/Auckland day bucket', () => {
+    const items = [
+      makeItem({ id: 'queued-sun', status: 'queued', scheduledFor: '2026-07-18T19:00:00.000Z' }), // 07:00 Sun 19 NZ
+      makeItem({ id: 'approved-mon', status: 'approved', scheduledFor: '2026-07-19T20:00:00.000Z' }), // 08:00 Mon 20 NZ
+      makeItem({ id: 'published-sat', status: 'published', scheduledFor: '2026-07-17T20:00:00.000Z', publishedAt: '2026-07-18T02:00:00.000Z' }) // 08:00 Sat 18 NZ
+    ];
+    const { byDayKey, unscheduled, publishedByDayKey } = groupItemsForCalendar(items, days);
+    expect(byDayKey['2026-07-19']).toHaveLength(1);
+    expect(byDayKey['2026-07-19'][0].id).toBe('queued-sun');
+    expect(byDayKey['2026-07-20']).toHaveLength(1);
+    expect(byDayKey['2026-07-20'][0].id).toBe('approved-mon');
+    expect(byDayKey['2026-07-18']).toHaveLength(1);
+    expect(byDayKey['2026-07-18'][0].id).toBe('published-sat');
+    expect(unscheduled).toEqual([]);
+    expect(publishedByDayKey['2026-07-18'].id).toBe('published-sat');
+  });
+
+  it('routes items with no scheduledFor or out-of-window dates to Unscheduled', () => {
+    const items = [
+      makeItem({ id: 'no-sched', status: 'queued', scheduledFor: null }),
+      makeItem({ id: 'far-past', status: 'queued', scheduledFor: '2026-06-01T00:00:00.000Z' }),
+      makeItem({ id: 'far-future', status: 'queued', scheduledFor: '2027-01-01T00:00:00.000Z' })
+    ];
+    const { byDayKey, unscheduled } = groupItemsForCalendar(items, days);
+    expect(unscheduled).toHaveLength(3);
+    expect(unscheduled.map((i) => i.id).sort()).toEqual(['far-future', 'far-past', 'no-sched']);
+    expect(Object.values(byDayKey).every((arr) => arr.length === 0)).toBe(true);
+  });
+
+  it('filters removed items from both buckets', () => {
+    const items = [
+      makeItem({ id: 'kept', status: 'queued', scheduledFor: '2026-07-18T19:00:00.000Z' }),
+      makeItem({ id: 'gone', status: 'removed', removedAt: '2026-07-15T00:00:00.000Z', scheduledFor: '2026-07-18T19:00:00.000Z' }),
+      makeItem({ id: 'gone-no-sched', status: 'removed', removedAt: '2026-07-15T00:00:00.000Z' })
+    ];
+    const { byDayKey, unscheduled } = groupItemsForCalendar(items, days);
+    expect(byDayKey['2026-07-19']).toHaveLength(1);
+    expect(byDayKey['2026-07-19'][0].id).toBe('kept');
+    expect(unscheduled).toEqual([]);
+  });
+});
+
+describe('dayDropBlocked', () => {
+  const published = { id: 'pub', status: 'published', scheduledFor: '2026-07-18T20:00:00.000Z' };
+
+  it('reports blocked when a different item is dragged onto a published day', () => {
+    const result = dayDropBlocked({ '2026-07-19': published }, '2026-07-19', 'other-id');
+    expect(result.blocked).toBe(true);
+    expect(result.publishedItem).toBe(published);
+  });
+
+  it('does not block when the dragged item is the published one (no-op case)', () => {
+    const result = dayDropBlocked({ '2026-07-19': published }, '2026-07-19', 'pub');
+    expect(result.blocked).toBe(false);
+    expect(result.publishedItem).toBe(published);
+  });
+
+  it('does not block when the target day has no published item', () => {
+    const result = dayDropBlocked({}, '2026-07-19', 'other-id');
+    expect(result.blocked).toBe(false);
+    expect(result.publishedItem).toBeNull();
+  });
+});
+
+describe('SCHEDULER_TIME_ZONE constant', () => {
+  it('is locked to Pacific/Auckland', () => {
+    expect(SCHEDULER_TIME_ZONE).toBe('Pacific/Auckland');
+  });
+});

--- a/docs/specs/content-scheduler-calendar-view-2026-07-16-tech-design.md
+++ b/docs/specs/content-scheduler-calendar-view-2026-07-16-tech-design.md
@@ -1,0 +1,205 @@
+---
+status: draft
+task_id: 95e65d06-e529-466e-a6b0-d8dfb1e2eb87
+product_spec: /Users/quinnstoffer/.openclaw/workspace/brain/tasks/specs/in-progress/content-scheduler-calendar-view-2026-07-16.md
+shipped_pr: null
+shipped_date: null
+---
+
+# Content Scheduler 10-day calendar view — tech design
+
+## Product spec link
+
+- Product spec: `/Users/quinnstoffer/.openclaw/workspace/brain/tasks/specs/in-progress/content-scheduler-calendar-view-2026-07-16.md`
+- Approved by Tom in the product spec.
+
+## Task and implementation context
+
+- Task ID: `95e65d06-e529-466e-a6b0-d8dfb1e2eb87`
+- Task title: `🔧 Content Scheduler: 10-Day Calendar View`
+- Branch: `task-95e65d06-content-scheduler-calendar-view`
+- Worktree: `~/workspaces/rowan/sindustries-task-95e65d06-content-scheduler-calendar-view`
+- Repository: `Stoffer-Industries/sindustries`
+
+## Product intent summary
+
+Mission Control's Content Scheduler should make the upcoming publishing plan visible as a 10-day forward calendar from today through today + 9 in `Pacific/Auckland`. Approved, queued, and published scheduler items appear as cards on their scheduled day; items without an in-window `scheduledFor` appear in an Unscheduled overflow area. Tom can drag non-published cards between day columns to reschedule them while preserving the time-of-day. Published cards are read-only, visually distinct, and each day with a published item blocks dropping a second item into that day with an inline error.
+
+## Service boundary and data ownership
+
+- Domain owner remains the existing Content Scheduler backend surface exposed through `apps/mission-control/src/contentSchedulerApi.js`.
+- This task is UI-first and does not introduce a new service boundary.
+- The existing item contract is enough for the calendar: `id`, `body`, `source`, `status`, `scheduledFor`, `approvedAt`, `approvedBy`, `publishedAt`, `publishedUrl`, `publishError`, `position`, `createdAt`, `updatedAt`.
+- Rescheduling uses the existing `PATCH /content-scheduler/items/:id` client helper (`updateItem`) with `{ scheduledFor }`. The backend already refuses updates to `published`/`removed` items; the UI will additionally prevent dragging published cards before a request is made.
+- The max-one-published-per-day rule is already enforced for publishing. This task adds the calendar-side drop guard so Tom cannot move another card onto a day that already contains a published item.
+
+## `.openclaw` boundary notes
+
+- None for implementation. The product spec lives under `.openclaw/workspace/brain`, but all code and durable repo documentation changes are in `Stoffer-Industries/sindustries`.
+- Do not read or write `.openclaw` runtime state as part of the implementation beyond the already-approved product spec reference.
+
+## Implementation plan
+
+### 1. Refactor Content Scheduler view into calendar primitives
+
+Scope:
+
+- `apps/mission-control/src/tabs/ContentSchedulerTab.jsx`
+- `apps/mission-control/src/styles/components.css`
+- `apps/mission-control/SPEC.md` when implementation ships
+
+Plan:
+
+- Keep the existing composer and action handlers (`create`, `approve`, `unapprove`, `publish`, `remove`, `save`) intact.
+- Replace the three status group sections as the primary listing with a calendar layout:
+  - A 10-column grid for today through today + 9.
+  - Each column header labels the day using `Pacific/Auckland`, e.g. `Wed 16 Jul`.
+  - Each column uses `CardContainer variant="column"` where practical and `Card` for items, matching the tasks/kanban card-column visual language.
+  - A separate `Unscheduled` overflow `CardContainer variant="column"` appears below or beside the calendar for items with no `scheduledFor` or a date outside the 10-day window.
+- Extract small pure helpers in the same file initially; move to `apps/mission-control/src/tabs/contentSchedulerCalendar.js` only if the component becomes unwieldy:
+  - `buildCalendarDays(now, timeZone)` → 10 day descriptors with `{ key: 'YYYY-MM-DD', label, dateParts }`.
+  - `getAucklandDayKey(isoTimestamp)` → `YYYY-MM-DD` for grouping by Pacific/Auckland date.
+  - `groupItemsForCalendar(items, days)` → `{ byDayKey, unscheduled }`, including queued/approved/published non-removed items.
+  - `getPublishedItemForDay(items, dayKey)` → published card, if any, for header/drop guarding.
+- Keep the existing queue list only if needed as a secondary debugging fallback during implementation. The shipped primary view should be the calendar plus overflow, not three status groups competing with it.
+
+### 2. Card rendering and visual states
+
+- Reuse the current item card body/action logic where possible, renaming `ItemRow` to `SchedulerItemCard` or keeping it if the diff is smaller.
+- Add `Badge` from `@sindustries/ui/react` for status pills and published indicators.
+- Published cards:
+  - Render in their scheduled/published day column when in the 10-day window.
+  - Add a `Published` badge and muted/greyed styling.
+  - Set `draggable={false}` and omit edit/remove/approve/unapprove controls as the current UI already does for published status.
+- Non-published cards:
+  - Keep edit, approve/unapprove, publish, and remove actions.
+  - Show compact metadata: source, scheduled local date/time when present, approved status, publish errors.
+- Day header states:
+  - Normal: day label plus count of cards.
+  - Published day: show a small `Published today` / `Published` badge or lock indicator in the header.
+  - Drop refused: show inline error text in the target column header/body; clear it on the next successful drop or when dragging over another valid day.
+
+### 3. Drag-and-drop reschedule interaction
+
+The approved product spec asks for native HTML5 drag-and-drop and explicitly avoids a new drag library. The implementation should therefore extend the existing native drag approach instead of adding `dnd-kit`/`react-dnd`.
+
+- Track drag state with local React state:
+  - `draggingItemId`
+  - `dragOverDayKey` or `dragOverZone` (`day:<key>` / `unscheduled`)
+  - `calendarDropError` as `{ dayKey, message } | null`
+- On card drag start:
+  - Refuse if `item.status === 'published'`.
+  - Write the item id into `event.dataTransfer` and set an explicit effect (`move`).
+- On day column drag over:
+  - `preventDefault()` only for non-published dragged items.
+  - Apply a dashed/brand outline to the target column using existing design tokens.
+- On drop to a day:
+  - Look up the source item from current `items`.
+  - If the source item is missing or published, no-op and show no request.
+  - If the target day already contains a different published item, refuse the drop, set inline error `Already has a published post — choose another day.`, and do not call the API.
+  - Compute a new `scheduledFor` for the target `Pacific/Auckland` date while preserving the source HH:MM where present, otherwise defaulting to `09:00`.
+  - Call `updateItem(id, { scheduledFor: nextIso }, { actor: ACTOR })`, then `reload()`.
+- On drop to Unscheduled:
+  - Optional but useful: support moving a non-published item to overflow by setting `scheduledFor: null`. If this is too much scope, the overflow can be a display-only drop target; the required behavior is day-to-day rescheduling.
+- Remove or isolate the old queue-only reorder drag path so it does not conflict with calendar drag. `reorderItems` is not needed for date rescheduling.
+
+### 4. Pacific/Auckland date/time helpers
+
+Timezone handling is the main correctness risk. The UI should not rely on the browser/system local timezone except as a fallback.
+
+- Define `const SCHEDULER_TIME_ZONE = 'Pacific/Auckland'`.
+- Use `Intl.DateTimeFormat('en-NZ', { timeZone: SCHEDULER_TIME_ZONE, ... })` for:
+  - Day labels.
+  - Day keys (`YYYY-MM-DD`).
+  - Extracting the source item HH:MM.
+- Implement a tested `zonedDateTimeToIso(dayKey, hour, minute, timeZone)` helper using `Intl` offset correction:
+  1. Start with a UTC guess from the target date/time.
+  2. Format that instant in `Pacific/Auckland`.
+  3. Calculate the minute delta between formatted parts and requested parts.
+  4. Adjust the UTC instant and verify the formatted date/time matches.
+  5. Return ISO string, or throw a friendly error if conversion fails.
+- Preserve HH:MM from `scheduledFor` if valid; default to `09:00` when missing/invalid.
+- Add unit coverage for at least one standard-time and one DST date so rescheduling does not silently drift by a day/hour.
+
+### 5. Max-one-published-per-day guard
+
+- Build a `publishedByDayKey` map from loaded `items` where `status === 'published'` and the grouping day is in Pacific/Auckland.
+- Header indicator appears when a day has any published item.
+- Drop refusal applies when:
+  - Target day has a published item, and
+  - Dragged item is not that same published item (published items cannot drag anyway), and
+  - Dragged item is non-published.
+- This guard intentionally blocks queued/approved cards from being scheduled onto a day with an already-published card. It does not block multiple queued/approved cards on the same future day unless one is already published, matching the task wording.
+
+### 6. Styling and layout
+
+- Add focused `.content-scheduler-calendar*` classes to `apps/mission-control/src/styles/components.css`.
+- Desktop Mission Control only: use horizontal scroll if 10 columns cannot fit comfortably.
+- Suggested structure:
+  - `.content-scheduler-calendar` as `display: grid; grid-template-columns: repeat(10, minmax(220px, 1fr)); gap: var(--si-space-4); overflow-x: auto;`
+  - `.content-scheduler-day-column` using existing card container surfaces.
+  - `.content-scheduler-day-column--published` and `--drop-error` modifiers.
+  - `.content-scheduler-card--published` muted opacity/background.
+- Keep existing error banner behavior for API errors; add per-column drop error for refused reschedules.
+
+## Data model and API contract changes
+
+No database schema change is planned.
+
+Existing API usage:
+
+- `GET /content-scheduler/items` — unchanged; the frontend groups the returned items into calendar days.
+- `PATCH /content-scheduler/items/:id` — used for drag reschedule with `{ scheduledFor: <ISO string|null> }`.
+- `GET /content-scheduler/today-status` — keep for the existing day-status strip, but do not use it as the only source for future day publish locks because it only describes today.
+
+`scheduledFor` update rules on drag:
+
+- Target day comes from the dropped calendar column's `Pacific/Auckland` date key.
+- Time comes from the existing `scheduledFor` interpreted in `Pacific/Auckland`.
+- If the item has no valid time, use `09:00` Pacific/Auckland.
+- Store the result as UTC ISO via existing `updateItem` behavior.
+- Published items are not draggable and cannot be patched by this flow.
+
+## Workflow, cron, and skill changes
+
+- No cron changes.
+- No agent skill changes.
+- No publishing workflow changes: Tom still explicitly publishes items; this task only changes visibility and rescheduling.
+- Update `apps/mission-control/SPEC.md` in the implementation PR to document the calendar as the Content Scheduler primary screen and link the new test coverage.
+- If a durable system doc for Content Scheduler exists after service extraction lands, update that doc on ship. On the current main branch the closest durable doc is `docs/systems/content-factory.md`; update only if implementation changes its described runtime behavior.
+
+## Test plan
+
+Run at minimum:
+
+- `npm --workspace @sindustries/mission-control test -- ContentSchedulerTab.test.jsx`
+- `npm --workspace @sindustries/mission-control test`
+- `npm --workspace @sindustries/mission-control build`
+
+Add/adjust component tests in `apps/mission-control/src/tabs/ContentSchedulerTab.test.jsx` and pure helper tests if helpers are split into a separate module.
+
+| AC | Verification layer | Planned coverage |
+| --- | --- | --- |
+| AC1 | Component test | Freeze/mock current date to a known Pacific/Auckland day and assert 10 day columns render from today through today + 9 with labels like `Wed 16 Jul`. |
+| AC2 | Component test | Mock queued, approved, and published items with in-window `scheduledFor` values; assert each appears in the correct Pacific/Auckland day column as task-style cards with status badges. |
+| AC3 | Component test | Mock items with `scheduledFor: null`, invalid/outside-past date, and outside-future date; assert they render in `Unscheduled` and not in the 10 day columns. |
+| AC4 | Component test + helper unit coverage | Simulate native drag/drop from one day column to another and assert `updateItem` is called with an ISO timestamp on the target date preserving HH:MM; add a no-time/default case asserting `09:00`. |
+| AC5 | Component test | Render a published item and assert it has the published badge/muted class, lacks drag affordance (`draggable=false`), and does not expose edit/remove controls. |
+| AC6 | Component test | Render a target day with a published item, drag a queued/approved item onto that day, assert no `updateItem` call occurs and an inline error is shown in that day column/header. |
+
+Manual smoke after tests:
+
+1. Start Mission Control against the local Content Scheduler API.
+2. Open `/content-scheduler`.
+3. Create or use sample queued/approved/published rows across multiple dates.
+4. Verify drag between days updates the scheduled date while preserving the visible time.
+5. Verify a published day refuses another dropped card and shows the inline error.
+
+## Open questions and risks
+
+- **Timezone conversion:** Pacific/Auckland must be explicit. Relying on Tom's browser timezone would be simpler but brittle; use `Intl` helpers and tests, especially around DST.
+- **Spec/library mismatch:** The task prompt mentioned `dnd-kit`/`react-dnd` as likely options, but the Tom-approved product spec says to use native HTML5 drag API and add no new dependency. This design follows the approved spec.
+- **Published day semantics:** The requirement blocks dropping onto a day that already has a published item. It does not block multiple queued/approved items on a day with no published item; preserving that behavior avoids inventing stricter scheduling rules.
+- **Calendar orientation wording:** The spec says row/columns inconsistently. This design uses 10 day columns because AC1 and the prompt call out a 10-day column calendar; the Unscheduled area can sit below or beside depending on cleanest desktop layout.
+- **Existing reorder behavior:** The old queue reorder drag path may become obsolete. Removing it is acceptable if the calendar is the primary view and no acceptance criterion requires position reordering.
+- **E2E coverage:** Existing Mission Control coverage for this tab is Vitest component-level rather than browser E2E. Component tests are the right layer for native drag events here unless the repo already has an e2e harness available at implementation time.


### PR DESCRIPTION
Old body: 5787 chars, 60 lines
New body: 5708 chars, 59 lines
tent Scheduler's primary view with a 10-day forward calendar (today through today + 9) in Pacific/Auckland. Approved, queued, and published items render as cards in their scheduled day; items with no `scheduledFor` or a date outside the window land in an `Unscheduled` overflow area. Native HTML5 drag-and-drop between day columns reschedules cards while preserving time-of-day, and dropping onto a day that already has a published item is refused inline (no API call).

Companion to PR #245 (auto-post): the auto-post worker writes `publishedAt` / `publishedUrl` to items, and this view surfaces them in the calendar so Tom can see published days at a glance.

Tech design: `docs/specs/content-scheduler-calendar-view-2026-07-16-tech-design.md` (already on this branch, commit 54240ec).
Task: `95e65d06-e529-466e-a6b0-d8dfb1e2eb87` (`🔧 Content Scheduler: 10-Day Calendar View`).

## Acceptance Criteria

- [x] AC1: The Content Scheduler tab renders a 10-day calendar — columns from today through today + 9 — each column labelled with the day name and date (e.g. "Wed 16 Jul"). (🧪 testID: cal-10-day-render)
- [x] AC2: Each column shows approved and queued items whose scheduledFor falls on that calendar day (Pacific/Auckland), rendered as cards using the tasks UI card/column styling. (🧪 testID: cal-renders-in-window-items)
- [x] AC3: Items with no scheduledFor or a date outside the 10-day window appear in an "Unscheduled" overflow area below or beside the calendar. (🧪 testID: cal-unscheduled-overflow)
- [x] AC4: Tom can drag a card from one day column to another; on drop, the item's scheduledFor is updated to the same time-of-day but on the target date (preserving HH:MM, or defaulting to 09:00 if no time was set). (🧪 testID: cal-drag-reschedule)
- [x] AC5: Published items are shown read-only in their published day column with a visual indicator (e.g. greyed card, "Published" badge) and cannot be dragged. (🧪 testID: cal-published-readonly)
- [x] AC6: The calendar respects the existing max-one-published-per-day rule: if a day already has a published item, its column header shows a visual indicator and dragging a second item onto that day is refused with an inline error. (🧪 testID: cal-published-drop-block)
## System Spec

`docs/systems/content-scheduler.md` — added in PR #258 (this PR's companion), so the merged pair (#257 + #258) covers implementation + durable system spec together. Covers the Content Scheduler end-to-end (data model, API surface, calendar runtime flow with drag-and-drop + max-one-per-day drop guard, Intl.DateTimeFormat timezone handling for NZST/NZDT + DST start edge, guardPublish outcomes, X client abstraction, runbook notes, test plan), and links to docs/systems/content-scheduler-auto-post.md for the auto-post subsystem and docs/specs/content-scheduler-service-extraction-tech-design.md for the planned service extraction. PR #258 also rewrites apps/mission-control/SPEC.md Flow 7 to describe the 10-day calendar view and updates the Screens table Content row, E2e Coverage row, and Data Sources Content Scheduler bullet.

## Test plan

- Full mission-control suite: 161/161 green across 11 files (`npm test` in `apps/mission-control`).
- New unit + component tests (file/test-name → AC mapping below):

### `contentSchedulerCalendar.test.js` (22 cases) — AC1, AC2, AC3, AC4, AC6
- `buildCalendarDays > returns 10 day entries starting from today in Pacific/Auckland` (AC1)
- `buildCalendarDays > keeps keys sequential across the DST boundary (early-October NZ DST start)` (AC1)
- `buildCalendarDays > uses the provided timezone instead of Pacific/Auckland when overridden` (AC1)
- `groupItemsForCalendar > places in-window items into their Pacific/Auckland day bucket` (AC2)
- `groupItemsForCalendar > routes items with no scheduledFor or out-of-window dates to Unscheduled` (AC3)
- `rescheduleIsoForDay > preserves the source item HH:MM when present` (AC4)
- `rescheduleIsoForDay > defaults to 09:00 when the source has no scheduledFor` (AC4)
- `dayDropBlocked > reports blocked when a different item is dragged onto a published day` (AC6)

### Implementation guards under test (no Playwright testID)
- `apps/mission-control/src/tabs/contentSchedulerCalendar.js:rescheduleIsoForDay` — AC4 HH:MM preservation
- `apps/mission-control/src/tabs/contentSchedulerCalendar.js:dayDropBlocked` — AC6 max-one-published-per-day rule

### `ContentSchedulerTab.test.jsx` (15 cases) — AC1, AC2, AC3, AC4, AC5, AC6
- `renders loading state then the calendar + unscheduled on mount` (AC1)
- `renders in-window items in the correct Pacific/Auckland day columns with status badges` (AC2)
- `routes items with no scheduledFor or out-of-window dates to Unscheduled` (AC3)
- `drag-drop to another day updates scheduledFor preserving HH:MM` (AC4)
- `drag-drop with no source time defaults scheduledFor to 09:00 local` (AC4)
- `published cards render with the Published badge and cannot be dragged` (AC5)
- `refuses to drop onto a day with an existing published item and shows an inline error` (AC6)

- Manual verification: Tom will see the new view in dev. Open the Content Scheduler tab, observe 10 columns labelled in NZ local time, drag a queued card between days, attempt to drag onto a published day to see the inline error.

## Out of scope (parking lot)

- Replacing native HTML5 drag-and-drop with a richer DnD library — spec asked for native.
- A separate queue-only fallback view — the calendar supersedes the prior three-group layout.
- Persisting drop-error messages across reloads — they are UI-local state.
- Migrating from Pacific/Auckland hardcoded to a per-user setting — current scope is NZ-only.

