### PR TITLE
fix(content): releases default to published, stale checker flags drafts

### DIFF
--- a/agents/skills/content/sindustries-copy/SKILL.md
+++ b/agents/skills/content/sindustries-copy/SKILL.md
@@ -135,7 +135,11 @@ Each output maps to a JSON file in that directory:
 | story | `stories/[slug].json` | title, slug, dek, body, source, visibility |
 | stack | `stacks.json` | title, slug, category, summary, updatedAt, visibility |
 
-All new content starts with `visibility: "draft"` unless Tom explicitly sets it to `"published"`.
+**Visibility defaults by type:**
+- `release` → always `"published"`. A release is an announcement of something already shipped; drafting it defeats the purpose.
+- `experiment`, `system`, `stack`, `story` → `"draft"` by default. These contain narrative and first-person voice that needs approval before going live.
+
+Never set a release to `"draft"` unless Tom explicitly asks.
 
 ---
 

--- a/agents/skills/content/sindustries-stale-content/check_stale_content.py
+++ b/agents/skills/content/sindustries-stale-content/check_stale_content.py
@@ -72,6 +72,16 @@ def main() -> None:
         if fpath.exists():
             all_stale.extend(check_file(fpath, threshold))
 
+    # Draft releases are always a signal — releases should always be published.
+    draft_releases: list[str] = []
+    releases_path = CONTENT_ROOT / "releases.json"
+    if releases_path.exists():
+        try:
+            releases = json.loads(releases_path.read_text())
+            draft_releases = [r.get("slug", "?") for r in releases if r.get("visibility") == "draft"]
+        except (json.JSONDecodeError, OSError):
+            pass
+
     if all_stale:
         print(f"STALE_CONTENT: {len(all_stale)} item(s) not updated in >{THRESHOLD_DAYS} days:")
         for item in all_stale:
@@ -79,6 +89,11 @@ def main() -> None:
             print(f"  - {item['file']} / {item['slug']} ({item['status']}, {days} days)")
     else:
         print(f"STALE_CHECK_OK: all active experiments/systems updated within {THRESHOLD_DAYS} days")
+
+    if draft_releases:
+        print(f"DRAFT_RELEASES: {len(draft_releases)} release(s) still visibility:draft — should be published:")
+        for slug in draft_releases:
+            print(f"  - {slug}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two changes so draft releases don't accumulate again:

- **sindustries-copy SKILL.md**: releases now default to `visibility: "published"`. A release is an announcement of something already shipped — drafting it defeats the point. Experiments, systems, stories, and stacks stay `draft`-by-default since they need narrative approval.
- **stale-content checker**: added a `DRAFT_RELEASES` check that flags any release still at `draft` visibility, so the weekly review surfaces it immediately rather than six weeks later.

## Test plan

- [ ] Verify the stale checker outputs `DRAFT_RELEASES: 0` after PR #293 merges
- [ ] Confirm new releases added by Ivy default to published going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)