### PR TITLE
chore(code-garden): fix .env.example to document OAuth 1.0a X credentials [2026-W30]

### DIFF
--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -294,7 +294,7 @@ No new performance concerns this week. The Content Scheduler auto-post correctly
 - *Risk:* Low. This is additive with a feature-flag (only enforces when env var is set).
 - *Follow-up classification:* `tracked-code-task` — security-hardening code work; not code-garden safe.
 
-**0-B. Fix `services/tasks-api/.env.example` to list the actual OAuth 1.0a vars** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**0-B. Fix `services/tasks-api/.env.example` to list the actual OAuth 1.0a vars** ✅ [PR #266](https://github.com/Stoffer-Industries/sindustries/pull/266)
 - *Description:* Replace `X_API_BEARER_TOKEN` with `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` with inline comments explaining each and linking to the X Developer Portal doc for OAuth 1.0a.
 - *Files:* `services/tasks-api/.env.example`
 - *AC:* All four OAuth 1.0a vars documented; `X_API_BEARER_TOKEN` removed; a developer can enable real X posting by following the example alone.

--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -294,7 +294,7 @@ No new performance concerns this week. The Content Scheduler auto-post correctly
 - *Risk:* Low. This is additive with a feature-flag (only enforces when env var is set).
 - *Follow-up classification:* `tracked-code-task` — security-hardening code work; not code-garden safe.
 
-**0-B. Fix `services/tasks-api/.env.example` to list the actual OAuth 1.0a vars**
+**0-B. Fix `services/tasks-api/.env.example` to list the actual OAuth 1.0a vars** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 - *Description:* Replace `X_API_BEARER_TOKEN` with `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` with inline comments explaining each and linking to the X Developer Portal doc for OAuth 1.0a.
 - *Files:* `services/tasks-api/.env.example`
 - *AC:* All four OAuth 1.0a vars documented; `X_API_BEARER_TOKEN` removed; a developer can enable real X posting by following the example alone.

--- a/services/tasks-api/.env.example
+++ b/services/tasks-api/.env.example
@@ -24,9 +24,15 @@ OTEL_ENVIRONMENT=dev
 # Content Scheduler — X (Twitter) publishing
 # Selection rules (see services/tasks-api/src/routes/contentSchedulerPublish.ts):
 #   X_CLIENT=fake   (default in dev/test): returns FakeXClient, no network calls
-#   X_CLIENT=real   : requires X_API_BEARER_TOKEN; returns null with MISSING_CREDENTIALS otherwise
+#   X_CLIENT=real   : requires the four OAuth 1.0a credentials below; returns null with MISSING_CREDENTIALS otherwise
 #   X_CLIENT unset  : same as fake
 # X_HANDLE is the Twitter handle to attribute published posts to; defaults to 'sindustries'.
-X_CLIENT=fake
-# X_API_BEARER_TOKEN=
+#
+# OAuth 1.0a credentials for X (Twitter) API. Generate these in the X Developer Portal
+# (https://developer.twitter.com/en/portal) under your app's "Keys and tokens" tab.
+# Required when X_CLIENT=real; ignored otherwise.
+# X_API_KEY=                      # API Key (Consumer Key)
+# X_API_SECRET=                   # API Key Secret (Consumer Secret)
+# X_ACCESS_TOKEN=                 # Access Token
+# X_ACCESS_TOKEN_SECRET=          # Access Token Secret
 # X_HANDLE=sindustries


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W30.md
- **Finding:** [High] `services/tasks-api/.env.example` documents the wrong X env vars
- `services/tasks-api/.env.example` documented `X_API_BEARER_TOKEN` while the code (`contentSchedulerPublish.ts:206-213`, `xTweet.ts` via `getXClient()`) requires four OAuth 1.0a vars (`X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`). Replaced the bearer-token stub with commented-out OAuth 1.0a entries and a link to the X Developer Portal so an operator following the example can enable real X posting without hitting `MISSING_CREDENTIALS`. Pure docs change — no behavior or API surface change. Tests (`contentScheduler.test.ts`) already reference the OAuth 1.0a vars, so docs now match code + tests.

## System Spec
No system spec change — `.env.example` is a developer-facing ops doc for env-var wiring, not a system behaviour contract. Audit finding 0-B (W30) and the W29 High finding on `x-actor` publish auth remain the right places to track the broader X-publishing security story.

## Test plan
- [ ] `services/tasks-api/.env.example` lists all four OAuth 1.0a vars with inline comments; no `X_API_BEARER_TOKEN` reference remains
- [ ] Existing `services/tasks-api/test/contentScheduler.test.ts` still references the OAuth 1.0a vars unchanged
- [ ] No logic changes — diff is purely `services/tasks-api/.env.example` plus the `0-B` audit marker

🌱 Code garden — non-functional cleanup only