### PR TITLE
docs(factory): centralize PR AC evidence rules

### DIFF
--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -131,6 +131,8 @@ Before writing any code on a feature task, write the tech design:
 
 ### PR requirements
 - The implementation PR body must include all parent task ACs, with `- [x]` for done and evidence annotation, or `- [ ]` for not yet done
+- Use the canonical PR AC evidence rules in `agents/skills/dev/pr-open/SKILL.md`; do not copy old examples from shipped tech designs. `file:` is **not valid** evidence.
+- Each checked AC must keep the task AC text verbatim and append canonical evidence at the end; do not rewrite the AC text to include files/tests
 - Each PR body must list which parent ACs its sub-ACs contribute to
 - Do not include the AC checklist in tech design docs or any other non-implementation PR body — ACs in a merged PR body are treated by the lobster as "covered"; only include them when the code is actually done
 

--- a/docs/specs/add-e2e-to-feature-factory-tech-design.md
+++ b/docs/specs/add-e2e-to-feature-factory-tech-design.md
@@ -31,28 +31,27 @@ No `.openclaw` runtime change is required. No schema or API surface changes — 
 
 The feature factory v2 spec already states that every AC in a feature-task PR needs at least one E2E test unless explicitly marked not possible with a reason. Until now this was a human convention rather than a machine check. This task makes the lobster enforce it at the `doing → acceptance` gate.
 
-A PR is treated as compliant when each AC line in the PR body provides either:
-
-- A test reference, formatted as either `(testID: <id>)` or `(file: <path>:<test-name>)`, appended to the AC line; or
-- An explicit annotation `not tested: <reason>` justifying why no test exists.
+A PR is treated as compliant when each checked AC line in the PR body provides one of the current evidence annotations documented in `agents/skills/dev/pr-open/SKILL.md`.
 
 If any AC is checked (`- [x]`) and lacks evidence, the lobster blocks acceptance and posts a task comment listing every AC that needs evidence along with the expected formats.
 
 The PR template (in `agents/skills/dev/pr-open/SKILL.md`) prompts Rowan to attach the annotation when opening a feature-task PR so evidence is captured at write time rather than caught later.
 
+> Historical note: this tech design originally allowed `(file: ...)` evidence. That option was later removed because agents used it to cite implementation files rather than tests. Do not copy stale examples from this shipped design; `agents/skills/dev/pr-open/SKILL.md` is canonical.
+
 ## PR Body Evidence Format
 
-Each `- [x] AC<N>: <description>` line may be suffixed with one of:
+Each `- [x] AC<N>: <description>` line may be suffixed with one of the current evidence formats in `agents/skills/dev/pr-open/SKILL.md`, for example:
 
 ```markdown
-- [x] AC1: Title reflects stored value. (testID: 1234)
-- [x] AC2: Board view supports sort by priority. (file: apps/tasks/src/BoardView.jsx:42)
+- [x] AC1: Title reflects stored value. (testID: title-stored-value)
+- [x] AC2: Board view supports sort by priority. (testID: board-sort-priority)
 - [x] AC3: Archived tasks render with reduced opacity. (not tested: visual treatment is a manual review step; design system token supplies the color)
 ```
 
 Recognition rules:
 
-- A single space followed by `(testID: <value>)`, `(file: <path>:<test-name>)`, or `(not tested: <text up to closing paren>)` is treated as evidence.
+- The canonical accepted formats live in `agents/skills/dev/pr-open/SKILL.md`; keep this spec as background, not the process source of truth.
 - A bare `not tested` without a reason is treated as missing evidence — the lobster surfaces it.
 - Multi-PR tasks (where a task is split into workstreams across PRs): each PR's body only needs evidence for the ACs it claims. Uncovered ACs simply don't appear on that PR's Acceptance Criteria list. The lobster validates per-PR, not per-task, so each PR independently needs evidence for what it advertises.
 
@@ -65,7 +64,7 @@ The lobster matches the same `- [ ] AC<N>` style that the product spec / task de
 - New function `parse_pr_evidence(body: &str) -> Vec<AcEvidence>` returning one record per `- [x]` AC line:
   - `ac_label: String` — captured `AC<number>` token
   - `description: String` — the AC body without evidence
-  - `evidence: Option<Evidence>` — `TestId(String)`, `FileRef { path, test_name }`, or `NotTested { reason }`
+  - `evidence: Option<Evidence>` — current accepted variants are defined by the implementation and documented in `agents/skills/dev/pr-open/SKILL.md`
 - New function `verify_pr_acs(body: &str) -> Vec<String>` returning a list of human-readable failure strings (empty on success). It scans only the `## Acceptance Criteria` (or `## ACs`) section header, parses each checked AC line, and emits one failure per AC missing evidence.
 - Helper `extract_ac_section(body: &str) -> &str` returns just the AC section text or the entire body when no header is present (defensive default so PRs without a header still get validated).
 
