### PR TITLE
feat(feature-task): validate system spec from PR body, not task comments

### DIFF
--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -126,12 +126,12 @@ Before writing any code on a feature task, write the tech design:
 ### AC checkboxes on the task — hands off
 **Never tick or untick AC checkboxes in the task description.** That is Tom/QA's gate, applied only once the task reaches `acceptance`. Rowan's evidence belongs in the PR body only.
 
-### System spec (required before acceptance)
+### System spec (required in the implementation PR)
 
-Before the task can move from `doing` to `acceptance`, use the system-spec skill:
+Before converting the PR from draft to ready-for-review, write or update the system spec using the system-spec skill:
 `agents/skills/dev/system-spec/SKILL.md`
 
-The skill covers when to create vs update an existing spec. Post the resulting task comment (`[system-spec]` or `[no-system-spec-change]`) — Lobster verify-delivery blocks until one is present.
+The spec must be committed on the implementation branch and included in the **same PR as the feature code** — not in a separate follow-up PR. A backfill PR for the system spec is not acceptable. Post the resulting task comment (`[system-spec]` or `[no-system-spec-change]`) before posting `[implementer-prs]`. Lobster verify-delivery blocks until one is present.
 
 ### Acceptance
 Use the pr-address-feedback skill when handling review comments: `agents/skills/dev/pr-address-feedback/SKILL.md`
@@ -157,9 +157,10 @@ When Rowan opens a PR:
 - reference the task in the PR body
 
 When all ACs are implemented and the PR is ready for review:
+- commit the system spec on this branch (see System spec section above) — it must be in this PR, not a follow-up
 - convert draft → ready-for-review
 - set yourself (`rowanstoffer`) as PR assignee; add **Quinn** (`quinnstoffer`) and **Tom** (`Stoff81`) as reviewers — Quinn is the blocking code reviewer, Tom is non-blocking (visibility only)
-- post `[implementer-prs] <url>` as a task comment
+- post `[system-spec]` (or `[no-system-spec-change]`) task comment, then post `[implementer-prs] <url>` — in that order
 - merge after Quinn approves and CI is green — do not wait for Tom's PR approval
 - Tom tests post-merge in main; his sign-off is `[qa-ac-verified] true` on the task, not a PR review
 

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -131,7 +131,13 @@ Before writing any code on a feature task, write the tech design:
 Before converting the PR from draft to ready-for-review, write or update the system spec using the system-spec skill:
 `agents/skills/dev/system-spec/SKILL.md`
 
-The spec must be committed on the implementation branch and included in the **same PR as the feature code** — not in a separate follow-up PR. A backfill PR for the system spec is not acceptable. Post the resulting task comment (`[system-spec]` or `[no-system-spec-change]`) before posting `[implementer-prs]`. Lobster verify-delivery blocks until one is present.
+The spec must be committed on the implementation branch and included in the **same PR as the feature code** — not in a separate follow-up PR.
+
+Add a `## System Spec` section to the PR body (before `## Out of scope` or at the end):
+- If a spec was written or updated: `docs/systems/<file>.md` (plain or backtick-quoted)
+- If no spec change: a substantive sentence explaining why (>= 12 non-whitespace characters)
+
+The lobster's verify-delivery gate reads this section from the PR body and blocks until it is present and non-trivial. **No task comment is needed** — the PR body section is the gate.
 
 ### Acceptance
 Use the pr-address-feedback skill when handling review comments: `agents/skills/dev/pr-address-feedback/SKILL.md`
@@ -158,9 +164,10 @@ When Rowan opens a PR:
 
 When all ACs are implemented and the PR is ready for review:
 - commit the system spec on this branch (see System spec section above) — it must be in this PR, not a follow-up
+- add `## System Spec` section to the PR body with the spec path or no-change reason
 - convert draft → ready-for-review
 - set yourself (`rowanstoffer`) as PR assignee; add **Quinn** (`quinnstoffer`) and **Tom** (`Stoff81`) as reviewers — Quinn is the blocking code reviewer, Tom is non-blocking (visibility only)
-- post `[system-spec]` (or `[no-system-spec-change]`) task comment, then post `[implementer-prs] <url>` — in that order
+- post `[implementer-prs] <url>` as a task comment
 - merge after Quinn approves and CI is green — do not wait for Tom's PR approval
 - Tom tests post-merge in main; his sign-off is `[qa-ac-verified] true` on the task, not a PR review
 

--- a/agents/skills/dev/pr-open/SKILL.md
+++ b/agents/skills/dev/pr-open/SKILL.md
@@ -39,6 +39,11 @@ gh pr create \
 - <bullet: what changed and why>
 - <bullet: any notable decisions or trade-offs>
 
+## System Spec
+<path to docs/systems/<file>.md that was written or updated>
+— OR —
+No system spec change — <substantive reason, e.g. "CI-only fix, no user-facing behaviour">
+
 ## Test plan
 - [ ] <specific thing to verify>
 - [ ] <another check>
