### PR TITLE
chore(code-garden): replace hard-coded paths in lobster yaml with env vars [2026-W30]

### DIFF
--- a/agents/workflows/content-tasks/content-task.lobster.yaml
+++ b/agents/workflows/content-tasks/content-task.lobster.yaml
@@ -6,7 +6,7 @@ args:
   tasksApiBaseUrl:
     default: ${TASKS_API_BASE_URL}
   sindustriesRepo:
-    default: /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries
+    default: ${SINDUSTRIES_REPO}
   ivyCapacityLimit:
     default: 1
   dryRun:

--- a/agents/workflows/feature-task/code-task.lobster.yaml
+++ b/agents/workflows/feature-task/code-task.lobster.yaml
@@ -21,9 +21,9 @@ args:
   tasksApiBaseUrl:
     default: ${TASKS_API_BASE_URL}
   sindustriesRepo:
-    default: /Users/quinnstoffer/workspaces/rowan/sindustries
+    default: ${SINDUSTRIES_REPO}
   workspaceRoot:
-    default: /Users/quinnstoffer/.openclaw/workspace
+    default: ${WORKSPACE_ROOT}
   dryRun:
     default: false
 

--- a/agents/workflows/feature-task/feature-task.lobster.yaml
+++ b/agents/workflows/feature-task/feature-task.lobster.yaml
@@ -6,9 +6,9 @@ args:
   tasksApiBaseUrl:
     default: ${TASKS_API_BASE_URL}
   sindustriesRepo:
-    default: /Users/quinnstoffer/workspaces/rowan/sindustries
+    default: ${SINDUSTRIES_REPO}
   workspaceRoot:
-    default: /Users/quinnstoffer/.openclaw/workspace
+    default: ${WORKSPACE_ROOT}
   dryRun:
     default: false
 

--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -353,7 +353,7 @@ No new performance concerns this week. The Content Scheduler auto-post correctly
 - *Effort:* M
 - *Follow-up classification:* `garden-safe`.
 
-**2-C. Replace hard-coded paths in `feature-task.lobster.yaml` with env vars** (carries from W29) ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**2-C. Replace hard-coded paths in `feature-task.lobster.yaml` with env vars** (carries from W29) ✅ [PR #281](https://github.com/Stoffer-Industries/sindustries/pull/281)
 - *Files:* `agents/workflows/feature-task/feature-task.lobster.yaml`, `agents/workflows/feature-task/code-task.lobster.yaml`, `agents/workflows/content-tasks/content-task.lobster.yaml`
 - *AC:* No absolute paths.
 - *Effort:* S

--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -353,8 +353,8 @@ No new performance concerns this week. The Content Scheduler auto-post correctly
 - *Effort:* M
 - *Follow-up classification:* `garden-safe`.
 
-**2-C. Replace hard-coded paths in `feature-task.lobster.yaml` with env vars** (carries from W29)
-- *Files:* `agents/workflows/feature-task/feature-task.lobster.yaml`
+**2-C. Replace hard-coded paths in `feature-task.lobster.yaml` with env vars** (carries from W29) ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+- *Files:* `agents/workflows/feature-task/feature-task.lobster.yaml`, `agents/workflows/feature-task/code-task.lobster.yaml`, `agents/workflows/content-tasks/content-task.lobster.yaml`
 - *AC:* No absolute paths.
 - *Effort:* S
 - *Follow-up classification:* `garden-safe`.


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W30.md
- **Finding:** [Medium] `feature-task.lobster.yaml:9-11` still hard-codes Rowan's filesystem paths (carryover from W29)
- Replaced `sindustriesRepo` and `workspaceRoot` `args.defaults` with `${SINDUSTRIES_REPO}` and `${WORKSPACE_ROOT}` env-var references in three lobster yamls (`feature-task`, `code-task`, `content-tasks`), matching the existing `${TASKS_API_BASE_URL}` pattern. Audit flagged `feature-task.lobster.yaml`; the two sister files (`code-task.lobster.yaml` shipped in PR #276 and `content-task.lobster.yaml`) share the same shape and were fixed in the same PR to avoid leaving them hard-coded while the third becomes portable.

## Test plan
- [ ] YAML parses cleanly (validated with `python3 -c "import yaml; yaml.safe_load(open('agents/workflows/feature-task/feature-task.lobster.yaml'))"` for all three files)
- [ ] No logic changes — diff is purely a default-value swap from absolute path to env-var reference
- [ ] Next lobster run resolves `${SINDUSTRIES_REPO}` and `${WORKSPACE_ROOT}` from env (operators on Tom/Quinn machines will need the env vars set, same as `${TASKS_API_BASE_URL}` today)

## Audit follow-up
- Marked 2026-W30 finding **2-C** as done with `✅ [PR #TBD]`.

🌱 Code garden — non-functional cleanup only