### PR TITLE
feat(gymtrack): agent API for planned workouts (task f520c396, AC1)

### DIFF
--- a/apps/gymtrack/.env.example
+++ b/apps/gymtrack/.env.example
@@ -1,10 +1,14 @@
 # GymTrack — Supabase configuration
 #
-# Both values are PUBLIC-by-design: Vite inlines them into the JS bundle at build time.
+# VITE_* values are PUBLIC-by-design: Vite inlines them into the JS bundle at build time.
 # The anon key is intended to be public; RLS policies are the gate.
+#
+# SUPABASE_SERVICE_ROLE_KEY is server-only. NEVER commit a real value.
+# It is used only by Vercel/serverless API routes for privileged Supabase lookups.
 #
 # These values are provisioned by Quinn in Vercel project settings (not committed).
 # Local dev: copy this file to `.env` and fill in values from Supabase project API settings.
 
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key-here
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here

--- a/apps/gymtrack/api/agent/planned-workouts.js
+++ b/apps/gymtrack/api/agent/planned-workouts.js
@@ -1,0 +1,211 @@
+// apps/gymtrack/api/agent/planned-workouts.js
+//
+// Vercel serverless handler for POST /api/agent/planned-workouts.
+//
+// Authenticated agents submit a planned workout for the user behind their
+// bearer token. Validates payload bounds, inserts parent + child rows, and
+// returns { plannedWorkoutId, setCount } on success.
+//
+// Request body:
+//   {
+//     "scheduledFor": "2026-07-24",          // YYYY-MM-DD
+//     "title": "Upper Body Strength",        // non-empty
+//     "notes": "optional agent rationale",   // optional
+//     "exercises": [
+//       {
+//         "name": "Bench Press",
+//         "sets": [
+//           { "reps": 8, "weight": 80, "unit": "kg", "notes": "RPE 7" }
+//         ]
+//       }
+//     ]
+//   }
+//
+// Response:
+//   201 { "plannedWorkoutId": "<uuid>", "setCount": <number> }
+//   400 { "error": "invalid_request", "message": "<reason>" }
+//   401 { "error": "invalid_api_key" }
+//   405 { "error": "method_not_allowed" }
+//   500 { "error": "server_error", "message": "<reason>" }
+
+import {
+  adminClient,
+  badRequest,
+  rejectIfWrongMethod,
+  resolveAgentIdentity,
+  unauthorized
+} from '../../server/agentAuth.js';
+
+const MAX_EXERCISES_PER_PLAN = 25;
+const MAX_SETS_PER_EXERCISE = 20;
+const MAX_TOTAL_SETS = 200;
+
+function isPositiveInt(n) {
+  return Number.isInteger(n) && n > 0;
+}
+
+function isNonNegativeNumber(n) {
+  return typeof n === 'number' && Number.isFinite(n) && n >= 0;
+}
+
+/**
+ * Validate the POST body shape and bounds. Returns null on success or a
+ * human-readable error message describing the first violation found.
+ */
+export function validatePlannedWorkoutBody(body) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return 'Body must be a JSON object.';
+  }
+  const { scheduledFor, title, notes, exercises } = body;
+
+  if (typeof scheduledFor !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(scheduledFor)) {
+    return 'scheduledFor must be a YYYY-MM-DD date string.';
+  }
+  if (typeof title !== 'string' || title.trim().length === 0) {
+    return 'title must be a non-empty string.';
+  }
+  if (notes != null && typeof notes !== 'string') {
+    return 'notes must be a string when provided.';
+  }
+  if (!Array.isArray(exercises) || exercises.length === 0) {
+    return 'exercises must be a non-empty array.';
+  }
+  if (exercises.length > MAX_EXERCISES_PER_PLAN) {
+    return `exercises must have at most ${MAX_EXERCISES_PER_PLAN} entries.`;
+  }
+
+  let totalSets = 0;
+  for (let ei = 0; ei < exercises.length; ei += 1) {
+    const exercise = exercises[ei];
+    if (!exercise || typeof exercise !== 'object' || Array.isArray(exercise)) {
+      return `exercises[${ei}] must be an object.`;
+    }
+    if (typeof exercise.name !== 'string' || exercise.name.trim().length === 0) {
+      return `exercises[${ei}].name must be a non-empty string.`;
+    }
+    if (!Array.isArray(exercise.sets) || exercise.sets.length === 0) {
+      return `exercises[${ei}].sets must be a non-empty array.`;
+    }
+    if (exercise.sets.length > MAX_SETS_PER_EXERCISE) {
+      return `exercises[${ei}].sets must have at most ${MAX_SETS_PER_EXERCISE} entries.`;
+    }
+    totalSets += exercise.sets.length;
+    if (totalSets > MAX_TOTAL_SETS) {
+      return `Total set count across all exercises must not exceed ${MAX_TOTAL_SETS}.`;
+    }
+    for (let si = 0; si < exercise.sets.length; si += 1) {
+      const set = exercise.sets[si];
+      if (!set || typeof set !== 'object' || Array.isArray(set)) {
+        return `exercises[${ei}].sets[${si}] must be an object.`;
+      }
+      if (!isPositiveInt(set.reps)) {
+        return `exercises[${ei}].sets[${si}].reps must be a positive integer.`;
+      }
+      if (!isNonNegativeNumber(set.weight)) {
+        return `exercises[${ei}].sets[${si}].weight must be a non-negative number.`;
+      }
+      const unit = set.unit ?? 'kg';
+      if (unit !== 'kg' && unit !== 'lb') {
+        return `exercises[${ei}].sets[${si}].unit must be 'kg' or 'lb'.`;
+      }
+      if (set.notes != null && typeof set.notes !== 'string') {
+        return `exercises[${ei}].sets[${si}].notes must be a string when provided.`;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Flatten the validated body into row arrays for parent + child inserts.
+ */
+export function buildInsertRows({ userId, keyId, body }) {
+  const setRows = [];
+  body.exercises.forEach((exercise) => {
+    exercise.sets.forEach((set, idx) => {
+      setRows.push({
+        planned_workout_id: undefined, // filled in after parent insert
+        exercise_name: exercise.name.trim(),
+        set_index: idx + 1,
+        target_reps: set.reps,
+        target_weight: set.weight,
+        unit: set.unit ?? 'kg',
+        notes: set.notes?.trim() || null
+      });
+    });
+  });
+  const parentRow = {
+    user_id: userId,
+    agent_key_id: keyId,
+    scheduled_for: body.scheduledFor,
+    title: body.title.trim(),
+    notes: body.notes?.trim() || null,
+    status: 'planned'
+  };
+  return { parentRow, setRows };
+}
+
+export default async function handler(req, res) {
+  if (rejectIfWrongMethod(req, res, ['POST'])) return;
+
+  let identity;
+  try {
+    identity = await resolveAgentIdentity(req);
+  } catch (err) {
+    return res.status(500).json({ error: 'server_error', message: err?.message ?? 'Auth lookup failed.' });
+  }
+  if (!identity) return unauthorized(res);
+
+  // Vercel does not always pre-parse JSON, depending on the runtime config;
+  // accept either a parsed body or a JSON string.
+  const body = typeof req.body === 'string'
+    ? safeJsonParse(req.body)
+    : req.body;
+
+  const validationError = validatePlannedWorkoutBody(body);
+  if (validationError) return badRequest(res, validationError);
+
+  const client = adminClient();
+  const { parentRow, setRows } = buildInsertRows({
+    userId: identity.user_id,
+    keyId: identity.key_id,
+    body
+  });
+
+  const { data: parent, error: parentErr } = await client
+    .from('planned_workouts')
+    .insert(parentRow)
+    .select()
+    .single();
+
+  if (parentErr || !parent) {
+    return res
+      .status(500)
+      .json({ error: 'server_error', message: parentErr?.message ?? 'Insert failed.' });
+  }
+
+  if (setRows.length > 0) {
+    const rowsWithFk = setRows.map((row) => ({ ...row, planned_workout_id: parent.id }));
+    const { error: setsErr } = await client.from('planned_workout_sets').insert(rowsWithFk);
+    if (setsErr) {
+      // Roll back the parent so we never leave a plan with zero target sets.
+      await client.from('planned_workouts').delete().eq('id', parent.id);
+      return res
+        .status(500)
+        .json({ error: 'server_error', message: setsErr.message });
+    }
+  }
+
+  return res.status(201).json({
+    plannedWorkoutId: parent.id,
+    setCount: setRows.length
+  });
+}
+
+function safeJsonParse(s) {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}

--- a/apps/gymtrack/server/agentAuth.js
+++ b/apps/gymtrack/server/agentAuth.js
@@ -1,0 +1,125 @@
+// apps/gymtrack/server/agentAuth.js
+//
+// Shared server-only helper for the /api/agent/* serverless endpoints.
+//
+// Responsibilities:
+//   - Parse the `Authorization: Bearer <token>` header.
+//   - Hash the token with SHA-256 and look up a non-revoked row in
+//     gymtrack_agent_api_keys.
+//   - Return the resolved identity (user_id + key_id), or null on auth failure.
+//   - Provide common response helpers (401 / 405 / 400).
+//
+// This module lives OUTSIDE the api/ directory on purpose: Vercel treats every
+// file in api/ as a route, and we want shared helpers to never be addressable
+// as public endpoints. Route handlers in apps/gymtrack/api/agent/* import from
+// here via relative paths.
+
+import { createClient } from '@supabase/supabase-js';
+import { createHash } from 'node:crypto';
+
+let _adminClient = null;
+
+export function _resetAdminClientForTests() {
+  _adminClient = null;
+}
+
+/**
+ * Returns a memoized Supabase client configured with the service-role key.
+ * Throws if required env vars are missing — that is a deploy-time configuration
+ * error and must surface, not be silently swallowed.
+ */
+export function adminClient() {
+  if (_adminClient) return _adminClient;
+  const url = process.env.VITE_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    throw new Error(
+      'GymTrack agent API: VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set.'
+    );
+  }
+  _adminClient = createClient(url, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false }
+  });
+  return _adminClient;
+}
+
+/**
+ * Hash a bearer token with SHA-256. Returns the lowercase hex digest.
+ * Exported so tests can pre-compute expected hashes.
+ */
+export function hashToken(token) {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * Parse `Authorization: Bearer <token>`. Returns the token string or null if
+ * the header is missing or malformed. Case-insensitive scheme matching.
+ */
+export function parseBearerToken(req) {
+  const header = req?.headers?.authorization ?? req?.headers?.Authorization;
+  if (!header || typeof header !== 'string') return null;
+  const match = header.match(/^Bearer\s+(\S+)$/i);
+  return match ? match[1] : null;
+}
+
+/**
+ * Resolve the agent identity behind a request.
+ *
+ * Returns `{ user_id, key_id }` on success, or `null` on any auth failure
+ * (missing header, malformed token, no matching row, revoked row).
+ *
+ * Throws on database errors so the caller can distinguish a server problem
+ * from a client auth failure.
+ *
+ * Best-effort: fires an async `last_used_at` update without awaiting it.
+ */
+export async function resolveAgentIdentity(req) {
+  const token = parseBearerToken(req);
+  if (!token) return null;
+
+  const client = adminClient();
+  const { data, error } = await client
+    .from('gymtrack_agent_api_keys')
+    .select('id, user_id')
+    .eq('token_hash', hashToken(token))
+    .is('revoked_at', null)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return null;
+
+  // Fire-and-forget touch of last_used_at — never block the response.
+  client
+    .from('gymtrack_agent_api_keys')
+    .update({ last_used_at: new Date().toISOString() })
+    .eq('id', data.id)
+    .then(() => {}, () => {});
+
+  return { user_id: data.user_id, key_id: data.id };
+}
+
+/**
+ * Reject non-matching HTTP methods. Returns true if a 405 was already sent and
+ * the caller should bail out.
+ */
+export function rejectIfWrongMethod(req, res, allowed) {
+  const allowedUpper = allowed.map((m) => m.toUpperCase());
+  if (allowedUpper.includes((req.method || '').toUpperCase())) return false;
+  res.setHeader('Allow', allowedUpper.join(', '));
+  res.status(405).json({ error: 'method_not_allowed' });
+  return true;
+}
+
+/**
+ * Send a 401 with the canonical agent API error shape.
+ */
+export function unauthorized(res, message = 'invalid_api_key') {
+  res.status(401).json({ error: message });
+}
+
+/**
+ * Send a 400 with a structured invalid_request payload.
+ */
+export function badRequest(res, message) {
+  res.status(400).json({ error: 'invalid_request', message });
+}

--- a/apps/gymtrack/src/lib/agentAuth.test.js
+++ b/apps/gymtrack/src/lib/agentAuth.test.js
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+
+// Mock @supabase/supabase-js so we can control the client factory and the
+// chainable queries used by adminClient() and resolveAgentIdentity().
+const { mockCreateClient } = vi.hoisted(() => ({
+  mockCreateClient: vi.fn()
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: mockCreateClient
+}));
+
+import {
+  _resetAdminClientForTests,
+  adminClient,
+  badRequest,
+  hashToken,
+  parseBearerToken,
+  rejectIfWrongMethod,
+  resolveAgentIdentity,
+  unauthorized
+} from '../../server/agentAuth.js';
+
+function buildChain(terminal) {
+  // Returns a Proxy that is chainable for any method, and resolves to `terminal`
+  // at the end (supports `.single()` and `.maybeSingle()` explicit terminators).
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'then') return (resolve) => resolve(terminal);
+        if (prop === 'single') return () => Promise.resolve(terminal);
+        if (prop === 'maybeSingle') return () => Promise.resolve(terminal);
+        return () => proxy;
+      }
+    }
+  );
+  return proxy;
+}
+
+const ORIGINAL_ENV = { ...process.env };
+
+function makeRes() {
+  const headers = {};
+  return {
+    headers,
+    statusCode: 200,
+    body: null,
+    setHeader(name, value) {
+      headers[name] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+beforeEach(() => {
+  _resetAdminClientForTests();
+  mockCreateClient.mockReset();
+  process.env.VITE_SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.restoreAllMocks();
+});
+
+describe('hashToken', () => {
+  it('returns a 64-character lowercase hex SHA-256 digest', () => {
+    const token = 'abc123token';
+    const expected = createHash('sha256').update(token).digest('hex');
+    expect(hashToken(token)).toBe(expected);
+    expect(hashToken(token)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(hashToken('hello')).toBe(hashToken('hello'));
+  });
+
+  it('produces different digests for different inputs', () => {
+    expect(hashToken('hello')).not.toBe(hashToken('hellp'));
+  });
+});
+
+describe('parseBearerToken', () => {
+  it('extracts the token from a standard Authorization header', () => {
+    expect(parseBearerToken({ headers: { authorization: 'Bearer abc123' } })).toBe('abc123');
+  });
+
+  it('is case-insensitive on the scheme', () => {
+    expect(parseBearerToken({ headers: { authorization: 'bearer abc123' } })).toBe('abc123');
+    expect(parseBearerToken({ headers: { authorization: 'BEARER abc123' } })).toBe('abc123');
+  });
+
+  it('returns null when the header is missing', () => {
+    expect(parseBearerToken({ headers: {} })).toBeNull();
+    expect(parseBearerToken({})).toBeNull();
+    expect(parseBearerToken(null)).toBeNull();
+  });
+
+  it('returns null when the scheme is wrong', () => {
+    expect(parseBearerToken({ headers: { authorization: 'Basic abc123' } })).toBeNull();
+    expect(parseBearerToken({ headers: { authorization: 'Token abc123' } })).toBeNull();
+  });
+
+  it('returns null when the token is empty or whitespace only', () => {
+    expect(parseBearerToken({ headers: { authorization: 'Bearer ' } })).toBeNull();
+    expect(parseBearerToken({ headers: { authorization: 'Bearer\t' } })).toBeNull();
+  });
+
+  it('accepts a capitalized Authorization header (Node convention)', () => {
+    expect(parseBearerToken({ headers: { Authorization: 'Bearer xyz' } })).toBe('xyz');
+  });
+
+  it('tolerates extra whitespace between the scheme and the token', () => {
+    expect(parseBearerToken({ headers: { authorization: 'Bearer   multi-token' } })).toBe(
+      'multi-token'
+    );
+  });
+});
+
+describe('rejectIfWrongMethod', () => {
+  it('returns false and does not respond when the method is allowed', () => {
+    const res = makeRes();
+    const sent = rejectIfWrongMethod({ method: 'POST' }, res, ['POST']);
+    expect(sent).toBe(false);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBeNull();
+  });
+
+  it('responds 405 with the Allow header when the method is not allowed', () => {
+    const res = makeRes();
+    const sent = rejectIfWrongMethod({ method: 'GET' }, res, ['POST']);
+    expect(sent).toBe(true);
+    expect(res.statusCode).toBe(405);
+    expect(res.headers.Allow).toBe('POST');
+    expect(res.body).toEqual({ error: 'method_not_allowed' });
+  });
+
+  it('accepts the method case-insensitively', () => {
+    const res = makeRes();
+    const sent = rejectIfWrongMethod({ method: 'post' }, res, ['POST']);
+    expect(sent).toBe(false);
+  });
+
+  it('lists every allowed method in the Allow header', () => {
+    const res = makeRes();
+    rejectIfWrongMethod({ method: 'PATCH' }, res, ['GET', 'POST']);
+    expect(res.headers.Allow).toBe('GET, POST');
+  });
+});
+
+describe('unauthorized', () => {
+  it('responds 401 with the default error code', () => {
+    const res = makeRes();
+    unauthorized(res);
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ error: 'invalid_api_key' });
+  });
+
+  it('honours a custom error message', () => {
+    const res = makeRes();
+    unauthorized(res, 'missing_api_key');
+    expect(res.body).toEqual({ error: 'missing_api_key' });
+  });
+});
+
+describe('badRequest', () => {
+  it('responds 400 with the canonical invalid_request shape', () => {
+    const res = makeRes();
+    badRequest(res, 'title is required');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'invalid_request', message: 'title is required' });
+  });
+});
+
+describe('adminClient', () => {
+  it('throws a clear deploy-time error if VITE_SUPABASE_URL is missing', () => {
+    delete process.env.VITE_SUPABASE_URL;
+    expect(() => adminClient()).toThrow(/VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY/);
+  });
+
+  it('throws a clear deploy-time error if SUPABASE_SERVICE_ROLE_KEY is missing', () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    expect(() => adminClient()).toThrow(/VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY/);
+  });
+
+  it('memoizes the client so createClient is only called once across calls', () => {
+    mockCreateClient.mockReturnValue({ from: vi.fn() });
+    const a = adminClient();
+    const b = adminClient();
+    expect(a).toBe(b);
+    expect(mockCreateClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes auth options that disable session persistence and token refresh', () => {
+    mockCreateClient.mockReturnValue({ from: vi.fn() });
+    adminClient();
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      'https://example.supabase.co',
+      'service-role-key',
+      expect.objectContaining({
+        auth: { persistSession: false, autoRefreshToken: false }
+      })
+    );
+  });
+});
+
+describe('resolveAgentIdentity', () => {
+  it('returns null without hitting the database when no Authorization header is present', async () => {
+    mockCreateClient.mockReturnValue({ from: vi.fn() });
+    const result = await resolveAgentIdentity({ headers: {} });
+    expect(result).toBeNull();
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('returns the user_id and key_id when the hashed token matches an active row', async () => {
+    const token = 'good-token';
+    const lookup = buildChain({ data: { id: 'key-1', user_id: 'user-1' }, error: null });
+    const update = buildChain({ error: null });
+    const fromMock = vi
+      .fn()
+      .mockReturnValueOnce(lookup)
+      .mockReturnValueOnce(update);
+    mockCreateClient.mockReturnValue({ from: fromMock });
+
+    const result = await resolveAgentIdentity({ headers: { authorization: `Bearer ${token}` } });
+    expect(result).toEqual({ user_id: 'user-1', key_id: 'key-1' });
+    expect(fromMock).toHaveBeenCalledWith('gymtrack_agent_api_keys');
+  });
+
+  it('returns null when no row matches the hashed token', async () => {
+    const lookup = buildChain({ data: null, error: null });
+    mockCreateClient.mockReturnValue({ from: vi.fn().mockReturnValueOnce(lookup) });
+
+    const result = await resolveAgentIdentity({ headers: { authorization: 'Bearer unknown' } });
+    expect(result).toBeNull();
+  });
+
+  it('throws on database errors so the caller can distinguish server vs auth failure', async () => {
+    const lookup = buildChain({ data: null, error: new Error('connection refused') });
+    mockCreateClient.mockReturnValue({ from: vi.fn().mockReturnValueOnce(lookup) });
+
+    await expect(
+      resolveAgentIdentity({ headers: { authorization: 'Bearer whatever' } })
+    ).rejects.toThrow(/connection refused/);
+  });
+
+  it('does not throw when the fire-and-forget last_used_at update rejects', async () => {
+    const lookup = buildChain({ data: { id: 'key-1', user_id: 'user-1' }, error: null });
+    const update = buildChain({ data: null, error: new Error('write conflict') });
+    const fromMock = vi
+      .fn()
+      .mockReturnValueOnce(lookup)
+      .mockReturnValueOnce(update);
+    mockCreateClient.mockReturnValue({ from: fromMock });
+
+    await expect(
+      resolveAgentIdentity({ headers: { authorization: 'Bearer whatever' } })
+    ).resolves.toEqual({ user_id: 'user-1', key_id: 'key-1' });
+  });
+});

--- a/apps/gymtrack/src/lib/plannedWorkouts.test.js
+++ b/apps/gymtrack/src/lib/plannedWorkouts.test.js
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildInsertRows,
+  validatePlannedWorkoutBody
+} from '../../api/agent/planned-workouts.js';
+
+describe('validatePlannedWorkoutBody', () => {
+  const validBody = () => ({
+    scheduledFor: '2026-07-24',
+    title: 'Upper Body Strength',
+    notes: 'agent rationale',
+    exercises: [
+      {
+        name: 'Bench Press',
+        sets: [{ reps: 8, weight: 80, unit: 'kg', notes: 'RPE 7' }]
+      }
+    ]
+  });
+
+  it('accepts a well-formed body', () => {
+    expect(validatePlannedWorkoutBody(validBody())).toBeNull();
+  });
+
+  it('rejects a non-object body', () => {
+    expect(validatePlannedWorkoutBody(null)).toMatch(/JSON object/);
+    expect(validatePlannedWorkoutBody(undefined)).toMatch(/JSON object/);
+    expect(validatePlannedWorkoutBody('string')).toMatch(/JSON object/);
+    expect(validatePlannedWorkoutBody([])).toMatch(/JSON object/);
+  });
+
+  it('requires a YYYY-MM-DD scheduledFor', () => {
+    const body = validBody();
+    body.scheduledFor = '07/24/2026';
+    expect(validatePlannedWorkoutBody(body)).toMatch(/YYYY-MM-DD/);
+  });
+
+  it('rejects an empty-string scheduledFor', () => {
+    const body = validBody();
+    body.scheduledFor = '';
+    expect(validatePlannedWorkoutBody(body)).toMatch(/YYYY-MM-DD/);
+  });
+
+  it('requires a non-empty title', () => {
+    const body = validBody();
+    body.title = '   ';
+    expect(validatePlannedWorkoutBody(body)).toMatch(/title/);
+  });
+
+  it('rejects notes that are not a string when provided', () => {
+    const body = validBody();
+    body.notes = 42;
+    expect(validatePlannedWorkoutBody(body)).toMatch(/notes must be a string/);
+  });
+
+  it('requires a non-empty exercises array', () => {
+    const body = validBody();
+    body.exercises = [];
+    expect(validatePlannedWorkoutBody(body)).toMatch(/non-empty array/);
+  });
+
+  it('enforces the per-plan exercises cap (25)', () => {
+    const body = validBody();
+    body.exercises = Array.from({ length: 26 }, () => ({
+      name: 'Bench',
+      sets: [{ reps: 5, weight: 50 }]
+    }));
+    expect(validatePlannedWorkoutBody(body)).toMatch(/at most 25/);
+  });
+
+  it('requires each exercise name to be a non-empty string', () => {
+    const body = validBody();
+    body.exercises[0].name = '';
+    expect(validatePlannedWorkoutBody(body)).toMatch(/name must be a non-empty string/);
+  });
+
+  it('requires each exercise to have a non-empty sets array', () => {
+    const body = validBody();
+    body.exercises[0].sets = [];
+    expect(validatePlannedWorkoutBody(body)).toMatch(/sets must be a non-empty array/);
+  });
+
+  it('enforces the per-exercise sets cap (20)', () => {
+    const body = validBody();
+    body.exercises[0].sets = Array.from({ length: 21 }, () => ({ reps: 5, weight: 50 }));
+    expect(validatePlannedWorkoutBody(body)).toMatch(/at most 20/);
+  });
+
+  it('enforces the total-sets cap (200)', () => {
+    const body = validBody();
+    body.exercises = Array.from({ length: 11 }, (_, i) => ({
+      name: `Exercise ${i}`,
+      sets: Array.from({ length: 20 }, () => ({ reps: 5, weight: 50 }))
+    }));
+    expect(validatePlannedWorkoutBody(body)).toMatch(/200/);
+  });
+
+  it('requires reps to be a positive integer', () => {
+    const body = validBody();
+    body.exercises[0].sets[0].reps = 0;
+    expect(validatePlannedWorkoutBody(body)).toMatch(/reps must be a positive integer/);
+    body.exercises[0].sets[0].reps = 1.5;
+    expect(validatePlannedWorkoutBody(body)).toMatch(/reps must be a positive integer/);
+    body.exercises[0].sets[0].reps = '5';
+    expect(validatePlannedWorkoutBody(body)).toMatch(/reps must be a positive integer/);
+  });
+
+  it('requires weight to be a non-negative finite number', () => {
+    const body = validBody();
+    body.exercises[0].sets[0].weight = -1;
+    expect(validatePlannedWorkoutBody(body)).toMatch(/weight must be a non-negative number/);
+    body.exercises[0].sets[0].weight = '80';
+    expect(validatePlannedWorkoutBody(body)).toMatch(/weight must be a non-negative number/);
+    body.exercises[0].sets[0].weight = NaN;
+    expect(validatePlannedWorkoutBody(body)).toMatch(/weight must be a non-negative number/);
+  });
+
+  it('accepts zero weight (bodyweight movements)', () => {
+    const body = validBody();
+    body.exercises[0].sets[0].weight = 0;
+    expect(validatePlannedWorkoutBody(body)).toBeNull();
+  });
+
+  it('defaults the unit to kg when missing', () => {
+    const body = validBody();
+    delete body.exercises[0].sets[0].unit;
+    expect(validatePlannedWorkoutBody(body)).toBeNull();
+  });
+
+  it('rejects an unknown unit', () => {
+    const body = validBody();
+    body.exercises[0].sets[0].unit = 'stones';
+    expect(validatePlannedWorkoutBody(body)).toMatch(/unit must be 'kg' or 'lb'/);
+  });
+
+  it('rejects non-string set notes when provided', () => {
+    const body = validBody();
+    body.exercises[0].sets[0].notes = 5;
+    expect(validatePlannedWorkoutBody(body)).toMatch(/notes must be a string/);
+  });
+
+  it('reports the offending exercise and set index for fast debugging', () => {
+    const body = validBody();
+    body.exercises[1] = { name: 'Squat', sets: [{ reps: 0, weight: 100 }] };
+    expect(validatePlannedWorkoutBody(body)).toMatch(/exercises\[1\]\.sets\[0\]\.reps/);
+  });
+});
+
+describe('buildInsertRows', () => {
+  it('flattens parent and child rows with user_id and key_id', () => {
+    const { parentRow, setRows } = buildInsertRows({
+      userId: 'user-1',
+      keyId: 'key-1',
+      body: {
+        scheduledFor: '2026-07-24',
+        title: 'Upper Body',
+        notes: 'workout rationale',
+        exercises: [
+          {
+            name: 'Bench Press',
+            sets: [
+              { reps: 8, weight: 80, unit: 'kg', notes: 'RPE 7' },
+              { reps: 8, weight: 82.5, unit: 'kg' }
+            ]
+          }
+        ]
+      }
+    });
+
+    expect(parentRow).toEqual({
+      user_id: 'user-1',
+      agent_key_id: 'key-1',
+      scheduled_for: '2026-07-24',
+      title: 'Upper Body',
+      notes: 'workout rationale',
+      status: 'planned'
+    });
+
+    expect(setRows).toHaveLength(2);
+    expect(setRows[0]).toMatchObject({
+      planned_workout_id: undefined,
+      exercise_name: 'Bench Press',
+      set_index: 1,
+      target_reps: 8,
+      target_weight: 80,
+      unit: 'kg',
+      notes: 'RPE 7'
+    });
+    expect(setRows[1]).toMatchObject({
+      set_index: 2,
+      target_weight: 82.5,
+      notes: null
+    });
+  });
+
+  it('trims whitespace from string fields', () => {
+    const { parentRow, setRows } = buildInsertRows({
+      userId: 'user-1',
+      keyId: 'key-1',
+      body: {
+        scheduledFor: '2026-07-24',
+        title: '  Upper Body  ',
+        notes: '  rationale  ',
+        exercises: [
+          {
+            name: '  Bench Press  ',
+            sets: [{ reps: 5, weight: 50, notes: '  warmup  ' }]
+          }
+        ]
+      }
+    });
+
+    expect(parentRow.title).toBe('Upper Body');
+    expect(parentRow.notes).toBe('rationale');
+    expect(setRows[0].exercise_name).toBe('Bench Press');
+    expect(setRows[0].notes).toBe('warmup');
+  });
+
+  it('defaults unit to kg and notes to null when missing', () => {
+    const { setRows } = buildInsertRows({
+      userId: 'u',
+      keyId: 'k',
+      body: {
+        scheduledFor: '2026-07-24',
+        title: 'Plan',
+        exercises: [{ name: 'Bench', sets: [{ reps: 5, weight: 50 }] }]
+      }
+    });
+    expect(setRows[0].unit).toBe('kg');
+    expect(setRows[0].notes).toBeNull();
+  });
+
+  it('numbers sets sequentially per exercise starting at 1', () => {
+    const { setRows } = buildInsertRows({
+      userId: 'u',
+      keyId: 'k',
+      body: {
+        scheduledFor: '2026-07-24',
+        title: 'Plan',
+        exercises: [
+          {
+            name: 'A',
+            sets: [{ reps: 5, weight: 50 }, { reps: 5, weight: 50 }, { reps: 5, weight: 50 }]
+          },
+          {
+            name: 'B',
+            sets: [{ reps: 5, weight: 50 }]
+          }
+        ]
+      }
+    });
+    expect(setRows.map((r) => r.set_index)).toEqual([1, 2, 3, 1]);
+    expect(setRows.slice(0, 3).map((r) => r.exercise_name)).toEqual(['A', 'A', 'A']);
+    expect(setRows[3].exercise_name).toBe('B');
+  });
+});

--- a/apps/gymtrack/src/lib/plannedWorkoutsHandler.test.js
+++ b/apps/gymtrack/src/lib/plannedWorkoutsHandler.test.js
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the agent auth module so we can stub adminClient() and
+// resolveAgentIdentity() independently of the real supabase client. The
+// response helpers (badRequest, unauthorized, rejectIfWrongMethod) are passed
+// through from the real module so the handler's bailing-on-truthy contract
+// keeps working unchanged.
+const mockAdminClient = { from: vi.fn() };
+
+vi.mock('../../server/agentAuth.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    adminClient: () => mockAdminClient,
+    resolveAgentIdentity: vi.fn()
+  };
+});
+
+import handler from '../../api/agent/planned-workouts.js';
+import { resolveAgentIdentity } from '../../server/agentAuth.js';
+
+function buildChain(terminal) {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'then') return (resolve) => resolve(terminal);
+        if (prop === 'single') return () => Promise.resolve(terminal);
+        if (prop === 'maybeSingle') return () => Promise.resolve(terminal);
+        return () => proxy;
+      }
+    }
+  );
+  return proxy;
+}
+
+function makeRes() {
+  const headers = {};
+  return {
+    headers,
+    statusCode: 200,
+    body: null,
+    setHeader(name, value) {
+      headers[name] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+const validBody = {
+  scheduledFor: '2026-07-24',
+  title: 'Upper Body',
+  notes: 'agent rationale',
+  exercises: [
+    {
+      name: 'Bench Press',
+      sets: [
+        { reps: 8, weight: 80, unit: 'kg', notes: 'RPE 7' },
+        { reps: 8, weight: 82.5, unit: 'kg' }
+      ]
+    },
+    {
+      name: 'Squat',
+      sets: [{ reps: 5, weight: 100, unit: 'kg' }]
+    }
+  ]
+};
+
+beforeEach(() => {
+  mockAdminClient.from.mockReset();
+  resolveAgentIdentity.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('POST /api/agent/planned-workouts', () => {
+  it('returns 405 with the Allow header for non-POST methods', async () => {
+    const res = makeRes();
+    await handler({ method: 'GET', headers: {}, body: {} }, res);
+    expect(res.statusCode).toBe(405);
+    expect(res.headers.Allow).toBe('POST');
+    expect(res.body).toEqual({ error: 'method_not_allowed' });
+    expect(resolveAgentIdentity).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when no agent identity is resolved', async () => {
+    resolveAgentIdentity.mockResolvedValueOnce(null);
+    const res = makeRes();
+    await handler(
+      { method: 'POST', headers: { authorization: 'Bearer unknown' }, body: validBody },
+      res
+    );
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ error: 'invalid_api_key' });
+    expect(mockAdminClient.from).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when resolveAgentIdentity throws', async () => {
+    resolveAgentIdentity.mockRejectedValueOnce(new Error('connection refused'));
+    const res = makeRes();
+    await handler(
+      { method: 'POST', headers: { authorization: 'Bearer whatever' }, body: validBody },
+      res
+    );
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error).toBe('server_error');
+    expect(res.body.message).toMatch(/connection refused/);
+    expect(mockAdminClient.from).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with the validation message when the body is malformed', async () => {
+    resolveAgentIdentity.mockResolvedValueOnce({ user_id: 'user-1', key_id: 'key-1' });
+    const res = makeRes();
+    await handler(
+      { method: 'POST', headers: { authorization: 'Bearer good' }, body: { title: '' } },
+      res
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+    expect(res.body.message).toMatch(/scheduledFor/);
+    expect(mockAdminClient.from).not.toHaveBeenCalled();
+  });
+
+  it('inserts the parent then the children and returns 201 with plannedWorkoutId + setCount', async () => {
+    resolveAgentIdentity.mockResolvedValueOnce({ user_id: 'user-1', key_id: 'key-1' });
+    mockAdminClient.from
+      .mockReturnValueOnce(buildChain({ data: { id: 'plan-uuid' }, error: null }))
+      .mockReturnValueOnce(buildChain({ error: null }));
+
+    const res = makeRes();
+    await handler(
+      { method: 'POST', headers: { authorization: 'Bearer good' }, body: validBody },
+      res
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({ plannedWorkoutId: 'plan-uuid', setCount: 3 });
+    expect(mockAdminClient.from.mock.calls[0][0]).toBe('planned_workouts');
+    expect(mockAdminClient.from.mock.calls[1][0]).toBe('planned_workout_sets');
+  });
+
+  it('rolls back the parent insert when the child insert fails', async () => {
+    resolveAgentIdentity.mockResolvedValueOnce({ user_id: 'user-1', key_id: 'key-1' });
+    mockAdminClient.from
+      .mockReturnValueOnce(buildChain({ data: { id: 'plan-uuid' }, error: null }))
+      .mockReturnValueOnce(buildChain({ error: new Error('FK violation') }))
+      .mockReturnValueOnce(buildChain({ error: null }));
+
+    const res = makeRes();
+    await handler(
+      { method: 'POST', headers: { authorization: 'Bearer good' }, body: validBody },
+      res
+    );
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error).toBe('server_error');
+    expect(res.body.message).toMatch(/FK violation/);
+    expect(mockAdminClient.from.mock.calls[0][0]).toBe('planned_workouts');
+    expect(mockAdminClient.from.mock.calls[1][0]).toBe('planned_workout_sets');
+    expect(mockAdminClient.from.mock.calls[2][0]).toBe('planned_workouts');
+  });
+
+  it('returns 500 when the parent insert itself fails', async () => {
+    resolveAgentIdentity.mockResolvedValueOnce({ user_id: 'user-1', key_id: 'key-1' });
+    mockAdminClient.from.mockReturnValueOnce(
+      buildChain({ data: null, error: new Error('parent insert failed') })
+    );
+
+    const res = makeRes();
+    await handler(
+      { method: 'POST', headers: { authorization: 'Bearer good' }, body: validBody },
+      res
+    );
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error).toBe('server_error');
+    expect(res.body.message).toMatch(/parent insert failed/);
+    expect(mockAdminClient.from.mock.calls[0][0]).toBe('planned_workouts');
+    expect(mockAdminClient.from.mock.calls).toHaveLength(1);
+  });
+
+  it('parses a stringified JSON body for Vercel runtime variance', async () => {
+    resolveAgentIdentity.mockResolvedValueOnce({ user_id: 'user-1', key_id: 'key-1' });
+    mockAdminClient.from
+      .mockReturnValueOnce(buildChain({ data: { id: 'plan-uuid' }, error: null }))
+      .mockReturnValueOnce(buildChain({ error: null }));
+
+    const res = makeRes();
+    await handler(
+      {
+        method: 'POST',
+        headers: { authorization: 'Bearer good' },
+        body: JSON.stringify(validBody)
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({ plannedWorkoutId: 'plan-uuid', setCount: 3 });
+  });
+});

--- a/apps/gymtrack/supabase/migrations/20260723170000_agent_powered_workouts.sql
+++ b/apps/gymtrack/supabase/migrations/20260723170000_agent_powered_workouts.sql
@@ -1,0 +1,144 @@
+-- GymTrack Agent-Powered Workouts — agent API keys + planned workouts (task f520c396).
+--
+-- Adds three tables that let a user generate per-user API keys, allow external
+-- agents to submit planned workouts, and link actual logged sets back to the
+-- planned targets. Also adds two nullable foreign-key columns on the existing
+-- workouts / workout_sets tables so a logged workout can reference its plan.
+--
+-- Apply via:
+--   supabase db push
+-- or:
+--   psql -f apps/gymtrack/supabase/migrations/20260723170000_agent_powered_workouts.sql
+--
+-- .openclaw boundary:
+--   No Vercel env vars or secrets are set in this migration.
+--   Deployment secrets (VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, etc.) are
+--   outside repo scope; if missing during implementation, post `[openclaw-needed]`
+--   with the exact env var names and target deployment.
+
+----------------------------------------------------------------------
+-- 1) agent API keys — one row per agent credential a user has generated
+----------------------------------------------------------------------
+
+create table if not exists public.gymtrack_agent_api_keys (
+  id            uuid primary key default gen_random_uuid(),
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  label         text not null,
+  -- SHA-256 hex digest of the bearer token. Plaintext tokens are never stored.
+  token_hash    text not null unique,
+  -- First 8 chars of the plaintext token for display in the UI list only.
+  token_prefix  text not null,
+  last_used_at  timestamptz,
+  revoked_at    timestamptz,
+  created_at    timestamptz not null default now()
+);
+
+create index if not exists gymtrack_agent_api_keys_user_idx
+  on public.gymtrack_agent_api_keys (user_id);
+
+-- Lookup by hash on every request; partial index excludes revoked keys.
+create index if not exists gymtrack_agent_api_keys_hash_idx
+  on public.gymtrack_agent_api_keys (token_hash)
+  where revoked_at is null;
+
+----------------------------------------------------------------------
+-- 2) planned workouts — created by an agent on behalf of a user
+----------------------------------------------------------------------
+
+create table if not exists public.planned_workouts (
+  id              uuid primary key default gen_random_uuid(),
+  user_id         uuid not null references auth.users(id) on delete cascade,
+  agent_key_id    uuid references public.gymtrack_agent_api_keys(id) on delete set null,
+  scheduled_for   date not null,
+  title           text not null,
+  notes           text,
+  status          text not null default 'planned'
+                    check (status in ('planned', 'started', 'completed', 'archived')),
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+
+create index if not exists planned_workouts_user_scheduled_idx
+  on public.planned_workouts (user_id, scheduled_for desc);
+
+-- Reuse the set_updated_at() function from the init migration.
+drop trigger if exists planned_workouts_set_updated_at on public.planned_workouts;
+create trigger planned_workouts_set_updated_at
+  before update on public.planned_workouts
+  for each row execute function public.set_updated_at();
+
+----------------------------------------------------------------------
+-- 3) planned workout sets — one row per target set
+----------------------------------------------------------------------
+
+create table if not exists public.planned_workout_sets (
+  id                 uuid primary key default gen_random_uuid(),
+  planned_workout_id uuid not null references public.planned_workouts(id) on delete cascade,
+  exercise_name      text not null,
+  set_index          int  not null,
+  target_reps        int  not null check (target_reps > 0),
+  target_weight      numeric not null check (target_weight >= 0),
+  unit               text not null default 'kg' check (unit in ('kg', 'lb')),
+  notes              text,
+  created_at         timestamptz not null default now()
+);
+
+create index if not exists planned_workout_sets_plan_idx
+  on public.planned_workout_sets (planned_workout_id, set_index);
+
+----------------------------------------------------------------------
+-- 4) link logged workouts / sets back to their plan
+----------------------------------------------------------------------
+
+alter table public.workouts
+  add column if not exists planned_workout_id uuid
+    references public.planned_workouts(id) on delete set null;
+
+alter table public.workout_sets
+  add column if not exists planned_set_id uuid
+    references public.planned_workout_sets(id) on delete set null;
+
+create index if not exists workouts_user_plan_idx
+  on public.workouts (user_id, planned_workout_id);
+
+----------------------------------------------------------------------
+-- 5) RLS
+----------------------------------------------------------------------
+
+alter table public.gymtrack_agent_api_keys enable row level security;
+alter table public.planned_workouts       enable row level security;
+alter table public.planned_workout_sets   enable row level security;
+
+-- API keys: user sees/creates/revokes only their own. Token plaintext is never
+-- stored, so reads return metadata (prefix / label / timestamps) only.
+drop policy if exists gymtrack_agent_api_keys_user_isolation on public.gymtrack_agent_api_keys;
+create policy gymtrack_agent_api_keys_user_isolation on public.gymtrack_agent_api_keys
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Planned workouts: user sees/inserts/updates only their own.
+drop policy if exists planned_workouts_user_isolation on public.planned_workouts;
+create policy planned_workouts_user_isolation on public.planned_workouts
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Planned sets: scoped through the parent planned_workout's user_id.
+drop policy if exists planned_workout_sets_user_isolation on public.planned_workout_sets;
+create policy planned_workout_sets_user_isolation on public.planned_workout_sets
+  for all
+  using (
+    exists (
+      select 1 from public.planned_workouts p
+      where p.id = planned_workout_sets.planned_workout_id
+        and p.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.planned_workouts p
+      where p.id = planned_workout_sets.planned_workout_id
+        and p.user_id = auth.uid()
+    )
+  );

