### PR TITLE
chore(agents): move lobster work from heartbeat to cron + dev env out-of-scope

### DIFF
--- a/agents/crons/prompts/backlog-maintenance.md
+++ b/agents/crons/prompts/backlog-maintenance.md
@@ -1,0 +1,67 @@
+Run a backlog maintenance pass: find open tasks with no taskType and assign them the correct type.
+
+## Step 1 — Fetch untyped tasks
+
+```bash
+curl -s "http://localhost:4001/api/v1/tasks?status=open&limit=1000" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+tasks = [t for t in data.get('data', []) if not t.get('taskType')]
+print(json.dumps(tasks, indent=2))
+"
+```
+
+If the list is empty, say exactly: NO_REPLY
+
+## Step 2 — Classify each task
+
+Read the type selection rules in:
+`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-create/SKILL.md`
+
+For each task, evaluate its title and description against the type decision table:
+
+| Signal | Type |
+|--------|------|
+| New capability, has spec or AC | `feature` |
+| Bug fix, refactor, cleanup, chore, migration | `code` |
+| Investigation, spike, feasibility, output is a doc | `research` |
+| SIndustries website content update | `content` |
+
+**Clear cases** — one type is obvious from title+description alone → auto-patch.
+**Ambiguous cases** — genuinely unclear or could be multiple types → skip and log as incident (do NOT guess).
+
+Tasks with `source:bookmark-review-pipeline` tag and `taskType: null` are pre-feature candidates waiting for Tom's spec approval. Do NOT auto-type these as `feature` — they have their own promotion flow. Skip them silently.
+
+## Step 3 — Apply clear classifications
+
+For each clear case, PATCH the task type via the API:
+
+```bash
+curl -s -X PATCH "http://localhost:4001/api/v1/tasks/<task-id>" \
+  -H "Content-Type: application/json" \
+  -d '{"taskType": "<type>"}'
+```
+
+Post a task comment explaining the auto-classification:
+```
+[backlog-maintenance] Auto-typed as `<type>` based on title/description. Rule applied: <one-line reason>.
+```
+
+## Step 4 — Log ambiguous tasks as incidents
+
+For each ambiguous task, write a watching entry to `brain/state/quinn-ops-state.json`:
+- Slug: `backlog-untyped-<task-id-prefix>-<YYYY-MM-DD>`
+- severity: `low`
+- needsTom: false (watching only, do not escalate)
+- lastAction: describe what was ambiguous
+
+Read/write the ops state file using the pattern in HEARTBEAT.md's OPS STATE MANAGEMENT section.
+
+## Step 5 — Report
+
+Output a brief summary:
+- N tasks auto-typed (list title + type assigned)
+- M tasks skipped as ambiguous (list titles)
+- K tasks skipped as bookmark-pipeline candidates
+
+If N = 0 and M = 0: say exactly: NO_REPLY

--- a/agents/crons/prompts/task-lobsters.md
+++ b/agents/crons/prompts/task-lobsters.md
@@ -1,0 +1,30 @@
+Run the Feature Factory and Content Task workflow lobsters once each.
+
+## 1. Feature Task Lobster
+
+```
+TASKS_API_BASE_URL=${TASKS_API_BASE_URL:-http://localhost:4001/api/v1} python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/feature-task/run.py
+```
+
+The runner discovers active tasks in `open`, `ready`, `doing`, and `acceptance` where `taskType == "feature"` (or `feature-factory` tag), then invokes Lobster for each task.
+
+**If the lobster reports `ready_checks_blocked` due to missing `[tech-design]`:**
+- Check if Rowan is free (no tasks in `doing` assigned to Rowan):
+  `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/tasks_api_client.py list --assignee Rowan --status doing --summary`
+- If Rowan is free: read the tech-design skill and spawn Rowan as a background subagent to write the tech design:
+  `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/dev/tech-design/SKILL.md`
+- If Rowan is busy: log a watching entry in `brain/state/quinn-ops-state.json` (slug: `feature-task-<task-id-prefix>-ready_checks-<YYYY-MM-DD>`).
+
+## 2. Content Task Lobster
+
+```
+TASKS_API_BASE_URL=${TASKS_API_BASE_URL:-http://localhost:4001/api/v1} python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/content-tasks/run.py --json
+```
+
+Report only failures, blocked closed-unmerged PRs, or meaningful transitions.
+
+## Soft-fail handling
+
+Read /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/notify-soft-fail/SKILL.md and follow it.
+If either lobster exits non-zero or returns `ok: false`, escalate to Lox's main session.
+If both succeed with no actionable output, say exactly: NO_REPLY

