### PR TITLE
fix(content-workflow): treat SKIPPED CI checks as passing

### DIFF
--- a/agents/workflows/content-tasks/scripts/common.py
+++ b/agents/workflows/content-tasks/scripts/common.py
@@ -337,7 +337,7 @@ def gh_pr_ci_state(url: str) -> str:
     if not checks:
         return "UNKNOWN"
     states = [check["state"] for check in checks]
-    if all(state == "SUCCESS" for state in states):
+    if all(state in {"SUCCESS", "SKIPPED"} for state in states):
         return "SUCCESS"
     if any(state in {"FAILURE", "FAILED", "ERROR", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"} for state in states):
         return "FAILURE"


### PR DESCRIPTION
## Summary

- `gh_pr_ci_state` required ALL checks to be `SUCCESS` to return a passing state — but GitHub emits `SKIPPED` for conditional steps (e.g. `EAS update on main`) that intentionally don't run on content PRs
- A single `SKIPPED` check caused the overall CI state to fall through to `UNKNOWN`, blocking the doing→acceptance transition in `pr_transition.py`
- Fix: treat `{"SUCCESS", "SKIPPED"}` as passing when evaluating overall CI state

## Root cause

PR #256 (content task 2026-07-17) had `EAS update on main: SKIPPED` — correct and expected for a content PR. The lobster's dry-run reported it as a failure, keeping the task stuck in `doing`.

## Test plan

- [ ] Existing `test_pr_transition_headings.py` passes (1 test, confirmed locally)
- [ ] Content task dry-run for the 2026-07-17 task advances cleanly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)