@@ -89,14 +88,14 @@ Failure messages follow the existing pattern (`"PR {url} — AC{label} ({head}):
 
 ### 3. Update the PR template
 
-In `agents/skills/dev/pr-open/SKILL.md`, expand the body template section to include a reminder that each AC line must end with `(testID: <id>)`, `(file: <path>:<test-name>)`, or `(not tested: <reason>)`. The template already lists ACs; the change is a one-line note explaining the evidence requirement.
+In `agents/skills/dev/pr-open/SKILL.md`, expand the body template section to include a reminder that each AC line must end with one of the canonical evidence annotations. The template already lists ACs; the change is a one-line note explaining the evidence requirement.
 
 ### 4. Tests
 
 New tests in `agents/workflows/feature-task/src/main.rs` `mod tests`:
 
 - `parse_pr_evidence_recognises_test_id` — `- [x] AC1: Foo (testID: 1234)` parses to `Some(TestId("1234"))`.
-- `parse_pr_evidence_recognises_file_ref` — `(file: agents/workflows/feature-task/src/main.rs: test_name)` parses to `FileRef`; numeric line-only file refs are rejected so the implementation matches the task AC.
+- `parse_pr_evidence_rejects_file_annotation` — `(file: agents/workflows/feature-task/src/main.rs: test_name)` is not accepted as evidence.
 - `parse_pr_evidence_recognises_not_tested_reason` — `(not tested: requires manual click flow)` parses to a reason.
 - `parse_pr_evidence_rejects_bare_not_tested` — bare `not tested` without parens or reason is `None`.
 - `verify_pr_acs_passes_when_all_have_evidence` — full body with annotations returns empty failures.
@@ -120,7 +119,7 @@ Fixtures go under `agents/workflows/feature-task/fixtures/pr-bodies/` with one f
 - Manual smoke:
   - open a feature-task PR with one AC missing evidence
   - inspect `verify-delivery` output (via `feature-task.lobster.yaml` step on the task) — should report one failure
-  - amend the PR body to include `(file: ...)` or `(not tested: ...)` for the missing AC
+  - amend the PR body to include a canonical evidence annotation for the missing AC
   - re-run `verify-delivery` — empty failures
 
 Coverage summary:
@@ -134,6 +133,6 @@ Coverage summary:
 ## Open Questions and Risks
 
 - **Multi-PR workstreams:** a parent task with three PRs (workstream A/B/C) will have each PR advertising only the ACs that workstream claims. The validation is per-PR, which matches the existing `body_has_checked_acceptance` per-PR behaviour. If product decides the lobster should additionally verify the union of ACs across all PRs covers every AC in the task description, that becomes a follow-up — out of scope here, flagged for later.
-- **Test ID vs file ref choice:** the spec lets `testID` and `file:line` coexist. The lobster does not need to validate that the file exists on disk — that responsibility stays with Tom/Quinn at review time. Risk is moderate but bounded.
+- **Evidence source of truth:** the exact accepted evidence annotations live in `agents/skills/dev/pr-open/SKILL.md` and the Rust parser. Avoid duplicating the allowed list in shipped tech designs; stale examples caused agents to keep using removed formats.
 - **PR body header drift:** the lobster matches `## Acceptance Criteria` and `## ACs` (case-insensitive). If a PR uses a different heading (e.g. `## ✅ Acceptance Criteria`), the defensive `extract_ac_section` falls back to scanning the whole body, which still works because AC lines are uniquely tagged with `AC<N>`.
 - **No system spec change.** The lobster binary is internal agent tooling, not a user-facing system. No `docs/systems/` update. The PR-side skill change is documentation, not system behaviour. The `no-system-spec-change` rationale will be posted on the PR.

--- a/docs/specs/lobster-task-ac-subsection-scope-tech-design.md
+++ b/docs/specs/lobster-task-ac-subsection-scope-tech-design.md
@@ -62,7 +62,9 @@ Identical wording to today. If the matching subsection is empty (or missing), `p
 
 ### `verify_pr_acs_failures` is unchanged
 
-It operates on the whole section by design. Evidence format checking does not depend on which task an AC belongs to: every checked `- [x] ACn: ...` line in the PR body must carry `(testID: ...)`, `(file: ...)`, `(not tested: ...)`, or `(not code: ...)`. The function continues to scan the whole section.
+It operates on the whole section by design. Evidence format checking does not depend on which task an AC belongs to: every checked `- [x] ACn: ...` line in the PR body must carry one of the current evidence formats documented in `agents/skills/dev/pr-open/SKILL.md`. The function continues to scan the whole section.
+
+Note: this tech design predates removal of `file:` evidence. Do not treat old examples in shipped tech designs as the current process contract; `pr-open/SKILL.md` is canonical.
 
 ## Edge cases
 

--- a/docs/systems/feature-task-workflow.md
+++ b/docs/systems/feature-task-workflow.md
@@ -69,17 +69,11 @@ The Rust CLI under `agents/workflows/feature-task/` owns parsing, gate enforceme
 
 A stub like "No change" (< 12 non-whitespace chars) is treated as missing and blocks acceptance. **The system spec must be committed in the same PR as the feature code** — a separate backfill PR is not acceptable. No task comment is needed; the PR body section is the gate. See `agents/skills/dev/pr-open/SKILL.md` for the canonical PR body template.
 
-**AC text check (doing → acceptance, pre-merge):** before the lobster will let the task advance from `doing` to `acceptance`, it compares every task description AC against the **open** PR body. If any AC is missing from the PR, has altered text, or lacks a valid evidence annotation `(testID|file|not tested|not code)`, the transition is blocked with a `[feature-task-progress-checklist]` comment listing the specific failures — the task stays in `doing` until Rowan opens a fix PR that lists every AC verbatim with evidence. Tom may edit ACs in the task description during QA — spec drift does not block this gate (it is covered by the resync feature; see task b2ab54db).
+**AC text check (doing → acceptance, pre-merge):** before the lobster will let the task advance from `doing` to `acceptance`, it compares every task description AC against the **open** PR body. If any AC is missing from the PR, has altered text, or lacks a valid evidence annotation `(testID|not tested|not code|pr)`, the transition is blocked with a `[feature-task-progress-checklist]` comment listing the specific failures — the task stays in `doing` until Rowan opens a fix PR that lists every AC verbatim with evidence. Tom may edit ACs in the task description during QA — spec drift does not block this gate (it is covered by the resync feature; see task b2ab54db).
 
 Note: prior versions of this workflow ran an equivalent AC text check at the `post-merge` stage (the "QA bounce") that moved a task back from `acceptance` to `doing` if the latest merged PR's AC text didn't match. That path was removed because it triggered after merge, forcing a wasteful revert + fix-PR round-trip. The check now runs pre-merge so mistakes are caught before the PR is merged.
 
-**PR AC evidence formats** — priority order (use the first that applies):
-- `(🧪 testID: <id>)` — e2e (Playwright) or unit test reference. **Default — always prefer this.**
-- `(⚠️ not tested: <reason>)` — explicit opt-out; requires a substantive reason
-- `(📄 not code: <reason>)` — AC fulfilled outside the codebase (doc, spec, config)
-- `(🔗 pr: #<n>)` — covered by another merged PR
-
-`file:` has been removed (it was being used to cite implementation files rather than tests). Emojis are optional but encouraged for visual clarity in reviews.
+**PR AC evidence formats:** the canonical process lives in `agents/skills/dev/pr-open/SKILL.md`. Do not duplicate the accepted-format list here; the Lobster parser and `pr-open` skill are the source of truth. Historical note: `file:` evidence was removed because agents used it to cite implementation files rather than tests.
 
 ### 4. `done` — terminal
 
@@ -131,6 +125,69 @@ Note: prior versions of this workflow ran an equivalent AC text check at the `po
 | `cargo run -- feedback-aggregate` | `acceptance` gate | Aggregates `CHANGES_REQUESTED` feedback to Rowan |
 | `cargo run -- post-merge` | `done` gate | Verifies all PRs merged + post-merge CI green + system spec |
 | `agents/workflows/feature-task/run.py` | dispatcher | One-tick invocation: discovers active feature tasks and runs the Lobster pipeline per task |
+
+### Terminal invocation
+
+Run the normal dispatcher, which discovers active `feature` and `code` tasks and invokes the right Lobster YAML once per task:
+
+```bash
+cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries
+TASKS_API_BASE_URL=http://localhost:4001/api/v1 \
+  agents/workflows/feature-task/run.py --dry-run
+```
+
+Run one specific feature-task Lobster pipeline directly. If `lobster` is not on your shell `PATH`, use the OpenClaw-managed binary at `/Users/quinnstoffer/.openclaw/tools/node-v24.15.0/bin/lobster` or temporarily prepend that directory to `PATH`:
+
+```bash
+cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries
+export PATH="/Users/quinnstoffer/.openclaw/tools/node-v24.15.0/bin:$PATH"
+lobster run --mode tool agents/workflows/feature-task/feature-task.lobster.yaml \
+  --args-json '{"taskId":"TASK_ID_HERE","tasksApiBaseUrl":"http://localhost:4001/api/v1","sindustriesRepo":"/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries","workspaceRoot":"/Users/quinnstoffer/.openclaw/workspace","dryRun":true}'
+```
+
+Swap `feature-task.lobster.yaml` for `code-task.lobster.yaml` when manually targeting a `taskType: code` task. Set `"dryRun":false` only when you want the run to write task status/comments.
+
+Dry runs still return the gate result on stdout. Checklist-style blockers appear in the JSON envelope's `failures` array and `actionTaken` field, but dry runs do **not** post the `[feature-task-progress-checklist]` task comment. Non-dry runs both return the same failure envelope and write the task comment when the failure fingerprint is new.
+
+For a readable terminal checklist across every active feature/code task, use a temporary formatter script rather than a fragile one-line Python command:
+
+```bash
+cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries
+export PATH="/Users/quinnstoffer/.openclaw/tools/node-v24.15.0/bin:$PATH"
+
+cat > /tmp/feature_factory_format.py <<'PY'
+import json, sys
+
+data = json.load(sys.stdin)
+print(f"Feature factory dry-run: {data.get('count', 0)} task(s)")
+
+for result in data.get('results', []):
+    env = result.get('envelope') or {}
+    outputs = env.get('output') or []
+    final = outputs[-1] if outputs else {}
+    task = final.get('task') or {}
+    failures = final.get('failures') or []
+
+    title = task.get('title') or '(title unavailable)'
+    status = task.get('status') or '?'
+    action = final.get('actionTaken') or '?'
+    icon = '✅' if not failures and final.get('criteriaMet') else '⚠️'
+
+    print(f"\n{icon} {title}")
+    print(f"   {result.get('taskId')} · status={status} · action={action}")
+
+    if failures:
+        print('   Missing / blocked:')
+        for failure in failures:
+            print(f"   - {failure}")
+    else:
+        print('   No checklist blockers.')
+PY
+
+TASKS_API_BASE_URL=http://localhost:4001/api/v1 \
+  python3 agents/workflows/feature-task/run.py --dry-run 2>/dev/null \
+  | python3 /tmp/feature_factory_format.py
+```
 
 ---
 
@@ -263,7 +320,7 @@ The `.openclaw/` directory is outside this repo. Any required `.openclaw` change
 | `PATCH` succeeds despite stale ACs | Other event types (status change, dependency add, tag edit) don't re-check the checksum | Pass the updated `description` through `PATCH /tasks/:id` first so the drift check fires there. |
 | CI green but PR not merged | Reviewer has not approved | Wait for `APPROVED` review state; Lobster will not mark `done` until GitHub merge is recorded |
 | Task bounced to `doing` from `acceptance` | (legacy — the post-merge QA bounce path was removed; AC text mismatches now block at the doing → acceptance gate before merge instead) | n/a |
-| `doing -> acceptance` blocked on AC text | Open PR body is missing an AC, has altered AC text, or lacks a valid evidence annotation `(testID|file|not tested|not code)` | Update the PR body so every task AC appears verbatim with evidence; `[feature-task-progress-checklist]` comment lists the specific failures |
+| `doing -> acceptance` blocked on AC text | Open PR body is missing an AC, has altered AC text, or lacks a valid evidence annotation `(testID|not tested|not code|pr)` | Update the PR body so every task AC appears verbatim with evidence; `[feature-task-progress-checklist]` comment lists the specific failures |
 | `acceptance -> done` blocked with "Missing `[qa-ac-verified] true`" | Tom has not signed off | Tom posts `[qa-ac-verified] true` after verifying ACs on staging |
 
 ---


### PR DESCRIPTION
## Summary
- Centralize PR AC evidence rules on `agents/skills/dev/pr-open/SKILL.md` instead of duplicating accepted formats across workflow docs and shipped tech designs.
- Update Rowan's workflow to point at the canonical PR-open skill, explicitly reject `file:` evidence, and require verbatim AC text with evidence appended.
- Reframe old tech-design mentions of `(file: ...)` as historical/rejection notes so agents don't copy stale process examples.

## System Spec
No system spec change — documentation/process cleanup only; no user-facing runtime behaviour changed.

## Test plan
- [x] `git diff --check`
- [x] `rg` verified active process docs no longer list `file:` as accepted PR AC evidence; remaining hits are historical/rejection notes only.

🤖 Generated with OpenClaw