--- a/agents/definitions/lox/HEARTBEAT.md
+++ b/agents/definitions/lox/HEARTBEAT.md
@@ -6,6 +6,8 @@ My operating principles are in `SOUL.md`. The 3-rule framework (investigate → 
 
 Do not run broad maintenance or updates from heartbeat. Exact scheduled checks belong in cron.
 
+**Out-of-scope reminder (Tom 2026-07-19):** dev env (`MODE=dev` data plane — tasks-api :4000, budget-api :4000, dev postgres :6432, dev Tilt) is NOT Lox's charter. Don't probe it on heartbeat, don't alert Tom about it, don't run any runbook for it. Rowan drives dev himself. Full policy in `SOUL.md` "Out of Scope".
+
 ## Incident feed
 
 Incidents are created in Telegram DMs with Tom channel by cron and heartbeat agents when a failure is detected. Lox reads new messages from that channel, investigates, applies fixes if safe, and escalates to Tom with `openclaw message send --channel telegram --account lox --target 6435140143 --message "<message>"`.
@@ -175,3 +177,31 @@ This check is the **same diagnostic that caught Ivy's stall on 2026-06-05** (her
 **Known false-positive history (2026-06-07):** Lox incorrectly flagged Ivy's main session as stale because (a) the staleness check was reading the wrong session type for isolatedSession agents, and (b) the expected cadence was listed as 10 min when the actual config is 4h. Both bugs are fixed in this update.
 
 See `infra/runbooks/agent-main-session-stale-no-heartbeat.md` for the full diagnostic + recovery procedure.
+
+## Common false-positive patterns
+
+These are detection/classification bugs that produce noisy or wrong outputs even when the underlying check is healthy. Add new ones as they recur — pattern-matching on what *almost* failed is cheaper than re-debugging from scratch.
+
+### Existence-probe chains must end with `|| true`
+
+When a heartbeat/turn needs to check "does this file/dir exist?" across multiple candidate paths, the naive form exits non-zero the moment the first missing path is hit, which OpenClaw renders as `⚠️ 🛠️ Exec failed` even when "not found" is exactly the expected result. Saw this on 2026-07-19 (#481) when verifying prior runbook/incident-tracking claims:
+
+```bash
+# BAD — exit 2 on first missing dir, exit 1 on first unmatched glob.
+# OpenClaw flags the whole chain as a failure even though each line's
+# output is what we wanted.
+ls -la .../infra/runbooks/ && \
+ls -la .../infra/RUNBOOKS* && \
+ls -la .../brain/state/lox-incident-state.json
+
+# GOOD — `|| true` flattens each probe's exit to 0, so the chain stays
+# green when "not found" is the answer. Read each line's output to
+# classify the result.
+ls -la .../infra/runbooks/ || true
+ls -la .../infra/RUNBOOKS*  || true
+ls -la .../brain/state/lox-incident-state.json || true
+```
+
+Rule: any existence/optional-path probe in a heartbeat procedure should end with `|| true`. Reserve non-zero exits for checks where "not found" really is a failure (mandatory config files, expected runbook targets, etc.).
+
+Related: see also the Tailscale-wedge false-positive lesson in `MEMORY.md` — the `pgrep <GUI-binary>` check is what distinguishes a genuine wedge from an operator-quit state. Same shape: a partial signature matches the alert, but one extra probe disambiguates.

--- a/agents/definitions/lox/SOUL.md
+++ b/agents/definitions/lox/SOUL.md
@@ -25,6 +25,7 @@ Keep the OpenClaw instance, host environment, and all agent cron/heartbeat jobs 
 - Product feature implementation (Rowan owns builder work)
 - Cloud deployment architecture (expand later when cloud begins)
 - CI ownership (keep out for now)
+- **Dev env (`MODE=dev` data plane — tasks-api :4000, budget-api :4000, dev postgres :6432, dev Tilt)** — Tom 2026-07-19: "remove the dev env from your remit. I don't care if that goes down. It's temporary for testing as needed." Lox does not probe, alert on, escalate, or auto-repair it. Rowan drives dev himself when he needs it. If Rowan explicitly asks Lox for dev help, that's an ad-hoc ask — answer it once, don't reopen monitoring.
 
 ## How I Work — The 3-Rule Framework
 

--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -4,72 +4,21 @@
 
 ---
 
-BOOKMARK STATE OBSERVABILITY
-
-Heartbeat does not curate bookmarks, write specs, validate spec artifacts, or
-advance bookmark review state. Production bookmark curation and spec generation
-now run from the bookmark review cron.
-
-1. Read the state analyzer skill:
-   `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/bookmarks/state/SKILL.md`
-2. Run the compact analyzer:
-   `python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/bookmarks/state/scripts/run_bookmark_state_analyzer.py --json`
-3. **Only output if at least one of these is true:**
-   - `approvalPendingCount > 0` (new approvals waiting for Tom — report which items)
-   - A stall appeared that is NOT already in ops state (specs requested but missing, tasks blocked)
-   - **Otherwise: skip this section entirely. Do not report counts, stale items, or unchanged state.**
-4. Track new stalls in `brain/state/quinn-ops-state.json` under OPS STATE MANAGEMENT.
-5. Do not mutate bookmark state from heartbeat.
-
----
-
 TECH DESIGN APPROVAL
 
 Quinn approves tech designs on behalf of Tom during heartbeat. Tom has delegated this.
 
 Each heartbeat:
-1. Run the feature task workflow check (see FEATURE TASK LOBSTER CHECK below).
-2. Find feature tasks with a `[tech-design]` comment but no proper `[tech-design-approved] true` comment:
+1. Find feature tasks with a `[tech-design]` comment but no proper `[tech-design-approved] true` comment:
    `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py --json`
    The script mirrors the lobster's parser (`tagged_values` + `tech_design_approved` in `agents/workflows/feature-task/src/main.rs`): a comment counts as approval only if its trimmed text STARTS WITH the tag and the first whitespace-separated token after the tag is `true` (case-insensitive). Substring matches in the lobster's progress-checklist complaints (e.g. `Missing task comment [tech-design-approved] true`) are intentionally NOT counted.
-3. **If 0 pending: skip this section entirely. No output.**
-4. For each pending task:
+2. **If 0 pending: skip this section entirely. No output.**
+3. For each pending task:
    - Read the design at the linked path.
    - Check: all required sections present, aligned with spec, no unbounded scope, `.openclaw` boundary notes where relevant.
    - If it looks good: post task comment `[tech-design-approved] true`
    - If something looks wrong or risky: flag to Tom via Telegram instead of approving.
-5. Do not approve a design that was written in the same heartbeat pass (let Rowan write it, Quinn approves next pass).
-
----
-
-CONTENT TASK LOBSTER CHECK
-
-Quinn dispatches content task workflow passes from heartbeat; Lobster owns all status transitions.
-Run:
-`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/content-tasks/run.py --json`
-Report only failures, blocked closed-unmerged PRs, or meaningful transitions. If nothing actionable: no output.
-
----
-
-FEATURE TASK LOBSTER CHECK
-
-Quinn dispatches feature task workflow passes from heartbeat; Lobster owns all status transitions.
-Run:
-`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/feature-task/run.py`
-Report only failures, newly blocked tasks, or meaningful transitions. **Do not report tasks already in ops state with `escalatedAt` set — Tom has already been notified. Do not summarise routine doing/acceptance counts.**
-
-**Ops-state logging rule for blocked tasks:** When the lobster reports any `*_blocked` action on a task, check ops-state for an entry whose slug includes both the task ID AND the current gate (e.g. `verify_delivery`, `ready_checks`, `qa_ac_verified`). A task-level entry from a *different* gate does NOT count — create a new entry. Slug format: `feature-task-<task-id-prefix>-<gate>-<YYYY-MM-DD>`. This prevents a resolved blockage from masking a new one on the same task.
-
-**When the lobster reports `ready_checks_blocked` due to missing `[tech-design]`:**
-- Check if Rowan is free (no tasks in `doing` assigned to Rowan)
-- If Rowan is free: spawn Rowan as a background subagent to write the tech design (see tech-design skill)
-- If Rowan is busy: log to quinn-ops-state.json as a watching entry; do not re-spawn
-- Do NOT just report the stall without acting — dispatching Rowan is Quinn's job here
-
-**Heartbeat/subagent reporting contract:**
-- Heartbeat progress that matters to Tom should be announced here by Quinn's heartbeat output.
-- Rowan subagent completions are worker results: collect them back into the spawning Quinn heartbeat/session, then summarize the meaningful progress in Quinn's own heartbeat output.
-- Do not let Rowan subagent completion text become a standalone Tom-facing progress announcement; Tom should see the heartbeat summary, not raw worker handoff output.
+4. Do not approve a design that was written in the same heartbeat pass (let Rowan write it, Quinn approves next pass).
 
 ---
 
@@ -206,7 +155,6 @@ for inc in needs_tom(all_incidents):
 After completing all sections, check both `quinn-ops-state.json` and `brain/state/lox-incident-state.json`:
 
 **Before escalating any `needsTom` entry, re-validate it is still a real problem:**
-- For bookmark pipeline stalls: re-run the bookmark state analyzer. If `approvalPendingCount == 0` and no genuine stall exists (no `spec_created` items without a `specPath`, no items stuck in the same status for multiple heartbeats), mark the entry `resolved` with `resolvedAt: <now>` and do NOT escalate.
 - For feature task stalls: re-check the lobster output. If the task is no longer in the reported state, mark resolved.
 - For any other stall: if the original condition is no longer detectable in live state, mark `false_positive` rather than escalating.
 - Only escalate if the condition is confirmed present in live state this pass.

--- a/agents/skills/ops/tasks-api/tasks_api_client.py
+++ b/agents/skills/ops/tasks-api/tasks_api_client.py
@@ -55,7 +55,7 @@ def get_task(task_id: str, base_url: str | None = None) -> dict:
 
 def list_tasks(
     limit: int = 20,
-    status: str | None = None,
+    status: str | list[str] | None = None,
     assignee: str | None = None,
     blocked: bool | None = None,
     ready: bool | None = None,
@@ -66,6 +66,14 @@ def list_tasks(
 ) -> list:
     """List tasks with optional filters. Returns list of task dicts."""
     base = base_url or get_base_url()
+    # If multiple statuses requested, fan out one call per status and merge.
+    if isinstance(status, list):
+        results = []
+        for s in status:
+            results.extend(list_tasks(limit=limit, status=s, assignee=assignee,
+                                       blocked=blocked, ready=ready, priority=priority,
+                                       q=q, base_url=base_url, **extra_params))
+        return results
     params = {"limit": str(limit)}
     if status is not None:
         params["status"] = status

--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -1,0 +1,464 @@
+# Repo Audit — sindustries — 2026-W30 (2026-07-14 → 2026-07-20)
+
+**Generated:** 2026-07-20 (Monday cron)
+**Auditor:** Quinn (Chief of Staff)
+**Target:** `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`
+**Type:** Full four-phase audit
+
+---
+
+## Executive Summary
+
+**Health grade: B-** (unchanged from W29 — the biggest week of new work in a month but the same two Critical `budget-api` findings still ship on `main`, and multiple new surfaces added this week widen the exposure surface without matching auth).
+
+This week the repo took its largest step yet: a brand-new `apps/gymtrack` app (Vite + React + Supabase MVP with RLS-enforced schema, task 18256740), a full Content Scheduler auto-post subsystem (`services/tasks-api/src/routes/autoPostWorker.ts`, `contentSchedulerJobs.ts`, `contentSchedulerJobs.inProcess.ts`, `contentSchedulerJobs.bullmq.ts`, `autoPostWorkerMain.ts`, and 465-line `contentSchedulerAutoPost.test.ts`), a generic `POST /api/v1/x/tweets` endpoint (`services/tasks-api/src/routes/xTweet.ts`) used by the bookmark author-tweet flow (`agents/workflows/bookmarks/scripts/x_author_tweet.py`, 314 lines + 400 lines of tests), a 10-day calendar view for Content Scheduler, budget-mobile TestFlight/OTA distribution, a bookmarks Sankey + states-over-time dashboard rewrite, a large feature-task workflow overhaul (Rust `main.rs` grew from ~5100 to 6538 lines) with PR-body system-spec validation and role-based PR ownership, and the audit follow-up code-task workflow doc. Also good: W29 finding on Content Scheduler validation extraction is resolved (PR #251, `contentSchedulerValidation.ts`), and `apps/mission-control/SPEC.md` was updated to include Content Scheduler. The bad news: all Critical W26/W27/W28/W29 `budget-api` security findings still ship unchanged on `main` — `userId` from body/query without a session check (`services/budget-api/src/routes/transactions.ts:14`), `AkahuConnection.accessToken` plaintext `String` column (`services/budget-api/prisma/schema.prisma:42`), and IDOR via path params. The W29 High finding on `x-actor` unauthenticated Content Scheduler publish is not only still open — the codebase added a second wholly-unauthenticated write endpoint `POST /api/v1/x/tweets` (`services/tasks-api/src/routes/xTweet.ts:33-99`) that will post directly to X on behalf of the Sindustries account when `X_CLIENT=real`. Additionally, the `.env.example` was updated but points at the wrong env vars (`X_API_BEARER_TOKEN`) — the real client uses OAuth 1.0a (`X_API_KEY`/`X_API_SECRET`/`X_ACCESS_TOKEN`/`X_ACCESS_TOKEN_SECRET`) per `contentSchedulerPublish.ts:205-217`.
+
+**Top 3 risks:** (1) `POST /api/v1/x/tweets` is a brand-new unauthenticated endpoint that posts to the real Sindustries X account when `X_CLIENT=real` — comment at `xTweet.ts:19-23` acknowledges the risk and requires that tasks-api stay localhost-only, but there is no runtime enforcement of that requirement; (2) Content Scheduler auto-post uses an in-memory `Map<jobId, Entry>` (`contentSchedulerJobs.inProcess.ts:46`, `setTimeout` + `unref()` at `:97-112`) — every pending auto-post job is lost on any API restart or crash, and the "worker" entrypoint (`autoPostWorkerMain.ts:19-29`) creates a separate isolated Map that will never receive API-enqueued jobs, silently making the "run the worker" story a no-op; (3) `services/tasks-api/.env.example:24-32` documents `X_API_BEARER_TOKEN` but the code requires four OAuth 1.0a env vars — an operator following the example will silently get `MISSING_CREDENTIALS` at publish time.
+
+**Top 3 opportunities:** (1) Add a shared header-token guard middleware (`X_TASKS_API_INTERNAL_SECRET`) to `xTweet.ts` and Content Scheduler write endpoints — closes both the new-this-week High finding and the carryover W29 High in one small change; (2) Rewrite `services/tasks-api/.env.example` to list the four OAuth 1.0a vars — a five-line edit that eliminates a real runtime surprise for anyone enabling real X posting; (3) Add a `gymtrack-tests` CI job and add `agents/workflows/bookmarks/scripts/tests/` to Python test discovery — both new subsystems have thorough tests that never run in CI, so regressions land unnoticed.
+
+---
+
+## Repo Map
+
+**Purpose:** Mono-repo for Stoffer Industries product surfaces — Tasks API + React app, a budgeting product (mobile + API + shared domain), a public-facing website, a "Mission Control" (Pulse) shell app hosting multiple operational surfaces (Tasks, Content Scheduler, Bookmarks, Design System, SIndustries brand tab), a brand-new GymTrack single-user workout tracker (Supabase-backed), shared UI/design-token/OTel packages, and an AI agent operations layer (bookmark pipeline, content scheduler, cron definitions, feature-factory workflow, x-author-tweet notifier).
+
+**Stack:**
+- Node 22, npm workspaces (`package.json:9-14`).
+- Web apps: React 18 + Vite (`apps/tasks`, `apps/website`, `apps/mission-control`, `apps/gymtrack`).
+- Mobile app: React Native + Expo SDK 54 (`apps/budget-mobile`); TestFlight OTA via EAS Update on `main`.
+- Services: Express 4 + Prisma 5 + PostgreSQL 16 (`services/tasks-api`, `services/budget-api`).
+- Auth/DB (GymTrack): Supabase Auth + Postgres with RLS user-isolation policies.
+- Shared packages: `@sindustries/ui`, `@sindustries/design-tokens`, `@sindustries/otel-node`, `@sindustries/budget-domain`.
+- Workflows: Rust binary + Lobster pipeline + Python launcher (`agents/workflows/feature-task`); main.rs now 6538 lines.
+- Agent infra: Python `agents/lib/` (incident state parser + JSON schema), `agents/workflows/bookmarks/scripts/` (x_author_tweet.py, analytics_db.py, spec-lifecycle scripts).
+- Tests: Vitest everywhere; Playwright for tasks-app and gymtrack e2e; Python `unittest`; Rust `cargo test`.
+- Local runtime: Docker Compose (Postgres) + Tilt; CI on GitHub Actions with service-container Postgres.
+
+**Architecture sketch:**
+```
+React (apps/mission-control :5174)
+  ├─ TasksTab            iframe → React (apps/tasks :5173)
+  ├─ ContentSchedulerTab fetch  → Express (services/tasks-api :4001/content-scheduler)
+  ├─ BookmarksTab        fetch  → brain/state/*.json (filesystem read)
+  ├─ FlowMetricsTab      fetch  → tasks-api metrics/backlog + P90
+  ├─ DesignSystemTab     local component render
+  └─ SIndustriesTab      iframe → apps/website
+
+React (apps/tasks) ── fetch ──▶ Express (services/tasks-api :4000/:4001)
+                                     ├─ Prisma      → Postgres schema tasks_api
+                                     ├─ OTel SDK    → OTLP → Tempo/Prometheus
+                                     ├─ contentScheduler routes (create/approve/publish/reorder/…)
+                                     ├─ autoPostWorker (in-process setTimeout adapter)
+                                     └─ xTweet router → X API (OAuth 1.0a) when X_CLIENT=real
+
+Vite/React (apps/gymtrack :5179) ── @supabase/supabase-js ──▶ Supabase Auth + Postgres
+                                                                └─ RLS: user_id = auth.uid()
+
+Expo/RN (apps/budget-mobile) ── fetch ──▶ Express (services/budget-api :4002)
+                                                └─ Prisma → Postgres schema budget_api
+                                                └─ fetch → Akahu OAuth + API
+
+AI agents
+  ├─ bookmark pipeline
+  │    └─ x_author_tweet.py → POST /api/v1/x/tweets (unauthenticated in-cluster call)
+  ├─ feature-task workflow (Rust) → tasks-api + gh CLI + PR-body system-spec check
+  └─ agents/lib/incident_state.py → brain/state/*ops-state*.json + schema
+```
+
+**Key directories:**
+- `apps/mission-control/` — Pulse shell; five tabs. `BookmarksTab.jsx` grew to 811 lines with Sankey + states-over-time; `ContentSchedulerTab.jsx` grew from 450 → 637 lines with the 10-day calendar view.
+- `apps/tasks/` — Kanban + backlog. `App.jsx` still at 972 lines.
+- `apps/website/` — Public website; JSON-file CMS on Vercel.
+- `apps/budget-mobile/` — Expo React Native; now with EAS Update OTA from main + TestFlight distribution.
+- `apps/gymtrack/` — **NEW** — Single-user workout tracker; Vite + React + Supabase; RLS-enforced schema in `supabase/migrations/20260708120000_init_workouts.sql`.
+- `services/tasks-api/` — Express API; Tasks CRUD + Content Scheduler + Content Scheduler auto-post subsystem + generic `POST /x/tweets`.
+- `services/budget-api/` — Express API; all W26–W29 IDOR/plaintext-token findings unchanged.
+- `agents/workflows/bookmarks/scripts/` — Now hosts `x_author_tweet.py` (314 lines) + `analytics_db.py` (169 lines) + 400 lines of x-author-tweet tests + Postgres analytics mirror.
+- `agents/workflows/feature-task/src/main.rs` — 6538 lines, 115 functions; the largest single file in the repo.
+- `docs/systems/` — 13 system docs (added `code-task-workflow.md`, `content-scheduler-auto-post.md`, `content-scheduler.md`).
+- `docs/specs/` — 40+ tech-design and spec docs.
+
+**Surprises from discovery:**
+- The Content Scheduler auto-post design ships a full `JobSchedulerAdapter` abstraction with in-process and BullMQ variants — but the BullMQ file is a stub that throws (`contentSchedulerJobs.bullmq.ts:47-73`), and the in-process adapter uses `setTimeout` inside a single Node process. So the production story ("cloud swap is a single-class change") depends on an unwritten file, and the current v1 loses all pending jobs on any restart.
+- `autoPostWorkerMain.ts` (`services/tasks-api/src/autoPostWorkerMain.ts`) is packaged as a "worker" you can run in a separate process, but with the current in-process adapter it constructs a NEW in-memory Map (`main:19-22`) that has no connection to the API's Map. Running the worker in a second process does nothing useful in v1.
+- The new `POST /api/v1/x/tweets` endpoint is unauthenticated by design (`xTweet.ts:19-23` explicitly says "if tasks-api ever stops being localhost-only, this route MUST be locked down"), but the calling Python script defaults to `http://localhost:4001/api/v1` (`x_author_tweet.py:173`) and there is no boot-time refusal to start `xTweet` on a non-loopback bind.
+- The bookmark author-tweet flow has 400 lines of tests in `agents/workflows/bookmarks/scripts/tests/test_x_author_tweet.py` — none of which run in CI because the workflow discovers tests only under `tests/` (`ci.yml:52-55`).
+- `apps/gymtrack/` is fully engineered — RLS policies, Playwright e2e, jsdom-based Vitest, `.env.example`, deployment story — but there is no `gymtrack-tests` job in CI (`ci.yml` has jobs for every other workspace).
+- The W29 finding on the `.env.example` for X was addressed, but incorrectly: `.env.example:24-32` documents `X_API_BEARER_TOKEN` while the code actually uses OAuth 1.0a with four separate env vars (`contentSchedulerPublish.ts:208-214`).
+
+---
+
+## Audit Report
+
+### Architecture & design
+
+**[High] Auto-post in-process adapter is a data-loss risk on any API restart or crash.**
+- *Where:* `services/tasks-api/src/routes/contentSchedulerJobs.inProcess.ts:46,97-112`, `services/tasks-api/src/app.ts:19-29`
+- *Why it matters:* The in-process adapter holds pending jobs in `new Map<string, Entry>()` and uses `setTimeout(..., delayMs)` with `.unref()`. Any restart of the tasks-api process (deploy, crash, OOM) drops every scheduled auto-post silently. Combined with the fact that `autoPostScheduledAt` is persisted to Postgres but never re-hydrated at boot, an item scheduled for tomorrow that survives an API restart will never publish. The tech design comment (`contentSchedulerJobs.inProcess.ts:5-17`) admits the adapter is v1, but the failure mode is not documented in the operator-facing README and there is no boot-time rehydration.
+- *Severity:* High (new — subsystem shipped this week)
+
+**[High] `autoPostWorkerMain.ts` cannot receive jobs enqueued by the API process.**
+- *Where:* `services/tasks-api/src/autoPostWorkerMain.ts:19-29`, `services/tasks-api/src/app.ts:19-29`
+- *Why it matters:* The API's `installDefaultAdapter()` creates its own `createInProcessJobSchedulerAdapter()` instance with an in-memory Map. The separate worker main function creates a fresh instance. In-process adapters cannot share memory across Node processes, so running the worker is a silent no-op in v1. The comment at `autoPostWorkerMain.ts:8-11` says "v1 simplification" but the file still gets shipped as `content-scheduler:worker`, and there is no boot-time refusal to run it when the in-process adapter is active.
+- *Severity:* High (new)
+
+**[Medium] `ContentSchedulerTab.jsx` monolith grew from 450 → 637 lines.**
+- *Where:* `apps/mission-control/src/tabs/ContentSchedulerTab.jsx`
+- *Why it matters:* The calendar-view work added 187 lines to an already-flagged monolith. Fact — line count. Judgment — this widens the change surface for the next contributor and the pattern `tasks/_*` extraction was already recommended in W28/W29.
+- *Severity:* Medium (carryover — worse than W29)
+
+**[Medium] `BookmarksTab.jsx` is now 811 lines with Sankey + time-series + KPI + list logic in one file.**
+- *Where:* `apps/mission-control/src/tabs/BookmarksTab.jsx`
+- *Why it matters:* The Sankey + states-over-time rewrite (commit `41cb58b`) added significant DOM + d3 logic to the tab. All hooks, all d3-sankey rendering, all funnel/pending-approval/recent-transitions logic live in one file. This is the same shape as `ContentSchedulerTab.jsx` — a new monolith.
+- *Severity:* Medium (new)
+
+**[Medium] `agents/workflows/feature-task/src/main.rs` is a 6538-line monolith with 115 functions.**
+- *Where:* `agents/workflows/feature-task/src/main.rs`
+- *Why it matters:* Fact — line count and function count via `grep -c '^fn '`. Judgment — a Rust binary of this size that owns the full lifecycle (load-task, spec-check, ready-checks, verify-delivery, feedback-aggregate, post-merge) invites accidental coupling between stages. This week added ~1432 lines to it. A `mod`-per-stage split would let each stage have its own tests without repeatedly compiling the whole binary.
+- *Severity:* Medium (worsening)
+
+**[Medium] `feature-task.lobster.yaml:9-11` still hard-codes Rowan's filesystem paths.**
+- *Where:* `agents/workflows/feature-task/feature-task.lobster.yaml:9,11`
+- *Why it matters:* `sindustriesRepo: /Users/quinnstoffer/workspaces/rowan/sindustries` and `workspaceRoot: /Users/quinnstoffer/.openclaw/workspace` are Rowan-machine paths. This finding was flagged in W29 with a specific fix (env-var references). Not resolved.
+- *Severity:* Medium (carryover — unchanged from W29)
+
+### Code quality
+
+**[Medium] `apps/tasks/src/App.jsx` still 972 lines.**
+- *Where:* `apps/tasks/src/App.jsx`
+- *Why it matters:* Unchanged since W29. Continued growth risk noted then; no code change this week.
+- *Severity:* Medium (carryover)
+
+**[Low] `apps/gymtrack/src/lib/workouts.js` mixes auth and CRUD without a shared error type.**
+- *Where:* `apps/gymtrack/src/lib/workouts.js:25-35,42-56,63-78,85-93,100-108,115-118`
+- *Why it matters:* `createWorkout` fetches the user before insert (`getUser()`) but the sibling functions (`addSet`, `listWorkouts`, `deleteWorkout`) do not — they rely on RLS to reject. If Supabase's `getUser()` ever fails silently, the caller has no way to distinguish "not authenticated" from "RLS refused". A consistent auth-guard would make the invariant explicit and testable.
+- *Severity:* Low (new)
+
+### Security
+
+**[Critical] `budget-api` reads `userId` from request body/query on every route except `/me` — no Bearer token validation.**
+- *Where:* `services/budget-api/src/routes/transactions.ts:14`, `akahu.ts`, `alerts.ts`, `cards.ts`
+- *Why it matters:* Any caller who guesses or obtains a valid user UUID can read/write all transactions, balance history, alert configs, linked cards, and Akahu connections for that user. The only "auth" is a UUID in the URL or body.
+- *Severity:* Critical (carryover — unchanged since W26)
+
+**[Critical] `AkahuConnection.accessToken` stored as plaintext `String` in Postgres.**
+- *Where:* `services/budget-api/prisma/schema.prisma:42`
+- *Why it matters:* Akahu access tokens grant ongoing read access to linked NZ bank accounts. A DB dump yields live banking credentials.
+- *Severity:* Critical (carryover — unchanged since W26)
+
+**[High] `POST /api/v1/x/tweets` is a new unauthenticated write endpoint that posts to the real Sindustries X account when `X_CLIENT=real`.**
+- *Where:* `services/tasks-api/src/routes/xTweet.ts:33-99`, mounted at `services/tasks-api/src/app.ts:82`
+- *Why it matters:* The route explicitly documents (`xTweet.ts:19-23`) that it is intended for in-cluster callers and requires that the tasks-api stay localhost-only. There is no runtime enforcement of that requirement — the router is mounted unconditionally, the port bind is controlled by `PORT` env, and CORS lets in the mission-control origin. If tasks-api is ever exposed on a LAN interface (e.g. for a mobile emulator), any caller can post to the Sindustries X account.
+- *Severity:* High (new this week)
+
+**[High] Content Scheduler publish endpoint remains unauthenticated (carryover W29 High).**
+- *Where:* `services/tasks-api/src/routes/contentScheduler.ts:50-54,337-376`
+- *Why it matters:* The `actor(req)` function (`:50-54`) trusts the `x-actor` header without verification. The publish route (`:337`) invokes the shared publish service which will post to X when the item is approved. Same failure mode as the new `xTweet.ts` — any LAN-accessible caller can trigger a real X post.
+- *Severity:* High (carryover — unchanged from W29)
+
+**[High] `services/tasks-api/.env.example` documents the wrong X env vars.**
+- *Where:* `services/tasks-api/.env.example:24-32`, contrast with `contentSchedulerPublish.ts:205-217`
+- *Why it matters:* The example lists `X_API_BEARER_TOKEN` (line 27, 31). The real client requires four OAuth 1.0a vars: `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`. An operator who follows the `.env.example` and sets `X_CLIENT=real` will get `MISSING_CREDENTIALS` at runtime with no clear diagnostic path — the exact failure mode the W29 audit was trying to prevent. Notably, `contentScheduler.test.ts` and `xTweet.test.ts` were updated to reference the OAuth 1.0a vars (commits `a9ccaff`, `40f9ef3`, `a9ccaff`) but the `.env.example` was not.
+- *Severity:* High (new — actively misleading)
+
+**[Medium] IDOR via path parameters on `cards.ts`, `alerts.ts` — no ownership lookup.**
+- *Where:* `services/budget-api/src/routes/cards.ts`, `alerts.ts`
+- *Why it matters:* Unchanged since W27.
+- *Severity:* Medium (carryover)
+
+**[Low] GymTrack `.env.example` and README correctly explain the anon-key threat model.**
+- *Where:* `apps/gymtrack/supabase/README.md:47-54`, `apps/gymtrack/src/lib/supabase.js:14-24`
+- *Why it matters:* Positive finding — the anon key threat model is explicitly documented ("public-by-design; RLS is the gate"). The RLS migration (`supabase/migrations/20260708120000_init_workouts.sql:54-76`) correctly gates both `workouts` and `workout_sets` on `auth.uid()`. This is the right defensive posture for a Supabase-hosted app.
+- *Severity:* Low (positive — noted so future audits don't re-flag)
+
+### Testing
+
+**[High] New bookmark author-tweet tests (400 lines) do not run in CI.**
+- *Where:* `agents/workflows/bookmarks/scripts/tests/test_x_author_tweet.py`, `.github/workflows/ci.yml:40-55`
+- *Why it matters:* The `python-workflow-tests` job runs `python -m unittest discover -s tests -p 'test_*.py'` — only against the top-level `tests/` directory. The 400-line test suite for `x_author_tweet.py` (which posts to the real X API in prod) sits at `agents/workflows/bookmarks/scripts/tests/` and is invisible to CI. Any regression to the LLM compose, URL parser, or HTTP error mapping lands unnoticed.
+- *Severity:* High (new — silent test-coverage gap on a security-relevant path)
+
+**[Medium] GymTrack has 5 test files (Vitest + Playwright) but no CI job to run them.**
+- *Where:* `apps/gymtrack/src/**/*.test.jsx`, `.github/workflows/ci.yml`
+- *Why it matters:* Every other workspace has a dedicated CI job (`mission-control-tests`, `tasks-app-tests`, `budget-api-tests`, `website-app-tests`, etc.) but there is no `gymtrack-tests` job. GymTrack's e2e story (Playwright + Supabase) is documented in `apps/gymtrack/README.md:26-28` but not wired to CI.
+- *Severity:* Medium (new)
+
+**[Low] Auto-post integration tests (`contentSchedulerAutoPost.test.ts`, 465 lines) exercise the in-process adapter only.**
+- *Where:* `services/tasks-api/test/contentSchedulerAutoPost.test.ts`
+- *Why it matters:* The tests are thorough for the current adapter but never assert that the BullMQ adapter (`contentSchedulerJobs.bullmq.ts`) matches the same interface. Because the BullMQ adapter is a stub that throws (`bullmq.ts:67-72`), no test would catch a shape-drift between the two adapters.
+- *Severity:* Low (new — acceptable given BullMQ is v2 scope)
+
+### Performance
+
+No new performance concerns this week. The Content Scheduler auto-post correctly uses a single `setTimeout` per job (no polling). The 10-day calendar view builds a memoized structure via `useMemo` (`ContentSchedulerTab.jsx:1-4`). GymTrack's `listSetsForWorkouts` uses an `in()` filter for batched fetches.
+
+### Dependencies
+
+**[Low] GymTrack pins `jsdom@^25.0.1` while the repo root and other workspaces use `^29.0.1`.**
+- *Where:* `apps/gymtrack/package.json:20`, root `package.json:16`
+- *Why it matters:* jsdom v25 → v29 has real behaviour differences (URL parser, DOMPurify, form handling). A test that passes in gymtrack and fails elsewhere (or vice versa) will confuse future contributors. Low today but noted.
+- *Severity:* Low (new)
+
+**[Low] `services/budget-api` still uses `vitest@^2.1.2` while the rest of the repo uses `^4.1.8`.**
+- *Where:* `services/budget-api/package.json`
+- *Why it matters:* Unchanged since W29. Two major versions behind.
+- *Severity:* Low (carryover)
+
+### DevEx & operations
+
+**[Medium] EAS OTA publishes on every merge to `main` without a manual gate.**
+- *Where:* `.github/workflows/ci.yml:9-38`
+- *Why it matters:* Fact — the `eas-update-on-main` job publishes an OTA update on every push to `main`. Judgment — for TestFlight distribution to Tom this is fine at the current cadence, but there is no guard against publishing a broken update (no health-check, no post-publish rollback path documented). The blast radius today is one user; consider it before broadening distribution.
+- *Severity:* Medium (new — mild future risk, not an immediate defect)
+
+**[Low] CI `python-workflow-tests` uses `PYTHONPATH: agents/skills/tasks-api-ops` which only covers one scripts dir.**
+- *Where:* `.github/workflows/ci.yml:52-55`
+- *Why it matters:* The workflow imports `tasks_api_ops` from `agents/skills/tasks-api-ops`, but the new bookmarks scripts import from `agents/workflows/bookmarks/scripts/`. Without extending discovery, new Python subsystems land untested.
+- *Severity:* Low (new — related to High testing finding above)
+
+### Documentation
+
+**[Low] `docs/systems/content-scheduler-auto-post.md` describes the JobSchedulerAdapter interface but does not document that the in-process adapter loses jobs on restart.**
+- *Where:* `docs/systems/content-scheduler-auto-post.md`
+- *Why it matters:* Operators need to know the failure mode. The tech-design does discuss "cloud swap = single-class change" but the currently-shipping v1 has an operational limitation that's not captured in the current system doc.
+- *Severity:* Low (new)
+
+### Strengths
+
+- **GymTrack ships with the right security posture out of the gate.** RLS-enforced on both tables (`workouts_user_isolation`, `workout_sets_user_isolation` in `supabase/migrations/20260708120000_init_workouts.sql:54-76`), the anon key threat model is explicitly documented, and the schema uses `auth.uid()` for both `USING` and `WITH CHECK` clauses.
+- **Content Scheduler auto-post design is clean.** `decideAutoPostAction` (`contentSchedulerJobs.ts:97-155`) is a pure function with a clear state machine; the stale-version defense in the worker (`autoPostWorker.ts:67-69`) is a well-thought-out belt-and-suspenders check; the abstraction boundary between routes / adapter / worker is well-drawn.
+- **Feature-task workflow tightening is measurable progress.** PR-body system-spec validation (`0a3c742`, `3c9a6b3`), role-based PR ownership (`c0c125a`), and the audit follow-up code-task workflow doc (`20eb707`) all move the feature-factory closer to being a self-serve, opinionated pipeline.
+- **The bookmark author-tweet flow is safety-conscious.** `try_post_author_tweet` (`x_author_tweet.py:236-299`) never bubbles exceptions to the caller, the LLM prompt (`:100-122`) has explicit "MUST NOT" clauses for marketing language and hashtags, and the 280-char cap is defensively re-checked.
+- **Prisma migrations continue to have unique timestamps** and the `check-migration-prefixes.sh` CI step is holding the line.
+
+---
+
+## Improvement Strategy
+
+### Theme 1 — Close the LAN-exposure risk on tasks-api write endpoints (widened this week)
+
+**Finding driver:** The Content Scheduler publish (`contentScheduler.ts:337`) and the new `POST /x/tweets` (`xTweet.ts:33`) both write to the real X account when `X_CLIENT=real`. Neither has any auth.
+
+**Target state:** A shared `requireInternalSecret` middleware guards every tasks-api write endpoint. `X_TASKS_API_INTERNAL_SECRET` is documented in `.env.example`. The Python callers (`x_author_tweet.py`, mission-control fetches) send the header. Boot refuses to start the API on non-loopback bind unless the secret is set.
+
+**Principle:** "Internal service" is a description, not a mechanism. Any endpoint that can post to a real social account, spend money, or send email must have an enforced boundary.
+
+**Trade-off not fixing:** Full session-based auth for tasks-api is out of scope for this MVP; a shared secret is enough short-term.
+
+**Done when:** All Content Scheduler and xTweet write routes return 401 without the correct `X-Internal-Secret` header when `X_TASKS_API_INTERNAL_SECRET` is set. Tests cover positive and negative paths for both endpoints.
+
+### Theme 2 — Auth-first on `budget-api` (carries from W26)
+
+**Finding driver:** All Critical budget-api findings are unchanged since W26. No code-level remediation on `main`.
+
+**Target state / Principle / Trade-off / Done when:** Unchanged from W29 Theme 1. The `requireSession` middleware needs to land; ownership lookups follow.
+
+### Theme 3 — Make auto-post survive restarts (before v2 traffic)
+
+**Finding driver:** The in-process adapter loses jobs on any restart; the "worker" main is a stub in disguise. Neither is called out in the operator-facing docs.
+
+**Target state:** On boot, the API queries all `contentSchedulerItem` rows where `status = 'approved' AND scheduledFor > now() AND autoPostJobId IS NOT NULL` and re-schedules a timer for each. Alternatively, ship the BullMQ adapter and mark in-process as test-only.
+
+**Principle:** Persistence lives in Postgres; the in-memory queue is a cache of intent, not the source of truth.
+
+**Done when:** Restart the API mid-schedule; the item still publishes at `scheduledFor`. Docs (`content-scheduler-auto-post.md`) explicitly explain the failure mode of the in-process adapter.
+
+### Theme 4 — Encrypt sensitive credentials at rest
+
+**Finding driver:** `AkahuConnection.accessToken` still plaintext.
+
+**Target state / Principle / Trade-off / Done when:** Unchanged from W29 Theme 2.
+
+### Theme 5 — Close the CI test-coverage gaps
+
+**Finding driver:** GymTrack tests + bookmark author-tweet tests both sit unrun in CI despite substantial investment.
+
+**Target state:** `gymtrack-tests` CI job runs `npm test --workspace gymtrack` and Playwright with a mocked/local Supabase; `python-workflow-tests` extends discovery to `agents/workflows/**/tests` so any workflow gets tested by convention.
+
+**Principle:** A test that doesn't run in CI is a lie about coverage.
+
+**Done when:** CI runs both suites on every PR; a deliberately broken test in either suite fails the build.
+
+---
+
+## Task Plan
+
+### Milestone 0 — Safety net
+
+**0-A. Ship `requireInternalSecret` middleware for tasks-api write endpoints** (Theme 1)
+- *Description:* Add `services/tasks-api/src/middleware/requireInternalSecret.ts` that reads `X_TASKS_API_INTERNAL_SECRET` from env and rejects requests without a matching `X-Internal-Secret` header (401). Apply it to the Content Scheduler write routes (create, approve, unapprove, publish, remove, reorder, patch) and the `POST /x/tweets` route. Update `x_author_tweet.py:call_x_tweets_route` to send the header. Document the env var in `.env.example`.
+- *Files:* `services/tasks-api/src/middleware/requireInternalSecret.ts` (new), `services/tasks-api/src/routes/contentScheduler.ts`, `services/tasks-api/src/routes/xTweet.ts`, `services/tasks-api/.env.example`, `agents/workflows/bookmarks/scripts/x_author_tweet.py`.
+- *AC:* Missing/incorrect header returns 401 on all guarded routes when the env var is set; correct header succeeds; test coverage in `xTweet.test.ts` and `contentScheduler.test.ts`.
+- *Effort:* M (half-day)
+- *Risk:* Low. This is additive with a feature-flag (only enforces when env var is set).
+- *Follow-up classification:* `tracked-code-task` — security-hardening code work; not code-garden safe.
+
+**0-B. Fix `services/tasks-api/.env.example` to list the actual OAuth 1.0a vars**
+- *Description:* Replace `X_API_BEARER_TOKEN` with `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` with inline comments explaining each and linking to the X Developer Portal doc for OAuth 1.0a.
+- *Files:* `services/tasks-api/.env.example`
+- *AC:* All four OAuth 1.0a vars documented; `X_API_BEARER_TOKEN` removed; a developer can enable real X posting by following the example alone.
+- *Effort:* S (<2h)
+- *Risk:* None.
+- *Quick win:* Yes — trivial, eliminates a real runtime surprise.
+- *Follow-up classification:* `garden-safe` — pure docs update.
+
+**0-C. Add `gymtrack-tests` CI job**
+- *Description:* Add a new job to `.github/workflows/ci.yml` that installs deps, runs `npm test --workspace gymtrack`, and optionally runs Playwright against a mocked Supabase (or gate the e2e behind Vercel preview).
+- *Files:* `.github/workflows/ci.yml`
+- *AC:* Every PR runs GymTrack unit + component tests; a deliberately broken test fails CI.
+- *Effort:* S (<2h)
+- *Risk:* Low.
+- *Quick win:* Yes.
+- *Follow-up classification:* `garden-safe`.
+
+**0-D. Add `agents/workflows/**/tests/**` to Python test discovery**
+- *Description:* Update the `python-workflow-tests` job to discover tests in both `tests/` and `agents/workflows/*/tests/` (and `agents/workflows/*/scripts/tests/`) so the new bookmark author-tweet suite runs. Extend `PYTHONPATH` to include the bookmarks scripts directory.
+- *Files:* `.github/workflows/ci.yml`
+- *AC:* `test_x_author_tweet.py` runs in CI; a deliberately failing test breaks the build.
+- *Effort:* S (<2h)
+- *Risk:* Low.
+- *Quick win:* Yes.
+- *Follow-up classification:* `garden-safe`.
+
+### Milestone 1 — Critical fixes
+
+**1-A. Write `requireSession` middleware for `budget-api`** (carries from W26–W29)
+- *Description / Files / AC / Effort / Risk:* Unchanged from W29.
+- *Follow-up classification:* `tracked-code-task` — carries an open task if one exists; if not, create one during the audit-follow-up pass.
+
+**1-B. Encrypt `AkahuConnection.accessToken` at rest** (carries from W29)
+- *Description / Files / AC / Effort / Risk:* Unchanged from W29.
+- *Follow-up classification:* `tracked-code-task`.
+
+**1-C. Rehydrate auto-post schedules on API boot** (Theme 3)
+- *Description:* Add a boot hook in `services/tasks-api/src/app.ts` (or `bin/serve.ts`) that on process start queries all approved items with future `scheduledFor` and calls `applyAutoPostSchedule` for each. This closes the data-loss window for the in-process adapter.
+- *Files:* `services/tasks-api/src/app.ts`, `services/tasks-api/src/routes/contentScheduler.ts` (export `applyAutoPostSchedule`), new test in `contentSchedulerAutoPost.test.ts`.
+- *AC:* After a simulated process restart (test kills and recreates the adapter), the pending item's job is rescheduled; the worker still fires at the original `scheduledFor` (± clock-skew grace).
+- *Effort:* M
+- *Risk:* Medium — needs care around double-scheduling if `autoPostScheduleVersion` is not incremented.
+- *Follow-up classification:* `tracked-code-task`.
+
+### Milestone 2 — High-leverage improvements
+
+**2-A. Extract `useContentScheduler` hook + row/calendar sub-components from `ContentSchedulerTab.jsx`**
+- *Description:* Same decomposition target as W29 Theme 4, now larger (637 lines).
+- *AC:* No sub-file exceeds 250 lines.
+- *Effort:* M
+- *Follow-up classification:* `garden-safe` (behaviour-preserving refactor).
+
+**2-B. Extract `BookmarksTab.jsx` Sankey + time-series into sub-components**
+- *Description:* Split `BookmarksTab.jsx` (811 lines) into `BookmarksTab.jsx` (container), `BookmarksSankeyChart.jsx`, `BookmarksStatesOverTimeChart.jsx`, `BookmarksFunnelList.jsx`, `BookmarksPendingApprovals.jsx`.
+- *AC:* Container ≤ 200 lines; each chart component owns its own render + local state.
+- *Effort:* M
+- *Follow-up classification:* `garden-safe`.
+
+**2-C. Replace hard-coded paths in `feature-task.lobster.yaml` with env vars** (carries from W29)
+- *Files:* `agents/workflows/feature-task/feature-task.lobster.yaml`
+- *AC:* No absolute paths.
+- *Effort:* S
+- *Follow-up classification:* `garden-safe`.
+
+**2-D. Split `agents/workflows/feature-task/src/main.rs` by stage**
+- *Description:* Break `main.rs` into `mod load_task`, `mod spec_check`, `mod ready_checks`, `mod verify_delivery`, `mod feedback_aggregate`, `mod post_merge`, `mod pr_body`, `mod state`. Move shared helpers into `mod util`.
+- *Files:* `agents/workflows/feature-task/src/**`
+- *AC:* No single Rust source file exceeds 800 lines; existing `cargo test` passes unchanged.
+- *Effort:* L (1–2 days)
+- *Risk:* Low — pure structural change, but the file is large so care around imports.
+- *Follow-up classification:* `garden-safe`.
+
+### Milestone 3 — Quality & polish
+
+**3-A. Document the in-process adapter's failure mode in `docs/systems/content-scheduler-auto-post.md`**
+- *Effort:* S
+- *Follow-up classification:* `garden-safe`.
+
+**3-B. Upgrade `budget-api` vitest to v4** (carries from W29)
+- *Effort:* S
+- *Follow-up classification:* `garden-safe`.
+
+**3-C. Align `apps/gymtrack` `jsdom` to root `^29.0.1`**
+- *Effort:* S
+- *Risk:* Low — jsdom 25 → 29 may change DOM behaviour; run gymtrack tests before merging.
+- *Follow-up classification:* `garden-safe`.
+
+### Quick wins (high impact, S effort)
+- 0-B (fix `.env.example` X vars)
+- 0-C (`gymtrack-tests` CI job)
+- 0-D (Python discovery extension)
+- 2-C (env-var paths in lobster yaml)
+- 3-A (document in-process adapter limitation)
+
+### Top-3 implementation sketches
+
+**0-A — `requireInternalSecret` middleware**
+```ts
+// services/tasks-api/src/middleware/requireInternalSecret.ts
+import type { Request, Response, NextFunction } from 'express';
+export function requireInternalSecret(req: Request, res: Response, next: NextFunction) {
+  const expected = process.env.X_TASKS_API_INTERNAL_SECRET;
+  if (!expected) return next(); // disabled when unset (dev/test default)
+  const got = req.headers['x-internal-secret'];
+  if (typeof got !== 'string' || got !== expected) {
+    return res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'invalid internal secret' } });
+  }
+  next();
+}
+```
+Wire it in `app.ts`:
+```ts
+app.use('/api/v1/content-scheduler', requireInternalSecret, contentSchedulerRouter);
+app.use('/api/v1/x', requireInternalSecret, xTweetRouter());
+```
+The Python caller sets `req.headers["x-internal-secret"] = os.getenv("X_TASKS_API_INTERNAL_SECRET", "")`.
+
+**1-C — Boot-time rehydration of auto-post schedules**
+```ts
+// services/tasks-api/src/lib/rehydrateAutoPost.ts
+export async function rehydrateAutoPostSchedules() {
+  const now = new Date();
+  const pending = await prisma.contentSchedulerItem.findMany({
+    where: {
+      status: 'approved',
+      scheduledFor: { gt: now }
+    }
+  });
+  for (const item of pending) {
+    await applyAutoPostSchedule(
+      item.id,
+      { id: item.id, status: 'approved', scheduledFor: item.scheduledFor,
+        autoPostJobId: null, autoPostScheduleVersion: item.autoPostScheduleVersion },
+      { status: 'approved', scheduledFor: item.scheduledFor as Date }
+    );
+  }
+}
+```
+Called from `app.ts` after `installDefaultAdapter()`.
+
+**0-D — Extend Python test discovery**
+```yaml
+# .github/workflows/ci.yml (python-workflow-tests job)
+      - name: Run Python workflow tests
+        env:
+          PYTHONPATH: >-
+            agents/skills/tasks-api-ops:agents/workflows/bookmarks/scripts:agents/lib
+        run: |
+          python -m unittest discover -s tests -p 'test_*.py'
+          python -m unittest discover -s agents/workflows/bookmarks/scripts/tests -p 'test_*.py'
+          python -m unittest discover -s agents/workflows/bookmarks/tests -p 'test_*.py'
+          python -m unittest discover -s agents/lib -p 'test_*.py'
+```
+
+---
+
+## Open Questions
+
+1. **`xTweet` route auth model:** Should `POST /api/v1/x/tweets` require the same `X-Internal-Secret` as Content Scheduler, or a different token so the two callers rotate independently? Tom's call. Recommend: same secret for MVP, split only when a second caller appears with a different threat model.
+
+2. **BullMQ adapter roadmap:** The v1 code ships a stub that throws. Is BullMQ a Q3 objective, or should we ship a Postgres-backed queue (using an existing table like `contentSchedulerItem.autoPostScheduledAt` as the scheduling source) and skip Redis entirely? Postgres-backed is one fewer service to run in prod; BullMQ is faster for many small delayed jobs.
+
+3. **GymTrack production Supabase project:** README says "once Quinn has provisioned the Supabase project" but there is no reference to the project id, region, or backup strategy in the repo. Is the project set up? If yes, add a `docs/systems/gymtrack.md` capturing the operational contract; if no, that blocks the CI test job from running Playwright against a real backend.
+
+4. **budget-api network exposure:** Same open question as W29. Without a clear answer, the Critical findings sit at "urgent-ish" — one number would let us calibrate.
+
+5. **`AkahuConnection` backfill:** Same open question as W29. Adding here so it doesn't get dropped.


### PR DESCRIPTION
## Summary

W30 audit follow-up that didn't fit in PR #264 (weekly review doc itself):

- **Lox HEARTBEAT/SOUL**: add `MODE=dev` data plane to out-of-scope per Tom 2026-07-19 directive. Add "Common false-positive patterns" section documenting the "existence probes must end with `|| true`" lesson from 2026-07-19 incident triage.
- **Quinn HEARTBEAT**: trim `BOOKMARK STATE OBSERVABILITY`, `CONTENT TASK LOBSTER CHECK`, and `FEATURE TASK LOBSTER CHECK` sections — now owned by the new `task-lobsters.md` and existing `bookmark-review-lobster.md` cron prompts. Keeps tech-design approval + ops-state management as the only heartbeat-resident tasks.
- **`tasks_api_client.list_tasks`**: accept `status` as `str | list[str]`, fanning out one call per status when multiple given. Used by HEARTBEAT to fetch `ready|doing|acceptance` in one go.
- **`agents/crons/prompts/task-lobsters.md`** (new): cron prompt running both feature-task and content-task lobsters, with `ready_checks_blocked` Rowan-dispatch rule and ops-state watching fallback.
- **`agents/crons/prompts/backlog-maintenance.md`** (new): cron prompt that finds open tasks with no `taskType` and patches them to `feature` / `code` / `research` / `content` per the `tasks-create` taxonomy; logs unclassifiable tasks to `brain/state/quinn-ops-state.json` under `watching`.

## System Spec
No system spec change — agent operating procedures + tooling, no user-facing behaviour.

## Test plan

- [ ] Re-run Quinn and Lox heartbeats — verify they don't emit duplicate lobster warnings now that the work lives in `task-lobsters.md`.
- [ ] Re-run the task-lobsters cron once manually and verify both lobsters exit 0 with `[feature-task-progress-checklist]` output parsed.
- [ ] Re-run the backlog-maintenance cron once manually and verify the dry-run classification on current untyped backlog.
- [ ] `python3 agents/skills/ops/tasks-api/tasks_api_client.py list --assignee Rowan --status ready --status doing --status acceptance summary` — verify the new multi-status fan-out returns the same tasks as the prior three single-status calls (5 tasks, identical ids).
- [ ] Confirm Lox's heartbeat does not probe `MODE=dev` data plane (no `:4000`, `:6432`, dev Tilt references in the polling script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)