### PR TITLE
docs(systems): Content Scheduler system spec + calendar view backfill

### DIFF
--- a/apps/mission-control/SPEC.md
+++ b/apps/mission-control/SPEC.md
@@ -77,30 +77,49 @@ surface.
    - Renders correctly in both light and dark mode via the
      `@sindustries/design-tokens/styles.css` palette that the shell
      already loads — no new opaque colours.
-7. **Manage the Content Scheduler queue.** User is on the Content tab.
+7. **Manage the Content Scheduler 10-day calendar.** User is on the Content tab.
    - On mount, fetches the queue from the Tasks API
      (`/api/v1/content-scheduler/items`) and today's publish status
      (`/api/v1/content-scheduler/today-status`).
-   - Renders the day-status banner ("✓ 0/1 posts published today" etc.)
-     so the operator can see at-a-glance whether the daily X-post cap is
-     reached.
-   - **Create.** The "Add to queue" form takes a content source URL (the
-     page is rendered for preview via the Tasks-API proxy), a label, and
-     an optional scheduled-for timestamp. Submit posts to the Tasks API
-     and prepends the new item to the local list.
-   - **Queue actions.** Each non-published item exposes Approve,
-     Unapprove, Publish, Remove, and ↑/↓ reorder controls. Reorder
-     patches the item's `position` via the Tasks API and re-sorts the
-     list optimistically.
+   - Renders the **day-status banner** ("✓ 0/1 posts published today" etc.)
+     at the bottom so the operator can see at-a-glance whether the daily
+     X-post cap is reached.
+   - **Composer (top).** The "Add to queue" form takes a tweet body
+     (≤1000 chars), a source (`ops_notes` / `cto_craft` / `manual` /
+     `other`), and an optional `scheduledFor` timestamp. Submit posts to
+     the Tasks API and reloads the calendar.
+   - **Calendar grid.** The primary view is a 10-day forward calendar
+     from today through today + 9 in `Pacific/Auckland`. Each day is a
+     column labelled "Wed 16 Jul" style (weekday short + day + month
+     short). Approved, queued, and published items render as cards in
+     the day column matching their `scheduledFor` date.
+   - **Unscheduled overflow.** Items with no `scheduledFor` or a date
+     outside the 10-day window appear in an "Unscheduled" overflow panel
+     after the calendar grid.
+   - **Drag-and-drop reschedule.** Tom drags a non-published card onto
+     a different day column. The client computes the new ISO via
+     `Intl.DateTimeFormat` (handles NZST/NZDT and the DST start edge),
+     preserving the existing HH:MM or defaulting to 09:00, and PATCHes
+     `/api/v1/content-scheduler/items/:id`. **No reorder API call is
+     made when the drop is refused at the UI layer** — see the max-one
+     guard below.
+   - **Published cards.** `draggable={false}`, greyed style, with a
+     "Published" badge and the X post URL link when present. The day
+     column header shows a `✓ Published` indicator when a card on that
+     day has already published.
    - **Approve gate.** Items are not publishable until `approvedAt` is