--- a/docs/specs/gymtrack-agent-powered-workouts-tech-design.md
+++ b/docs/specs/gymtrack-agent-powered-workouts-tech-design.md
@@ -1,0 +1,226 @@
+---
+status: draft
+task_id: f520c396-9664-4210-b149-180371dc8a53
+product_spec: brain/tasks/specs/in-progress/gymtrack-agent-powered-workouts.md
+shipped_pr: null
+shipped_date: null
+---
+
+# GymTrack Agent-Powered Workouts — tech design
+
+## Links
+
+- Product spec: `brain/tasks/specs/in-progress/gymtrack-agent-powered-workouts.md`
+- Task: `f520c396-9664-4210-b149-180371dc8a53` (`GymTrack Agent-Powered Workouts`)
+- Tasks API record: `http://localhost:4001/api/v1/tasks/f520c396-9664-4210-b149-180371dc8a53`
+- Prior GymTrack MVP design: `docs/specs/gymtrack-mvp-tech-design.md`
+- Existing app: `apps/gymtrack/`
+
+## Repositories
+
+- Primary repo: `Stoffer-Industries/sindustries`
+- Branch: `task-f520c396-gymtrack-agent-powered-workouts`
+- Worktree: `/Users/quinnstoffer/workspaces/rowan/sindustries-task-f520c396-gymtrack-agent-powered-workouts`
+- No secondary repo changes expected.
+
+## Product intent
+
+The task describes the desired outcome as:
+
+> An AI agent can create a planned workout for a GymTrack user before they go to the gym. The user opens the app, sees their workout ready, and logs actual performance set by set. Both planned targets and actual results are stored and visible side by side. Any user can sign up to GymTrack, generate an API key, and connect their own agent.
+
+This builds on the shipped GymTrack MVP app: authenticated users can already log actual workout sets and view recent history. This feature adds an agent-facing write/read API, user-generated API keys, planned workout storage, and UI flows for logging actuals against plan targets.
+
+## Source-read note
+
+The product spec path is iCloud-backed under `brain/`; this agent hit macOS `Operation not permitted` when reading the file directly. The task description has been rebuilt from that spec and includes the accepted intent, ACs, checksum, and Rowan workstream, so this design is grounded on that task record plus current repo inspection.
+
+## Service boundary and data ownership
+
+- GymTrack owns its own app domain and data model under `apps/gymtrack/` and its Supabase schema.
+- Supabase remains the source of truth for GymTrack workouts. The SIndustries Tasks API is not involved in workout data.
+- The browser app may use the public Supabase anon key under RLS. Agent access must not expose the Supabase service-role key; any API-key validation that needs privileged lookup runs in server-side Vercel functions or equivalent serverless runtime under `apps/gymtrack/api/`.
+- API keys are user-owned GymTrack credentials, not OpenClaw credentials. Keys authenticate agents to GymTrack only.
+- Extraction plan: if GymTrack grows beyond a small SPA plus serverless API, move API-key auth and planning endpoints into a dedicated GymTrack service. Keep the request/response contracts below stable so agents do not depend on Supabase internals.
+
+## `.openclaw` boundary
+
+- No `.openclaw/` files should be edited in this repo PR.
+- Deployment secrets are outside repo scope: `SUPABASE_SERVICE_ROLE_KEY` (server-only), `VITE_SUPABASE_URL`, and `VITE_SUPABASE_ANON_KEY` need to be present in the GymTrack deployment. If missing during implementation, post `[openclaw-needed]` with the exact env var names and target deployment.
+- Real API keys generated for users are secrets. Do not commit examples containing real tokens; docs should use `gym_sk_example...` placeholders only.
+
+## Acceptance criteria recap
+
+- **AC1:** An authenticated agent can submit a planned workout containing one or more exercises, each with one or more target sets (reps and weight). The planned workout is stored and associated with a specific user.
+- **AC2:** When a user logs actual performance against a planned workout, both the targets and the actuals are stored and linked. A user can see, for each set, the planned target alongside what they actually did.
+- **AC3:** An authenticated agent can retrieve a user recent workout history (last N sessions) and the progression history for a specific exercise, so it can inform the next planned workout.
+
+## Implementation plan
+
+### Data model and migrations
+
+Add a second GymTrack migration, e.g. `apps/gymtrack/supabase/migrations/20260723170000_agent_powered_workouts.sql`.
+
+New tables:
+
+- `public.gymtrack_agent_api_keys`
+  - `id uuid primary key default gen_random_uuid()`
+  - `user_id uuid not null references auth.users(id) on delete cascade`
+  - `label text not null`
+  - `token_hash text not null unique`
+  - `token_prefix text not null`
+  - `last_used_at timestamptz`
+  - `revoked_at timestamptz`
+  - `created_at timestamptz not null default now()`
+- `public.planned_workouts`
+  - `id uuid primary key default gen_random_uuid()`
+  - `user_id uuid not null references auth.users(id) on delete cascade`
+  - `agent_key_id uuid references public.gymtrack_agent_api_keys(id) on delete set null`
+  - `scheduled_for date not null`
+  - `title text not null`
+  - `notes text`
+  - `status text not null default 'planned' check (status in ('planned','started','completed','archived'))`
+  - `created_at timestamptz not null default now()`
+  - `updated_at timestamptz not null default now()`
+- `public.planned_workout_sets`
+  - `id uuid primary key default gen_random_uuid()`
+  - `planned_workout_id uuid not null references public.planned_workouts(id) on delete cascade`
+  - `exercise_name text not null`
+  - `set_index int not null`
+  - `target_reps int not null check (target_reps > 0)`
+  - `target_weight numeric not null check (target_weight >= 0)`
+  - `unit text not null default 'kg' check (unit in ('kg','lb'))`
+  - `notes text`
+  - `created_at timestamptz not null default now()`
+
+Modify existing tables:
+
+- `workouts.planned_workout_id uuid references public.planned_workouts(id) on delete set null`
+- `workout_sets.planned_set_id uuid references public.planned_workout_sets(id) on delete set null`
+- Optionally `workout_sets.actual_notes text` if the UI needs per-set notes; keep out if not needed for ACs.
+
+Indexes:
+
+- `planned_workouts_user_scheduled_idx on planned_workouts(user_id, scheduled_for desc)`
+- `planned_workout_sets_plan_idx on planned_workout_sets(planned_workout_id, set_index)`
+- `agent_api_keys_hash_idx on gymtrack_agent_api_keys(token_hash) where revoked_at is null`
+- `workouts_user_plan_idx on workouts(user_id, planned_workout_id)`
+
+RLS:
+
+- Enable RLS on all new tables.
+- Authenticated users can select/insert/update/delete only their own API-key metadata and planned workouts.
+- For API key rows, expose `token_prefix`/metadata in the browser but never token plaintext; only the client-side generation screen sees the token once before hashing/inserting.
+- Planned workout set policies scope through the parent planned workout's `user_id`.
+- Serverless functions use the Supabase service-role key only after validating the bearer token hash; they must still explicitly write rows under the resolved `user_id`.
+
+### Agent API contract
+
+Add Vercel/serverless functions under `apps/gymtrack/api/agent/` so agents have a stable HTTPS contract independent of Supabase table shape.
+
+Authentication:
+
+- Header: `Authorization: Bearer gym_sk_<random>`
+- Server hashes the token with SHA-256 and looks up a non-revoked row in `gymtrack_agent_api_keys`.
+- On success, set `last_used_at = now()` asynchronously/best-effort and operate as that `user_id`.
+- On failure, return `401 { "error": "invalid_api_key" }`.
+
+Endpoints:
+
+- `POST /api/agent/planned-workouts`
+  - Request:
+    ```json
+    {
+      "scheduledFor": "2026-07-24",
+      "title": "Upper Body Strength",
+      "notes": "Optional agent rationale",
+      "exercises": [
+        {
+          "name": "Bench Press",
+          "sets": [
+            { "reps": 8, "weight": 80, "unit": "kg", "notes": "RPE 7" }
+          ]
+        }
+      ]
+    }
+    ```
+  - Validation: at least one exercise and one set; positive reps; non-negative weight; `unit` in `kg|lb`; max payload bounds to prevent accidental huge plans.
+  - Response: `201 { "plannedWorkoutId": "...", "setCount": 1 }`.
+- `GET /api/agent/history?limit=10`
+  - Returns recent completed workouts with actual sets and linked planned target fields when available.
+  - Bounds `limit` to a safe range, e.g. 1-50.
+- `GET /api/agent/exercises/:exerciseName/progression?limit=20`
+  - Returns chronological set history for that exercise: date, reps, weight, unit, optional planned reps/weight.
+  - Normalize matching with exact case-insensitive name for v1; defer aliases/synonyms.
+
+Implementation files:
+
+- `apps/gymtrack/api/agent/_auth.js` — token hashing, Supabase admin client, key lookup, shared error helpers.
+- `apps/gymtrack/api/agent/planned-workouts.js` — POST handler and insert transaction logic.
+- `apps/gymtrack/api/agent/history.js` — recent workout query.
+- `apps/gymtrack/api/agent/exercises/[exerciseName]/progression.js` or Vercel-compatible route equivalent — progression query.
+- `apps/gymtrack/src/lib/agentKeys.js` — browser helpers to create/revoke/list keys.
+- `apps/gymtrack/src/lib/plans.js` — browser helpers to list today's/open planned workouts and convert a plan into actual workout rows.
+
+### Browser app changes
+
+- Add an API key management screen reachable from the signed-in app, e.g. `/settings/agents`.
+  - Generate a random token in the browser using `crypto.getRandomValues`.
+  - Store only `sha256(token)` plus a short `token_prefix` in Supabase.
+  - Show the full token once with copy affordance and a warning that it cannot be recovered.
+  - List existing keys by label/prefix/created/last-used and allow revoke.
+- Update the workout route to show the user's next planned workout first.
+  - If a plan exists for today or the nearest future date, render each planned set with target reps/weight.
+  - Add actual reps/weight inputs next to each planned target.
+  - Saving creates a `workouts` row linked to `planned_workout_id` and `workout_sets` rows linked to each `planned_set_id`, then marks the plan `completed`.
+  - Preserve the existing freeform logging path when there is no plan.
+- Update history view to include planned-vs-actual details when linked plan data exists.
+- Update `apps/gymtrack/SPEC.md` for the new user flows: generate agent API key, view planned workout, log actuals against targets, inspect planned-vs-actual history.
+- Update `apps/gymtrack/README.md` with agent API examples and deployment env var requirements.
+
+### Workflow, cron, and skill changes
+
+- No SIndustries agent workflow or cron changes are required.
+- No OpenClaw skill changes are required.
+- Add documentation examples that an external agent can use, but do not register a live OpenClaw agent integration in this task.
+
+## Test plan
+
+### Unit and integration tests
+
+- Add serverless handler tests for `_auth`, `planned-workouts`, `history`, and `progression` with Supabase client mocked.
+- Add `agentKeys` tests for token format, SHA-256 hashing, one-time display state, and revoke behaviour.
+- Add `plans` tests for mapping planned set rows to actual set rows.
+- Extend existing `workouts` tests to cover `planned_workout_id` and `planned_set_id` linkage.
+
+### Component tests
+
+- API-key settings screen: create flow shows token once; key list shows prefixes only; revoke removes active key.
+- Workout logger: planned workout renders target and actual columns; saving calls the linked-plan helper and clears/completes the plan.
+- History list: planned target and actual result are visible side by side.
+
+### E2E tests
+
+Use Playwright against the GymTrack app with mocked/stubbed Supabase or a seeded local test project, whichever matches the existing GymTrack E2E setup during implementation.
+
+- User signs in, generates an API key, copies the one-time token.
+- Agent API creates a planned workout with at least one exercise and one target set.
+- User opens `/workout`, sees the plan, enters actuals, saves.
+- User opens `/history`, sees planned target and actual result side by side.
+- Agent API fetches recent history and exercise progression and receives the new workout data.
+
+### AC verification matrix
+
+| AC | Verification layer | Planned evidence |
+|---|---|---|
+| AC1 | API integration + E2E | `POST /api/agent/planned-workouts` test creates a stored plan for the API-key owner; E2E creates a plan through the agent endpoint and verifies it appears in app state. |
+| AC2 | Component + E2E | Planned workout logger test verifies target/actual fields and saved linkage; E2E verifies history displays planned target beside actual reps/weight. |
+| AC3 | API integration | `GET /api/agent/history` and `GET /api/agent/exercises/:exerciseName/progression` tests verify owner-scoped recent sessions and exercise progression payloads, including linked planned targets when present. |
+
+## Open questions and risks
+
+- **Spec read boundary:** direct spec-file access was blocked; if Quinn sees nuance missing from the source spec, update this design before approval.
+- **Serverless runtime:** current GymTrack is a static Vite app. Vercel functions are the lightest way to keep API-key validation server-side; if GymTrack is not deployed on Vercel, adjust to the actual host's function runtime before implementation.
+- **API-key plaintext:** users will only see generated tokens once. That is safer, but support docs need to make recovery/revoke clear.
+- **Transactions:** Supabase JS does not provide multi-statement transactions directly from serverless handlers unless using RPC. For plan creation, prefer a Postgres RPC (`create_planned_workout`) if partial inserts become likely; otherwise insert parent then child rows and clean up parent on child failure.
+- **Exercise name normalization:** exact case-insensitive progression is enough for v1, but agents may send aliases. Defer alias tables unless acceptance testing shows this blocks usefulness.


