### PR TITLE
chore(skills): add PR label conventions for task type and origin

### DIFF
--- a/agents/skills/dev/pr-open/SKILL.md
+++ b/agents/skills/dev/pr-open/SKILL.md
@@ -17,6 +17,12 @@ Use this skill whenever you need to open a pull request in the Sindustries repos
 
 Always set `--assignee` to the implementation owner/opener and `--reviewer` to the designated reviewer(s). Check the invoking skill, task, or workflow for reviewer routing. If the reviewer is not stated, stop and ask/escalate — do **not** guess a default reviewer.
 
+**Labels are required on every PR.** See `agents/skills/dev/pr-process/SKILL.md` for the full label table. Quick reference:
+- Task-driven PRs: `feature-task`, `content-task`, or `code-task` (match `taskType`)
+- Quinn proactive fix with no task: `workflow-garden`
+- Tom asked in chat: `direct-ask`
+- Labels are not mutually exclusive — apply all that apply.
+
 For feature-task PRs, the opener is the task implementer/assignee. Reviewers are the blocking reviewer plus any visibility-only reviewers defined by the workflow. The reviewer must not open the implementer's PR on their own account.
 
 Use the opener's GitHub identity/token for `gh pr create`. Before creating the PR, verify the active GitHub login matches the intended opener:
@@ -34,6 +40,7 @@ gh pr create \
   --title "<type>(<scope>): <short description>" \
   --assignee <opener-github-username> \
   --reviewer <reviewer-github-username>[,<visibility-reviewer>] \
+  --label <origin-label>[,<task-type-label>] \
   --body "$(cat <<'EOF'
 ## Summary
 - <bullet: what changed and why>

--- a/agents/skills/dev/pr-process/SKILL.md
+++ b/agents/skills/dev/pr-process/SKILL.md
@@ -59,14 +59,39 @@ gh api user --jq '.login'
 
 ---
 
+## PR Labels
+
+Every PR must carry at least one label identifying its origin. Apply labels at `gh pr create` time via `--label`.
+
+### Task-type labels (apply based on `taskType`)
+
+| Label | When to use |
+|---|---|
+| `feature-task` | PR created by the feature task lobster workflow |
+| `content-task` | PR created by the content task lobster workflow |
+| `code-task` | PR created by the code task lobster workflow |
+| `code-garden` | Code quality / structural cleanup PRs (existing) |
+| `code-audit` | Weekly repo audit PRs (existing) |
+
+### Origin labels (apply based on who initiated the work)
+
+| Label | When to use |
+|---|---|
+| `workflow-garden` | Proactive fixes or improvements Quinn opens on her own initiative (no task, no direct ask) |
+| `direct-ask` | PR requested directly by Tom in chat — include the original ask in the PR body |
+
+Labels are not mutually exclusive. A PR can be both `workflow-garden` and `direct-ask` if Tom spotted an issue in chat and Quinn fixed it.
+
+---
+
 ## Example role mappings
 
 This skill is role-based, not agent-based. Any agent can play any role on a given PR. The split is: one role opens the PR, one or more review it, the opener merges after all approvals + green CI.
 
 Concrete patterns in our workflows:
 
-- **Feature tasks:** The task implementer/assignee opens the PR and is the PR assignee. The blocking reviewer is Quinn; Tom may be added as a visibility-only reviewer for GitHub inbox visibility. The opener/assignee merges after Quinn approves and CI is green — do not wait for Tom's PR approval. Tom tests post-merge in main; his sign-off is the `[qa-ac-verified] true` task comment. The feature-task workflow is role-based: implementer opens/merges, reviewer reviews. Do not hardcode a specific agent into the workflow.
-- **Content tasks:** opener opens (`--assignee <self>`, `--reviewer quinn,tomstoffer`). Quinn and Tom review. Opener merges after both approvals.
+- **Feature tasks:** The task implementer/assignee opens the PR and is the PR assignee. The blocking reviewer is Quinn; Tom may be added as a visibility-only reviewer for GitHub inbox visibility. The opener/assignee merges after Quinn approves and CI is green — do not wait for Tom's PR approval. Tom tests post-merge in main; his sign-off is the `[qa-ac-verified] true` task comment. The feature-task workflow is role-based: implementer opens/merges, reviewer reviews. Do not hardcode a specific agent into the workflow. Apply `--label feature-task` at PR creation.
+- **Content tasks:** opener opens (`--assignee <self>`, `--reviewer quinn,tomstoffer`, `--label content-task`). Quinn and Tom review. Opener merges after both approvals.
 - **Code-garden tasks:** opener opens with `--label code-garden`, reviewer reviews against the code-garden guardrail (no behavior change). Opener merges after approval.
 - **Cross-repo PRs (workspace repo, infra scripts):** same pattern — opener opens, reviewer reviews, opener merges.
 


### PR DESCRIPTION
## Summary
- Lands a commit (`45a89ff`) that was authored by Rowan on 2026-07-25 but never merged — it was pushed to `fix/spec-drift-resync-dedup` after PR #289 (from that same branch) had already merged, so it was stranded and never landed on `main`
- Adds a PR-label table to `pr-process/SKILL.md` (task-type labels: `feature-task`/`content-task`/`code-task`/`code-garden`/`code-audit`; origin labels: `workflow-garden`/`direct-ask`) plus a quick-reference note and `--label` flag in the `gh pr create` example in `pr-open/SKILL.md`
- Found while investigating why PR #302 (and 13 PRs before it back to #290) shipped with no label — this doc change was supposed to have already closed that gap

## System Spec
No system spec change — skill/process doc only, no user-facing behaviour.

## Test plan
- [ ] Diff matches the original `45a89ff` commit exactly (cherry-picked, no modifications) — confirm via `git show 45a89ff` vs this PR's diff
- [ ] Next PR opened via `pr-open` skill includes a `--label` flag per the new convention