### PR TITLE
feat(backlog-maintenance): add spec integrity checks

### DIFF
--- a/agents/crons/prompts/backlog-maintenance.md
+++ b/agents/crons/prompts/backlog-maintenance.md
@@ -11,8 +11,6 @@ print(json.dumps(tasks, indent=2))
 "
 ```
 
-If the list is empty, say exactly: NO_REPLY
-
 ## Step 2 — Classify each task
 
 Read the type selection rules in:
@@ -57,11 +55,96 @@ For each ambiguous task, write a watching entry to `brain/state/quinn-ops-state.
 
 Read/write the ops state file using the pattern in HEARTBEAT.md's OPS STATE MANAGEMENT section.
 
-## Step 5 — Report
+## Step 5 — Spec integrity: feature tasks missing a spec
+
+Fetch all open feature tasks and check each one has a valid spec file on disk.
+
+```bash
+curl -s "http://localhost:4001/api/v1/tasks?status=open&taskType=feature&limit=1000" | python3 -c "
+import json, sys, re, os
+
+WORKSPACE = '/Users/quinnstoffer/.openclaw/workspace'
+data = json.load(sys.stdin)
+tasks = data.get('data', [])
+problems = []
+for t in tasks:
+    desc = t.get('description', '')
+    m = re.search(r'brain/tasks/specs/\S+\.md', desc)
+    if not m:
+        problems.append({'id': t['id'], 'title': t['title'], 'issue': 'no_spec_link'})
+    else:
+        path = os.path.join(WORKSPACE, m.group(0))
+        if not os.path.exists(path):
+            problems.append({'id': t['id'], 'title': t['title'], 'issue': 'spec_file_missing', 'path': m.group(0)})
+print(json.dumps(problems, indent=2))
+"
+```
+
+For each problem:
+- `no_spec_link` — the task description has no `**Spec:** brain/tasks/specs/...` line at all. Log a watching incident and post a task comment:
+  `[backlog-maintenance] No spec file linked. Add a **Spec:** line to the description pointing to brain/tasks/specs/<status>/<name>.md, then run the spec-author skill.`
+- `spec_file_missing` — a spec path is referenced but the file does not exist on disk. Log a watching incident and post a task comment:
+  `[backlog-maintenance] Spec file <path> is linked but does not exist. Create or restore it using the spec-author skill.`
+
+Incident slug: `backlog-spec-missing-<task-id-prefix>-<YYYY-MM-DD>`, severity: `medium`, needsTom: false.
+
+Do NOT auto-create spec files — spec content requires understanding the task. Flag and let Quinn or Tom author the spec.
+
+## Step 6 — Spec integrity: spec files with no task
+
+Check each open or in-progress spec file to confirm a task references it.
+
+```bash
+python3 << 'EOF'
+import os, re, json, urllib.request
+
+WORKSPACE = '/Users/quinnstoffer/.openclaw/workspace'
+SPEC_DIRS = [
+    os.path.join(WORKSPACE, 'brain/tasks/specs/open'),
+    os.path.join(WORKSPACE, 'brain/tasks/specs/in-progress'),
+]
+
+# Collect all active spec paths (relative to WORKSPACE)
+spec_files = []
+for d in SPEC_DIRS:
+    if os.path.isdir(d):
+        for f in os.listdir(d):
+            if f.endswith('.md'):
+                rel = os.path.relpath(os.path.join(d, f), WORKSPACE)
+                spec_files.append(rel)
+
+if not spec_files:
+    print(json.dumps([]))
+else:
+    # Fetch all open tasks
+    with urllib.request.urlopen('http://localhost:4001/api/v1/tasks?status=open&limit=1000') as r:
+        tasks = json.loads(r.read())['data']
+
+    # Build set of spec paths referenced by tasks
+    referenced = set()
+    for t in tasks:
+        for m in re.finditer(r'brain/tasks/specs/\S+\.md', t.get('description', '')):
+            referenced.add(m.group(0))
+
+    orphans = [p for p in spec_files if p not in referenced]
+    print(json.dumps(orphans, indent=2))
+EOF
+```
+
+For each orphan spec file:
+1. Read the first 30 lines to determine if it has enough content to be a real task (not just a stub).
+2. If it looks like a real spec (has ## Outcome or ## Acceptance Criteria sections): create a feature task using the Tasks API with `taskType: feature`, title from the spec's `# Spec —` header, and description including the `**Spec:** <rel-path>` link. Post a task comment: `[backlog-maintenance] Task created from orphaned spec file.`
+3. If it looks like a stub or notes fragment: log a watching incident and skip task creation.
+
+Incident slug for stubs: `backlog-orphan-spec-<filename-prefix>-<YYYY-MM-DD>`, severity: `low`, needsTom: false.
+
+## Step 7 — Report
 
 Output a brief summary:
 - N tasks auto-typed (list title + type assigned)
 - M tasks skipped as ambiguous (list titles)
 - K tasks skipped as bookmark-pipeline candidates
+- P feature tasks with spec problems (list title + issue)
+- Q orphan spec files found (list filename + action taken)
 
-If N = 0 and M = 0: say exactly: NO_REPLY
+If all counts are 0: say exactly: NO_REPLY


### PR DESCRIPTION
## Summary
- Adds Step 5: scans open feature tasks for missing `**Spec:**` link or spec file that doesn't exist on disk — logs incident and posts task comment, does not auto-create specs
- Adds Step 6: scans `brain/tasks/specs/open/` and `in-progress/` for orphan spec files with no task referencing them — auto-creates a feature task for real specs (has Outcome/AC sections), logs watching incident for stubs
- Updates Step 7 report to include spec problem counts

## System Spec
No system spec change — cron prompt update only, no code or system behaviour change.

## Test plan
- [ ] Manual: run the backlog-maintenance cron and confirm it reports spec problems without false positives
- [ ] Manual: create a test orphan spec file and verify a task gets auto-created

🤖 Generated with [Claude Code](https://claude.com/claude-code)