-     set (per-item explicit approval — AC6 of the feature spec). The
-     Publish button is disabled with a tooltip when the item is
-     unapproved.
-   - **Publish cap.** The Tasks API rejects publish attempts that would
-     exceed one post per `Pacific/Auckland` day; the client surfaces the
-     409 response with a tooltip ("Max one X post per day — already
-     published today"). Published items flip to a "published at <ISO>"
-     badge with the X post URL when the response includes one.
+     set. The Publish button is disabled with a tooltip when the item is
+     unapproved. Manual publish is still available in the composer flow
+     for on-demand posting; event-driven auto-publish on `scheduledFor`
+     arrival is documented in the [auto-post system spec](../systems/content-scheduler-auto-post.md).
+   - **Max-one-published-per-day guard.** When Tom drags a card onto a
+     day column that already has a published item, the drop is refused
+     at the UI layer with the inline error `"Already has a published
+     post — choose another day."`. No API call is made. The same rule is
+     enforced server-side by `guardPublish` (`code:
+     already_published_today`, `409 Conflict`) for manual and auto-post
+     publish attempts. The day boundary is computed in
+     `Pacific/Auckland` on both sides.
 
 
 ## Screens
@@ -112,7 +131,7 @@ surface.
 | Bookmarks | `/bookmarks` | `Tabs/BookmarksTab.jsx` | Bookmark pipeline dashboard (KPIs, curations, Sankey of the curation pipeline, funnel, per-topic counts, state counts over time, recent transitions); toolbar filters by time window + topic |
 | Flow metrics | `/flow-metrics` | `Tabs/FlowMetricsTab.jsx` | Filter row (assignee, tag), metric cards, throughput chart, WIP chart |
 | Design System | `/design-system` | `Tabs/DesignSystemTab.jsx` | Shared `DesignSystemPage` specimen (Tokens / Pulse / Brand); follows the shell's `data-si-theme` (the Mission Control tab bar is the canonical navigation — no in-page back link, no in-page theme toggle) |
-| Content | `/content-scheduler` | `Tabs/ContentSchedulerTab.jsx` | Content scheduler queue: list + create/approve/publish/remove/reorder; embeds content via iframe + Tasks-API proxy |
+| Content | `/content-scheduler` | `Tabs/ContentSchedulerTab.jsx` | Content scheduler 10-day calendar: composer + 10-column day grid (Pacific/Auckland) + Unscheduled overflow + drag-and-drop reschedule; max-one-published-per-day drop guard at the UI layer |
 | SIndustries | `/sindustries` | `Tabs/SIndustriesTab.jsx` | Embedded `sindustries.co.nz` via iframe; falls back to an external-link card if the upstream `X-Frame-Options`/`CSP` blocks embedding (timeout-based detection, ~8s) |
 | 404 / unknown path | `/<anything>` | falls back to Tasks tab | The default tab renders; no error surface |
 
@@ -144,7 +163,7 @@ specimen mount.
 | State source fetch | Vitest: `bookmarkStateSource.test.js` covers parallel fetch + 404 → empty defaults |
 | BookmarksTab render | Vitest: `tabs/BookmarksTab.test.jsx` covers loading/data/error/refresh paths |
 | SIndustries tab iframe + fallback | Vitest: `tabs/SIndustriesTab.test.jsx` covers initial iframe render, fallback after timeout, and success-path load event |
-| Content Scheduler queue lifecycle | Vitest: `tabs/ContentSchedulerTab.test.jsx` covers create/approve/publish/remove; day-status cap, approve gate, and reorder are exercised via the component |
+| Content Scheduler 10-day calendar | Vitest: `tabs/ContentSchedulerTab.test.jsx` covers composer create/approve/publish/remove, calendar grid layout, Unscheduled overflow, drag-and-drop reschedule (HH:MM preservation + 09:00 default), max-one-per-day drop guard, published read-only badge, today-status banner; pure helpers in `tabs/contentSchedulerCalendar.test.js` cover NZST/NZDT offset + DST start edge + day-key grouping |
 
 ## Data Sources
 
@@ -166,10 +185,17 @@ specimen mount.
   `apps/mission-control/src/tasksApi.js` (`getTasks`).
 - **Content Scheduler** state is read from the Tasks API at
   `/api/v1/content-scheduler/items` and `/api/v1/content-scheduler/today-status`.
-  The publish flow is server-side (Tasks API posts to X with bearer auth);
+  The publish flow is server-side (Tasks API posts to X with OAuth 1.0a);
   the Mission Control client never holds X credentials. The "max one
-  X post per day" rule is computed in `Pacific/Auckland`. See
-  `docs/specs/content-scheduler-tab-tech-design.md` for the full design.
+  X post per day" rule is computed in `Pacific/Auckland` on both the
+  client (UI drop guard) and the server (`guardPublish`). The calendar
+  grid uses native HTML5 drag-and-drop; pure timezone helpers live in
+  `apps/mission-control/src/tabs/contentSchedulerCalendar.js` and use
+  `Intl.DateTimeFormat` to handle the NZST/NZDT offset and DST start
+  edge. Auto-publish on `scheduledFor` arrival is a separate subsystem
+  documented in [`docs/systems/content-scheduler-auto-post.md`](../systems/content-scheduler-auto-post.md).
+  See [`docs/systems/content-scheduler.md`](../systems/content-scheduler.md)
+  for the full system contract.
 - **Bookmark state** is read by the Bookmarks tab from
   `brain/state/bookmark-review-state.json` and
   `brain/state/bookmark-transitions.jsonl` via the dev-only Vite plugin

--- a/docs/specs/content-scheduler-calendar-view-2026-07-16-tech-design.md
+++ b/docs/specs/content-scheduler-calendar-view-2026-07-16-tech-design.md
@@ -1,9 +1,9 @@
 ---
-status: draft
+status: shipped
 task_id: 95e65d06-e529-466e-a6b0-d8dfb1e2eb87
 product_spec: /Users/quinnstoffer/.openclaw/workspace/brain/tasks/specs/in-progress/content-scheduler-calendar-view-2026-07-16.md
-shipped_pr: null
-shipped_date: null
+shipped_pr: 257
+shipped_date: 2026-07-18
 ---
 
 # Content Scheduler 10-day calendar view — tech design

--- a/docs/systems/content-scheduler.md
+++ b/docs/systems/content-scheduler.md
@@ -1,0 +1,241 @@
+# Content Scheduler
+
+**Status:** Live (calendar view shipped)
+**Last updated:** 2026-07-19
+**Owner:** Rowan (engineering) · Tom (product)
+**Repos:** `Stoffer-Industries/sindustries`
+**Related PRs:**
+- [PR #213](https://github.com/Stoffer-Industries/sindustries/pull/213) — original Content Scheduler tab + backend (task 115e8d89)
+- [PR #257](https://github.com/Stoffer-Industries/sindustries/pull/257) — 10-day calendar view (task 95e65d06)
+- [PR #245](https://github.com/Stoffer-Industries/sindustries/pull/245) — event-driven auto-post (task ac74e9bb), see [auto-post system spec](./content-scheduler-auto-post.md)
+
+**Related tasks:** `115e8d89` (initial tab), `95e65d06` (calendar view), `ac74e9bb` (auto-post), `94d5e4fc` (future service extraction)
+**Related tech designs:**
+- [Tab + backend](../specs/content-scheduler-tab-tech-design.md)
+- [Calendar view](../specs/content-scheduler-calendar-view-2026-07-16-tech-design.md)
+- [Service extraction](../specs/content-scheduler-service-extraction-tech-design.md)
+
+---
+
+## What this is
+
+The Content Scheduler is the Mission Control tab that lets Tom queue tweet copy, schedule it to specific days, and publish to X without leaving the shell. The primary view is a 10-day forward calendar (today through today + 9) in `Pacific/Auckland`. Each day is a column; approved, queued, and published items appear as cards on their scheduled day. Items without a `scheduledFor` in the window land in an Unscheduled overflow area. Tom drags cards between day columns to reschedule; published cards are read-only and each day column enforces a hard "max one published per day" rule with an inline error if violated.
+
+Manual publish is still available. Auto-publish of approved items whose `scheduledFor` has arrived is a separate subsystem documented in [`content-scheduler-auto-post.md`](./content-scheduler-auto-post.md).
+
+---
+
+## Architecture and ownership
+
+### Code
+
+- `apps/mission-control/src/tabs/ContentSchedulerTab.jsx` — UI. Composer at the top, 10-day calendar grid below, "Unscheduled" overflow section after the grid, day-status banner at the bottom.
+- `apps/mission-control/src/tabs/contentSchedulerCalendar.js` — pure helpers: `buildCalendarDays`, `getAucklandDayKey`, `getAucklandTimeOfDay`, `zonedDateTimeToIso` (handles NZST/NZDT offset + DST start), `rescheduleIsoForDay`, `groupItemsForCalendar`, `dayDropBlocked`.
+- `apps/mission-control/src/contentSchedulerApi.js` — Mission Control API client (list/create/update/approve/unapprove/publish/remove/reorder + today-status).
+- `apps/mission-control/src/styles/components.css` — calendar grid CSS (10-column flex grid, `Unscheduled` panel, drop-target outline).
+- `services/tasks-api/src/routes/contentScheduler.ts` — Express routes. Mounted under `/api/v1`.
+- `services/tasks-api/src/routes/contentSchedulerPublish.ts` — `guardPublish`, `XClient` interface, `RealXClient` (OAuth 1.0a), `FakeXClient` (CI), `getXClient()`, `getAucklandTodayParts()`.
+- `services/tasks-api/src/routes/contentSchedulerPublishService.ts` — `publishContentSchedulerItem` shared between manual and auto-post paths so guard semantics cannot drift.
+- `services/tasks-api/src/routes/contentSchedulerJobs.ts` + `.inProcess.ts` + `.bullmq.ts` — auto-post job queue adapter. See [auto-post system spec](./content-scheduler-auto-post.md).
+- `services/tasks-api/prisma/schema.prisma` — `ContentSchedulerItem` model + `ContentSchedulerItemStatus` / `ContentSchedulerSource` enums.
+- `apps/mission-control/SPEC.md` — Pulse-level behavioural contract (Flow 7).
+
+### Service boundary
+
+The Content Scheduler backend currently lives inside `services/tasks-api` for historical reasons (PR #213 landed before the service-extraction work). This is treated as **temporary coupling**. A dedicated `services/content-scheduler-api` is planned under task `94d5e4fc`; the design at [`docs/specs/content-scheduler-service-extraction-tech-design.md`](../specs/content-scheduler-service-extraction-tech-design.md) defines the extraction. Mission Control will call Content Scheduler API directly once the extraction lands — it should not get an aggregate backend.
+
+Mission Control owns the calendar UI. The Tasks API owns the data plane until extraction. The X (Twitter) API is reached only through the server-side `XClient` abstraction; the browser never holds X credentials.
+
+---
+
+## Data model
+
+### `ContentSchedulerItem` (Prisma)
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | server-assigned |
+| `body` | `VarChar(1000)` | tweet copy; max 1000 chars |
+| `source` | `ContentSchedulerSource` | `ops_notes` \| `cto_craft` \| `manual` \| `other` |
+| `sourceRef` | `String?` | optional URL/reference back to the source signal |
+| `status` | `ContentSchedulerItemStatus` | `draft` \| `queued` \| `approved` \| `published` \| `removed` |
+| `scheduledFor` | `DateTime?` | optional ISO timestamp; drives calendar placement and auto-post |
+| `position` | `Int` | ascending sort within `queued` items (manual reorder) |
+| `approvedAt` | `DateTime?` | set when explicit approval recorded; required before publish |
+| `approvedBy` | `String?` | actor name (currently `Tom`) |
+| `publishedAt` | `DateTime?` | server timestamp on successful publish |
+| `publishedUrl` | `String?` | X post URL returned by publish integration |
+| `publishError` | `String?` | last publish failure reason; surfaced in UI and on item |
+| `createdAt`, `updatedAt` | `DateTime` | Prisma `@default(now())` / `@updatedAt` |
+| `removedAt` | `DateTime?` | soft-delete marker |
+
+Indexes: `(status, position)`, `(status, scheduledFor)`, `(status, publishedAt)`.
+
+Terminal statuses: `published`, `removed`. Items in `removed` are kept in the table for audit and are not returned by the default `GET /items` listing.
+
+### Status state machine
+
+```
+        create
+   ──►  queued  ──approve──►  approved  ──publish──►  published
+            │                    │                       │
+            ├──remove──► removed ├──remove──► removed  └───(terminal)
+            │                    │
+            └────unapprove───────┘
+```
+
+- `draft` exists for parity with the earlier spec but the current UI composes items directly into `queued`. `draft` is reserved for future "save without queue" affordances.
+- `published` is reached only via `POST /items/:id/publish` (manual) or via the auto-post worker (see [auto-post system spec](./content-scheduler-auto-post.md)). Both call the shared `publishContentSchedulerItem` service.
+- `removed` is a soft-delete; rows are retained.
+
+---
+
+## API surface
+
+All routes are mounted under `/api/v1` from `services/tasks-api/src/app.ts`. CORS allows `x-actor` so the Mission Control client can send the operator identity.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/content-scheduler/items` | List non-`removed` items. Used by the calendar grouping helper. |
+| `POST` | `/content-scheduler/items` | Create a new item. Defaults: `status=queued`, `source=manual`, `position=next` |
+| `PATCH` | `/content-scheduler/items/:id` | Edit `body`, `scheduledFor`, `source`, `sourceRef`. Reschedules preserve HH:MM client-side; server stores ISO. |
+| `POST` | `/content-scheduler/items/:id/approve` | Set `approvedAt`/`approvedBy`. Enqueues auto-post job. |
+| `POST` | `/content-scheduler/items/:id/unapprove` | Clear approval. Cancels auto-post job. |
+| `POST` | `/content-scheduler/items/:id/publish` | Manual publish. Runs `guardPublish` then `publishContentSchedulerItem`. |
+| `POST` | `/content-scheduler/items/:id/remove` | Soft-delete; sets `status=removed`, `removedAt=now`. |
+| `POST` | `/content-scheduler/reorder` | Body: `{ ids: string[] }`. Rewrites `position` for `queued` items only. |
+| `GET` | `/content-scheduler/today-status` | `{ publishedCount, cap, publishedItemId }` for `Pacific/Auckland` today. Drives the day-status banner and the "max reached" UI hint. |
+
+### `guardPublish` outcomes
+
+`guardPublish` is the single source of truth for "can this item publish right now?". It returns one of:
+
+- `{ ok: true, ... }` — proceed.
+- `{ ok: false, code: 'not_approved' }` — `approvedAt IS NULL`. The `Publish` button is also disabled in the UI.
+- `{ ok: false, code: 'already_published_today' }` — `today.publishedCount >= cap` and the item is not the one already published.
+- `{ ok: false, code: 'missing_credentials' }` — `getXClient()` returned `null` because the X OAuth env vars are not set; the publish route returns `503`.
+
+The route maps each guard code to a structured `4xx`/`5xx` response with a stable error code. The Mission Control client surfaces these inline.
+
+---
+
+## Runtime flow
+
+### Calendar view
+
+1. Mission Control mounts `ContentSchedulerTab`.
+2. On mount the tab calls `GET /items` and `GET /today-status` in parallel.
+3. `groupItemsForCalendar(items, days, 'Pacific/Auckland')` partitions items into one bucket per day-key plus an `Unscheduled` bucket for items with no `scheduledFor` or a date outside the 10-day window.
+4. The grid renders 10 day columns labelled "Wed 16 Jul" style (weekday short + day + month short), plus an `Unscheduled` overflow panel.
+5. Tom drags a non-published card onto a different day column:
+   - `dataTransfer.setData('text/plain', itemId)` on drag start; `preventDefault` + `setDragOverId` on drag over.
+   - On drop, the client calls `dayDropBlocked(publishedByDayKey, targetDayKey, itemId)` first.
+     - If the target day already has a published item, no API call is made; the UI shows the inline error `"Already has a published post — choose another day."` and the drag is refused at the UI layer.
+   - Otherwise the client computes `rescheduleIsoForDay(item, targetDayKey)`: preserves the existing HH:MM if present, defaults to `09:00` if not, and uses `Intl.DateTimeFormat` with `timeZone: 'Pacific/Auckland'` to get the correct UTC offset (handles NZST/NZDT and the DST start edge).
+   - The client calls `PATCH /items/:id` with `{ scheduledFor: <new ISO> }` and reloads.
+6. Published cards have `draggable={false}`, a greyed style, and a "Published" badge. Their day column shows a `✓ Published` indicator.
+7. The day-status banner at the bottom shows `✓ N / cap posts published today` from the latest `today-status` poll.
+
+### Publish (manual)
+
+1. Tom clicks **Publish** on an approved item whose `scheduledFor` has arrived.
+2. The Mission Control client calls `POST /items/:id/publish` with `x-actor: Tom`.
+3. The route calls `guardPublish(item, today)`. Any non-`ok` outcome is returned as a structured `409` (cap) or `400` (not approved) response.
+4. On `ok`, the route calls `publishContentSchedulerItem` which:
+   - Fetches the X client (`RealXClient` or `FakeXClient`).
+   - Posts the tweet via OAuth 1.0a.
+   - On success: sets `publishedAt`, `publishedUrl`.
+   - On failure: writes the error to `publishError` and leaves `status` at `approved` so Tom can retry.
+5. The route returns the updated item. The client reloads.
+
+### Publish (auto-post)
+
+See [auto-post system spec](./content-scheduler-auto-post.md). Briefly: approve / reschedule enqueues a delayed job; the job fires at `scheduledFor`, calls the shared `publishContentSchedulerItem`, and self-cancels if the item is no longer `approved` or has been manually published.
+
+### Timezone handling
+
+- All calendar math is in `Pacific/Auckland`. The `SCHEDULER_TIME_ZONE` constant in `contentSchedulerCalendar.js` is the single source of truth.
+- `Intl.DateTimeFormat` (with `timeZoneName: 'longOffset'`) is used to compute the correct UTC offset for any given local date — this avoids the bug where fixed-offset libraries give the wrong answer across the NZ DST start (last Sunday of September).
+- Day boundaries are computed via `getAucklandDayKey(value, 'Pacific/Auckland')`, which formats a Date as `YYYY-MM-DD` in the target zone.
+- The server (`getAucklandTodayParts`) and the client (`buildCalendarDays`) use the same Intl-based approach so the UI's "today" matches the server's "today" for publish-cap checks.
+
+---
+
+## Data contracts and observability
+
+- API responses are JSON. Errors carry `{ error: { code: string, message: string } }` shapes — clients pattern-match on `code`, not on `message`.
+- The X client is selected at request time from env vars: `X_CLIENT=real` forces `RealXClient`; otherwise `getXClient()` returns `RealXClient` only when **all four** of `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` are set, else `null`. Local dev / CI default to `FakeXClient` (set by tests).
+- Mission Control never logs X tokens. The server logs publish success/failure at INFO / ERROR with the item id and the truncated error message.
+- The auto-post worker logs job enqueue / fire / cancel at INFO with `jobId`, `itemId`, and `version`. See [auto-post system spec § Runbook](./content-scheduler-auto-post.md#runbook).
+
+---
+
+## Runbook notes and common failure modes
+
+### `GET /content-scheduler/today-status` returns `publishedCount` >= `cap` for a day Tom is sure he hasn't posted to
+
+- The day boundary uses `Pacific/Auckland`. An X post that landed at `23:30 UTC` (i.e. `11:30 NZST` next day) is counted against the **NZ** day, not the UTC day. Check the item's `publishedAt` and convert to `Pacific/Auckland` to confirm.
+- If a row has `status=published` with `publishedAt` on the wrong day, it is a real bug — escalate. Do not delete rows.
+
+### Publish fails with `missing_credentials` even though the X OAuth env vars look right
+
+- `getXClient()` requires **all four** of `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`. Missing one returns `null`.
+- Set `X_CLIENT=real` to fail loudly on missing vars rather than silently returning `null`.
+
+### `Pacific/Auckland` day changes mid-session
+
+- The calendar rebuilds day keys on each reload. If the user's browser/system clock drifts, two items can end up in different day columns across reloads. The browser-side `buildCalendarDays(now)` is the source of truth; the server-side `getAucklandTodayParts(now)` is the source of truth for publish-cap checks. If they disagree, server wins — the client must accept the guard result and not retry.
+
+### Item scheduled in NZST but visible as one day earlier / later in the calendar
+
+- This is the NZ DST start (last Sunday of September). At `03:00 local` the clock jumps to `04:00`. Items scheduled at `02:30` on that date are ambiguous. `zonedDateTimeToIso` handles the offset via Intl, but the UI should be inspected directly. If the wrong day is rendered, file a bug — do not edit the data.
+
+### Service extraction (future, task `94d5e4fc`)
+
+- The Content Scheduler tables/routes will move from `services/tasks-api` to `services/content-scheduler-api`.
+- Mission Control will switch from `tasksApi.js` to a new `contentSchedulerApi.js`-equivalent client pointing at the new host.
+- The X client lives on the new service, not on Mission Control.
+- The design at [`docs/specs/content-scheduler-service-extraction-tech-design.md`](../specs/content-scheduler-service-extraction-tech-design.md) covers the migration plan and the rollback path.
+
+---
+
+## Test plan and E2E coverage
+
+| Layer | Coverage |
+|---|---|
+| Pure helpers (`contentSchedulerCalendar.js`) | `contentSchedulerCalendar.test.js` covers timezone, NZST/NZDT offset, DST start edge, scheduling defaults, day-key grouping, drop-guard logic |
+| UI (`ContentSchedulerTab.jsx`) | `ContentSchedulerTab.test.jsx` covers mount/loading/error/retry, calendar grid layout, drag-and-drop reschedule, Unscheduled overflow, published read-only badge, max-one-per-day inline error, today-status banner |
+| API (`services/tasks-api`) | `contentScheduler.test.ts` covers CRUD, approve/unapprove, publish guard outcomes (incl. `not_approved`, `already_published_today`, `missing_credentials`), reorder, today-status |
+| Auto-post (`services/tasks-api`) | `contentSchedulerAutoPost.test.ts` covers the job queue adapter, BullMQ placeholder, in-process timer, end-to-end publish-via-auto-post |
+
+Mission Control suite: 161/161 green as of PR #257 merge.
+
+---
+
+## Key file locations
+
+| What | Where |
+|---|---|
+| UI tab | `apps/mission-control/src/tabs/ContentSchedulerTab.jsx` |
+| Calendar helpers | `apps/mission-control/src/tabs/contentSchedulerCalendar.js` |
+| API client | `apps/mission-control/src/contentSchedulerApi.js` |
+| Calendar grid CSS | `apps/mission-control/src/styles/components.css` |
+| Express routes | `services/tasks-api/src/routes/contentScheduler.ts` |
+| Publish guard + X client | `services/tasks-api/src/routes/contentSchedulerPublish.ts` |
+| Shared publish service | `services/tasks-api/src/routes/contentSchedulerPublishService.ts` |
+| Auto-post jobs | `services/tasks-api/src/routes/contentSchedulerJobs*.ts` |
+| Prisma model | `services/tasks-api/prisma/schema.prisma` |
+| App behavioural contract | `apps/mission-control/SPEC.md` (Flow 7) |
+| Auto-post subsystem spec | `docs/systems/content-scheduler-auto-post.md` |
+| Tech designs | `docs/specs/content-scheduler-*-tech-design.md` |
+
+---
+
+## Known gaps / future work
+
+- **Service extraction** (task `94d5e4fc`): move out of `services/tasks-api` into a dedicated `services/content-scheduler-api` per [`docs/specs/content-scheduler-service-extraction-tech-design.md`](../specs/content-scheduler-service-extraction-tech-design.md).
+- **`draft` affordance**: the data model supports `draft` but the UI never produces one. If a "save without queueing" button is added, it should land in a follow-up PR.
+- **Multi-channel publishing**: ACs are X-only. TikTok, LinkedIn, etc. are future channels.
+- **Media attachments** (images / video): not supported in the model or the X client. Future work.
+- **Thread composition**: a single Content Scheduler item is a single tweet. Thread drafts are out of scope for v1.
+- **Per-user actor attribution**: `approvedBy` is a free-form string. The future Multi-user support work should formalise this.


### PR DESCRIPTION
## Summary
- Backfills the durable docs required by `docs/CONVENTIONS.md` for PR #257 (`feat(content-scheduler): 10-day calendar view`, task 95e65d06), which shipped without the system spec or app `SPEC.md` update that the on-ship checklist calls for.
- New `docs/systems/content-scheduler.md` covers the Content Scheduler end-to-end: data model, API surface, calendar runtime flow with drag-and-drop + max-one-per-day drop guard, `Intl.DateTimeFormat` timezone handling (NZST/NZDT + DST start edge), `guardPublish` outcomes, X client abstraction, runbook notes, test plan. Links to `content-scheduler-auto-post.md` for the auto-post subsystem and `content-scheduler-service-extraction-tech-design.md` for the planned service extraction.
- Tech-design frontmatter updated: `status: shipped`, `shipped_pr: 257`, `shipped_date: 2026-07-18`.
- `apps/mission-control/SPEC.md` Flow 7 rewritten to describe the 10-day calendar view; the Screens table Content row, the E2e Coverage row, and the Data Sources Content Scheduler bullet updated to reflect the calendar + Intl timezone handling + auto-post subsystem link.

## Acceptance Criteria (shipped in PR #257)

- [x] AC1: The Content Scheduler tab renders a 10-day calendar — columns from today through today + 9 — each column labelled with the day name and date (e.g. "Wed 16 Jul")
- [x] AC2: Each column shows approved and queued items whose scheduledFor falls on that calendar day (Pacific/Auckland), rendered as cards using the tasks UI card/column styling
- [x] AC3: Items with no scheduledFor or a date outside the 10-day window appear in an "Unscheduled" overflow area below or beside the calendar
- [x] AC4: Tom can drag a card from one day column to another; on drop, the item's scheduledFor is updated to the same time-of-day but on the target date (preserving HH:MM, or defaulting to 09:00 if no time was set)
- [x] AC5: Published items are shown read-only in their published day column with a visual indicator (e.g. greyed card, "Published" badge) and cannot be dragged
- [x] AC6: The calendar respects the existing max-one-published-per-day rule: if a day already has a published item, its column header shows a visual indicator and dragging a second item onto that day is refused with an inline error

## Test plan
- [ ] Verify `docs/systems/content-scheduler.md` matches the shipped code (data model fields match Prisma schema, API routes match `services/tasks-api/src/routes/contentScheduler.ts`, helper exports match `apps/mission-control/src/tabs/contentSchedulerCalendar.js`, guard codes match `guardPublish`).
- [ ] Verify `apps/mission-control/SPEC.md` Flow 7 reads coherently with the new system spec and no longer references the deprecated list/↑↓ controls.
- [ ] Verify all PR #257 ACs are covered somewhere in the docs (calendar grid, Unscheduled overflow, drag-and-drop with HH:MM preservation + 09:00 default, published read-only badge, max-one-per-day drop guard, today-status banner).
- [ ] No logic changes — diff is docs-only.

🤖 Generated with [openclaw](https://openclaw.ai)

Co-Authored-By: Rowan Stoffer <rowanstoffer@gmail.com>