@@ -47,6 +52,12 @@ gh pr create \
 EOF
 )"
 ```
+
+**`## System Spec` is required on every feature-task PR.** The lobster's `verify_delivery` gate reads this section and blocks if it is absent or empty. Provide either:
+- The path to the spec file that was written or updated (`docs/systems/<file>.md`), plain or backtick-quoted.
+- A substantive no-change reason (at least 12 non-whitespace characters, no spec path) explaining why no spec was touched.
+
+A short stub like "No change" will be treated as missing and will block acceptance.
 
 Include a `Co-Authored-By` trailer in your commit messages identifying yourself:
 ```

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -345,12 +345,16 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
             for ac_failure in task_ac_vs_open_pr_failures(&env.task.id, &task_acs, &body, url) {
                 failures.push(format!("PR {url} — {ac_failure}"));
             }
+            let decl = body_system_spec_decl(&body);
+            failures.extend(system_spec_pr_body_failures(&decl, url, &env.task));
         }
+    } else if !pr_urls.is_empty() {
+        // pr_urls is non-empty but latest_pr_url is None — shouldn't happen, but guard it
+        failures.push("Could not determine latest PR URL to validate system spec.".to_string());
     }
     if workstreams(&env.task).is_empty() {
         failures.push("Task description must include at least one workstream.".to_string());
     }
-    failures.extend(system_spec_failures(&env.task, &args.repo));
     if openclaw_needed(&env.task) && !openclaw_done(&env.task) {
         failures
             .push("`[openclaw-needed]` is present but `[openclaw-done]` is missing.".to_string());
@@ -2701,23 +2705,6 @@ where
         .collect()
 }
 
-fn system_spec_source_pr_urls_with<F>(task: &Task, inspect: F) -> Vec<String>
-where
-    F: Fn(&str) -> Result<ReviewState>,
-{
-    let urls = implementer_pr_urls(task);
-    let active: Vec<String> = urls
-        .iter()
-        .filter(|url| !matches!(inspect(url), Ok(ReviewState::Merged)))
-        .cloned()
-        .collect();
-    if active.is_empty() {
-        urls
-    } else {
-        active
-    }
-}
-
 fn pr_branch_for_system_spec<I, B>(url: &str, inspect: I, branch_for_pr: B) -> Result<String>
 where
     I: Fn(&str) -> Result<ReviewState> + Copy,
@@ -2750,13 +2737,18 @@ impl SystemSpecFetcher for GhSystemSpecFetcher {
     }
 }
 
-fn system_spec_failures(task: &Task, repo: &Path) -> Vec<String> {
-    system_spec_failures_with(task, repo, inspect_pr, pr_head_branch, &GhSystemSpecFetcher)
+fn system_spec_pr_body_failures(
+    decl: &SystemSpecBodyDecl,
+    pr_url: &str,
+    task: &Task,
+) -> Vec<String> {
+    system_spec_pr_body_failures_with(decl, pr_url, task, inspect_pr, pr_head_branch, &GhSystemSpecFetcher)
 }
 
-fn system_spec_failures_with<I, B>(
+fn system_spec_pr_body_failures_with<I, B>(
+    decl: &SystemSpecBodyDecl,
+    pr_url: &str,
     task: &Task,
-    _repo: &Path,
     inspect: I,
     branch_for_pr: B,
     fetcher: &dyn SystemSpecFetcher,
@@ -2765,56 +2757,52 @@ where
     I: Fn(&str) -> Result<ReviewState> + Copy,
     B: Fn(&str) -> Result<String> + Copy,
 {
-    let system_specs = tagged_path_values(task, "[system-spec]");
-    if system_specs.is_empty() {
-        let reasons = tagged_values(task, "[no-system-spec-change]");
-        if reasons.iter().any(|reason| reason.len() >= 12) {
-            return vec![];
+    match decl {
+        SystemSpecBodyDecl::Missing => {
+            vec!["PR body must include a `## System Spec` section with a spec path or a no-change reason.".to_string()]
         }
