### PR TITLE
chore(code-garden): extend Python test discovery to workflow script tests [2026-W30]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,13 @@ jobs:
 
       - name: Run Python workflow tests
         env:
-          PYTHONPATH: agents/skills/tasks-api-ops
-        run: python -m unittest discover -s tests -p 'test_*.py'
+          PYTHONPATH: >-
+            agents/skills/tasks-api-ops:agents/workflows/bookmarks/scripts:agents/lib
+        run: |
+          python -m unittest discover -s tests -p 'test_*.py'
+          python -m unittest discover -s agents/workflows/bookmarks/scripts/tests -p 'test_*.py'
+          python -m unittest discover -s agents/workflows/bookmarks/tests -p 'test_*.py'
+          python -m unittest discover -s agents/lib -p 'test_*.py'
 
   otel-node-tests:
     name: otel-node unit tests

--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -312,7 +312,7 @@ No new performance concerns this week. The Content Scheduler auto-post correctly
 - *Quick win:* Yes.
 - *Follow-up classification:* `garden-safe`.
 
-**0-D. Add `agents/workflows/**/tests/**` to Python test discovery** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**0-D. Add `agents/workflows/**/tests/**` to Python test discovery** ✅ [PR #273](https://github.com/Stoffer-Industries/sindustries/pull/273)
 - *Description:* Update the `python-workflow-tests` job to discover tests in both `tests/` and `agents/workflows/*/tests/` (and `agents/workflows/*/scripts/tests/`) so the new bookmark author-tweet suite runs. Extend `PYTHONPATH` to include the bookmarks scripts directory.
 - *Files:* `.github/workflows/ci.yml`
 - *AC:* `test_x_author_tweet.py` runs in CI; a deliberately failing test breaks the build.

--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -312,7 +312,7 @@ No new performance concerns this week. The Content Scheduler auto-post correctly
 - *Quick win:* Yes.
 - *Follow-up classification:* `garden-safe`.
 
-**0-D. Add `agents/workflows/**/tests/**` to Python test discovery**
+**0-D. Add `agents/workflows/**/tests/**` to Python test discovery** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 - *Description:* Update the `python-workflow-tests` job to discover tests in both `tests/` and `agents/workflows/*/tests/` (and `agents/workflows/*/scripts/tests/`) so the new bookmark author-tweet suite runs. Extend `PYTHONPATH` to include the bookmarks scripts directory.
 - *Files:* `.github/workflows/ci.yml`
 - *AC:* `test_x_author_tweet.py` runs in CI; a deliberately failing test breaks the build.


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W30.md
- **Finding:** [Low / garden-safe] 0-D — Add `agents/workflows/**/tests/**` to Python test discovery
- Extends the `python-workflow-tests` CI job in `.github/workflows/ci.yml` to discover tests under `agents/workflows/bookmarks/scripts/tests/`, `agents/workflows/bookmarks/tests/`, and `agents/lib/` in addition to the existing top-level `tests/`. Pure YAML change with no app behaviour impact; +75 tests (29 agents/lib + 42 x_author_tweet + 4 spec_lifecycle) now run on every PR.

## Test plan
- [ ] `python -m unittest discover -s agents/workflows/bookmarks/scripts/tests -p 'test_*.py'` runs the 42 x_author_tweet tests
- [ ] `python -m unittest discover -s agents/workflows/bookmarks/tests -p 'test_*.py'` runs the 4 spec_lifecycle tests
- [ ] `python -m unittest discover -s agents/lib -p 'test_*.py'` runs the 29 agents_lib tests
- [ ] Existing top-level `tests/` discovery still runs
- [ ] CI: `python-workflow-tests` job on this PR exercises the new pattern and passes
- [ ] No logic changes — diff is purely CI workflow YAML

🌱 Code garden — non-functional cleanup only