### PR TITLE
docs(gymtrack): document agent-powered workouts in app spec + README

### DIFF
--- a/agents/skills/dev/pr-review/SKILL.md
+++ b/agents/skills/dev/pr-review/SKILL.md
@@ -64,6 +64,7 @@ If the PR is linked to a task (look for `Task:` or `Linked task:` in the body, o
 
 1. Read the task body in the Tasks API (`tasks_api_client.py get <task-id>`).
 2. For each AC in the task, find the corresponding change in the diff. If any AC is not delivered, request changes — **do not approve until every AC has a matching change**.
+2a. **App-spec check (do this before approving, not after merge).** Independently verify the app-spec requirement, separate from the lobster's `## System Spec` section. If the repo path touched includes `apps/<app>/` and that app has an `apps/<app>/SPEC.md`, check whether the diff also updates `SPEC.md` for any user-visible behaviour change the PR introduces. The lobster's `## System Spec` section is **not** sufficient evidence here — it covers `docs/systems/*.md` only and PR authors have cited it without actually touching the app spec. If the app has a SPEC.md and this PR changes user-visible behaviour without touching it, **request changes** — do not approve, even if all task ACs otherwise have matching code changes.
 3. When every AC is accounted for, mark the AC checkboxes in the task body as done (`- [ ]` → `- [x]`) using your role's check-off script:
    - **Quinn (content reviewer):** runs `check_off_quinn_acs.py`:
      ```bash

--- a/apps/gymtrack/README.md
+++ b/apps/gymtrack/README.md
@@ -51,6 +51,35 @@ Environment variables are set in the Vercel project (NOT in the repo):
 
 See `supabase/README.md` for the migration apply + RLS smoke-test steps.
 
+## Agent API
+
+Agents (external tools, LLM assistants) can plan and read workouts on a user's behalf via bearer-token-authenticated serverless endpoints under `/api/agent/`. Full contract, request/response shapes, and known gaps are documented in `SPEC.md` ("Agent API" section) — read that before integrating.
+
+Quick reference:
+
+```bash
+curl -X POST https://<deployment>/api/agent/planned-workouts \
+  -H "Authorization: Bearer gym_sk_example..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scheduledFor": "2026-08-01",
+    "title": "Upper Body Strength",
+    "exercises": [
+      { "name": "Bench Press", "sets": [{ "reps": 8, "weight": 80, "unit": "kg" }] }
+    ]
+  }'
+
+curl https://<deployment>/api/agent/history?limit=10 \
+  -H "Authorization: Bearer gym_sk_example..."
+
+curl https://<deployment>/api/agent/exercises/Bench%20Press/progression?limit=20 \
+  -H "Authorization: Bearer gym_sk_example..."
+```
+
+**There is no self-service key-generation UI yet** — a user cannot currently obtain a bearer token without direct Supabase access. See `SPEC.md` Known gaps and follow-up tasks tracking an MCP server + OAuth/social-login flow for this.
+
+Server-only env var required for these endpoints (do not expose to the browser bundle): `SUPABASE_SERVICE_ROLE_KEY`.
+
 ## Files of interest
 
 - `src/main.jsx` — entry; wires `<AuthProvider>` + `<BrowserRouter>`.
@@ -58,7 +87,11 @@ See `supabase/README.md` for the migration apply + RLS smoke-test steps.
 - `src/lib/supabase.js` — singleton Supabase client; fails fast if env vars are missing.
 - `src/lib/auth.jsx` — `useAuth()` hook (session, signIn, signOut, …).
 - `src/lib/workouts.js` — `createWorkout`, `addSets`, `listWorkouts`, `listSetsForWorkouts`, `deleteWorkout`.
-- `src/components/WorkoutLogger.jsx` — log-workout screen.
+- `src/lib/plans.js` — `fetchPlannedWorkoutForDate`, `fetchPlannedWorkoutById`, `markPlannedWorkoutCompleted` — browser-side plan-mode helpers.
+- `src/components/WorkoutLogger.jsx` — log-workout screen (freeform + plan mode).
 - `src/components/HistoryList.jsx` — last-30-days history view.
 - `src/components/LoginScreen.jsx` — sign-in screen.
+- `server/agentAuth.js` — shared agent bearer-token auth + Supabase admin client (server-only, outside `api/` so it is never itself a public route).
+- `api/agent/planned-workouts.js`, `api/agent/history.js`, `api/agent/exercises/[exerciseName]/progression.js` — agent API route handlers.
 - `supabase/migrations/20260708120000_init_workouts.sql` — schema + RLS.
+- `supabase/migrations/20260723170000_agent_powered_workouts.sql` — agent API keys + planned workouts schema + RLS.

--- a/apps/gymtrack/SPEC.md
+++ b/apps/gymtrack/SPEC.md
@@ -1,16 +1,19 @@
 # GymTrack — Behavioural spec
 
-Task: `18256740` (Shape GymTrack MVP from saved prototype).
-Tech design: `docs/specs/gymtrack-mvp-tech-design.md`.
-Product spec: `brain/tasks/specs/gymtrack-mvp-2026-07-07.md`.
+Task: `18256740` (Shape GymTrack MVP from saved prototype), `f520c396` (Agent-Powered Workouts).
+Tech design: `docs/specs/gymtrack-mvp-tech-design.md`, `docs/specs/gymtrack-agent-powered-workouts-tech-design.md`.
+Product spec: `brain/tasks/specs/gymtrack-mvp-2026-07-07.md`, `brain/tasks/specs/in-progress/gymtrack-agent-powered-workouts.md`.
 
 ## Overview
 
 GymTrack is a single-user workout tracker for Tom. It is a standalone SPA deployed at a stable URL, accessible from iOS Safari without an app install. Workouts are persisted in Supabase, scoped to Tom's user account via RLS. The MVP replaces the localStorage-based prototype (`apps/gymtrack/` on `feat/gymtrack-prototype`) with a real auth + real database.
 
+As of task `f520c396`, an authenticated agent can also submit a **planned workout** on Tom's behalf via a server-side API. The app surfaces the plan (if one exists for the selected date) in place of freeform logging, lets Tom log actuals against each planned set, and stores both target and actual values side by side. Agents can also read back recent history and per-exercise progression to inform the next plan.
+
 ## Users
 
 - **Tom** — sole user in v1. Email + password sign-in. RLS is configured to scope all data to `auth.uid() = user_id` so even if a second user is provisioned in error, they cannot read Tom's data.
+- **Agents** — authenticate to the agent-facing API via a bearer token (see [Agent API](#agent-api) below). An agent acts as the `user_id` its token was issued for; it cannot see or write other users' data. **As of this writing there is no self-service key-generation UI in the app** — every issued token today has been created by direct Supabase service-role insert, not through a flow a real external agent/user could complete unassisted. See Non-goals / Known gaps.
 
 ## Flows
 
@@ -37,6 +40,15 @@ GymTrack is a single-user workout tracker for Tom. It is a standalone SPA deploy
 1. From `/history`, the last 30 days of workouts load.
 2. Workouts are grouped by date (newest first). Each workout shows its set count and the per-set breakdown (exercise, set index, reps × weight unit).
 3. Empty state: "No workouts in the last 30 days. Log one from the Log tab."
+
+### Log a workout against a plan (AC2, agent-powered)
+
+1. From `/workout`, if a planned workout exists for the selected date (`status` in `planned`/`started`), the screen renders **plan mode** instead of the freeform form.
+2. Plan mode shows the plan's title and optional notes, then one table per exercise. Each row shows the target (reps × weight + unit) and editable actual-reps/actual-weight/unit inputs, pre-filled with the target values.
+3. An "Add an extra (non-planned) set" form remains available below the plan for sets outside the plan.
+4. Tap "Save workout" → creates a `workouts` row linked to the plan (`planned_workout_id`) and one `workout_sets` row per planned set (linked via `planned_set_id`) using the actual values entered, plus any extra freeform sets. The plan is marked `completed`.
+5. On success → success banner; plan clears from the screen (a `completed` plan is not re-shown for that date).
+6. If no plan exists for the selected date, the screen falls back to freeform logging (see "Log a workout" above). **The date shown is whatever is in the date picker — it defaults to today, not the plan's `scheduled_for` date.** If an agent creates a plan for a future date, Tom must change the date picker to that date to see it; the plan does not surface early.
 
 ### Sign out
 
@@ -77,6 +89,30 @@ All protected routes (`/workout`, `/history`) are wrapped in `<AuthGate>` which:
 - Component banners (`status.error`) render the error message inline; the user can retry.
 - The app fails fast at startup if `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` are missing (clear error pointing to `.env.example`).
 
+## Agent API
+
+Server-side (Vercel serverless) endpoints under `apps/gymtrack/api/agent/`, implemented in `apps/gymtrack/server/agentAuth.js` + per-route handlers. These are separate from the browser app's Supabase anon-key access — they use the Supabase **service-role key** server-side and authenticate the caller via a bearer token, not a Supabase session.
+
+### Auth
+
+- Header: `Authorization: Bearer <token>`.
+- Server hashes the token with SHA-256 and looks up a non-revoked row in `public.gymtrack_agent_api_keys` (`token_hash`, `revoked_at is null`).
+- On success, the request acts as that row's `user_id`; `last_used_at` is updated best-effort.
+- On failure (missing/malformed header, no matching row, revoked): `401 { "error": "invalid_api_key" }`.
+- **Known gap:** there is no in-app flow for a user to generate their own key yet. Every key that exists today was inserted directly via the Supabase service-role key from outside the app (see Known gaps below).
+
+### Endpoints
+
+- `POST /api/agent/planned-workouts` — create a planned workout (title, optional notes, `scheduledFor` date, list of exercises each with target sets). Validates bounds (max 25 exercises, max 20 sets/exercise, max 200 sets total; positive reps; non-negative weight; unit `kg`/`lb`). Returns `201 { plannedWorkoutId, setCount }`. Implementation: `apps/gymtrack/api/agent/planned-workouts.js`.
+- `GET /api/agent/history?limit=1..50` (default 10) — the caller's recent workouts with sets, including linked planned target (if any) per set. Implementation: `apps/gymtrack/api/agent/history.js`.
+- `GET /api/agent/exercises/:exerciseName/progression?limit=1..200` (default 20) — chronological set history for one exercise (case-insensitive exact match), with linked planned target per set. Implementation: `apps/gymtrack/api/agent/exercises/[exerciseName]/progression.js`.
+
+All three return `400 invalid_request` on bad input, `401 invalid_api_key` on auth failure, `405 method_not_allowed` on wrong verb, `500 server_error` on unexpected failure.
+
+### Discovery
+
+**There is no machine-readable API discovery surface (no OpenAPI spec, no MCP server, no `/api/agent` index route).** An agent needs this SPEC.md section or direct source access to know the contract exists. This is a known gap — see Known gaps below.
+
 ## E2E coverage
 
 | Flow                | Spec file                              |
@@ -85,6 +121,8 @@ All protected routes (`/workout`, `/history`) are wrapped in `<AuthGate>` which:
 | Add 2 sets → save → see in history | `test/e2e/log-workout.spec.ts` |
 
 Playwright runs against the Vite dev server on port 5179 with `iPhone 13` device emulation.
+
+**Agent API and plan-mode flows have unit/component coverage (`src/lib/plannedWorkoutsHandler.test.js`, `src/lib/historyHandler.test.js`, `src/lib/progressionHandler.test.js`, `src/lib/agentAuth.test.js`, `src/lib/plannedWorkouts.test.js`) but no Playwright e2e coverage yet.** Add e2e coverage for: agent creates a plan → plan renders in plan mode → actuals saved → history/progression reflect it.
 
 ## Out of scope (v1)
 


### PR DESCRIPTION
## Summary
- `apps/gymtrack/SPEC.md` and `README.md` were never updated when task f520c396 (GymTrack Agent-Powered Workouts, PRs #285 + #296) shipped, despite the approved tech design explicitly listing both as implementation steps. Caught during Tom's manual QA pass on 2026-07-27.
- SPEC.md: documents the agent API contract (auth, 3 endpoints, request/response shapes, known gaps), the new plan-mode flow (AC2), and the date-picker gotcha that caused confusion during QA (a plan only surfaces on its `scheduled_for` date, not automatically on load).
- README.md: documents the agent API for external integrators with curl examples, lists the new `server/`/`api/` files and the agent-powered-workouts migration.
- Explicitly flags two known gaps in SPEC.md for follow-up tasks: no self-service API-key generation UI, and no machine-readable API discovery (no MCP server / OpenAPI spec).

## System Spec
No change — GymTrack has no `docs/systems/gymtrack.md` (Tom does not want one created for this app). This PR closes the `apps/<app>/SPEC.md` gap only, per the doc taxonomy in `docs/CONVENTIONS.md`.

## Test plan
- [ ] Read `apps/gymtrack/SPEC.md` end to end — confirm the Agent API section matches the actual handler behavior in `api/agent/*.js`.
- [ ] Confirm the plan-mode flow description matches `WorkoutLogger.jsx` behavior (target/actual table, date-picker gating).
- [ ] Confirm README curl examples are runnable against the deployed endpoints.

Related skill-hardening follow-up (separate commit/PR to come): the `pr-open`/`feature-task-create` skills and lobster gate need a stronger nudge so implementation PRs that skip an app-spec update get caught before merge, not after Tom's manual QA.

🤖 Generated with Claude Code