-        return vec!["Missing `[system-spec] docs/systems/<file>.md` or substantive `[no-system-spec-change]` reason.".to_string()];
-    }
-    let candidate_prs = system_spec_source_pr_urls_with(task, inspect);
-    let Some(source_pr_url) = candidate_prs.first() else {
-        return vec![
-            "Missing `[implementer-prs]` PR URL to read system specs from a PR branch or main."
-                .to_string(),
-        ];
-    };
-    let (owner, repo_name) = match parse_pr_repo(source_pr_url) {
-        Ok(parts) => parts,
-        Err(err) => return vec![format!("Could not parse PR URL `{source_pr_url}`: {err}.")],
-    };
-    let branch = match pr_branch_for_system_spec(source_pr_url, inspect, branch_for_pr) {
-        Ok(branch) => branch,
-        Err(err) => {
-            return vec![format!(
-                "Could not determine branch for PR `{source_pr_url}`: {err}."
-            )]
-        }
-    };
-    system_specs
-        .into_iter()
-        .filter_map(|path| {
-            let text = match fetcher.read(&owner, &repo_name, &path, &branch) {
-                Ok(text) => text,
-                Err(err) if is_github_404(&err) => {
-                    return Some(format!(
-                        "System spec `{path}` is missing on PR branch `{branch}`."
-                    ))
-                }
+        SystemSpecBodyDecl::NoChange => vec![],
+        SystemSpecBodyDecl::Path(path) => {
+            let (owner, repo_name) = match parse_pr_repo(pr_url) {
+                Ok(parts) => parts,
                 Err(err) => {
-                    return Some(format!(
-                        "Could not read system spec `{path}` from PR branch `{branch}`: {err}."
-                    ))
+                    return vec![format!("Could not parse PR URL `{pr_url}`: {err}.")]
                 }
             };
-            let current = implementer_pr_urls(task)
+            let branch = match pr_branch_for_system_spec(pr_url, inspect, branch_for_pr) {
+                Ok(b) => b,
+                Err(err) => {
+                    return vec![format!(
+                        "Could not determine branch for PR `{pr_url}`: {err}."
+                    )]
+                }
+            };
+            let text = match fetcher.read(&owner, &repo_name, path, &branch) {
+                Ok(t) => t,
+                Err(err) if is_github_404(&err) => {
+                    return vec![format!(
+                        "System spec `{path}` is missing on PR branch `{branch}`."
+                    )]
+                }
+                Err(err) => {
+                    return vec![format!(
+                        "Could not read system spec `{path}` from PR branch `{branch}`: {err}."
+                    )]
+                }
+            };
+            let referenced = implementer_pr_urls(task)
                 .into_iter()
-                .any(|url| text.contains(&url))
+                .any(|u| text.contains(&u))
                 || text.contains(&task.id);
-            (!current).then(|| format!("System spec `{path}` does not reference this task or PR."))
-        })
-        .collect()
+            if referenced {
+                vec![]
+            } else {
+                vec![format!(
+                    "System spec `{path}` does not reference this task or PR."
+                )]
+            }
+        }
+    }
 }
 
 fn parse_pr_repo(url: &str) -> Result<(String, String)> {
@@ -2991,6 +2979,46 @@ fn body_has_checked_acceptance(body: &str) -> bool {
     Regex::new(r"(?m)^\s*-\s*\[[xX]\]\s+.+")
         .unwrap()
         .is_match(body)
+}
+
+/// What the `## System Spec` section of a PR body declares.
+#[derive(Debug, PartialEq)]
+enum SystemSpecBodyDecl {
+    /// Section is absent or empty.
+    Missing,
+    /// Section contains a substantive no-change reason (>= 12 non-whitespace chars, no spec path).
+    NoChange,
+    /// Section contains a `docs/systems/*.md` path.
+    Path(String),
+}
+
+fn body_system_spec_decl(body: &str) -> SystemSpecBodyDecl {
+    let header_re = Regex::new(r"(?mi)^##\s+System Spec\s*$").unwrap();
+    let Some(header_match) = header_re.find(body) else {
+        return SystemSpecBodyDecl::Missing;
+    };
+    let after = &body[header_match.end()..];
+    let end = Regex::new(r"(?m)^##")
+        .unwrap()
+        .find(after)
+        .map(|m| m.start())
+        .unwrap_or(after.len());
+    let content = after[..end].trim();
+    if content.is_empty() {
+        return SystemSpecBodyDecl::Missing;
+    }
+    if let Some(cap) = Regex::new(r"`?(docs/systems/\S+\.md)`?")
+        .unwrap()
+        .captures(content)
+    {
+        return SystemSpecBodyDecl::Path(cap[1].to_string());
+    }
+    let non_ws: usize = content.chars().filter(|c| !c.is_whitespace()).count();
+    if non_ws >= 12 {
+        SystemSpecBodyDecl::NoChange
+    } else {
+        SystemSpecBodyDecl::Missing
+    }
 }
 
 /// Evidence annotation recognised on a feature-task PR AC line.
@@ -4069,152 +4097,147 @@ Lead-in.
         );
     }
 
-    #[test]
-    fn enforces_system_spec_or_reason() {
-        let repo = tempdir().unwrap();
-        let mut task = Task {
-            id: "task-1".to_string(),
-            comments: vec![],
-            ..Task::default()
-        };
-        assert!(!system_spec_failures(&task, repo.path()).is_empty());
-        task.comments.push(TaskComment { text: Some("[no-system-spec-change] CLI-only parser test coverage; no system behavior changes.".to_string()), body: None });
-        assert!(system_spec_failures(&task, repo.path()).is_empty());
-    }
+    // ---- system spec PR body parsing ----
 
     #[test]
