### PR TITLE
fix(lobster): remove the ## System Spec PR-body gate

### DIFF
--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -145,7 +145,7 @@ Before writing any code on a feature task, write the tech design:
 ### AC checkboxes on the task — hands off
 **Never tick or untick AC checkboxes in the task description.** That is Tom/QA's gate, applied only once the task reaches `acceptance`. Rowan's evidence belongs in the PR body only.
 
-### System spec (required in the implementation PR)
+### System spec (documentation convention, not a lobster gate)
 
 Before converting the PR from draft to ready-for-review, write or update the system spec using the system-spec skill:
 `agents/skills/dev/system-spec/SKILL.md`
@@ -154,13 +154,11 @@ The spec must be committed on the implementation branch and included in the **sa
 
 Add a `## System Spec` section to the PR body (before `## Out of scope` or at the end):
 - If a spec was written or updated: `docs/systems/<file>.md` (plain or backtick-quoted)
-- If no spec change: a substantive sentence explaining why (>= 12 non-whitespace characters)
+- If no spec change: a short sentence explaining why
 
-The lobster's verify-delivery gate reads this section from the PR body and blocks until it is present and non-trivial. **No task comment is needed** — the PR body section is the gate.
+The lobster does **not** parse or block on this section — doc content is too varied to check reliably in code, so it's judgment-based. Write it anyway; it's the reviewer's fastest way to see whether behavior-level docs kept up with the change.
 
