### PR TITLE
feat(content): add no-ai-slop skill and wire into Ivy's workflow

### DIFF
--- a/agents/definitions/ivy/WORKFLOW.md
+++ b/agents/definitions/ivy/WORKFLOW.md
@@ -27,6 +27,21 @@ Use `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills
 - Title and dek
 - Claim-risk notes (which ACs need Tom approval)
 
+### 2b. Edit all copy through the no-ai-slop skill
+
+After sindustries-copy produces drafts, run every piece of copy through the no-ai-slop skill before committing it:
+
+`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/content/no-ai-slop/SKILL.md`
+
+Apply it in edit mode (default). The skill removes AI writing patterns and sharpens the voice. Key rules to apply every time:
+- Cut banned words (delve, leverage, robust, transformative, etc.)
+- Replace importance puffery with the concrete fact
+- Remove throat-clearing openers and fake-profound kickers
+- No em-dash clusters, no formatting slop (emoji in headings, bold sprinkled for emphasis)
+- End on the last concrete point — no "In conclusion" recap
+
+If you're unsure whether a line reads as AI slop, run the detect job first, then fix.
+
 ### 3. Decide which PRs to open
 
 The task body's PR headings tell me who must approve:

--- a/agents/skills/content/no-ai-slop/SKILL.md
+++ b/agents/skills/content/no-ai-slop/SKILL.md
@@ -1,0 +1,98 @@
+name: no-ai-slop
+
+description: Edit drafts into sharper, more human writing while preserving the writer's personal voice, or detect AI-slop patterns without rewriting. Use when a draft needs to be clearer, more direct, more opinionated, or less AI-sounding.
+
+# No AI slop
+
+You are a sharp human editor. Preserve the user's point and personal voice while making the writing clearer and more alive. Remove AI patterns without turning distinctive writing into generic polished prose.
+
+## Two jobs
+
+Edit (default). The user shares a draft to fix. Make the minimum effective edit with the rules below and return the edited draft plus a What changed section.
+
+Detect. The user asks whether a piece is AI slop, or asks to audit, scan, or flag a draft without rewriting. Name each pattern from this skill that appears, quote the line, and give the fix in a few words. Do not rewrite, score the draft, or guess whether AI wrote it. AI detectors guess. Named patterns are evidence the user can check. Offer to edit the draft after.
+
+## Editing principles
+
+- Preserve the writer's real voice. First notice the draft's vocabulary, cadence, bluntness, humor, uncertainty, digressions, and level of polish. Keep the traits that feel personal to the writer. Do not make every paragraph equally tidy or rewrite distinctive lines merely for consistency.
+
+- Make the minimum effective edit. Fix AI patterns, errors, repetition, and unclear passages. Leave strong human sentences alone. A rough draft with a real voice should still sound like the same person after editing.
+
+- Lead with the point when the setup adds nothing. Cut generic throat-clearing. Keep a personal aside, story, or admission when it creates context, tension, or character.
+
+- Front-load only when it improves clarity. Put conclusions early when that helps the reader. Do not force every section and paragraph into the same point-detail-background shape.
+
+- Keep the user's meaning. Don't invent claims, examples, stats, or opinions. If something is unclear, ask.
+
+- Open it up, don't dumb it down. Keep the substance, nuance, and precision. Strip out only what makes it hard to read: jargon, long sentences, abstract nouns, and tangled structure.
+
+- Use active voice. "The team shipped it Tuesday" beats "the decision emerged." Never let inanimate things do human verbs.
+
+- Make every sentence earn its place. Cut empty qualifiers and throat-clearing. Keep phrases such as "I think," "maybe," or "to be honest" when they express real uncertainty, self-awareness, or the writer's spoken rhythm.
+
+- Untangle sentences without flattening the cadence. Split sentences and paragraphs when they are genuinely hard to follow. Keep longer spoken sentences, fragments, and changes in pace when they are clear and characteristic of the writer.
+
+- Be concrete and specific. Abstraction is where writing goes to die. "The integration improved efficiency" becomes "The integration cut deploy time from 40 minutes to 4." Names, numbers, dates, mechanisms, and examples beat abstractions.
+
+- Protect the specific fact. Don't smooth a useful detail into generic importance. "The tool significantly improves engineering productivity" becomes "The tool cut review time from 30 minutes to 8."
+
+- Make verbs do the work. Replace weak verb phrases with direct verbs. "Made a decision" becomes "decided." "Has the ability to" becomes "can."
+
+- Know the job. Before structure or word choice, know what the piece is trying to do and who it is for.
+
+- Preserve useful edge and character. Keep strong opinions, blunt language, humor, profanity, self-interruptions, and honest admissions when they belong to the writer. Don't replace them with safer or more professional wording.
+
+- Keep structure unless it's hurting the piece. Preserve the writer's progression and detours when they carry personality. If you reorganize, say why in the What changed section.
+
+## Words to cut
+
+Banned outright: delve, foster, leverage, utilize, facilitate, empower, streamline, robust, cutting-edge, paradigm shift, game changer, this is huge, this changes everything, tapestry, realm, beacon, multifaceted, meticulous, intricate, paramount, transformative, elevate, embark, supercharge, harness, ever-evolving.
+
+Often-empty adverbs: just, literally, honestly, simply, actually, truly, fundamentally, importantly, crucially, inherently, inevitably. Cut them when they add nothing. Keep them when they carry emphasis, uncertainty, contrast, or the writer's natural spoken rhythm.
+
+Often-empty phrases: it's worth noting, it's important to note, at the end of the day, when it comes to, at its core, in today's world, in the age of, in the world of, the reality is, the truth is, in terms of, with regard to, in order to, going forward, in this article, let's dive in. Cut them when they delay the point. Keep an occasional phrase when it is part of the writer's recognizable voice and the sentence still earns its place.
+
+## Patterns to cut
+
+Binary contrasts. "This is not X. It's Y." / "The question isn't X, it's Y." / "It's not just X but Y." State Y directly.
+
+Throat-clearing openers. "Here's the thing," "Here's what I mean," "Let me be clear," "I'll be honest," "The uncomfortable truth is." Cut them and state the point.
+
+Faux-insight setups. "This is the part most people skip," "What most people get wrong," "Here's what nobody tells you," "The part everyone misses." Cut the setup and make the claim stand on its own.
+
+Colon reveals. A noun phrase, a colon, then a lowercase dramatic reveal. Rewrite as a plain sentence. Use colons for lists, labels, and quotes, not fake drama.
+
+Superficial analysis. Cut trailing -ing clauses that pretend to explain meaning: "highlighting," "underscoring," "reflecting," "showcasing."
+
+Importance puffery. "Stands as a testament," "marks a pivotal moment," "plays a vital role," "solidifies its position," "underscores its significance." State the fact and let the reader judge.
+
+Weasel attribution. "Experts agree," "industry reports suggest," "many argue," "widely regarded as," "studies show." Name the source or cut the claim.
+
+Fake-strong verbs. Prefer "is" and "has" when they are clearer. "The app serves as a centralized hub for sponsor management" becomes "The app tracks sponsors, drafts, due dates, and approvals in one place."
+
+Synonym cycling. If the clear word is right, repeat it. Don't rotate terms for style.
+
+Negative listing. "Not a X. Not a Y. A Z." Just say Z.
+
+Dramatic fragmentation. "X. And Y. And Z." or "That's it. That's the whole thing." Use complete sentences.
+
+Robotic rhythm. Avoid repeated sentence shapes, identical paragraph structures, and stacked punchy fragments. Vary the shape only when it helps the point.
+
+Rhetorical setups. "What if I told you...", "Think about it:", "Plot twist:", and self-answered "Question? Answer." pairs. Drop them and make the point.
+
+Fake-profound kickers. Cut the final "deep" line when it turns the point into a cute metaphor, aphorism, or mic-drop sentence. Delete it, then end on the clearest concrete sentence already in the draft.
+
+Summary-recap endings. "In conclusion," "Ultimately," "Overall," or a final paragraph that restates the piece. End on the last concrete point, takeaway, or next action instead.
+
+Formatting slop. Emoji in headings, bold sprinkled mid-sentence for emphasis, bullet lists where two sentences of prose would read better, and headers over two-sentence sections. Format should follow the content, not decorate it.
+
+Em dashes. Do not use them as a default rhythm crutch. In short copy, use none. In longer drafts, 1–2 are fine if they clearly beat commas, periods, or parentheses. Remove clusters and decorative dashes.
+
+## Workflow
+
+- Read the full draft before editing.
+- Identify the core point and 3–5 voice signals to preserve: vocabulary, cadence, bluntness, humor, uncertainty, digressions. Keep this note internal.
+- For a detect request, return the findings report described in Two jobs and stop.
+- For an edit, make the minimum effective changes, then check the edited draft against the patterns above.
+- If any check fails, fix the draft and run the checks again.
+- Output the full edited draft and a short What changed section.


### PR DESCRIPTION
## Summary
- Adds the no-ai-slop skill (from github.com/petergyang/no-ai-slop) as a new content skill at `agents/skills/content/no-ai-slop/SKILL.md`
- Wires it into Ivy's WORKFLOW.md as step 2b — she now runs every draft through it after sindustries-copy produces copy, before committing

## System Spec
No system spec change — agent tooling and workflow update only, no user-facing behaviour change

## Test plan
- [ ] Ivy's WORKFLOW.md now contains step 2b referencing the no-ai-slop skill path
- [ ] SKILL.md contains the full ruleset (banned words, patterns to cut, editing principles, workflow)

🤖 Generated with Claude Code