### PR TITLE
fix(tasks-api): validate task id format in :id routes

### DIFF
--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -16,7 +16,8 @@ import {
   normalizeString,
   normalizeTags,
   parseDate,
-  parseLimit
+  parseLimit,
+  parseTaskId
 } from './tasks/_validation.ts';
 import { decodeCursor, encodeCursor } from './tasks/_pagination.ts';
 import { formatTaskTitle, mapTask, mapTaskComment } from './tasks/_mapper.ts';
@@ -205,7 +206,8 @@ tasksRouter.get('/tasks', async (req, res, next) => {
 
 tasksRouter.get('/tasks/:id', async (req, res, next) => {
   try {
-    const { id } = req.params;
+    const id = parseTaskId(req.params.id);
+    if (!id) return badRequest(res, 'INVALID_TASK_ID', 'Task id must be a 36-char UUID');
 
     const task = await prisma.task.findFirst({
       where: { id, archivedAt: null },
@@ -300,7 +302,8 @@ tasksRouter.post('/tasks', async (req, res, next) => {
 
 tasksRouter.patch('/tasks/:id', async (req, res, next) => {
   try {
-    const { id } = req.params;
+    const id = parseTaskId(req.params.id);
+    if (!id) return badRequest(res, 'INVALID_TASK_ID', 'Task id must be a 36-char UUID');
     const existing = await prisma.task.findFirst({ where: { id, archivedAt: null } });
     if (!existing) return notFound(res, 'TASK_NOT_FOUND', 'Task not found');
 
@@ -439,7 +442,8 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
 
 tasksRouter.post('/tasks/:id/comments', async (req, res, next) => {
   try {
-    const { id } = req.params;
+    const id = parseTaskId(req.params.id);
+    if (!id) return badRequest(res, 'INVALID_TASK_ID', 'Task id must be a 36-char UUID');
     const existing = await prisma.task.findFirst({ where: { id, archivedAt: null } });
     if (!existing) return notFound(res, 'TASK_NOT_FOUND', 'Task not found');
     // Comments are meta-discussion, not scope changes. The drift check
@@ -469,7 +473,8 @@ tasksRouter.post('/tasks/:id/comments', async (req, res, next) => {
 
 tasksRouter.delete('/tasks/:id', async (req, res, next) => {
   try {
-    const { id } = req.params;
+    const id = parseTaskId(req.params.id);
+    if (!id) return badRequest(res, 'INVALID_TASK_ID', 'Task id must be a 36-char UUID');
 
     const existing = await prisma.task.findFirst({ where: { id, archivedAt: null } });
     if (!existing) return notFound(res, 'TASK_NOT_FOUND', 'Task not found');

--- a/services/tasks-api/src/routes/tasks/_validation.ts
+++ b/services/tasks-api/src/routes/tasks/_validation.ts
@@ -46,6 +46,20 @@ export function normalizeDependsOnIds(value) {
   return normalized;
 }
 
+/**
+ * Validate a task id from a route param. Returns the trimmed id when it
+ * matches the canonical 36-char dashed UUID shape, otherwise null. Routes
+ * should map null → 400 INVALID_TASK_ID so a malformed identifier surfaces
+ * as a clear client error instead of leaking Prisma's "Inconsistent column
+ * data: invalid UUID length" P2023 as a generic 500. The trim is defensive:
+ * URL-encoded path segments can carry stray whitespace.
+ */
+export function parseTaskId(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return uuidPattern.test(trimmed) ? trimmed : null;
+}
+
 export function acceptanceCriteriaText(description) {
   if (!description) return [];
   const criteria = [];

--- a/services/tasks-api/test/read-endpoints.test.ts
+++ b/services/tasks-api/test/read-endpoints.test.ts
@@ -305,12 +305,78 @@ describe('tasks api endpoints', () => {
 
     prismaMock.task.findFirst.mockResolvedValueOnce(null);
     const missingTask = await request(app)
-      .post('/api/v1/tasks/missing/comments')
+      .post('/api/v1/tasks/99999999-9999-9999-9999-999999999999/comments')
       .send({ author: 'Rowan', text: 'hello' });
     expect(missingTask.status).toBe(404);
     expect(missingTask.body).toEqual({
       error: { code: 'TASK_NOT_FOUND', message: 'Task not found' }
     });
+  });
+
+  it.each([
+    {
+      method: 'get',
+      path: '/api/v1/tasks/95e65d06',
+      label: 'GET /api/v1/tasks/:id rejects 8-char hex prefix',
+    },
+    {
+      method: 'patch',
+      path: '/api/v1/tasks/95e65d06',
+      label: 'PATCH /api/v1/tasks/:id rejects 8-char hex prefix',
+      body: { status: 'doing' },
+    },
+    {
+      method: 'post',
+      path: '/api/v1/tasks/95e65d06/comments',
+      label: 'POST /api/v1/tasks/:id/comments rejects 8-char hex prefix',
+      body: { author: 'Rowan', text: 'hello' },
+    },
+    {
+      method: 'delete',
+      path: '/api/v1/tasks/95e65d06',
+      label: 'DELETE /api/v1/tasks/:id rejects 8-char hex prefix',
+    },
+    {
+      method: 'get',
+      path: '/api/v1/tasks/not-a-uuid-at-all',
+      label: 'GET /api/v1/tasks/:id rejects arbitrary non-UUID string',
+    },
+    {
+      method: 'patch',
+      path: '/api/v1/tasks/11111111-1111-1111-1111-11111111111', // truncated by one char
+      label: 'PATCH /api/v1/tasks/:id rejects short-truncated UUID',
+      body: { status: 'doing' },
+    }
+  ])('$label with 400 INVALID_TASK_ID and skips the prisma lookup', async ({ method, path, body }) => {
+    const app = createApp();
+
+    const req = request(app)[method](path);
+    const response = body ? await req.send(body) : await req;
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: {
+        code: 'INVALID_TASK_ID',
+        message: 'Task id must be a 36-char UUID'
+      }
+    });
+    expect(prismaMock.task.findFirst).not.toHaveBeenCalled();
+    expect(prismaMock.task.update).not.toHaveBeenCalled();
+    expect(prismaMock.task.create).not.toHaveBeenCalled();
+    expect(prismaMock.taskComment.create).not.toHaveBeenCalled();
+  });
+
+  it('GET /api/v1/tasks/:id with valid-shape UUID but missing row returns 404 TASK_NOT_FOUND', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce(null);
+
+    const app = createApp();
+    const response = await request(app).get('/api/v1/tasks/99999999-9999-9999-9999-999999999999');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({
+      error: { code: 'TASK_NOT_FOUND', message: 'Task not found' }
+    });
+    expect(prismaMock.task.findFirst).toHaveBeenCalledTimes(1);
   });
 
   it('POST /api/v1/tasks creates a feature task', async () => {
@@ -756,7 +822,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.findFirst.mockResolvedValue(null);
 
     const app = createApp();
-    const response = await request(app).get('/api/v1/tasks/missing');
+    const response = await request(app).get('/api/v1/tasks/99999999-9999-9999-9999-999999999999');
 
     expect(response.status).toBe(404);
     expect(response.body).toEqual({


### PR DESCRIPTION
## Summary
- **What:** Tasks API `:id` route handlers return `400 INVALID_TASK_ID` for malformed UUIDs instead of leaking Prisma's `P2023` ("Inconsistent column data: invalid UUID length") as a generic 500.
- **Why:** Rowan's heartbeat (Tue 2026-07-21 09:27 NZST) surfaced the bug — passing the 8-char hex prefix that task list views render (`[95e65d06] title`) into a `/tasks/<id>` URL produces 500s. The right fix is server-side format validation; we already use `uuidPattern` for `dependsOnIds`, just not for `:id`.
- **Scope:** One helper (`parseTaskId` in `src/routes/tasks/_validation.ts`, reuses the existing `uuidPattern`) + four 2-line guards at the top of GET/PATCH/DELETE/POST-`:id/comments` in `src/routes/tasks.ts`. No DB, no schema, no model changes.

## System Spec
No system spec change — defensive input validation only. Behaviour change is limited to error codes (500 → 400 `INVALID_TASK_ID`) for paths that should never have reached Prisma; no new API surface.

## Test plan
- [ ] `npm test --workspace services/tasks-api` passes (108 tests, 7 new for the 400 path)
- [ ] `GET /tasks/95e65d06` → 400 `INVALID_TASK_ID` (was 500)
- [ ] `GET /tasks/<valid-uuid-not-in-db>` → 404 `TASK_NOT_FOUND` (unchanged)
- [ ] `GET /tasks/<valid-uuid-in-db>` → 200 with task payload (unchanged)
- [ ] PATCH/DELETE/POST `:id/comments` return 400 on malformed input
- [ ] Live smoke against `http://localhost:4001/api/v1/tasks/95e65d06` — should now be 400, not 500