### PR DESCRIPTION
## Summary

Fresh PR after #284 was closed at 2026-07-23T18:37:45Z (deploy-secrets gate). Branch `task-f520c396-gymtrack-agent-powered-workouts` reuses the same implementation commits from #284 plus `b23a44a`, which documents the server-only service-role env var in `apps/gymtrack/.env.example`. The close was not a code-quality concern; all CI was green (12/12 SUCCESS, gymtrack tests 76/76) at close. Re-opening with the deploy secrets surfaced as `[openclaw-needed]` so the lobster holds the task in `doing` until they're provisioned.

## AC1 implementation (task f520c396, AC1)

- Three new GymTrack tables (`gymtrack_agent_api_keys`, `planned_workouts`, `planned_workout_sets`) plus nullable FKs on `workouts` / `workout_sets`. Migration `20260723170000_agent_powered_workouts.sql` is additive (nullable / default 0) so it applies cleanly to existing data.
- Server-only auth helper `apps/gymtrack/server/agentAuth.js` (lives in `server/` rather than `api/` so Vercel does not expose it as a public route). Hashes bearer tokens with SHA-256, looks up active keys via the service-role client (memoized), exposes response helpers (401/405/400).
- `POST /api/agent/planned-workouts` — authenticated agents submit a plan (date + title + exercises + target sets); validates body shape and bounds (≤25 exercises × ≤20 sets, ≤200 total); inserts parent + child rows with parent-delete rollback on child insert failure.
- 57 new tests across three new files (76 total in `apps/gymtrack`, all green).

