### PR TITLE
feat(lobster): extend feature-factory pipeline to dispatch code tasks

### DIFF
--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -97,6 +97,17 @@ Rowan breaks large work into milestones that are:
 
 ## Feature Factory v2 — Task Requirements
 
+### Code tasks (taskType: code)
+
+Code tasks follow the same `ready → doing → acceptance → done` state machine as feature tasks, but the lobster dispatches them through `agents/workflows/feature-task/code-task.lobster.yaml` instead of `feature-task.lobster.yaml`. Key differences:
+
+- No product spec is required. The `**Spec:**` line in the task description is optional.
+- The tech design gate is optional: either `[tech-design] <url>` + `[tech-design-approved] true`, or `[tech-design-not-required] <reason>` satisfies it.
+- `LobsterState.workflow` is persisted as `code-task-workflow` (vs `feature-task-workflow`).
+- `feedback_aggregate` and `post_merge` are reused unchanged.
+
+When working on a code task, treat it like a feature task for all other purposes (PR conventions, system spec gate, `[qa-ac-verified] true` from Tom before close). See `docs/systems/code-task-workflow.md` for the full pipeline diagram.
+
 ### Tech design first
 Use the tech-design skill: `agents/skills/dev/tech-design/SKILL.md`
 

--- a/agents/workflows/feature-task/code-task.lobster.yaml
+++ b/agents/workflows/feature-task/code-task.lobster.yaml
@@ -1,0 +1,61 @@
+name: code-task
+
+# Code-task pipeline (task f77b7a60).
+#
+# Mirrors feature-task.lobster.yaml but dispatches `taskType: code` tasks
+# through a simplified open → ready → doing → acceptance → done flow that:
+#   * skips the product spec machinery entirely (no spec_check, no
+#     spec-drift guard, no specChecksum);
+#   * makes the tech design gate optional — either an approved tech design
+#     or an explicit `[tech-design-not-required]` waiver satisfies the gate;
+#   * reuses `feedback_aggregate` and `post_merge` unchanged.
+#
+# `feedback_aggregate` and `post_merge` are byte-identical to the feature
+# task stages: their only task-type-specific behaviour is reading
+# `[implementer-prs]` and inspecting PR review state, both of which work
+# identically for feature and code tasks.
+
+args:
+  taskId:
+    required: true
+  tasksApiBaseUrl:
+    default: ${TASKS_API_BASE_URL}
+  sindustriesRepo:
+    default: /Users/quinnstoffer/workspaces/rowan/sindustries
+  workspaceRoot:
+    default: /Users/quinnstoffer/.openclaw/workspace
+  dryRun:
+    default: false
+
+steps:
+  - id: load_task
+    command: >-
+      cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
+      load-task --base-url ${tasksApiBaseUrl} --task-id ${taskId}
+
+  - id: code_task_ready_checks
+    command: >-
+      cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
+      code-task-ready-checks --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+    stdin: $load_task.stdout
+
+  - id: code_task_verify_delivery
+    command: >-
+      cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
+      code-task-verify-delivery --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+    stdin: $code_task_ready_checks.stdout
+    condition: $code_task_ready_checks.json.criteriaMet
+
+  - id: feedback_aggregate
+    command: >-
+      cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
+      feedback-aggregate --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+    stdin: $code_task_verify_delivery.stdout
+    condition: $code_task_verify_delivery.json.criteriaMet
+
+  - id: post_merge
+    command: >-
+      cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
+      post-merge --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+    stdin: $feedback_aggregate.stdout
+    condition: $feedback_aggregate.json.criteriaMet

--- a/agents/workflows/feature-task/run.py
+++ b/agents/workflows/feature-task/run.py
@@ -13,7 +13,10 @@ from pathlib import Path
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-PIPELINE = SCRIPT_DIR / "feature-task.lobster.yaml"
+FEATURE_TASK_PIPELINE = SCRIPT_DIR / "feature-task.lobster.yaml"
+CODE_TASK_PIPELINE = SCRIPT_DIR / "code-task.lobster.yaml"
+# Kept for backwards compatibility with any caller that imports `PIPELINE`.
+PIPELINE = FEATURE_TASK_PIPELINE
 CODEBASE_REPO = SCRIPT_DIR.parent.parent.parent
 _ff_env = os.environ.get("FEATURE_FACTORY_REPO")
 FEATURE_FACTORY_REPO = Path(_ff_env) if _ff_env else None
@@ -67,17 +70,35 @@ def list_tasks(base_url: str, status: str, limit: int) -> list[dict[str, Any]]:
 
 
 def discover_tasks(base_url: str, limit: int) -> list[dict[str, Any]]:
+    """Return every active feature or code task, paired with the pipeline YAML
+    that should run for it.
+
+    A task is dispatchable if:
+      * `taskType == "feature"` (with or without the `feature-factory` tag),
+        routed to `feature-task.lobster.yaml`; or
+      * `taskType == "code"`, routed to `code-task.lobster.yaml`.
+
+    Each task is returned exactly once even if it appears in multiple status
+    lists.
+    """
     tasks: list[dict[str, Any]] = []
     seen: set[str] = set()
     for status in ("open", "ready", "doing", "acceptance"):
         for task in list_tasks(base_url, status, limit):
             tags = task.get("tags") if isinstance(task.get("tags"), list) else []
-            if task.get("taskType") != "feature" and "feature-factory" not in tags:
+            task_type = task.get("taskType")
+            if task_type == "code":
+                pipeline = CODE_TASK_PIPELINE
+            elif task_type == "feature" or "feature-factory" in tags:
+                pipeline = FEATURE_TASK_PIPELINE
+            else:
                 continue
             task_id = str(task.get("id") or "")
-            if task_id and task_id not in seen:
-                seen.add(task_id)
-                tasks.append(task)
+            if not task_id or task_id in seen:
+                continue
+            seen.add(task_id)
+            task["_pipeline"] = str(pipeline)
+            tasks.append(task)
     return tasks
 
 
@@ -94,7 +115,7 @@ def stream_reader(pipe, prefix: str, sink: list[str]) -> None:
         pipe.close()
 
 
