### PR TITLE
feat(ivy): Ivy self-assigns and merges her own content PRs

### DIFF
--- a/agents/definitions/ivy/DoD.md
+++ b/agents/definitions/ivy/DoD.md
@@ -11,11 +11,16 @@ A content task is only Done when all are true:
    - Both PRs authored and linked to the relevant weekly review item
 
 3. **PRs are open and reviewable**
-   - Tom-approval PR: authored by Ivy, targetting main
-   - Quinn-approval PR: authored by Ivy, targeting main
+   - All PRs: authored by Ivy, self-assigned to `ivystoffer`, targeting main
+   - Quinn-approval PR: reviewer set to `quinnstoffer`
+   - Tom-approval PR: reviewer set to `Stoff81`
    - Both pass CI (if applicable)
 
-4. **Handoff is complete**
+4. **PRs are merged**
+   - After each reviewer approves and CI is green, Ivy merges the PR via `gh pr merge --rebase --delete-branch`
+   - The Lobster detects merged PRs and transitions the task to `done`
+
+5. **Handoff is complete**
    - Task comments updated with PR URLs
    - Quinn notified of completion
    - A `[ivy-prs]` task comment with the PR URL(s) has been posted, in the exact format the Lobster parses

--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -41,7 +41,16 @@ I am a heartbeat agent. I check the Tasks API on a regular interval for content 
 3. For each `acceptance` task:
    a. Check the linked PR(s) for new review comments
    b. Address comments with new commits on the same branch — read and follow the assignee section of `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/dev/pr-process/SKILL.md`
-   c. The Lobster will move the task to `done` once all PRs are merged
+   c. For each PR: check review decision and CI status:
+      ```bash
+      GH_CONFIG_DIR=~/.config/gh-ivy gh pr view <url> --json reviewDecision,statusCheckRollup \
+        --jq '{decision: .reviewDecision, ci: [.statusCheckRollup[].state]}'
+      ```
+   d. If `reviewDecision` is `APPROVED` and all CI states are `SUCCESS`: merge the PR
+      ```bash
+      GH_CONFIG_DIR=~/.config/gh-ivy gh pr merge <number> --repo Stoffer-Industries/sindustries --rebase --delete-branch
+      ```
+   e. The Lobster moves the task to `done` once all PRs are merged
 
 4. For each `blocked` task:
    a. Read the blocked reason from the task
@@ -54,7 +63,7 @@ I am a heartbeat agent. I check the Tasks API on a regular interval for content 
 
 - Never patch task `status` - the Lobster owns transitions
 - Never open multiple PRs for the same AC - one Tom PR (if needed) and one Quinn PR max
-- Never close a PR unilaterally - let the approver merge
+- Never close a PR — merge only after the reviewer has approved and CI is green
 - Always write `[ivy-prs]` comment with the exact URL format the Lobster parses
 - Always check the ACs in PR body match the ACs in the task body
 

--- a/agents/definitions/ivy/WORKFLOW.md
+++ b/agents/definitions/ivy/WORKFLOW.md
@@ -30,10 +30,10 @@ Use `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills
 ### 3. Decide which PRs to open
 
 The task body's PR headings tell me who must approve:
-- **Quinn-approval section** -> I open a Quinn PR (Quinn reviews and merges)
-- **Tom-approval section** -> I open a Tom PR (Tom reviews and merges)
+- **Quinn-approval section** -> I open a Quinn PR (Quinn reviews; I merge after approval)
+- **Tom-approval section** -> I open a Tom PR (Tom reviews; I merge after approval)
 - **No Tom section in task** -> I do not open a Tom PR; Quinn approval is enough
-- **Both sections** -> I open two PRs (one per approver)
+- **Both sections** -> I open two PRs (one per approver); I merge each after its reviewer approves
 
 **Risk classification (from sindustries-copy skill) — use this when labelling:**
 - `low` → Quinn approves: factual metadata, stack updates, experiment status changes with evidence, `currentLearning` additions
@@ -73,21 +73,24 @@ GH_CONFIG_DIR=~/.config/gh-ivy git -C ~/workspaces/ivy/sindustries push -u origi
 
 Always tag with the `content-task` label: `GH_CONFIG_DIR=~/.config/gh-ivy gh pr create --label "content-task" ...`
 
-**PR assignees (required):**
-- Quinn-approval PR → `--assignee quinnstoffer`
-- Tom-approval PR → `--assignee Stoff81`
+**PR assignees and reviewers (required):**
+- Ivy self-assigns all PRs: `--assignee ivystoffer`
+- Quinn-approval PR → `--reviewer quinnstoffer`
+- Tom-approval PR → `--reviewer Stoff81`
 
 ```bash
 # Quinn PR example
 GH_CONFIG_DIR=~/.config/gh-ivy gh pr create \
   --title "content: ... (Quinn-approval)" \