## Deploy target

**GymTrack is deployed on Vercel** — confirmed via `apps/gymtrack/vercel.json` (framework: vite, outputDirectory: dist, SPA rewrites). The implementation assumes this: the API lives under `apps/gymtrack/api/agent/` (Vercel serverless convention), and `agentAuth.js` lives in `apps/gymtrack/server/` precisely because Vercel would otherwise expose it as a public route.

## [openclaw-needed] Deploy secrets

The AC1 implementation cannot be exercised against a real Supabase project until the following env vars are present in the GymTrack Vercel project (per the tech design's "Open Questions and Risks" section):

- `VITE_SUPABASE_URL` — Supabase project URL (public; inlined into Vite bundle at build)
- `VITE_SUPABASE_ANON_KEY` — Supabase anon key (public; RLS-gated)
- `SUPABASE_SERVICE_ROLE_KEY` — server-only key used by `apps/gymtrack/server/agentAuth.js` to look up `gymtrack_agent_api_keys` and write `last_used_at` outside of RLS. It is now documented in `apps/gymtrack/.env.example` with a server-only / never-commit-real-value warning.

Values are available to the operator in `~/.openclaw/.env` under the `GYMTRACK_SUPABASE_*` names. Do not paste real values into this PR or the repo.

Vercel CLI provisioning is currently blocked by a dead Vercel token (403 from both Rowan and Quinn sandboxes). The GymTrack Vercel project may not exist yet; Tom needs to create or locate it in the Vercel dashboard, then regenerate/provide a working Vercel token so Quinn/OpenClaw can provision these env vars.

Once these three are in the GymTrack Vercel project, the implementation is merge-ready. No code changes required post-merge — just the secret provisioning.

## System Spec

No system spec change — the agent API surface is mid-iteration (AC2 / AC3 will add `GET /api/agent/history` and `GET /api/agent/exercises/:name/progression`); the system spec will land once the full agent surface ships in one place, rather than half-documenting it now.

## Test plan

- [x] `npm test --workspace=apps/gymtrack` — 76 tests across 7 files all green (rerun at commit `b23a44a`)
- [ ] Apply migration `20260723170000_agent_powered_workouts.sql` to a fresh Supabase project; verify `gymtrack_agent_api_keys`, `planned_workouts`, `planned_workout_sets` exist with the expected columns / indexes / RLS policies *(requires deploy secrets)*
- [ ] Insert a row into `gymtrack_agent_api_keys` for a test user; POST a 2-exercise × 3-set plan with the corresponding bearer token; verify the parent row has `user_id` matching the key owner and three child rows in `planned_workout_sets` *(requires deploy secrets)*
- [ ] POST without `Authorization` → 401 `{ error: "invalid_api_key" }` *(requires deploy secrets)*
- [ ] POST with empty `title` → 400 with "title must be a non-empty string." *(requires deploy secrets)*
- [ ] POST with 26 exercises → 400 with "at most 25" message *(requires deploy secrets)*
- [ ] Forge a key whose `token_hash` matches an existing row but `revoked_at` is set → 401 *(requires deploy secrets)*

## Acceptance Criteria

- [x] AC1: An authenticated agent can submit a planned workout containing one or more exercises, each with one or more target sets (reps and weight). The planned workout is stored and associated with a specific user. (🧪 testID: `src/lib/plannedWorkoutsHandler.test.js > POST /api/agent/planned-workouts > inserts the parent then the children and returns 201 with plannedWorkoutId + setCount`; supporting coverage: `plannedWorkouts.test.js > validatePlannedWorkoutBody` and `> buildInsertRows`, `agentAuth.test.js > hashToken / parseBearerToken / rejectIfWrongMethod / unauthorized / badRequest / adminClient / resolveAgentIdentity`)
- [ ] AC2: When a user logs actual performance against a planned workout, both the targets and the actuals are stored and linked. A user can see, for each set, the planned target alongside what they actually did.
- [ ] AC3: An authenticated agent can retrieve a user's recent workout history (last N sessions) and the progression history for a specific exercise, so it can inform the next planned workout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)