### PR TITLE
chore(code-garden): align gymtrack jsdom to root ^29.0.1 [W30]

### DIFF
--- a/apps/gymtrack/package.json
+++ b/apps/gymtrack/package.json
@@ -25,7 +25,7 @@
     "@types/react": "^18.3.31",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^6.0.2",
-    "jsdom": "^25.0.1",
+    "jsdom": "^29.0.1",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"
   }

--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -195,7 +195,7 @@ No new performance concerns this week. The Content Scheduler auto-post correctly
 
 ### Dependencies
 
-**[Low] GymTrack pins `jsdom@^25.0.1` while the repo root and other workspaces use `^29.0.1`.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**[Low] GymTrack pins `jsdom@^25.0.1` while the repo root and other workspaces use `^29.0.1`.** ✅ [PR #305](https://github.com/Stoffer-Industries/sindustries/pull/305)
 - *Where:* `apps/gymtrack/package.json:20`, root `package.json:16`
 - *Why it matters:* jsdom v25 → v29 has real behaviour differences (URL parser, DOMPurify, form handling). A test that passes in gymtrack and fails elsewhere (or vice versa) will confuse future contributors. Low today but noted.
 - *Severity:* Low (new)

--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -195,7 +195,7 @@ No new performance concerns this week. The Content Scheduler auto-post correctly
 
 ### Dependencies
 
-**[Low] GymTrack pins `jsdom@^25.0.1` while the repo root and other workspaces use `^29.0.1`.**
+**[Low] GymTrack pins `jsdom@^25.0.1` while the repo root and other workspaces use `^29.0.1`.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 - *Where:* `apps/gymtrack/package.json:20`, root `package.json:16`
 - *Why it matters:* jsdom v25 → v29 has real behaviour differences (URL parser, DOMPurify, form handling). A test that passes in gymtrack and fails elsewhere (or vice versa) will confuse future contributors. Low today but noted.
 - *Severity:* Low (new)

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "@types/react": "^18.3.31",
         "@types/react-dom": "^18.3.7",
         "@vitejs/plugin-react": "^6.0.2",
-        "jsdom": "^25.0.1",
+        "jsdom": "^29.0.1",
         "vite": "^8.0.16",
         "vitest": "^4.1.8"
       }
@@ -98,47 +98,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
-      }
-    },
-    "apps/gymtrack/node_modules/jsdom": {
-      "version": "25.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
-      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssstyle": "^4.1.0",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.4.3",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.12",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.7.1",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.0.0",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0",
-        "ws": "^8.18.0",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "canvas": "^2.11.2"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
       }
     },
     "apps/mission-control": {


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W30.md
- **Finding:** [[Low] GymTrack pins `jsdom@^25.0.1` while the repo root and other workspaces use `^29.0.1`.](https://github.com/Stoffer-Industries/sindustries/blob/main/docs/repo-audits/2026-W30.md#dependencies)
- Bump `apps/gymtrack/package.json` jsdom dev-dependency from `^25.0.1` to `^29.0.1` so gymtrack tests run against the same jsdom version as every other workspace; resolves the "a test that passes in gymtrack and fails elsewhere (or vice versa) will confuse future contributors" footgun.

## Test plan
- [x] `npm test --workspace gymtrack` — 118 tests across 9 files pass with jsdom 29
- [x] No logic changes — diff is purely a dev-dependency bump (one line in `apps/gymtrack/package.json`, lockfile churn, audit marker)

🌱 Code garden — non-functional cleanup only