### PR TITLE
fix(workflows): resolve sindustriesRepo in content-tasks run.py

### DIFF
--- a/agents/workflows/content-tasks/run.py
+++ b/agents/workflows/content-tasks/run.py
@@ -12,6 +12,8 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 SCRIPTS_DIR = SCRIPT_DIR / "scripts"
 PIPELINE = SCRIPT_DIR / "content-task.lobster.yaml"
+CODEBASE_REPO = SCRIPT_DIR.parent.parent.parent
+REPO = Path(os.environ.get("SINDUSTRIES_REPO") or CODEBASE_REPO)
 
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
@@ -33,7 +35,9 @@ def _stream_reader(pipe, prefix: str, sink: list[str]) -> None:
 
 
 def run_workflow(task_id: str, capacity_limit: int) -> dict:
-    args_json = json.dumps({"taskId": task_id, "ivyCapacityLimit": capacity_limit})
+    args_json = json.dumps(
+        {"taskId": task_id, "ivyCapacityLimit": capacity_limit, "sindustriesRepo": str(REPO)}
+    )
     cmd = ["lobster", "run", "--mode", "tool", str(PIPELINE), "--args-json", args_json]
     log_debug("starting content-task pass for " + task_id)
     env = os.environ.copy()


### PR DESCRIPTION
## Summary
- `content-tasks/run.py` never passed `sindustriesRepo` in `args_json`; the YAML's `${SINDUSTRIES_REPO}` fallback resolved empty in cron/shell contexts, so every content-task pass failed with `ENOENT` on `load_task.py`
- Mirrors the working pattern already used in `feature-task/run.py`: derive the repo path from the script's own location, pass it explicitly

## Context
Found while verifying a Task Lobsters cron toolsAllow fix — the cron could now actually execute (previously it had been silently fabricating "steady-state" reports for ~40+ runs due to missing exec/read tools), which surfaced this pre-existing, separate bug in the content-task pipeline.

## Test plan
- [x] Verified `REPO` resolves to the correct sindustries checkout and `load_task.py` exists at that path
- [x] Ran `agents/workflows/content-tasks/run.py --json` directly against live tasks — pipeline now runs end-to-end (hits legitimate business-logic blockers instead of the path error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)