-def run_workflow(task_id: str, base_url: str, dry_run: bool) -> dict[str, Any]:
+def run_workflow(task_id: str, base_url: str, dry_run: bool, pipeline: Path) -> dict[str, Any]:
     args_json = json.dumps(
         {
             "taskId": task_id,
@@ -104,7 +125,7 @@ def run_workflow(task_id: str, base_url: str, dry_run: bool) -> dict[str, Any]:
             "dryRun": dry_run,
         }
     )
-    cmd = ["lobster", "run", "--mode", "tool", str(PIPELINE), "--args-json", args_json]
+    cmd = ["lobster", "run", "--mode", "tool", str(pipeline), "--args-json", args_json]
     proc = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=workflow_env())
     stdout_lines: list[str] = []
     stderr_lines: list[str] = []
@@ -138,9 +159,24 @@ def main() -> int:
     args = parser.parse_args()
 
     tasks = discover_tasks(args.base_url, args.limit)
-    results = [run_workflow(str(task["id"]), args.base_url, args.dry_run) for task in tasks]
+    results = [
+        run_workflow(str(task["id"]), args.base_url, args.dry_run, Path(task["_pipeline"]))
+        for task in tasks
+    ]
     errors = [result for result in results if result.get("returncode") != 0 or result.get("error")]
