### PR TITLE
docs(tasks): reference f520c396 + f170e344 in Related Tasks / PRs

### DIFF
--- a/docs/systems/tasks.md
+++ b/docs/systems/tasks.md
@@ -1,7 +1,7 @@
 # Tasks
 
 **Type:** System reference (data plane + workflows)
-**Last updated:** 2026-07-25
+**Last updated:** 2026-07-26
 **Owner:** Rowan (engineering) · Quinn (workflow orchestration) · Tom (product)
 **Repos:** `Stoffer-Industries/sindustries`
 **App spec:** `apps/tasks/SPEC.md`
@@ -656,6 +656,8 @@ TASKS_API_BASE_URL=http://localhost:4001/api/v1 \
 - Task `a5a4ed8f-e7c4-4b6c-8ac9-bb962211ac44` — spec folder lifecycle and bookmark/feature lobster sync
 - Task `b2ab54db` — fluid AC lifecycle (drift re-approval flow)
 - Task `f77b7a60-225c-445c-b3d9-042e38a86cde` — initial implementation of the code-task lobster extension (PR #276)
+- Task `f520c396-9664-4210-b149-180371dc8a53` — GymTrack Agent-Powered Workouts (PR #285, PR #296): planned_workouts schema + HMAC-signed agent endpoints for workout history + per-exercise progression. MVP behaviour in `apps/gymtrack/SPEC.md`; agent-specific schema/endpoints in the PR #285 + #296 migrations.
+- Task `f170e344-ea5f-4443-bebb-035948686fc1` — Post-Merge Feature Factory Analytics (tech design approved, impl pending capacity): analytics row writes at post-merge for the factory flow dashboard.
 - PR #145 — first-class `taskType` field on tasks (the foundation of routing)
 - PR #259 — system spec gate moved from `[system-spec]` task comment to `## System Spec` PR body section (shipped 2026-07-19)
 - PR #271 — `400 INVALID_TASK_ID` on malformed path UUIDs (`get`/`patch`/`delete`/`POST /comments`), shipped 2026-07-21


### PR DESCRIPTION
## Summary

Updates `docs/systems/tasks.md` to reference two in-flight feature tasks:

- **f520c396** (GymTrack Agent-Powered Workouts) — PR #285 + PR #296 both merged 2026-07-24/25. Tasks API verify-delivery gate checks whether `docs/systems/tasks.md` references the task or PR; the doc landed in PR #297 but did not include the in-flight task list, so the gate stayed blocked.
- **f170e344** (Post-Merge Feature Factory Analytics) — tech design approved (Quinn 2026-07-23T11:21), impl pending capacity gate (currently blocked on f520c396 exiting `doing`). Tracking here so the doc reflects the current in-flight set without waiting for ship events.

## Why now

The lobster's most recent verify-delivery check on f520c396 (2026-07-25T10:57Z, ~2h after PR #297 merged) still flagged:

> System spec `docs/systems/tasks.md` does not reference this task or PR.

Adding the references here clears that gate and lets the lobster promote f520c396 to `acceptance`, which in turn opens the capacity gate for f170e344 (and the two ready tasks waiting behind it: 3ba96b5e, 6a5783a7).

## Out of scope

- Full task list maintenance — these references go in when a task hits a state-machine boundary (tech design approval, PR open, PR merge), not on a recurring sweep.
- New system docs — this is an additive update to the existing consolidated tasks.md, not a new doc.

## Test plan

- [x] `git diff main..HEAD` shows only the +2 lines in Tasks / PRs and the "Last updated" date bump
- [ ] (post-merge) Confirm lobster's next verify-delivery pass on f520c396 finds the reference and promotes to `acceptance`