-**Do not name any other `docs/systems/*.md` file when explaining a no-change.** The lobster's parser grabs the first `docs/systems/*.md`-shaped string it finds in the section, whether or not it's your actual declaration — mentioning an existing doc for context will get parsed as a claimed update and silently pass the gate. Explain the no-change without naming any system-doc path.
-
-**This gate is separate from the app-spec requirement — check both, not just this one.** `agents/definitions/rowan/DoD.md` requires `apps/<app>/SPEC.md` updated whenever user-visible behaviour changes, independent of whether a system doc changed. The system-spec skill's consolidation bias (prefer existing docs, resist new files) is about `docs/systems/*.md` only — it is not a reason to skip an app spec update. Before converting draft → ready-for-review, check: does the app you touched have a `SPEC.md`, and does it describe behaviour you just added or changed? If yes, update it in this PR.
+**This is separate from the app-spec requirement — check both, not just this one.** `agents/definitions/rowan/DoD.md` requires `apps/<app>/SPEC.md` updated whenever user-visible behaviour changes, independent of whether a system doc changed. The system-spec skill's consolidation bias (prefer existing docs, resist new files) is about `docs/systems/*.md` only — it is not a reason to skip an app spec update. Before converting draft → ready-for-review, check: does the app you touched have a `SPEC.md`, and does it describe behaviour you just added or changed? If yes, update it in this PR.
 
 ### Acceptance
 Use the pr-address-feedback skill when handling review comments: `agents/skills/dev/pr-address-feedback/SKILL.md`

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -158,6 +158,10 @@ Add a `## System Spec` section to the PR body (before `## Out of scope` or at th
 
 The lobster's verify-delivery gate reads this section from the PR body and blocks until it is present and non-trivial. **No task comment is needed** — the PR body section is the gate.
 
+**Do not name any other `docs/systems/*.md` file when explaining a no-change.** The lobster's parser grabs the first `docs/systems/*.md`-shaped string it finds in the section, whether or not it's your actual declaration — mentioning an existing doc for context will get parsed as a claimed update and silently pass the gate. Explain the no-change without naming any system-doc path.
+
+**This gate is separate from the app-spec requirement — check both, not just this one.** `agents/definitions/rowan/DoD.md` requires `apps/<app>/SPEC.md` updated whenever user-visible behaviour changes, independent of whether a system doc changed. The system-spec skill's consolidation bias (prefer existing docs, resist new files) is about `docs/systems/*.md` only — it is not a reason to skip an app spec update. Before converting draft → ready-for-review, check: does the app you touched have a `SPEC.md`, and does it describe behaviour you just added or changed? If yes, update it in this PR.
+
 ### Acceptance
 Use the pr-address-feedback skill when handling review comments: `agents/skills/dev/pr-address-feedback/SKILL.md`
 

--- a/agents/skills/dev/pr-open/SKILL.md
+++ b/agents/skills/dev/pr-open/SKILL.md
@@ -59,6 +59,10 @@ EOF
 
 A short stub like "No change" will be treated as missing and will block acceptance.
 
+**Do not name any other `docs/systems/*.md` file in the no-change reason, even in passing.** The lobster's parser matches the *first* `docs/systems/\S+\.md`-shaped string anywhere in the section — it does not check whether you actually declared that file as updated. If your explanation mentions an existing system doc for context ("this already lives in docs/systems/tasks.md"), the lobster will treat that as your declared spec file and pass the gate even though nothing was touched. Write the no-change reason without naming any `docs/systems/*.md` path at all.
+
+**This section only covers `docs/systems/*.md`. It does not satisfy the app-spec requirement.** Per `docs/CONVENTIONS.md` (DoD item 3) and `agents/definitions/rowan/DoD.md`, if your change alters user-visible behaviour in an app that has an `apps/<app>/SPEC.md`, that file must be updated in this PR too — a system-doc no-change declaration does not exempt you from it. There is currently no automated gate for this, so check it by hand before opening the PR: does `apps/<app>/SPEC.md` exist, and does it describe the flow/screen you just changed? If yes, update it in the same PR and reference it in your AC evidence (`(📄 not code: updated apps/<app>/SPEC.md)`).
+
 Include a `Co-Authored-By` trailer in your commit messages identifying yourself:
 ```
 Co-Authored-By: <Your Name> <your-email>

--- a/agents/skills/dev/pr-open/SKILL.md
+++ b/agents/skills/dev/pr-open/SKILL.md
@@ -53,15 +53,9 @@ EOF
 )"
 ```
 
-**`## System Spec` is required on every feature-task PR.** The lobster's `verify_delivery` gate reads this section and blocks if it is absent or empty. Provide either:
-- The path to the spec file that was written or updated (`docs/systems/<file>.md`), plain or backtick-quoted.
-- A substantive no-change reason (at least 12 non-whitespace characters, no spec path) explaining why no spec was touched.
+**`## System Spec` is a documentation convention, not a lobster gate.** Note the path to the spec file you wrote or updated (`docs/systems/<file>.md`), or a short reason why none was touched. Nothing parses or blocks on this section — it's judgment-based, not automated, because doc content is too varied to check reliably in code.
 
-A short stub like "No change" will be treated as missing and will block acceptance.
-
-**Do not name any other `docs/systems/*.md` file in the no-change reason, even in passing.** The lobster's parser matches the *first* `docs/systems/\S+\.md`-shaped string anywhere in the section — it does not check whether you actually declared that file as updated. If your explanation mentions an existing system doc for context ("this already lives in docs/systems/tasks.md"), the lobster will treat that as your declared spec file and pass the gate even though nothing was touched. Write the no-change reason without naming any `docs/systems/*.md` path at all.
-
-**This section only covers `docs/systems/*.md`. It does not satisfy the app-spec requirement.** Per `docs/CONVENTIONS.md` (DoD item 3) and `agents/definitions/rowan/DoD.md`, if your change alters user-visible behaviour in an app that has an `apps/<app>/SPEC.md`, that file must be updated in this PR too — a system-doc no-change declaration does not exempt you from it. There is currently no automated gate for this, so check it by hand before opening the PR: does `apps/<app>/SPEC.md` exist, and does it describe the flow/screen you just changed? If yes, update it in the same PR and reference it in your AC evidence (`(📄 not code: updated apps/<app>/SPEC.md)`).
+**This section only covers `docs/systems/*.md`. It does not satisfy the app-spec requirement.** Per `docs/CONVENTIONS.md` (DoD item 3) and `agents/definitions/rowan/DoD.md`, if your change alters user-visible behaviour in an app that has an `apps/<app>/SPEC.md`, that file must be updated in this PR too — a system-doc no-change declaration does not exempt you from it. There is no automated gate for this either, so check it by hand before opening the PR: does `apps/<app>/SPEC.md` exist, and does it describe the flow/screen you just changed? If yes, update it in the same PR and reference it in your AC evidence (`(📄 not code: updated apps/<app>/SPEC.md)`).
 
 Include a `Co-Authored-By` trailer in your commit messages identifying yourself:
 ```

--- a/agents/skills/dev/system-spec/SKILL.md
+++ b/agents/skills/dev/system-spec/SKILL.md
@@ -43,3 +43,5 @@ Post the task comment:
 For code-only changes that do not alter system behavior, post a specific bypass reason:
 
 `[no-system-spec-change] <reason>`
+
+**Scope boundary — this skill governs `docs/systems/*.md` only.** The consolidation bias above (prefer updating an existing system doc, resist creating new files) applies to system docs specifically. It does not extend to `apps/<app>/SPEC.md`. If your change alters user-visible app behavior, `apps/<app>/SPEC.md` must still be updated in the same PR regardless of whether a system doc changed — see `docs/CONVENTIONS.md` (doc taxonomy #3, DoD item 3). Do not cite "no system doc change needed" as a reason to skip the app spec; they are two separate, independently-required checks.

--- a/agents/workflows/feature-task/Cargo.lock
+++ b/agents/workflows/feature-task/Cargo.lock
@@ -226,7 +226,6 @@ name = "feature-task"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
  "clap",
  "regex",
  "serde",

--- a/agents/workflows/feature-task/Cargo.toml
+++ b/agents/workflows/feature-task/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Context, Result};
-use base64::{engine::general_purpose, Engine as _};
 use clap::{ArgAction, Parser, Subcommand};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -467,17 +466,13 @@ fn code_task_verify_delivery(args: StageArgs) -> Result<Envelope> {
                 for ac_failure in task_ac_vs_open_pr_failures(&env.task.id, &task_acs, &body, url) {
                     failures.push(format!("PR {url} — {ac_failure}"));
                 }
-                let decl = body_system_spec_decl(&body);
-                failures.extend(system_spec_pr_body_failures(&decl, url, &env.task));
             }
             Err(err) => {
                 failures.push(format!(
-                    "Could not read PR body for {url}: {err}. Cannot validate AC text or system spec."
+                    "Could not read PR body for {url}: {err}. Cannot validate AC text."
                 ));
             }
         }
-    } else if !pr_urls.is_empty() {
-        failures.push("Could not determine latest PR URL to validate system spec.".to_string());
     }
     if workstreams(&env.task).is_empty() {
         failures.push("Task description must include at least one workstream.".to_string());
@@ -561,17 +556,13 @@ fn verify_delivery(args: StageArgs) -> Result<Envelope> {
                 for ac_failure in task_ac_vs_open_pr_failures(&env.task.id, &task_acs, &body, url) {
                     failures.push(format!("PR {url} — {ac_failure}"));
                 }
-                let decl = body_system_spec_decl(&body);
-                failures.extend(system_spec_pr_body_failures(&decl, url, &env.task));
             }
             Err(err) => {
                 failures.push(format!(
-                    "Could not read PR body for {url}: {err}. Cannot validate AC text or system spec."
+                    "Could not read PR body for {url}: {err}. Cannot validate AC text."
                 ));
             }
         }
-    } else if !pr_urls.is_empty() {
-        failures.push("Could not determine latest PR URL to validate system spec.".to_string());
     }
     if workstreams(&env.task).is_empty() {
         failures.push("Task description must include at least one workstream.".to_string());
@@ -2970,176 +2961,12 @@ where
         .collect()
 }
 
-fn pr_branch_for_system_spec<I, B>(url: &str, inspect: I, branch_for_pr: B) -> Result<String>
-where
-    I: Fn(&str) -> Result<ReviewState> + Copy,
-    B: Fn(&str) -> Result<String> + Copy,
-{
-    match inspect(url) {
-        Ok(ReviewState::Merged) => Ok("main".to_string()),
-        Ok(_) => branch_for_pr(url),
-        Err(err) => Err(err),
-    }
-}
-
 fn openclaw_needed(task: &Task) -> bool {
     !tagged_values(task, "[openclaw-needed]").is_empty()
 }
 
 fn openclaw_done(task: &Task) -> bool {
     !tagged_values(task, "[openclaw-done]").is_empty()
-}
-
-trait SystemSpecFetcher {
-    fn read(&self, owner: &str, repo: &str, path: &str, branch: &str) -> Result<String>;
-}
-
-struct GhSystemSpecFetcher;
-
-impl SystemSpecFetcher for GhSystemSpecFetcher {
-    fn read(&self, owner: &str, repo: &str, path: &str, branch: &str) -> Result<String> {
-        fetch_github_contents(owner, repo, path, branch)
-    }
-}
-
-fn system_spec_pr_body_failures(
-    decl: &SystemSpecBodyDecl,
-    pr_url: &str,
-    task: &Task,
-) -> Vec<String> {
-    system_spec_pr_body_failures_with(decl, pr_url, task, inspect_pr, pr_head_branch, &GhSystemSpecFetcher)
-}
-
-fn system_spec_pr_body_failures_with<I, B>(
-    decl: &SystemSpecBodyDecl,
-    pr_url: &str,
-    task: &Task,
-    inspect: I,
-    branch_for_pr: B,
-    fetcher: &dyn SystemSpecFetcher,
-) -> Vec<String>
-where
-    I: Fn(&str) -> Result<ReviewState> + Copy,
-    B: Fn(&str) -> Result<String> + Copy,
-{
-    match decl {
-        SystemSpecBodyDecl::Missing => {
-            vec!["PR body must include a `## System Spec` section with a spec path or a no-change reason.".to_string()]
-        }
-        SystemSpecBodyDecl::NoChange => vec![],
-        SystemSpecBodyDecl::Path(path) => {
-            let (owner, repo_name) = match parse_pr_repo(pr_url) {
-                Ok(parts) => parts,
-                Err(err) => {
-                    return vec![format!("Could not parse PR URL `{pr_url}`: {err}.")]
-                }
-            };
-            let branch = match pr_branch_for_system_spec(pr_url, inspect, branch_for_pr) {
-                Ok(b) => b,
-                Err(err) => {
-                    return vec![format!(
-                        "Could not determine branch for PR `{pr_url}`: {err}."
-                    )]
-                }
-            };
-            let text = match fetcher.read(&owner, &repo_name, path, &branch) {
-                Ok(t) => t,
-                Err(err) if is_github_404(&err) => {
-                    return vec![format!(
-                        "System spec `{path}` is missing on PR branch `{branch}`."
-                    )]
-                }
-                Err(err) => {
-                    return vec![format!(
-                        "Could not read system spec `{path}` from PR branch `{branch}`: {err}."
-                    )]
-                }
-            };
-            let referenced = implementer_pr_urls(task)
-                .into_iter()
-                .any(|u| text.contains(&u))
-                || text.contains(&task.id);
-            if referenced {
-                vec![]
-            } else {
-                vec![format!(
-                    "System spec `{path}` does not reference this task or PR."
-                )]
-            }
-        }
-    }
-}
-
-fn parse_pr_repo(url: &str) -> Result<(String, String)> {
-    let re = Regex::new(r"^https://github\.com/([^/]+)/([^/]+)/pull/\d+$").unwrap();
-    let caps = re
-        .captures(url)
-        .ok_or_else(|| anyhow!("expected GitHub PR URL"))?;
-    Ok((caps[1].to_string(), caps[2].to_string()))
-}
-
-fn pr_head_branch(url: &str) -> Result<String> {
-    let output = Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            url,
-            "--json",
-            "headRefName",
-            "--jq",
-            ".headRefName",
-        ])
-        .output()
-        .context("run gh pr view for head branch")?;
-    if !output.status.success() {
-        return Err(anyhow!(String::from_utf8_lossy(&output.stderr)
-            .trim()
-            .to_string()));
-    }
-    let branch = String::from_utf8(output.stdout)?.trim().to_string();
-    if branch.is_empty() {
-        return Err(anyhow!("empty PR head branch"));
-    }
-    Ok(branch)
-}
-
-fn fetch_github_contents(owner: &str, repo: &str, path: &str, branch: &str) -> Result<String> {
-    let endpoint = format!("repos/{owner}/{repo}/contents/{path}?ref={branch}");
-    let output = Command::new("gh")
-        .args(["api", &endpoint])
-        .output()
-        .context("run gh api for contents")?;
-    if !output.status.success() {
-        return Err(anyhow!(String::from_utf8_lossy(&output.stderr)
-            .trim()
-            .to_string()));
-    }
-    decode_github_contents_response(&String::from_utf8(output.stdout)?)
-}
-
-fn decode_github_contents_response(raw: &str) -> Result<String> {
-    let value: Value = serde_json::from_str(raw)?;
-    let encoding = value
-        .get("encoding")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    if encoding != "base64" {
-        return Err(anyhow!("unsupported GitHub contents encoding `{encoding}`"));
-    }
-    let content = value
-        .get("content")
-        .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("GitHub contents response missing `content`"))?;
-    let compact: String = content.chars().filter(|c| !c.is_whitespace()).collect();
-    let decoded = general_purpose::STANDARD
-        .decode(compact)
-        .context("decode GitHub contents base64")?;
-    String::from_utf8(decoded).context("GitHub contents file is not UTF-8")
-}
-
-fn is_github_404(err: &anyhow::Error) -> bool {
-    let message = err.to_string();
-    message.contains("HTTP 404") || message.contains("Not Found")
 }
 
 fn inspect_pr(url: &str) -> Result<ReviewState> {
@@ -3244,46 +3071,6 @@ fn body_has_checked_acceptance(body: &str) -> bool {
     Regex::new(r"(?m)^\s*-\s*\[[xX]\]\s+.+")
         .unwrap()
         .is_match(body)
-}
-
-/// What the `## System Spec` section of a PR body declares.
-#[derive(Debug, PartialEq)]
-enum SystemSpecBodyDecl {
-    /// Section is absent or empty.
-    Missing,
-    /// Section contains a substantive no-change reason (>= 12 non-whitespace chars, no spec path).
-    NoChange,
-    /// Section contains a `docs/systems/*.md` path.
-    Path(String),
-}
-
-fn body_system_spec_decl(body: &str) -> SystemSpecBodyDecl {
-    let header_re = Regex::new(r"(?mi)^##\s+System Spec\s*$").unwrap();
-    let Some(header_match) = header_re.find(body) else {
-        return SystemSpecBodyDecl::Missing;
-    };
-    let after = &body[header_match.end()..];
-    let end = Regex::new(r"(?m)^##")
-        .unwrap()
-        .find(after)
-        .map(|m| m.start())
-        .unwrap_or(after.len());
-    let content = after[..end].trim();
-    if content.is_empty() {
-        return SystemSpecBodyDecl::Missing;
-    }
-    if let Some(cap) = Regex::new(r"`?(docs/systems/\S+\.md)`?")
-        .unwrap()
-        .captures(content)
-    {
-        return SystemSpecBodyDecl::Path(cap[1].to_string());
-    }
-    let non_ws: usize = content.chars().filter(|c| !c.is_whitespace()).count();
-    if non_ws >= 12 {
-        SystemSpecBodyDecl::NoChange
-    } else {
-        SystemSpecBodyDecl::Missing
-    }
 }
 
 /// Evidence annotation recognised on a feature-task PR AC line.
@@ -4511,185 +4298,6 @@ Lead-in.
             parse_github_review_state(&fixture("github_required.json")).unwrap(),
             ReviewState::Required
         );
-    }
-
-    // ---- system spec PR body parsing ----
-
-    #[test]
-    fn body_system_spec_decl_missing_when_no_section() {
-        assert_eq!(
-            body_system_spec_decl("## Summary\nSome text.\n\n## Acceptance Criteria\n- [x] AC1"),
-            SystemSpecBodyDecl::Missing
-        );
-    }
-
-    #[test]
-    fn body_system_spec_decl_missing_when_section_empty() {
-        assert_eq!(
-            body_system_spec_decl("## Summary\nFoo.\n\n## System Spec\n\n## Acceptance Criteria"),
-            SystemSpecBodyDecl::Missing
-        );
-    }
-
-    #[test]
-    fn body_system_spec_decl_path_plain() {
-        assert_eq!(
-            body_system_spec_decl("## System Spec\ndocs/systems/content-scheduler.md — updated"),
-            SystemSpecBodyDecl::Path("docs/systems/content-scheduler.md".to_string())
-        );
-    }
-
-    #[test]
-    fn body_system_spec_decl_path_backtick() {
-        assert_eq!(
-            body_system_spec_decl("## System Spec\n`docs/systems/content-scheduler.md`"),
-            SystemSpecBodyDecl::Path("docs/systems/content-scheduler.md".to_string())
-        );
-    }
-
-    #[test]
-    fn body_system_spec_decl_no_change_substantive() {
-        assert_eq!(
-            body_system_spec_decl(
-                "## System Spec\nNo system spec change — CI env-var fix only, no user-facing behaviour."
-            ),
-            SystemSpecBodyDecl::NoChange
-        );
-    }
-
-    #[test]
-    fn body_system_spec_decl_no_change_too_short() {
-        assert_eq!(
-            body_system_spec_decl("## System Spec\nNo change"),
-            SystemSpecBodyDecl::Missing
-        );
-    }
-
-    // ---- system_spec_pr_body_failures_with ----
-
-    fn pr_url() -> &'static str {
-        "https://github.com/Stoffer-Industries/sindustries/pull/128"
-    }
-
-    fn task_with_pr() -> Task {
-        Task {
-            id: "task-1".to_string(),
-            comments: vec![TaskComment {
-                text: Some(
-                    format!("[implementer-prs] {}", pr_url()),
-                ),
-                body: None,
-            }],
-            ..Task::default()
-        }
-    }
-
-    #[test]
-    fn system_spec_body_missing_fails() {
-        assert_eq!(
-            system_spec_pr_body_failures_with(
-                &SystemSpecBodyDecl::Missing,
-                pr_url(),
-                &task_with_pr(),
-                |_| Ok(ReviewState::Approved),
-                |_| Ok("some-branch".to_string()),
-                &StubFetcher { body: String::new(), error: None },
-            ),
-            vec!["PR body must include a `## System Spec` section with a spec path or a no-change reason."]
-        );
-    }
-
-    #[test]
-    fn system_spec_body_no_change_passes() {
-        assert!(system_spec_pr_body_failures_with(
-            &SystemSpecBodyDecl::NoChange,
-            pr_url(),
-            &task_with_pr(),
-            |_| Ok(ReviewState::Approved),
-            |_| Ok("some-branch".to_string()),
-            &StubFetcher { body: String::new(), error: None },
-        )
-        .is_empty());
-    }
-
-    #[test]
-    fn system_spec_body_path_valid_passes() {
-        let task = task_with_pr();
-        assert!(system_spec_pr_body_failures_with(
-            &SystemSpecBodyDecl::Path("docs/systems/feature-task.md".to_string()),
-            pr_url(),
-            &task,
-            |_| Ok(ReviewState::Approved),
-            |_| Ok("task-branch".to_string()),
-            &StubFetcher { body: "References task-1".to_string(), error: None },
-        )
-        .is_empty());
-    }
-
-    #[test]
-    fn system_spec_body_path_missing_on_branch_fails() {
-        let task = task_with_pr();
-        assert_eq!(
-            system_spec_pr_body_failures_with(
-                &SystemSpecBodyDecl::Path("docs/systems/feature-task.md".to_string()),
-                pr_url(),
-                &task,
-                |_| Ok(ReviewState::Approved),
-                |_| Ok("task-branch".to_string()),
-                &StubFetcher { body: String::new(), error: Some("gh: Not Found (HTTP 404)".to_string()) },
-            ),
-            vec!["System spec `docs/systems/feature-task.md` is missing on PR branch `task-branch`."]
-        );
-    }
-
-    #[test]
-    fn system_spec_body_reads_from_main_when_pr_merged() {
-        let task = task_with_pr();
-        assert!(system_spec_pr_body_failures_with(
-            &SystemSpecBodyDecl::Path("docs/systems/feature-task.md".to_string()),
-            pr_url(),
-            &task,
-            |_| Ok(ReviewState::Merged),
-            |_| panic!("merged PR must read from main, not head branch"),
-            &StubFetcher { body: "References task-1".to_string(), error: None },
-        )
-        .is_empty());
-    }
-
-    #[test]
-    fn body_system_spec_decl_path_in_middle_of_section() {
-        let body = "## Summary\nFoo.\n\n## System Spec\nUpdated `docs/systems/content-scheduler.md` to cover the 10-day calendar.\n\n## Test plan\n- [ ] CI green";
-        assert_eq!(
-            body_system_spec_decl(body),
-            SystemSpecBodyDecl::Path("docs/systems/content-scheduler.md".to_string())
-        );
-    }
-
-    #[test]
-    fn decodes_github_contents_response() {
-        let raw = json!({
-            "encoding": "base64",
-            "content": "UmVmZXJlbmNlcyB0YXNrLTE=\n"
-        })
-        .to_string();
-        assert_eq!(
-            decode_github_contents_response(&raw).unwrap(),
-            "References task-1"
-        );
-    }
-
-    struct StubFetcher {
-        body: String,
-        error: Option<String>,
-    }
-
-    impl SystemSpecFetcher for StubFetcher {
-        fn read(&self, _owner: &str, _repo: &str, _path: &str, _branch: &str) -> Result<String> {
-            match &self.error {
-                Some(error) => Err(anyhow!(error.clone())),
-                None => Ok(self.body.clone()),
-            }
-        }
     }
 
     // ---- manual block guard (task 593ee264) ----

--- a/docs/systems/tasks.md
+++ b/docs/systems/tasks.md
@@ -232,9 +232,9 @@ The Lobster YAML composes the Rust CLI commands into status transitions. The Pyt
 - `[implementer-prs] <url>` task comment lists every open PR (legacy alias `[rowan-prs]` still accepted)
 - `[openclaw-needed]` task comment if any `.openclaw` file edits are required (with proposed diff + rollback note) — Rowan does not touch `.openclaw/` directly
 - PR body lists every parent task AC checked off with evidence annotations
-- PR body includes a `## System Spec` section (see below) — required before the PR is converted from draft to ready-for-review
+- PR body includes a `## System Spec` section (see below) — a documentation convention, not a lobster gate
 - When implementation is complete, post `[implementer-prs] <url>` task comment
-- Rust command: `feature-task verify-delivery` runs after the `[implementer-prs]` signal to confirm PRs, CI state, AC text, and system spec
+- Rust command: `feature-task verify-delivery` runs after the `[implementer-prs]` signal to confirm PRs, CI state, and AC text
 
 **`acceptance` — review and gate enforcement**
 
@@ -243,17 +243,11 @@ The Lobster YAML composes the Rust CLI commands into status transitions. The Pyt
   - All PRs linked from `[implementer-prs]` are merged
   - GitHub review state on every linked PR is `APPROVED` (no `CHANGES_REQUESTED` outstanding)
   - CI on the merged commits is green
-  - PR body `## System Spec` section declared (validated at `verify_delivery` — doing → acceptance gate, not acceptance → done)
   - No `[openclaw-needed]` pending without matching `[openclaw-done]` from Quinn
   - `[qa-ac-verified] true` task comment from Tom
 - Rust commands: `feature-task feedback-aggregate`, then `feature-task post-merge`
 
-**`## System Spec` PR body section (doing → acceptance, pre-merge):** `verify_delivery` reads the `## System Spec` section from the **latest implementer PR body** (highest PR number). The section must contain either:
-
-- A path to the spec file committed on the same branch: `docs/systems/<file>.md` (plain or backtick-quoted). The lobster fetches the file from the PR branch (or `main` when merged) and confirms it references the task ID or PR URL.
-- A substantive no-change reason (≥ 12 non-whitespace characters, no `docs/systems/` path): use when no system-level behaviour changed.
-
-A stub like "No change" (< 12 non-whitespace chars) is treated as missing and blocks acceptance. **The system spec must be committed in the same PR as the feature code** — a separate backfill PR is not acceptable. No task comment is needed; the PR body section is the gate. See `agents/skills/dev/pr-open/SKILL.md` for the canonical PR body template.
+**`## System Spec` PR body section (documentation convention, not enforced):** PR authors note in the PR body whether `docs/systems/<file>.md` was written or updated, or give a short reason why not. The lobster does not parse or validate this section — it was removed (2026-07-26) after repeated regex gaps (the parser couldn't distinguish an actual declaration from an incidental mention of an existing doc, and had no way to validate declaration quality). Doc content is too varied to check reliably in code; system-spec upkeep is now judgment-based, checked by the reviewer, not the lobster. See `agents/skills/dev/pr-open/SKILL.md` for the canonical PR body template.
 
 **AC text check (doing → acceptance, pre-merge):** before the lobster will let the task advance from `doing` to `acceptance`, it compares every task description AC against the **open** PR body. Every AC must appear in the PR body as a `- [x] **AC<N>` line — not a bullet, not `- [ ]`, not plain prose, not a `✅` emoji. The `- [x]` form is required because it is the only signal the lobster can machine-parse to confirm the AC is covered by this PR (or by a referenced merged predecessor PR on the same line, e.g. `PR #285`). The line must also carry an evidence annotation `(testID|not tested|not code|pr)` per `agents/skills/dev/pr-open/SKILL.md`. If an AC is missing, has altered text, lacks the checked-checkbox form, or lacks the evidence annotation, the transition is blocked with a `[feature-task-progress-checklist]` comment listing the specific failures — the task stays in `doing` until Rowan opens a fix PR that lists every AC verbatim with evidence. Tom may edit ACs in the task description during QA — spec drift does not block this gate (it is covered by the resync feature; see task b2ab54db). Rule added per Tom's 2026-07-25 21:12 NZST feedback after PR #296 shipped with ACs as bullets + ✅ emoji.
 
@@ -417,8 +411,8 @@ The three workflows share the same Rust binary (feature + code) and the same tas
 | `[openclaw-needed] <reason>` | Rowan | feature, code | Flag a `.openclaw` change for Quinn |
 | `[openclaw-done] <summary>` | Quinn | feature, code | `.openclaw` change applied |
 | `[qa-ac-verified] true` | Tom | feature, code | Explicit QA sign-off; required before `acceptance → done` |
-| `[system-spec] docs/systems/<file>.md` | Rowan | feature, code | System spec path (older convention; the PR body `## System Spec` section is now the gate) |
-| `[no-system-spec-change] <reason>` | Rowan | feature, code | Declares no system doc change needed (with reason) |
+| `[system-spec] docs/systems/<file>.md` | Rowan | feature, code | System spec path (legacy convention, not parsed by the lobster) |
+| `[no-system-spec-change] <reason>` | Rowan | feature, code | Declares no system doc change needed (legacy convention, not parsed by the lobster) |
 | `[spec-resynced] <summary>` | Lobster | feature | Drift resync: `checksum=<sha256>` + `driftFingerprint=<sha256>` |
 | `[feature-task-progress-checklist] ...` | Lobster | feature | Gate failure fingerprint; pre-merge AC text failures also land here |
 | `[code-task-progress-checklist] ...` | Lobster | code | Gate failure fingerprint |
@@ -520,7 +514,6 @@ The `409 SPEC_CHECKSUM_MISMATCH` response names the task id, the stored `specChe
 |---|---|---|
 | `ready → doing` blocked | Missing `[tech-design-approved]` or `specChecksum` drift | Quinn confirms Tom sign-off and posts `[tech-design-approved] true`; for drift, follow the resync path |
 | `[openclaw-needed]` never resolved | Quinn missed the heartbeat step | Quinn scans active tasks on the next heartbeat tick |
-| `doing → acceptance` blocked on system spec | PR body `## System Spec` section absent, empty, or stub (< 12 non-whitespace chars) | Add `## System Spec` to the PR body with the spec path or a substantive no-change reason; the spec file must be committed on the same branch |
 | Spec checksum mismatch | ACs edited after spec approval | Hits `PATCH /tasks/:id` when the description ACs change. Treat as spec drift: Lobster unchecks `**Approved by Tom**`, waits for Tom to re-check, then performs the resync path. Comments are drift-tolerant and remain usable for progress/checklist/resync signals. |
 | Spec lifecycle layout failure | Unexpected direct subdirectory under `brain/tasks/specs/` | Remove or migrate the unexpected subdir so only `open/`, `in-progress/`, and `done/` remain. The lobster creates missing expected dirs automatically. |
 | Stale `**Spec:**` line after a move | Prior run moved a spec but failed before patching the task description | Re-run the relevant lobster stage; move helpers treat destination-present/source-absent as idempotent and repair the task `**Spec:**` path. |
@@ -658,4 +651,6 @@ TASKS_API_BASE_URL=http://localhost:4001/api/v1 \
 - Task `f77b7a60-225c-445c-b3d9-042e38a86cde` — initial implementation of the code-task lobster extension (PR #276)
 - PR #145 — first-class `taskType` field on tasks (the foundation of routing)
 - PR #259 — system spec gate moved from `[system-spec]` task comment to `## System Spec` PR body section (shipped 2026-07-19)
+- PR #296 — surfaced two gaps in the `## System Spec` gate: the regex matched an incidental doc mention as a declaration, and the gate had no equivalent check for `apps/*/SPEC.md`
+- Removed the `## System Spec` PR-body gate entirely (2026-07-26, Tom: "docs are too vague to enforce with checks/code") rather than patching the regex — `verify_delivery` no longer reads or blocks on this section; it is reviewer-judgment only going forward
 - PR #271 — `400 INVALID_TASK_ID` on malformed path UUIDs (`get`/`patch`/`delete`/`POST /comments`), shipped 2026-07-21


### PR DESCRIPTION
## Summary
- Removed the `## System Spec` PR-body gate from the lobster entirely (`system_spec_pr_body_failures`, `body_system_spec_decl`, and their only-used-here helpers in `agents/workflows/feature-task/src/main.rs`) instead of patching the regex gaps found on PR #296.
- Per Tom's direction: doc content is too varied to check reliably in code — system-spec upkeep is reviewer judgment from here on, not an automated block on `doing → acceptance`.
- Docs updated to match: `docs/systems/tasks.md` (canonical gate description + tag vocabulary + troubleshooting table + history), `agents/skills/dev/pr-open/SKILL.md`, `agents/definitions/rowan/WORKFLOW.md`. The `## System Spec` PR-body section stays as a convention (still worth writing, still checked in `agents/skills/ops/factory-retro/SKILL.md`'s retro heuristic) — it's just no longer parsed or blocking.
- The separate app-spec (`apps/<app>/SPEC.md`) guidance added earlier in this PR is kept as-is — that was never lobster-enforced and isn't affected by this change.
- Removed the now-unused `base64` dependency (only consumer was the GitHub-contents-fetch helper this gate used to read spec files off the PR branch).

## Context
Original scope of this PR was docs-only guidance to work around two regex gaps in the gate (found on PR #296). Tom's follow-up: don't patch the check, remove it — "docs are too vague to enforce with checks/code."

## System Spec
No system spec change beyond this PR's own docs/systems/tasks.md update, which documents the removal itself.

## Test plan
- [x] `cargo test` in `agents/workflows/feature-task` — 171 passed, 0 failed
- [x] `cargo build` — compiles clean, no new warnings (two pre-existing unrelated dead-code warnings unchanged)
- [ ] Confirm no other PR/task currently relies on the `## System Spec` gate blocking `doing → acceptance` (none in flight reference it as of 2026-07-26)

🤖 Generated with Claude Code