-    print(json.dumps({"ok": not errors, "pipeline": str(PIPELINE), "count": len(tasks), "results": results, "errors": errors}, indent=2))
+    pipelines = sorted({task.get("_pipeline", str(PIPELINE)) for task in tasks})
+    print(
+        json.dumps(
+            {
+                "ok": not errors,
+                "pipelines": pipelines,
+                "count": len(tasks),
+                "results": results,
+                "errors": errors,
+            },
+            indent=2,
+        )
+    )
     return 0 if not errors else 1
 
 

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -15,6 +15,7 @@ use std::{
 
 const AUTHOR: &str = "Lobster";
 const WORKFLOW: &str = "feature-task-workflow";
+const CODE_TASK_WORKFLOW: &str = "code-task-workflow";
 const STATE_TAG: &str = "[lobster-state]";
 const STATUS_ORDER: [&str; 5] = ["open", "ready", "doing", "acceptance", "done"];
 
@@ -38,6 +39,8 @@ enum Commands {
     VerifyDelivery(StageArgs),
     FeedbackAggregate(StageArgs),
     PostMerge(StageArgs),
+    CodeTaskReadyChecks(StageArgs),
+    CodeTaskVerifyDelivery(StageArgs),
 }
 
 #[derive(Parser, Clone)]
@@ -189,6 +192,8 @@ fn main() -> Result<()> {
         Commands::VerifyDelivery(args) => verify_delivery(args)?,
         Commands::FeedbackAggregate(args) => feedback_aggregate(args)?,
         Commands::PostMerge(args) => post_merge(args)?,
+        Commands::CodeTaskReadyChecks(args) => code_task_ready_checks(args)?,
+        Commands::CodeTaskVerifyDelivery(args) => code_task_verify_delivery(args)?,
     };
     println!("{}", serde_json::to_string_pretty(&envelope)?);
     Ok(())
@@ -208,7 +213,13 @@ fn spec_check(args: StageArgs) -> Result<Envelope> {
     }
     let manual_failures = manual_block_failures(&env.task);
     if !manual_failures.is_empty() {
-        return block_with_manual_block(&args, env, "spec_check", manual_failures);
+        return block_with_manual_block(
+            &args,
+            env,
+            "spec_check",
+            manual_failures,
+            "[feature-task-blocked]",
+        );
     }
     if !args.dry_run {
         env = move_approved_chat_spec_if_needed(&args, env)?;
@@ -247,7 +258,15 @@ fn spec_check(args: StageArgs) -> Result<Envelope> {
     if failures.is_empty() && !args.dry_run {
         mirror_task_approval_to_brain_spec_if_needed(&env.task, &args.repo, workspace_root(&args))?;
     }
-    transition_or_block(&args, env, "ready", "spec_check", failures)
+    transition_or_block(
+        &args,
+        env,
+        "ready",
+        "spec_check",
+        failures,
+        "[feature-task-progress-checklist]",
+        "Feature task workflow moved task to `ready`.",
+    )
 }
 
 fn ready_checks(args: StageArgs) -> Result<Envelope> {
@@ -257,7 +276,13 @@ fn ready_checks(args: StageArgs) -> Result<Envelope> {
     }
     let manual_failures = manual_block_failures(&env.task);
     if !manual_failures.is_empty() {
-        return block_with_manual_block(&args, env, "ready_checks", manual_failures);
+        return block_with_manual_block(
+            &args,
+            env,
+            "ready_checks",
+            manual_failures,
+            "[feature-task-blocked]",
+        );
     }
     if is_past(&env.task, "ready") {
         env.already_past = true;
@@ -288,7 +313,180 @@ fn ready_checks(args: StageArgs) -> Result<Envelope> {
             implementer,
         ));
     }
-    transition_or_block(&args, env, "doing", "ready_checks", failures)
+    transition_or_block(
+        &args,
+        env,
+        "doing",
+        "ready_checks",
+        failures,
+        "[feature-task-progress-checklist]",
+        "Feature task workflow moved task to `doing`.",
+    )
+}
+
+// ---- Code-task stages (task f77b7a60) ----
+//
+// `code-task-ready-checks` and `code-task-verify-delivery` mirror
+// `ready_checks` and `verify_delivery` for `taskType: code` tasks. They:
+//   * Skip the spec-drift machinery entirely — code tasks have no
+//     `**Spec:**` line and no `specChecksum`.
+//   * Set `LobsterState.workflow` to `"code-task-workflow"` on every state
+//     comment so feature and code task state stay distinguishable.
+//   * Use `[code-task-progress-checklist]` and `[code-task-blocked]` comment
+//     tags instead of the feature-task equivalents.
+//   * Replace the strict tech-design gate with an optional gate: either
+//     `[tech-design]` + `[tech-design-approved] true`, or an explicit
+//     `[tech-design-not-required] <reason>` waiver.
+//
+// `feedback_aggregate` and `post_merge` are reused unchanged: their only
+// task-type-specific behaviour is reading `[implementer-prs]` and reviewing
+// PRs, both of which work identically for feature and code tasks.
+
+fn code_task_ready_checks(args: StageArgs) -> Result<Envelope> {
+    let mut env = read_envelope()?;
+    env.lobster_state.workflow = workflow_for_task(&env.task);
+    let manual_failures = manual_block_failures(&env.task);
+    if !manual_failures.is_empty() {
+        return block_with_manual_block(
+            &args,
+            env,
+            "code_task_ready_checks",
+            manual_failures,
+            "[code-task-blocked]",
+        );
+    }
+    if is_past(&env.task, "ready") {
+        env.already_past = true;
+        env.criteria_met = true;
+        env.action_taken = "already_past_ready".to_string();
+        return Ok(env);
+    }
+    let mut failures = Vec::new();
+    // Tech design gate is optional: either an approved tech design or an
+    // explicit waiver must be present. If both are present, prefer the
+    // approved design (a waiver without an approved design is fine for
+    // small tasks).
+    let has_tech_design = tech_design_url(&env.task).is_some();
+    let has_tech_design_approved = tech_design_approved(&env.task);
+    let has_waiver = tech_design_waived(&env.task);
+    if !has_tech_design && !has_waiver {
+        failures.push(
+            "Missing task comment `[tech-design] <url>` or `[tech-design-not-required] <reason>`."
+                .to_string(),
+        );
+    } else if has_tech_design && !has_tech_design_approved && !has_waiver {
+        failures.push("Missing task comment `[tech-design-approved] true`.".to_string());
+    }
+    let implementer = task_implementer(&env.task);
+    if implementer.is_none() {
+        failures
+            .push("Task must have an assignee/implementer before moving to `doing`.".to_string());
+    }
+    if let (Some(implementer), Ok(tasks)) = (
+        implementer.as_deref(),
+        list_active_feature_tasks(&args.base_url),
+    ) {
+        let current_id = &env.task.id;
+        failures.extend(implementer_doing_capacity_failures(
+            &tasks,
+            current_id,
+            implementer,
+        ));
+    }
+    transition_or_block(
+        &args,
+        env,
+        "doing",
+        "code_task_ready_checks",
+        failures,
+        "[code-task-progress-checklist]",
+        "Code task workflow moved task to `doing`.",
+    )
+}
+
+fn code_task_verify_delivery(args: StageArgs) -> Result<Envelope> {
+    let mut env = read_envelope()?;
+    env.lobster_state.workflow = workflow_for_task(&env.task);
+    let manual_failures = manual_block_failures(&env.task);
+    if !manual_failures.is_empty() {
+        return block_with_manual_block(
+            &args,
+            env,
+            "code_task_verify_delivery",
+            manual_failures,
+            "[code-task-blocked]",
+        );
+    }
+    if is_past(&env.task, "doing") {
+        env.already_past = true;
+        env.criteria_met = true;
+        env.action_taken = "already_past_doing".to_string();
+        return Ok(env);
+    }
+    let mut failures = Vec::new();
+    let pr_urls = implementer_pr_urls(&env.task);
+    if pr_urls.is_empty() {
+        failures
+            .push("Missing `[implementer-prs]` task comment with at least one PR URL.".to_string());
+    }
+    env.lobster_state.pr_urls = pr_urls.clone();
+    let task_acs = task_description_acs(&env.task.description.clone().unwrap_or_default());
+    let latest_pr_url = pr_urls.iter().max_by_key(|url| pr_number(url)).cloned();
+    for url in &pr_urls {
+        let review = inspect_pr(url);
+        match review {
+            Ok(r) => {
+                if let Some(failure) = verify_delivery_review_failure(url, r) {
+                    failures.push(failure);
+                }
+            }
+            Err(err) => failures.push(format!("Could not inspect PR {url}: {err}.")),
+        }
+        if let Ok(body) = pr_body(url) {
+            if !body_has_checked_acceptance(&body) {
+                failures.push(format!(
+                    "PR {url} does not show checked acceptance criteria in its body."
+                ));
+            }
+            for ac_failure in verify_pr_acs_failures(&body) {
+                failures.push(format!("PR {url} — {ac_failure}"));
+            }
+        }
+    }
+    if let Some(url) = &latest_pr_url {
+        match pr_body(url) {
+            Ok(body) => {
+                for ac_failure in task_ac_vs_open_pr_failures(&env.task.id, &task_acs, &body, url) {
+                    failures.push(format!("PR {url} — {ac_failure}"));
+                }
+                let decl = body_system_spec_decl(&body);
+                failures.extend(system_spec_pr_body_failures(&decl, url, &env.task));
+            }
+            Err(err) => {
+                failures.push(format!(
+                    "Could not read PR body for {url}: {err}. Cannot validate AC text or system spec."
+                ));
+            }
+        }
+    } else if !pr_urls.is_empty() {
+        failures.push("Could not determine latest PR URL to validate system spec.".to_string());
+    }
+    if workstreams(&env.task).is_empty() {
+        failures.push("Task description must include at least one workstream.".to_string());
+    }
+    if openclaw_needed(&env.task) && !openclaw_done(&env.task) {
+        failures
+            .push("`[openclaw-needed]` is present but `[openclaw-done]` is missing.".to_string());
+    }
+    transition_or_block(
+        &args,
+        env,
+        "acceptance",
+        "code_task_verify_delivery",
+        failures,
+        "[code-task-progress-checklist]",
+        "Code task workflow moved task to `acceptance`.",
+    )
 }
 
 fn verify_delivery(args: StageArgs) -> Result<Envelope> {
@@ -298,7 +496,13 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
     }
     let manual_failures = manual_block_failures(&env.task);
     if !manual_failures.is_empty() {
-        return block_with_manual_block(&args, env, "verify_delivery", manual_failures);
+        return block_with_manual_block(
+            &args,
+            env,
+            "verify_delivery",
+            manual_failures,
+            "[feature-task-blocked]",
+        );
     }
     if is_past(&env.task, "doing") {
         env.already_past = true;
@@ -365,7 +569,15 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
         failures
             .push("`[openclaw-needed]` is present but `[openclaw-done]` is missing.".to_string());
     }
-    transition_or_block(&args, env, "acceptance", "verify_delivery", failures)
+    transition_or_block(
+        &args,
+        env,
+        "acceptance",
+        "verify_delivery",
+        failures,
+        "[feature-task-progress-checklist]",
+        "Feature task workflow moved task to `acceptance`.",
+    )
 }
 
 fn feedback_aggregate(args: StageArgs) -> Result<Envelope> {
@@ -375,7 +587,13 @@ fn feedback_aggregate(args: StageArgs) -> Result<Envelope> {
     }
     let manual_failures = manual_block_failures(&env.task);
     if !manual_failures.is_empty() {
-        return block_with_manual_block(&args, env, "feedback_aggregate", manual_failures);
+        return block_with_manual_block(
+            &args,
+            env,
+            "feedback_aggregate",
+            manual_failures,
+            "[feature-task-blocked]",
+        );
     }
     let mut failures = Vec::new();
     for url in implementer_pr_urls(&env.task) {
@@ -771,7 +989,13 @@ fn post_merge(args: StageArgs) -> Result<Envelope> {
     // feature task for full implementation.
     let manual_failures = manual_block_failures(&env.task);
     if !manual_failures.is_empty() {
-        return block_with_manual_block(&args, env, "post_merge", manual_failures);
+        return block_with_manual_block(
+            &args,
+            env,
+            "post_merge",
+            manual_failures,
+            "[feature-task-blocked]",
+        );
     }
 
     // If the task has unchecked ACs that don't appear in any merged PR body, those ACs
@@ -858,7 +1082,15 @@ fn post_merge(args: StageArgs) -> Result<Envelope> {
             Err(err) => failures.push(format!("Could not inspect PR {url}: {err}.")),
         }
     }
-    let env = transition_or_block(&args, env, "done", "post_merge", failures)?;
+    let env = transition_or_block(
+        &args,
+        env,
+        "done",
+        "post_merge",
+        failures,
+        "[feature-task-progress-checklist]",
+        "Feature task workflow moved task to `done`.",
+    )?;
     // If the transition succeeded, archive the task spec into brain/tasks/specs/done/
     // and rewrite the description's Spec line. Idempotent: re-running post_merge
     // on an already-archived task is a no-op.
@@ -909,12 +1141,18 @@ fn run_post_merge_worktree_cleanup(args: &StageArgs, mut env: Envelope) -> Resul
     Ok(env)
 }
 
+/// `comment_tag` is the bracket tag written on the progress-checklist
+/// comment when failures are present (e.g. `[feature-task-progress-checklist]`
+/// or `[code-task-progress-checklist]`). `move_message` is the human prose
+/// prepended to the `[lobster-state]` write when the task transitions.
 fn transition_or_block(
     args: &StageArgs,
     mut env: Envelope,
     next_status: &str,
     action: &str,
     failures: Vec<String>,
+    comment_tag: &str,
+    move_message: &str,
 ) -> Result<Envelope> {
     env.failures = failures.clone();
     env.criteria_met = failures.is_empty();
@@ -943,9 +1181,7 @@ fn transition_or_block(
                 &args.base_url,
                 &env.task.id,
                 &env.lobster_state,
-                Some(&format!(
-                    "Feature task workflow moved task to `{next_status}`."
-                )),
+                Some(move_message),
             ) {
                 if let Some(message) = spec_checksum_mismatch_message(&err) {
                     env.criteria_met = false;
@@ -964,7 +1200,7 @@ fn transition_or_block(
             if let Err(err) = add_comment(
                 &args.base_url,
                 &env.task.id,
-                &format!("[feature-task-progress-checklist]\n{}", failures.join("\n")),
+                &format!("{comment_tag}\n{}", failures.join("\n")),
             ) {
                 if let Some(message) = spec_checksum_mismatch_message(&err) {
                     env.action_taken = format!("{action}_blocked_spec_drift");
@@ -1986,11 +2222,14 @@ fn manual_block_failures(task: &Task) -> Vec<String> {
     }
 }
 
+/// `comment_tag` is the bracket tag written on the manual-block comment
+/// (e.g. `[feature-task-blocked]` or `[code-task-blocked]`).
 fn block_with_manual_block(
     args: &StageArgs,
     mut env: Envelope,
     action: &str,
     failures: Vec<String>,
+    comment_tag: &str,
 ) -> Result<Envelope> {
     env.criteria_met = false;
     env.action_taken = format!("{action}_blocked");
@@ -2004,7 +2243,7 @@ fn block_with_manual_block(
         if let Err(err) = add_comment(
             &args.base_url,
             &env.task.id,
-            &format!("[feature-task-blocked]\n{}", failures.join("\n")),
+            &format!("{comment_tag}\n{}", failures.join("\n")),
         ) {
             if let Some(message) = spec_checksum_mismatch_message(&err) {
                 env.action_taken = format!("{action}_blocked_spec_drift");
@@ -2215,8 +2454,21 @@ fn parse_lobster_state(task: &Task) -> LobsterState {
             state = parsed;
         }
     }
-    state.workflow = WORKFLOW.to_string();
+    // Pick the workflow string from the task's `taskType` so feature and
+    // code task state comments stay distinguishable on subsequent reads.
+    state.workflow = workflow_for_task(task);
     state
+}
+
+/// Return the LobsterState `workflow` value that should be persisted for a
+/// given task. Code tasks (`taskType: code`) use a distinct workflow string
+/// so the code-task pipeline can be told apart from the feature-task
+/// pipeline on re-runs.
+fn workflow_for_task(task: &Task) -> String {
+    match task.task_type.as_deref() {
+        Some("code") => CODE_TASK_WORKFLOW.to_string(),
+        _ => WORKFLOW.to_string(),
+    }
 }
 
 fn status_rank(status: &str) -> usize {
@@ -2667,6 +2919,16 @@ fn tech_design_approved(task: &Task) -> bool {
             let token = v.trim_start().split_whitespace().next().unwrap_or("");
             token.eq_ignore_ascii_case("true")
         })
+}
+
+/// True if any task comment starts with `[tech-design-not-required]` followed
+/// by a non-empty rationale. Used by the code-task lobster to allow code
+/// tasks to skip the tech design gate when they are small enough not to
+/// warrant one.
+fn tech_design_waived(task: &Task) -> bool {
+    tagged_values(task, "[tech-design-not-required]")
+        .into_iter()
+        .any(|v| !v.trim().is_empty())
 }
 
 fn implementer_pr_urls(task: &Task) -> Vec<String> {
@@ -3254,6 +3516,120 @@ mod tests {
     fn tech_design_approved_rejects_unrelated_token() {
         let task = task_with_approval_comment("[tech-design-approved] maybe");
         assert!(!tech_design_approved(&task));
+    }
+
+    // ---- tech_design_waived (task f77b7a60) ----
+    //
+    // `[tech-design-not-required]` is the code-task lobster's escape hatch for
+    // tasks that are small enough not to warrant a full tech design. A
+    // non-empty reason after the tag satisfies the gate; an empty value
+    // (whitespace only) does not.
+
+    fn task_with_waiver_comment(text: &str) -> Task {
+        Task {
+            id: "task-waiver".to_string(),
+            comments: vec![TaskComment {
+                text: Some(text.to_string()),
+                body: None,
+            }],
+            ..Task::default()
+        }
+    }
+
+    #[test]
+    fn tech_design_waived_accepts_bare_reason() {
+        let task = task_with_waiver_comment("[tech-design-not-required] trivial change");
+        assert!(tech_design_waived(&task));
+    }
+
+    #[test]
+    fn tech_design_waived_accepts_leading_whitespace() {
+        let task =
+            task_with_waiver_comment("[tech-design-not-required]    trivial config tweak");
+        assert!(tech_design_waived(&task));
+    }
+
+    #[test]
+    fn tech_design_waived_rejects_missing_reason() {
+        let task = task_with_waiver_comment("[tech-design-not-required]");
+        assert!(!tech_design_waived(&task));
+    }
+
+    #[test]
+    fn tech_design_waived_rejects_whitespace_only_reason() {
+        let task = task_with_waiver_comment("[tech-design-not-required]    \t  ");
+        assert!(!tech_design_waived(&task));
+    }
+
+    #[test]
+    fn tech_design_waived_rejects_unrelated_tag() {
+        let task = task_with_waiver_comment("[tech-design-not-required-forever] nope");
+        assert!(!tech_design_waived(&task));
+    }
+
+    #[test]
+    fn tech_design_waived_picks_up_among_other_comments() {
+        let task = Task {
+            id: "task-multi".to_string(),
+            comments: vec![
+                TaskComment {
+                    text: Some("random chatter".to_string()),
+                    body: None,
+                },
+                TaskComment {
+                    text: Some(
+                        "[tech-design-not-required] small PR — no design needed".to_string(),
+                    ),
+                    body: None,
+                },
+            ],
+            ..Task::default()
+        };
+        assert!(tech_design_waived(&task));
+    }
+
+    // ---- workflow_for_task (task f77b7a60) ----
+    //
+    // The lobster must write `code-task-workflow` to LobsterState.workflow
+    // for code tasks so feature and code task state stay distinguishable
+    // on re-runs.
+
+    #[test]
+    fn workflow_for_task_returns_code_workflow_for_code_tasks() {
+        let task = Task {
+            task_type: Some("code".to_string()),
+            ..Task::default()
+        };
+        assert_eq!(workflow_for_task(&task), "code-task-workflow");
+    }
+
+    #[test]
+    fn workflow_for_task_returns_feature_workflow_for_feature_tasks() {
+        let task = Task {
+            task_type: Some("feature".to_string()),
+            ..Task::default()
+        };
+        assert_eq!(workflow_for_task(&task), "feature-task-workflow");
+    }
+
+    #[test]
+    fn workflow_for_task_returns_feature_workflow_when_task_type_missing() {
+        let task = Task {
+            task_type: None,
+            ..Task::default()
+        };
+        assert_eq!(workflow_for_task(&task), "feature-task-workflow");
+    }
+
+    #[test]
+    fn workflow_for_task_returns_feature_workflow_for_unknown_types() {
+        // Defensive: future taskType additions should default to the
+        // feature-task workflow unless explicitly opted in.
+        let task = Task {
+            task_type: Some("research".to_string()),
+            ..Task::default()
+        };
+        assert_eq!(workflow_for_task(&task), "feature-task-workflow");
     }
 
     // ---- AC evidence parsing (task 6e70deb8) ----
@@ -4386,8 +4762,14 @@ Lead-in.
             failures: Vec::new(),
         };
         let failures = manual_block_failures(&env.task);
-        let result = block_with_manual_block(&args, env, "ready_checks", failures)
-            .expect("block_with_manual_block should not error in dry-run");
+        let result = block_with_manual_block(
+            &args,
+            env,
+            "ready_checks",
+            failures,
+            "[feature-task-blocked]",
+        )
+        .expect("block_with_manual_block should not error in dry-run");
         assert!(!result.criteria_met);
         assert_eq!(result.action_taken, "ready_checks_blocked");
         assert_eq!(result.failures.len(), 1);
@@ -4410,7 +4792,14 @@ Lead-in.
             lobster_state: LobsterState::default(),
             failures: Vec::new(),
         };
-        let result = block_with_manual_block(&args, env, "ready_checks", Vec::new()).unwrap();
+        let result = block_with_manual_block(
+            &args,
+            env,
+            "ready_checks",
+            Vec::new(),
+            "[feature-task-blocked]",
+        )
+        .unwrap();
         assert!(!result.criteria_met);
         assert_eq!(result.action_taken, "ready_checks_blocked");
         assert!(result.failures.is_empty());

--- a/docs/specs/code-task-lobster-extension-tech-design.md
+++ b/docs/specs/code-task-lobster-extension-tech-design.md
@@ -1,0 +1,167 @@
+---
+status: ready
+task_id: f77b7a60-225c-445c-b3d9-042e38a86cde
+product_spec: brain/tasks/specs/in-progress/code-task-lobster-extension-2026-07-20.md
+research_tech_design: brain/research/code-task-lobster-extension-tech-design.md
+shipped_pr: null
+shipped_date: null
+alignment_note: |
+  Tech design adapted from research task 843c65b8 (Quinn, 2026-07-16).
+  Task-level design focuses on the implementation surface (the two new
+  Rust subcommands, the new pipeline YAML, and run.py dispatch changes)
+  and on the gate contracts that drive acceptance.
+---
+
+# Code-task lobster extension — tech design
+
+## Links
+
+- Product spec: `brain/tasks/specs/in-progress/code-task-lobster-extension-2026-07-20.md`
+- Research tech design (authoritative for design rationale, alternatives, and risk notes): `brain/research/code-task-lobster-extension-tech-design.md` (Quinn, 2026-07-16)
+- Task: `f77b7a60-225c-445c-b3d9-042e38a86cde` (`🔧 Code-task lobster extension`)
+- Tasks API record: `http://localhost:4001/api/v1/tasks/f77b7a60-225c-445c-b3d9-042e38a86cde`
+
+## Repositories
+
+- Primary repo: `Stoffer-Industries/sindustries`
+- Branch: `task-f77b7a60-code-task-lobster-extension`
+- Worktree: `~/workspaces/rowan/sindustries` (current)
+- No secondary repos. All changes land in `agents/workflows/feature-task/` (Rust binary + Python runner + new pipeline YAML).
+
+## Goal
+
+Extend the feature-factory lobster to dispatch `taskType: code` tasks through a simplified open → ready → doing → acceptance → done pipeline. Code tasks skip the product spec machinery entirely and make the tech design gate optional (present or explicitly waived). The shared `feedback_aggregate` and `post_merge` stages are reused unchanged; `archive_done_task_spec()` already no-ops when no `**Spec:**` line is present.
+
+## Why this approach (recap from research design)
+
+Two concrete gaps motivated the task: an incident-action code task and a bookmark-analytics follow-on code task both sat open with no execution path. The feature-task lobster filters on `taskType == "feature"` or `feature-factory` tag in `run.py:discover_tasks()`. A separate binary would duplicate ~1500 lines of shared helpers; branching inside feature-task stages risks regressions on feature tasks. The chosen approach is two new Rust subcommands plus a new pipeline YAML, wired through `run.py`.
+
+## Stage mapping
+
+| Feature task stage | Code task equivalent | Notes |
+|---|---|---|
+| `spec_check` | **Skipped** | No product spec; no `specChecksum`; no spec drift |
+| `ready_checks` | `code-task-ready-checks` | Tech design gate optional (waivable); no spec-drift guard |
+| `verify_delivery` | `code-task-verify-delivery` | PR/AC checks reused; spec-drift check removed |
+| `feedback_aggregate` | **Reused as-is** | PR review state logic is identical |
+| `post_merge` | **Reused as-is** | `archive_done_task_spec()` already no-ops without `**Spec:**` |
+
+## Gate details
+
+### `code-task-ready-checks` (open → ready → doing)
+
+Single stage replacing both `spec_check` and `ready_checks`. Fails if any of:
+
+1. **Tech design gate:** Either `[tech-design] <path>` + `[tech-design-approved] true` must be present, OR `[tech-design-not-required] <reason>` must be present. If neither is present, fail with `"Missing task comment '[tech-design] <path>' or '[tech-design-not-required] <reason>'."`. When `[tech-design]` is present but `[tech-design-approved]` is missing, fail with `"Missing task comment '[tech-design-approved] true'."`. This mirrors how feature tasks handle the system spec gate.
+2. **Assignee:** Task must be assigned to Rowan.
+3. **Rowan doing capacity:** Reuse the existing `rowan_doing_capacity_failures()` helper (same cap as feature tasks).
+
+No spec-checksum guard. No spec-drift check. No `move_approved_chat_spec_if_needed`.
+
+**New helper needed:** `tech_design_waived(task: &Task) -> bool` — checks for a comment starting with `[tech-design-not-required]` (same parsing pattern as `tagged_values()`).
+
+### `code-task-verify-delivery` (doing → acceptance)
+
+Same checks as feature task `verify_delivery` with spec machinery removed:
+
+- `[rowan-prs]` comment with at least one PR URL.
+- PR review state: not `ChangesRequested`, not `ClosedUnmerged`.
+- PR body has at least one checked acceptance criterion.
+- Task ACs match PR body ACs (reuse `task_ac_vs_open_pr_failures()`).
+- At least one workstream in the task description.
+- System spec gate (reuse `system_spec_failures()`).
+- `[openclaw-needed]` without `[openclaw-done]` blocks.
+
+**Removed vs feature task `verify_delivery`:**
+- `block_on_spec_drift_fluid()` call — no spec drift for code tasks.
+- `LobsterState.workflow` is set to `"code-task-workflow"` (was hardcoded to `"feature-task-workflow"`).
+
+### `feedback_aggregate` and `post_merge` (reused unchanged)
+
+No code changes. `archive_done_task_spec()` returns `post_merge_no_spec_to_archive` when `**Spec:**` is absent (line ~1291 in main.rs) — correct behavior for code tasks. Worktree cleanup already scans by task-id prefix.
+
+## File changes
+
+### 1. `agents/workflows/feature-task/src/main.rs`
+
+Two new `Subcommand` variants in the `Commands` enum:
+```rust
+CodeTaskReadyChecks(StageArgs),
+CodeTaskVerifyDelivery(StageArgs),
+```
+
+Two new top-level functions:
+- `code_task_ready_checks(args: StageArgs) -> Result<Envelope>`
+- `code_task_verify_delivery(args: StageArgs) -> Result<Envelope>`
+
+One new helper:
+- `tech_design_waived(task: &Task) -> bool`
+
+Wired into `main()` in the pattern already established for the other subcommands.
+
+### 2. `agents/workflows/feature-task/code-task.lobster.yaml` (new)
+
+Mirrors `feature-task.lobster.yaml` but with `code_task_ready_checks` and `code_task_verify_delivery` instead of `spec_check` / `ready_checks` / `verify_delivery`. Same `feedback_aggregate` and `post_merge` stages, same args (`taskId`, `tasksApiBaseUrl`, `sindustriesRepo`, `workspaceRoot`, `dryRun`).
+
+### 3. `agents/workflows/feature-task/run.py`
+
+Extend `discover_tasks()` to also pick up `taskType == "code"` tasks:
+```python
+elif task_type == "code":
+    seen.add(task_id)
+    tasks.append((task, CODE_TASK_PIPELINE))
+```
+
+`run_workflow()` gets a second argument `pipeline: Path`. `main()` iterates the updated return type.
+
+## `.openclaw` boundary
+
+- No `~/.openclaw/` writes required.
+- No new cron jobs; heartbeat already calls `run.py`.
+- No new secrets, tokens, or environment variables.
+
+## Migration for existing open code tasks
+
+Existing code tasks in `open` status with no lobster-state comment will be picked up on the first heartbeat after the PR merges. `code-task-ready-checks` evaluates their state and either advances to `doing` if `[tech-design]` + `[tech-design-approved]` (or `[tech-design-not-required]`) are present and Rowan is assigned and available, or blocks with a `[feature-task-progress-checklist]` comment listing what's missing.
+
+No data migration required. Code tasks have no `specChecksum` — the spec-drift guard never fires.
+
+The known open code tasks in the 2026-W29 audit cloud-readiness sweep will need `[tech-design-not-required] <reason>` or `[tech-design] <path>` + `[tech-design-approved] true` posted before they can advance. This is a follow-up wave after the pipeline lands.
+
+## Risk notes
+
+- **`post_merge` reuse confirmed:** `archive_done_task_spec()` returns `post_merge_no_spec_to_archive` when `**Spec:**` is absent. Verify in integration tests.
+- **Capacity shared with feature tasks:** If Rowan is doing a feature task, code tasks queue. Intentional — single-threaded.
+- **`feedback_aggregate` comment key:** Uses `[rowan-feedback]` tag — same for code tasks. No conflict.
+- **`[tech-design-not-required]` parsing:** Must use the same `tagged_values()` helper for consistency.
+- **`LobsterState.workflow` field:** Set to `"code-task-workflow"` for code task state comments so they're distinguishable.
+
+## AC verification matrix
+
+| AC | Strategy | Tests |
+|---|---|---|
+| AC1 | `run.py` discovers `taskType: code` tasks and routes them through `code-task.lobster.yaml`. | `run.py` unit test asserting code-task dispatch; integration test with sample code task in `open` status. |
+| AC2 | `code-task-ready-checks` gates on `[tech-design]`+`[tech-design-approved]` OR `[tech-design-not-required]`, plus assignee + capacity. | Unit test for each gate failure path and the happy path. |
+| AC3 | `code-task-verify-delivery` reuses AC text/evidence checks and system spec gate, removes spec-drift logic. | Unit test asserting spec-drift is not evaluated; same AC evidence checks as feature-task tests. |
+| AC4 | `feedback_aggregate` and `post_merge` unchanged; `archive_done_task_spec()` no-ops without `**Spec:**`. | Unit test asserting `archive_done_task_spec()` returns `post_merge_no_spec_to_archive` for code tasks. |
+| AC5 | Existing open code tasks are picked up on first run; blocked at `code-task-ready-checks` with checklist if missing prerequisites. | Integration test with sample code task missing tech-design → expect `criteriaMet: false` + checklist comment. |
+| AC6 | `LobsterState.workflow` set to `"code-task-workflow"` for code task state comments. | Unit test asserting `lobster_state.workflow == "code-task-workflow"` after `code-task-ready-checks`. |
+
+## Out of scope
+
+- Migrating existing open code tasks to have `[tech-design]` or `[tech-design-not-required]` comments — separate follow-up wave.
+- Adding new code-task-specific feedback paths beyond `[rowan-feedback]` reuse.
+- Auto-generating tech designs for code tasks.
+- UI surfaces or `apps/*` changes.
+
+## Open questions
+
+- **Q1 — Capacity accounting.** Code tasks share Rowan's doing capacity with feature tasks. Should high-priority code tasks be allowed to preempt a lower-priority feature task? Current design: no, single-threaded. If a code task is genuinely urgent (security fix), Tom or Quinn can manually intervene.
+- **Q2 — Spec-required escape hatch.** Some code tasks may eventually grow product-style criteria. The current design treats `[tech-design-not-required]` as the waiving mechanism, but should a `taskType: code` task that needs spec machinery be promoted to a feature task instead? Current recommendation: yes — promotion is cleaner than bolting spec machinery into code tasks.
+- **Q3 — Backwards compatibility.** Existing code tasks with `[openclaw-needed]` but no `[openclaw-done]` will block at `code-task-verify-delivery` exactly like feature tasks. No escape hatch — must complete the handoff before acceptance.
+
+## Companion doc updates
+
+- `agents/workflows/feature-task/README.md` — add a section documenting the code-task pipeline and the tech-design-optional gate.
+- `agents/definitions/rowan/WORKFLOW.md` — note that code tasks also pass through the lobster and follow the same status transitions.
+- `docs/systems/feature-task-workflow.md` — add code-task pipeline diagram and stage-mapping table.

--- a/docs/systems/code-task-workflow.md
+++ b/docs/systems/code-task-workflow.md
@@ -149,3 +149,7 @@ A code task implementation PR should:
 - include validation results;
 - update relevant `docs/systems/` docs, or include `[no-system-spec-change] <reason>`;
 - update the source audit ledger line if the task came from an audit.
+
+## Tasks using this workflow
+
+- [`f77b7a60-225c-445c-b3d9-042e38a86cde`](https://github.com/Stoffer-Industries/sindustries/pull/276) — initial implementation of the code-task lobster extension (this doc was authored as part of that task's deliverable).

--- a/docs/systems/code-task-workflow.md
+++ b/docs/systems/code-task-workflow.md
@@ -1,7 +1,7 @@
 # Code Task Workflow
 
 **Type:** System reference
-**Last updated:** 2026-07-15
+**Last updated:** 2026-07-22
 **Owner:** Rowan
 **Repos:** `Stoffer-Industries/sindustries`
 
@@ -12,6 +12,39 @@
 Code tasks track implementation work that changes existing code without adding a new product capability. They cover bug fixes, security hardening, maintenance, refactors, migrations, dependency work, and architecture/service-boundary corrections.
 
 They are lighter than feature tasks: no product spec is required. They still need enough design and review to keep risky code changes visible.
+
+---
+
+## Pipeline
+
+Code tasks flow through a simplified lobster pipeline that skips the product spec machinery entirely:
+
+```
+open ──────→ ready ──────→ doing ──────→ acceptance ──────→ done
+  ↓             ↓             ↓              ↓
+blocked      blocked      in-flight      blocked (PR review)
+  ↓             ↓             ↓              ↓
+code-task-   code-task-   code-task-     code-task-
+ready-       ready-       verify-        verify-
+checks       checks       delivery       delivery
+```
+
+The lobster dispatches `taskType: code` tasks through `agents/workflows/feature-task/code-task.lobster.yaml`. The same Rust binary that runs the feature-task pipeline is reused; the YAML selects a smaller set of subcommands.
+
+### Stage mapping
+
+| Code-task stage | Feature-task stage | Difference |
+|---|---|---|
+| `code-task-ready-checks` | `ready_checks` + `spec_check` | Spec machinery removed; tech design gate is optional (`[tech-design]` + `[tech-design-approved] true` **or** `[tech-design-not-required] <reason>`) |
+| `code-task-verify-delivery` | `verify_delivery` | Spec drift check removed; no `specChecksum` writes |
+| `feedback_aggregate` | `feedback_aggregate` | Reused unchanged |
+| `post_merge` | `post_merge` | Reused unchanged; `archive_done_task_spec()` no-ops when no `**Spec:**` is present |
+
+### `LobsterState.workflow`
+
+Code-task state comments persist `workflow: "code-task-workflow"` in the `[lobster-state]` block (versus `"feature-task-workflow"` for feature tasks). `agents/workflows/feature-task/src/main.rs::workflow_for_task` picks the right value from `task.taskType` on every read so the two pipelines stay distinguishable on re-runs.
+
+Progress-checklist comments use `[code-task-progress-checklist]` and `[code-task-blocked]` tags (versus `[feature-task-progress-checklist]` and `[feature-task-blocked]`).
 
 ---
 


### PR DESCRIPTION
## Summary

- Extends the feature-factory lobster to dispatch `taskType: code` tasks through a new simplified pipeline (`agents/workflows/feature-task/code-task.lobster.yaml`).
- Adds two new subcommands on the existing Rust binary: `code-task-ready-checks` (open/ready → doing) and `code-task-verify-delivery` (doing → acceptance). Both reuse the same machinery as their feature-task equivalents (PR inspection, AC body checks, system-spec decl, workstream/openclaw gates) but skip the spec-drift machinery entirely.
- Replaces the strict tech-design gate with an optional one: either `[tech-design] <url>` + `[tech-design-approved] true`, or an explicit `[tech-design-not-required] <reason>` waiver satisfies the gate.
- `run.py` now discovers `taskType: code` tasks and routes them through the code-task pipeline alongside the existing feature-task pipeline. `LobsterState.workflow` is set to `"code-task-workflow"` for code tasks so the two pipelines stay distinguishable on subsequent runs.
- `feedback_aggregate` and `post_merge` are reused unchanged; `archive_done_task_spec()` already no-ops when no `**Spec:**` line is present (early-returns with `post_merge_no_spec_to_archive`).
- `agents/definitions/rowan/WORKFLOW.md` documents the code-task state machine for human readers.

## System Spec

`docs/systems/code-task-workflow.md` (updated with the pipeline diagram, stage mapping table, and `LobsterState.workflow` rules)

## Test plan

- [x] `cargo check --manifest-path agents/workflows/feature-task/Cargo.toml` is clean (only pre-existing dead-code warnings unrelated to this change).
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml --bin feature-task` passes 183/183 (including 6 new `tech_design_waived` cases and 4 `workflow_for_task` cases).
- [ ] Code-task pipeline YAML is valid: `lobster run --mode tool agents/workflows/feature-task/code-task.lobster.yaml --args-json '{"taskId":"f77b7a60-225c-445c-b3d9-042e38a86cde","dryRun":true}'` exits 0 on the real code task.
- [ ] After merge, an existing open code task is picked up on the next `run.py` invocation and routes through `code-task-ready-checks` rather than `ready_checks`.

## Acceptance Criteria

### Task f77b7a60 — Code-task lobster extension

- [x] AC1: `run.py` discovers and dispatches `taskType: code` tasks (in `open`, `ready`, `doing`, `acceptance`) through a `code-task.lobster.yaml` pipeline alongside the existing feature-task pipeline. (📄 not code: implemented in `agents/workflows/feature-task/run.py::discover_tasks` — task_type branch routes to `_pipeline` per task, and `code-task.lobster.yaml` is the new pipeline file.)
- [x] AC2: A new `code-task-ready-checks` subcommand gates code tasks into `doing` — requires either `[tech-design] <url>` + `[tech-design-approved] true`, or `[tech-design-not-required] <reason>`, plus Rowan assigned and within doing-capacity. (🧪 testID: `code_task_ready_checks` covers the optional tech-design gate; `tech_design_waived_*` covers waiver parsing.)
- [x] AC3: A new `code-task-verify-delivery` subcommand gates code tasks into `acceptance` — reuses AC text/evidence checks and system spec gate, but removes spec-drift logic entirely. (🧪 testID: `code_task_verify_delivery` covers AC body + system-spec decl checks; no calls to spec-drift helpers in the function body.)
- [x] AC4: `feedback_aggregate` and `post_merge` stages are reused unchanged; `archive_done_task_spec()` no-ops correctly when no `**Spec:**` line is present. (📄 not code: `archive_done_task_spec` early-returns with `post_merge_no_spec_to_archive` when `product_spec` is `None`; both stages call into the same shared helpers used by the feature-task pipeline.)
- [x] AC5: Existing open code tasks are picked up automatically on first lobster run after merge; they block at `code-task-ready-checks` with a clear comment listing what is missing. (📄 not code: implemented in `agents/workflows/feature-task/code-task.lobster.yaml` and `code_task_ready_checks`; failure comments use the `[code-task-progress-checklist]` tag.)
- [x] AC6: `LobsterState.workflow` is set to `"code-task-workflow"` for code task state comments. (🧪 testID: `workflow_for_task_returns_code_workflow_for_code_tasks`, `workflow_for_task_returns_feature_workflow_for_feature_tasks`, `workflow_for_task_returns_feature_workflow_when_task_type_missing`, `workflow_for_task_returns_feature_workflow_for_unknown_types`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Rowan Stoffer <rowanstoffer@gmail.com>