-  --assignee quinnstoffer \
+  --assignee ivystoffer \
+  --reviewer quinnstoffer \
   --label "content-task" ...
 
 # Tom PR example
 GH_CONFIG_DIR=~/.config/gh-ivy gh pr create \
   --title "content: ... (Tom-approval)" \
-  --assignee Stoff81 \
+  --assignee ivystoffer \
+  --reviewer Stoff81 \
   --label "content-task" ...
 ```
 
@@ -119,13 +122,24 @@ Post this as a task comment immediately after opening the PR(s). The Lobster wil
 
 **If a PR is closed and I need to retry:** Post a new `[ivy-prs]` comment with the replacement PR URLs. The Lobster always reads the most recent `[ivy-prs]` comment, so the new one supersedes the old.
 
-### 6. Respond to review
+### 6. Respond to review and merge
 
 While the task is in `acceptance`:
 - Monitor both PRs for review comments
 - Address feedback with new commits on the same branch (never open a new PR)
 - Reply to review threads using `GH_CONFIG_DIR=~/.config/gh-ivy gh pr comment <url> --body "..."` — always use the ivy prefix or comments appear as rowanstoffer
-- When a review is satisfied, comment on the PR and it will be merged by the approver
+- Once the reviewer has approved (`reviewDecision: APPROVED`) and CI is green, **merge the PR yourself**:
+
+```bash
+GH_CONFIG_DIR=~/.config/gh-ivy gh pr merge <number> --repo Stoffer-Industries/sindustries --rebase --delete-branch
+```
+
+Check review decision before merging:
+```bash
+GH_CONFIG_DIR=~/.config/gh-ivy gh pr view <url> --json reviewDecision,statusCheckRollup --jq '{decision: .reviewDecision, ci: [.statusCheckRollup[].state]}'
+```
+
+Merge only when `reviewDecision` is `APPROVED` and all CI states are `SUCCESS`. The Lobster detects the merged PR and moves the task to `done`.
 
 ### 7. Status transitions are NOT my job
 

--- a/agents/workflows/content-tasks/scripts/common.py
+++ b/agents/workflows/content-tasks/scripts/common.py
@@ -381,6 +381,22 @@ def gh_pr_review_decision(url: str) -> str:
     return decision.strip().upper() if isinstance(decision, str) and decision.strip() else "UNKNOWN"
 
 
+def gh_pr_reviewers(url: str) -> list[str]:
+    """Return login names of all reviewers (requested + completed) for a PR."""
+    pr = gh_pr_view(url, ["reviewRequests", "reviews"])
+    logins: list[str] = []
+    for entry in pr.get("reviewRequests") or []:
+        login = entry.get("login")
+        if login and login not in logins:
+            logins.append(login)
+    for review in pr.get("reviews") or []:
+        author = review.get("author")
+        login = author.get("login") if isinstance(author, dict) else None
+        if login and login not in logins:
+            logins.append(login)
+    return logins
+
+
 def gh_pr_review_comments(url: str) -> list[dict[str, Any]]:
     parsed = parse_pr_url(url)
     if parsed is None:

--- a/agents/workflows/content-tasks/scripts/pr_transition.py
+++ b/agents/workflows/content-tasks/scripts/pr_transition.py
@@ -16,6 +16,7 @@ from common import (
     gh_pr_assignees,
     gh_pr_ci_checks,
     gh_pr_ci_state,
+    gh_pr_reviewers,
     heading_level,
     is_at,
     is_past,
@@ -108,6 +109,7 @@ def pr_heading_urls(task: dict) -> list[str]:
 
 QUINN_LOGINS = {"quinnstoffer"}
 TOM_LOGINS = {"stoff81"}
+IVY_LOGINS = {"ivystoffer"}
 
 
 def _heading_index_for_assignees(assignees: list[str]) -> int | None:
@@ -120,12 +122,38 @@ def _heading_index_for_assignees(assignees: list[str]) -> int | None:
     return None
 
 
+def _heading_index_for_pr(url: str) -> int | None:
+    """Return heading index for a PR.
+
+    Checks assignees first (legacy pattern where Quinn/Tom are assigned).
+    When Ivy self-assigns, falls back to reviewer logins to determine section.
+    Quinn reviewer → 0, Tom reviewer → 1.
+    """
+    try:
+        assignees = gh_pr_assignees(url)
+        idx = _heading_index_for_assignees(assignees)
+        if idx is not None:
+            return idx
+    except Exception:
+        pass
+    try:
+        reviewers = gh_pr_reviewers(url)
+        reviewer_logins = {r.lower() for r in reviewers if r}
+        if reviewer_logins & QUINN_LOGINS:
+            return 0
+        if reviewer_logins & TOM_LOGINS:
+            return 1
+    except Exception:
+        pass
+    return None
+
+
 def url_to_heading_index(url: str, pr_urls: list[str], description: str = "") -> int | None:
     """Map a PR URL to its owner heading index.
 
     Priority order:
     1. Scan owner sections in the description (URL already injected).
-    2. Look up PR assignees: quinnstoffer → 0 (Quinn), Stoff81 → 1 (Tom).
+    2. Look up PR assignees (legacy) or reviewers (Ivy self-assign flow).
     3. Fall back to reversed-position formula (fragile, last resort).
     """
     if not url or url not in pr_urls:
@@ -134,12 +162,9 @@ def url_to_heading_index(url: str, pr_urls: list[str], description: str = "") ->
         for idx, (block_text, _) in enumerate(owner_sections(description)):
             if url in block_text:
                 return idx
-    try:
-        idx = _heading_index_for_assignees(gh_pr_assignees(url))
-        if idx is not None:
-            return idx
-    except Exception:
-        pass
+    idx = _heading_index_for_pr(url)
+    if idx is not None:
+        return idx
     pos = pr_urls.index(url)
     return 1 - pos  # last resort: pr_urls[0] → Tom(1), pr_urls[1] → Quinn(0)
 
@@ -162,12 +187,8 @@ def inject_pr_urls_into_description(description: str, pr_urls: list[str]) -> str
         pr_num_match = re.search(r"pull/(\d+)", url or "")
         pr_label = f"PR #{pr_num_match.group(1)}" if pr_num_match else url
 
-        # Determine target heading by assignee first, fall back to first empty heading.
-        target_idx: int | None = None
-        try:
-            target_idx = _heading_index_for_assignees(gh_pr_assignees(url))
-        except Exception:
-            pass
+        # Determine target heading by assignee/reviewer, fall back to first empty heading.
+        target_idx: int | None = _heading_index_for_pr(url)
 
         if target_idx is not None:
             # Inject into the assignee-matched heading if it doesn't already have a PR URL.
@@ -327,15 +348,16 @@ def main() -> int:
                     failures.extend(ac_fails)
                     # Assignee check: heading_idx 0 = Quinn's section, 1 = Tom's section
                     assignees = gh_pr_assignees(url)
+                    # Accept ivy self-assign (new flow) or legacy approver-assign
                     expected_assignees = {
-                        0: {"quinnstoffer"},  # Quinn's PR → assign to Quinn
-                        1: {"Stoff81"},       # Tom's PR → assign to Tom
+                        0: {"quinnstoffer"} | IVY_LOGINS,  # Quinn's PR → Quinn or Ivy
+                        1: {"Stoff81"} | IVY_LOGINS,       # Tom's PR → Tom or Ivy
                     }
                     expected = expected_assignees.get(heading_idx, set())
                     if expected and not expected.intersection(set(assignees)):
                         failures.append(
-                            f"{url} is not assigned to {expected} — "
-                            f"PR must be assigned to the owner ({'Quinn' if heading_idx == 0 else 'Tom'})."
+                            f"{url} is not assigned to one of {expected} — "
+                            f"PR must be assigned to Ivy (self-merge flow) or the owner ({'Quinn' if heading_idx == 0 else 'Tom'})."
                         )
             except Exception as exc:
                 failures.append(f"Could not inspect PR description for {url}: {exc}")


### PR DESCRIPTION
## Summary

- Ivy now self-assigns all content PRs (`--assignee ivystoffer`) instead of assigning to the approver
- Reviewers are set explicitly: `--reviewer quinnstoffer` for Quinn PRs, `--reviewer Stoff81` for Tom PRs
- After the reviewer approves and CI is green, Ivy merges via `gh pr merge --rebase --delete-branch`
- Lobster `pr_transition.py` updated to route PRs to the correct owner heading using reviewer logins when Ivy self-assigns (backwards-compatible: legacy assignee-based routing still works)
- Assignee validation relaxed to accept `ivystoffer` on both Quinn and Tom heading sections
- `gh_pr_reviewers()` helper added to `common.py`

## Files changed

- `agents/definitions/ivy/WORKFLOW.md` — self-assign, reviewer flags, merge step
- `agents/definitions/ivy/HEARTBEAT.md` — acceptance loop now merges approved+green PRs
- `agents/definitions/ivy/DoD.md` — updated to reflect self-assign and merge responsibility
- `agents/workflows/content-tasks/scripts/common.py` — add `gh_pr_reviewers()`
- `agents/workflows/content-tasks/scripts/pr_transition.py` — `_heading_index_for_pr()` uses reviewer fallback; assignee validation accepts ivy

## Test plan

- [ ] New content task: verify Ivy opens PR with `--assignee ivystoffer --reviewer quinnstoffer/Stoff81`
- [ ] Lobster `pr_transition` dry-run on an ivy-assigned PR confirms correct heading section is resolved
- [ ] After Quinn approves a Quinn PR, verify Ivy's heartbeat merges it
- [ ] Legacy Quinn/Tom-assigned PRs still route correctly (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)