### PR TITLE
fix(bookmarks): check summaryDoc in priority recovery path

### DIFF
--- a/agents/workflows/bookmarks/scripts/lobster_list_curate_candidates.py
+++ b/agents/workflows/bookmarks/scripts/lobster_list_curate_candidates.py
@@ -216,12 +216,16 @@ def main() -> int:
         seen_keys.add(bk)
         existing = items.get(bk, {})
 
-        # Check if we have a valid review on disk - if so, skip (never rewrite)
-        if existing.get("reviewDoc"):
-            review_path = WORKSPACE / existing["reviewDoc"]
+        # Check if we have a valid review or summary on disk - if so, skip (never rewrite).
+        # summaryDoc is the new-pipeline equivalent of reviewDoc.
+        _active_doc = existing.get("reviewDoc") or existing.get("summaryDoc")
+        if _active_doc:
+            review_path = WORKSPACE / _active_doc
             if review_path.exists():
                 # Review exists - check content to see if it's "implement" but no specs.
                 # Two signals: old explicit classification OR new curation score.
+                # summaryDoc format never contains the classification string, so this
+                # safely falls through to the curation-score check.
                 content = review_path.read_text()
                 has_implement_classification = (
                     "Classified as 'implement'" in content


### PR DESCRIPTION
## Summary
- The lobster's candidate scan only entered the spec-recovery/priority path when `item.reviewDoc` was set. Items processed by the new curation pipeline write `summaryDoc` instead, so they fell through to `normal_candidates` even when they had a spec file and a high curation score — meaning approval requests were never sent for them.
- Fix: resolve the active doc as `reviewDoc || summaryDoc`. The content-based classification check is unaffected because summaryDoc format never contains "Classified as 'implement'", so the code falls through to the curation-score signal (the authoritative signal for new-pipeline items).
- Also patched `reviewStatus` to `spec_created` directly in state for the two items blocked by this bug (`4474b14b6f6d1916` — 'Service-as-a-software', score 9; `518e94369647b437` — Creator economy, score 7). Next lobster run will pick them up as priority candidates and send the approval requests.

## System Spec
No system spec change — bug fix to candidate scan logic, no behavioural contract change.

## Test plan
- [ ] 54 existing bookmark workflow tests still pass (`pytest tests/test_bookmark_workflow.py`)
- [ ] `lobster_list_curate_candidates.py --json` shows `4474b14b6f6d1916` and `518e94369647b437` in the first 5 candidates with `skipReview=True` and `spec_created` status
- [ ] After next lobster run, both items appear as `approval_pending` in state and Tom receives a spec approval request

🤖 Generated with Claude Code