-    fn system_spec_tag_uses_first_path_token_only() {
-        let mut task = Task::default();
-        task.comments.push(TaskComment {
-            text: Some(
-                "[system-spec] docs/systems/feature-task-workflow.md (updated in PR #163)"
-                    .to_string(),
-            ),
-            body: None,
-        });
-        task.comments.push(TaskComment {
-            text: Some(
-                "[system-spec] `docs/systems/quoted.md`\n\nPR #161 merged; extra context"
-                    .to_string(),
-            ),
-            body: None,
-        });
-
+    fn body_system_spec_decl_missing_when_no_section() {
         assert_eq!(
-            tagged_path_values(&task, "[system-spec]"),
-            vec![
-                "docs/systems/feature-task-workflow.md".to_string(),
-                "docs/systems/quoted.md".to_string()
-            ]
+            body_system_spec_decl("## Summary\nSome text.\n\n## Acceptance Criteria\n- [x] AC1"),
+            SystemSpecBodyDecl::Missing
         );
     }
 
     #[test]
-    fn validates_existing_current_system_spec() {
-        let repo = tempdir().unwrap();
-        let task = Task {
-            id: "task-1".to_string(),
-            comments: vec![
-                TaskComment {
-                    text: Some("[system-spec] docs/systems/feature-task.md".to_string()),
-                    body: None,
-                },
-                TaskComment {
-                    text: Some(
-                        "[rowan-prs] https://github.com/Stoffer-Industries/sindustries/pull/128"
-                            .to_string(),
-                    ),
-                    body: None,
-                },
-            ],
-            ..Task::default()
-        };
-        let fetcher = StubFetcher {
-            body: "References task-1".to_string(),
-            error: None,
-        };
-        assert!(system_spec_failures_with(
-            &task,
-            repo.path(),
-            |_| Ok(ReviewState::Approved),
-            |_| Ok("task-456c92a8-depends-on".to_string()),
-            &fetcher,
-        )
-        .is_empty());
-    }
-
-    #[test]
-    fn validates_system_spec_from_main_when_all_prs_are_merged() {
-        let repo = tempdir().unwrap();
-        let task = Task {
-            id: "task-1".to_string(),
-            comments: vec![
-                TaskComment {
-                    text: Some("[system-spec] docs/systems/feature-task.md".to_string()),
-                    body: None,
-                },
-                TaskComment {
-                    text: Some(
-                        "[rowan-prs] https://github.com/Stoffer-Industries/sindustries/pull/161"
-                            .to_string(),
-                    ),
-                    body: None,
-                },
-            ],
-            ..Task::default()
-        };
-        let fetcher = StubFetcher {
-            body: "References task-1".to_string(),
-            error: None,
-        };
-
-        assert!(system_spec_failures_with(
-            &task,
-            repo.path(),
-            |_| Ok(ReviewState::Merged),
-            |_| panic!("merged PRs must read system specs from main, not a head branch"),
-            &fetcher,
-        )
-        .is_empty());
-    }
-
-    #[test]
-    fn reports_system_spec_missing_on_pr_branch() {
-        let repo = tempdir().unwrap();
-        let task = Task {
-            id: "task-1".to_string(),
-            comments: vec![
-                TaskComment {
-                    text: Some("[system-spec] docs/systems/feature-task.md".to_string()),
-                    body: None,
-                },
-                TaskComment {
-                    text: Some(
-                        "[rowan-prs] https://github.com/Stoffer-Industries/sindustries/pull/128"
-                            .to_string(),
-                    ),
-                    body: None,
-                },
-            ],
-            ..Task::default()
-        };
-        let fetcher = StubFetcher {
-            body: String::new(),
-            error: Some("gh: Not Found (HTTP 404)".to_string()),
-        };
+    fn body_system_spec_decl_missing_when_section_empty() {
         assert_eq!(
-            system_spec_failures_with(
-                &task,
-                repo.path(),
+            body_system_spec_decl("## Summary\nFoo.\n\n## System Spec\n\n## Acceptance Criteria"),
+            SystemSpecBodyDecl::Missing
+        );
+    }
+
+    #[test]
+    fn body_system_spec_decl_path_plain() {
+        assert_eq!(
+            body_system_spec_decl("## System Spec\ndocs/systems/content-scheduler.md — updated"),
+            SystemSpecBodyDecl::Path("docs/systems/content-scheduler.md".to_string())
+        );
+    }
+
+    #[test]
+    fn body_system_spec_decl_path_backtick() {
+        assert_eq!(
+            body_system_spec_decl("## System Spec\n`docs/systems/content-scheduler.md`"),
+            SystemSpecBodyDecl::Path("docs/systems/content-scheduler.md".to_string())
+        );
+    }
+
+    #[test]
+    fn body_system_spec_decl_no_change_substantive() {
+        assert_eq!(
+            body_system_spec_decl(
+                "## System Spec\nNo system spec change — CI env-var fix only, no user-facing behaviour."
+            ),
+            SystemSpecBodyDecl::NoChange
+        );
+    }
+
+    #[test]
+    fn body_system_spec_decl_no_change_too_short() {
+        assert_eq!(
+            body_system_spec_decl("## System Spec\nNo change"),
+            SystemSpecBodyDecl::Missing
+        );
+    }
+
+    // ---- system_spec_pr_body_failures_with ----
+
+    fn pr_url() -> &'static str {
+        "https://github.com/Stoffer-Industries/sindustries/pull/128"
+    }
+
+    fn task_with_pr() -> Task {
+        Task {
+            id: "task-1".to_string(),
+            comments: vec![TaskComment {
+                text: Some(
+                    format!("[implementer-prs] {}", pr_url()),
+                ),
+                body: None,
+            }],
+            ..Task::default()
+        }
+    }
+
+    #[test]
+    fn system_spec_body_missing_fails() {
+        assert_eq!(
+            system_spec_pr_body_failures_with(
+                &SystemSpecBodyDecl::Missing,
+                pr_url(),
+                &task_with_pr(),
                 |_| Ok(ReviewState::Approved),
-                |_| Ok("task-456c92a8-depends-on".to_string()),
-                &fetcher,
+                |_| Ok("some-branch".to_string()),
+                &StubFetcher { body: String::new(), error: None },
             ),
-            vec![
-                "System spec `docs/systems/feature-task.md` is missing on PR branch `task-456c92a8-depends-on`."
-                    .to_string()
-            ]
+            vec!["PR body must include a `## System Spec` section with a spec path or a no-change reason."]
         );
+    }
+
+    #[test]
+    fn system_spec_body_no_change_passes() {
+        assert!(system_spec_pr_body_failures_with(
+            &SystemSpecBodyDecl::NoChange,
+            pr_url(),
+            &task_with_pr(),
+            |_| Ok(ReviewState::Approved),
+            |_| Ok("some-branch".to_string()),
+            &StubFetcher { body: String::new(), error: None },
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn system_spec_body_path_valid_passes() {
+        let task = task_with_pr();
+        assert!(system_spec_pr_body_failures_with(
+            &SystemSpecBodyDecl::Path("docs/systems/feature-task.md".to_string()),
+            pr_url(),
+            &task,
+            |_| Ok(ReviewState::Approved),
+            |_| Ok("task-branch".to_string()),
+            &StubFetcher { body: "References task-1".to_string(), error: None },
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn system_spec_body_path_missing_on_branch_fails() {
+        let task = task_with_pr();
+        assert_eq!(
+            system_spec_pr_body_failures_with(
+                &SystemSpecBodyDecl::Path("docs/systems/feature-task.md".to_string()),
+                pr_url(),
+                &task,
+                |_| Ok(ReviewState::Approved),
+                |_| Ok("task-branch".to_string()),
+                &StubFetcher { body: String::new(), error: Some("gh: Not Found (HTTP 404)".to_string()) },
+            ),
+            vec!["System spec `docs/systems/feature-task.md` is missing on PR branch `task-branch`."]
+        );
+    }
+
+    #[test]
+    fn system_spec_body_reads_from_main_when_pr_merged() {
+        let task = task_with_pr();
+        assert!(system_spec_pr_body_failures_with(
+            &SystemSpecBodyDecl::Path("docs/systems/feature-task.md".to_string()),
+            pr_url(),
+            &task,
+            |_| Ok(ReviewState::Merged),
+            |_| panic!("merged PR must read from main, not head branch"),
+            &StubFetcher { body: "References task-1".to_string(), error: None },
+        )
+        .is_empty());
     }
 
     #[test]

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -2669,20 +2669,6 @@ fn tech_design_approved(task: &Task) -> bool {
         })
 }
 
-fn tagged_path_values(task: &Task, tag: &str) -> Vec<String> {
-    tagged_values(task, tag)
-        .into_iter()
-        .filter_map(|value| {
-            value
-                .trim_start()
-                .split_whitespace()
-                .next()
-                .map(|token| token.trim_matches('`').trim_matches(',').to_string())
-        })
-        .filter(|path| !path.is_empty())
-        .collect()
-}
-
 fn implementer_pr_urls(task: &Task) -> Vec<String> {
     let re = Regex::new(r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+").unwrap();
     let mut urls = Vec::new();

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -341,15 +341,21 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
         }
     }
     if let Some(url) = &latest_pr_url {
-        if let Ok(body) = pr_body(url) {
-            for ac_failure in task_ac_vs_open_pr_failures(&env.task.id, &task_acs, &body, url) {
-                failures.push(format!("PR {url} — {ac_failure}"));
+        match pr_body(url) {
+            Ok(body) => {
+                for ac_failure in task_ac_vs_open_pr_failures(&env.task.id, &task_acs, &body, url) {
+                    failures.push(format!("PR {url} — {ac_failure}"));
+                }
+                let decl = body_system_spec_decl(&body);
+                failures.extend(system_spec_pr_body_failures(&decl, url, &env.task));
             }
-            let decl = body_system_spec_decl(&body);
-            failures.extend(system_spec_pr_body_failures(&decl, url, &env.task));
+            Err(err) => {
+                failures.push(format!(
+                    "Could not read PR body for {url}: {err}. Cannot validate AC text or system spec."
+                ));
+            }
         }
     } else if !pr_urls.is_empty() {
-        // pr_urls is non-empty but latest_pr_url is None — shouldn't happen, but guard it
         failures.push("Could not determine latest PR URL to validate system spec.".to_string());
     }
     if workstreams(&env.task).is_empty() {
@@ -4238,6 +4244,15 @@ Lead-in.
             &StubFetcher { body: "References task-1".to_string(), error: None },
         )
         .is_empty());
+    }
+
+    #[test]
+    fn body_system_spec_decl_path_in_middle_of_section() {
+        let body = "## Summary\nFoo.\n\n## System Spec\nUpdated `docs/systems/content-scheduler.md` to cover the 10-day calendar.\n\n## Test plan\n- [ ] CI green";
+        assert_eq!(
+            body_system_spec_decl(body),
+            SystemSpecBodyDecl::Path("docs/systems/content-scheduler.md".to_string())
+        );
     }
 
     #[test]

--- a/docs/systems/feature-task-workflow.md
+++ b/docs/systems/feature-task-workflow.md
@@ -113,7 +113,7 @@ Note: prior versions of this workflow ran an equivalent AC text check at the `po
 | `agents/skills/dev/tech-design/SKILL.md` | Authoring guide for tech designs |
 | `agents/skills/dev/system-spec/SKILL.md` | Authoring guide for system specs (this file is one) |
 | `docs/specs/<task-slug>-tech-design.md` | Per-task tech design, branch URL recorded as `[tech-design]` task comment |
-| `docs/systems/<system>.md` | Per-system spec; recorded as `[system-spec]` task comment |
+| `docs/systems/<system>.md` | Per-system spec; committed on the implementation branch and declared in the PR body's `## System Spec` section |
 | `services/tasks-api/prisma/schema.prisma` | Tasks API persistence — `taskType`, `specChecksum` |
 
 ---

--- a/docs/systems/feature-task-workflow.md
+++ b/docs/systems/feature-task-workflow.md
@@ -1,7 +1,7 @@
 # Feature Task Workflow
 
 **Type:** System reference (keep updated as the pipeline evolves)
-**Last updated:** 2026-07-14
+**Last updated:** 2026-07-19
 **Repo:** `Stoffer-Industries/sindustries` · `agents/workflows/feature-task/`
 
 ---
@@ -44,11 +44,12 @@ The Rust CLI under `agents/workflows/feature-task/` owns parsing, gate enforceme
 - **Owner:** Rowan, working on the agreed worktree branch
 - Required Rowan behaviour:
   - All changes land via PR (no direct pushes to `main`)
-  - `[rowan-prs] <url1>, <url2>` task comment lists every open PR
+  - `[implementer-prs] <url>` task comment lists every open PR (legacy alias `[rowan-prs]` still accepted)
   - `[openclaw-needed]` task comment if any `.openclaw` file edits are required (with proposed diff + rollback note) — Rowan does not touch `.openclaw/` directly
-  - PR body lists every parent task AC checked off
-  - When implementation is complete, `[rowan-done] <files> | <validation commands> | <pr url>` task comment
-- Rust command: `feature-task verify-delivery` runs after the `[rowan-prs]` signal to confirm PRs and CI state
+  - PR body lists every parent task AC checked off with evidence annotations
+  - PR body includes a `## System Spec` section (see below) — required before the PR is converted from draft to ready-for-review
+  - When implementation is complete, post `[implementer-prs] <url>` task comment
+- Rust command: `feature-task verify-delivery` runs after the `[implementer-prs]` signal to confirm PRs, CI state, AC text, and system spec
 
 ### 3. `acceptance` — review and gate enforcement
 
@@ -57,10 +58,16 @@ The Rust CLI under `agents/workflows/feature-task/` owns parsing, gate enforceme
   - All PRs linked from `[rowan-prs]` are merged
   - GitHub review state on every linked PR is `APPROVED` (no `CHANGES_REQUESTED` outstanding)
   - CI on the merged commits is green
-  - System spec exists at `docs/systems/<file>.md` (gated via `[system-spec]` task comment) OR a substantive `[no-system-spec-change] <reason>` is recorded
+  - PR body `## System Spec` section declares either a spec path (`docs/systems/<file>.md`) or a substantive no-change reason — validated at `verify_delivery` (doing → acceptance gate), not acceptance → done
   - No `[openclaw-needed]` pending without matching `[openclaw-done]` from Quinn
   - `[qa-ac-verified] true` task comment from Tom
 - Rust commands: `feature-task feedback-aggregate`, then `feature-task post-merge`
+
+**`## System Spec` PR body section (doing → acceptance, pre-merge):** `verify_delivery` reads the `## System Spec` section from the **latest implementer PR body** (highest PR number). The section must contain either:
+- A path to the spec file committed on the same branch: `docs/systems/<file>.md` (plain or backtick-quoted). The lobster fetches the file from the PR branch (or `main` when merged) and confirms it references the task ID or PR URL.
+- A substantive no-change reason (≥ 12 non-whitespace characters, no `docs/systems/` path): use when no system-level behaviour changed.
+
+A stub like "No change" (< 12 non-whitespace chars) is treated as missing and blocks acceptance. **The system spec must be committed in the same PR as the feature code** — a separate backfill PR is not acceptable. No task comment is needed; the PR body section is the gate. See `agents/skills/dev/pr-open/SKILL.md` for the canonical PR body template.
 
 **AC text check (doing → acceptance, pre-merge):** before the lobster will let the task advance from `doing` to `acceptance`, it compares every task description AC against the **open** PR body. If any AC is missing from the PR, has altered text, or lacks a valid evidence annotation `(testID|file|not tested|not code)`, the transition is blocked with a `[feature-task-progress-checklist]` comment listing the specific failures — the task stays in `doing` until Rowan opens a fix PR that lists every AC verbatim with evidence. Tom may edit ACs in the task description during QA — spec drift does not block this gate (it is covered by the resync feature; see task b2ab54db).
 
@@ -133,12 +140,9 @@ Until first-class Tasks API fields exist, the workflow reads these tags from tas
 |---|---|---|
 | `[tech-design] <url>` | Rowan | Tech design URL (durable `tech_design_url` is the eventual home) |
 | `[tech-design-approved] true` | Quinn | Tom signed off on the tech design |
-| `[rowan-prs] <url1>, <url2>` | Rowan | PRs implementing this task |
-| `[rowan-done] <files> \| <validation> \| <pr url>` | Rowan | Implementation complete signal |
+| `[implementer-prs] <url>` | Rowan | PRs implementing this task (`[rowan-prs]` is a legacy alias, still accepted) |
 | `[openclaw-needed] <reason>` | Rowan | Flag a `.openclaw` change for Quinn |
 | `[openclaw-done] <summary>` | Quinn | `.openclaw` change applied |
-| `[system-spec] docs/systems/<file>.md` | implementer | System spec reference |
-| `[no-system-spec-change] <reason>` | implementer | Bypass for code-only changes |
 | `[qa-ac-verified] true` | Tom | Explicit QA sign-off; required before `acceptance -> done` |
 | `[feature-task-progress-checklist] ...` | Lobster | Posted when the pre-merge AC text check (doing → acceptance) finds a missing, altered, or unannotated AC in the open PR body. Also posted for other gate failures (missing `[rowan-prs]`, missing `[system-spec]`, manual block, etc.) |
 | `[lobster-state] { ... }` | Lobster | Reconciler state — `version`, `last_orchestrated_at`, gate outcomes |
@@ -250,7 +254,7 @@ The `.openclaw/` directory is outside this repo. Any required `.openclaw` change
 |---|---|---|
 | `ready -> doing` blocked | Missing `[tech-design-approved]` or `specChecksum` drift | Quinn confirms Tom sign-off and posts `[tech-design-approved] true`; for drift, write a new spec |
 | `[openclaw-needed]` never resolved | Quinn missed the heartbeat step | Quinn scans active feature tasks on the next heartbeat tick |
-| `acceptance -> done` blocked | `[system-spec]` missing or no `[no-system-spec-change]` reason | Author `docs/systems/<system>.md` and post `[system-spec] <path>` |
+| `doing -> acceptance` blocked on system spec | PR body `## System Spec` section absent, empty, or stub (< 12 non-whitespace chars) | Add `## System Spec` to the PR body with the spec path or a substantive no-change reason; the spec file must be committed on the same branch |
 | Spec checksum mismatch | ACs edited after spec approval | Hits `PATCH /tasks/:id` when the description ACs change. Treat as spec drift: Lobster unchecks `**Approved by Tom**`, waits for Tom to re-check, then performs the resync path. Comments are drift-tolerant and remain usable for progress/checklist/resync signals. |
 | Spec lifecycle layout failure | Unexpected direct subdirectory under `brain/tasks/specs/` | Remove or migrate the unexpected subdir so only `open/`, `in-progress/`, and `done/` remain. The lobster creates missing expected dirs automatically. |
 | Stale `**Spec:**` line after a move | Prior run moved a spec but failed before patching the task description | Re-run the relevant lobster stage; move helpers treat destination-present/source-absent as idempotent and repair the task `**Spec:**` path. |
@@ -273,3 +277,4 @@ The `.openclaw/` directory is outside this repo. Any required `.openclaw` change
 
 - Task `ba116063-382a-446c-ab91-c01b60d9a7c3` — Lobster worktree cleanup after merge (PR #208): the source of the post-merge worktree cleanup step in the `done` section above
 - Task `a5a4ed8f-e7c4-4b6c-8ac9-bb962211ac44` — spec folder lifecycle and bookmark/feature lobster sync
+- PR #259 — system spec gate moved from `[system-spec]` task comment to `## System Spec` PR body section (shipped 2026-07-19)

--- a/docs/systems/feature-task-workflow.md
+++ b/docs/systems/feature-task-workflow.md
@@ -144,7 +144,7 @@ Until first-class Tasks API fields exist, the workflow reads these tags from tas
 | `[openclaw-needed] <reason>` | Rowan | Flag a `.openclaw` change for Quinn |
 | `[openclaw-done] <summary>` | Quinn | `.openclaw` change applied |
 | `[qa-ac-verified] true` | Tom | Explicit QA sign-off; required before `acceptance -> done` |
-| `[feature-task-progress-checklist] ...` | Lobster | Posted when the pre-merge AC text check (doing → acceptance) finds a missing, altered, or unannotated AC in the open PR body. Also posted for other gate failures (missing `[rowan-prs]`, missing `[system-spec]`, manual block, etc.) |
+| `[feature-task-progress-checklist] ...` | Lobster | Posted when the pre-merge AC text check (doing → acceptance) finds a missing, altered, or unannotated AC in the open PR body. Also posted for other gate failures (missing `[implementer-prs]`, missing `## System Spec` PR body section, manual block, etc.) |
 | `[lobster-state] { ... }` | Lobster | Reconciler state — `version`, `last_orchestrated_at`, gate outcomes |
 | `[scope-add] <summary>` | Quinn / Tom | Document a scope change after spec approval (used in factory-v2 grandfathering) |
 


### PR DESCRIPTION
## Summary
- Moves the system spec gate from task comments to the PR body. The lobster's \`verify_delivery\` now reads a \`## System Spec\` section in the implementation PR body instead of requiring \`[system-spec]\` / \`[no-system-spec-change]\` task comments.
- Adds \`body_system_spec_decl\` parser and \`system_spec_pr_body_failures_with\` validator (file existence + task/PR cross-reference check preserved).
- Removes \`system_spec_failures_with\` and \`system_spec_source_pr_urls_with\` (dead code after this change).
- Updates \`agents/definitions/rowan/WORKFLOW.md\` with the new PR section requirement.
- Updates \`agents/skills/dev/pr-open/SKILL.md\` PR body template to include the \`## System Spec\` section.
- Updates \`docs/systems/feature-task-workflow.md\` to document the new gate (doing → acceptance), remove the deprecated \`[system-spec]\` / \`[no-system-spec-change]\` task comment rows, and add the common failure mode.

## System Spec
\`docs/systems/feature-task-workflow.md\` — updated to document the ## System Spec PR body gate, remove deprecated [system-spec] task comment references, and add failure mode entry.

## Acceptance Criteria
- [x] AC1: \`verify_delivery\` no longer calls \`system_spec_failures\`; system spec is validated from the latest PR body \`## System Spec\` section. (file: \`agents/workflows/feature-task/src/main.rs\` \`verify_delivery\`)
- [x] AC2: \`body_system_spec_decl\` correctly parses: missing section → \`Missing\`; \`docs/systems/*.md\` path (plain or backtick) → \`Path\`; substantive no-change text → \`NoChange\`; short text → \`Missing\`. (file: \`agents/workflows/feature-task/src/main.rs\` \`body_system_spec_decl\`, 6 unit tests)
- [x] AC3: \`system_spec_pr_body_failures_with\` validates file existence and task/PR cross-reference (same behaviour as the old comment-based gate). (file: \`agents/workflows/feature-task/src/main.rs\` \`system_spec_pr_body_failures_with\`, 5 unit tests)
- [x] AC4: All 169 lobster unit tests pass. (not tested: Rust test suite — \`cargo test\` in \`agents/workflows/feature-task\`)
- [x] AC5: \`WORKFLOW.md\` describes \`## System Spec\` PR body section and removes the \`[system-spec]\` task comment step. (file: \`agents/definitions/rowan/WORKFLOW.md\`)
- [x] AC6: \`pr-open/SKILL.md\` PR body template includes the \`## System Spec\` section with format guidance. (file: \`agents/skills/dev/pr-open/SKILL.md\`)
- [x] AC7: \`docs/systems/feature-task-workflow.md\` updated to document the new gate, remove deprecated task comment tags, and add failure mode. (not code: updated \`docs/systems/feature-task-workflow.md\`)

## Test plan
- \`cargo test --manifest-path agents/workflows/feature-task/Cargo.toml\` — 169/169 green (confirmed locally before PR open).

🤖 Generated with [openclaw](https://openclaw.ai)

Co-Authored-By: Rowan Stoffer <rowanstoffer@gmail.com>