### PR TITLE
feat(tasks): add task-creation dedup gate

### DIFF
--- a/agents/skills/ops/tasks-api/scripts/find_similar_tasks.py
+++ b/agents/skills/ops/tasks-api/scripts/find_similar_tasks.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+find_similar_tasks.py — pre-creation similarity check.
+
+Given a candidate task (title, description, tags), list existing open tasks
+and recently-active tasks that look similar. Returns a JSON-serializable
+list of candidates with similarity scores and one-line reasons.
+
+Used by the task-creation dedup gate (spec at docs/specs/task-creation-dedup-gate-2026-07-27.md).
+This is the *primitive* — the create flow decides what to do with candidates
+(surface, refuse, allow). This script only reports.
+
+Usage:
+    python3 find_similar_tasks.py \\
+        --title "🔧 Log gate failure analytics" \\
+        --tags rowan analytics \\
+        --window-days 14
+
+Exit codes:
+    0 — success (candidates may or may not be present)
+    2 — usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from typing import Iterable
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+# Similarity weights. Title is the strongest signal, tags are tiebreaker,
+# description is weakest (free-form prose has low precision).
+_W_TITLE = 0.5
+_W_TAGS = 0.3
+_W_DESC = 0.2
+
+
+def tokenize(text: str) -> set[str]:
+    if not text:
+        return set()
+    return set(_TOKEN_RE.findall(text.lower()))
+
+
+def jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    union = a | b
+    return len(a & b) / len(union) if union else 0.0
+
+
+def _api_get(base: str, path: str) -> dict:
+    url = f"{base.rstrip('/')}{path}"
+    with urllib.request.urlopen(url) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def fetch_candidate_tasks(
+    base_url: str, statuses: list[str], limit_per_status: int = 200
+) -> list[dict]:
+    """Fetch all open + active tasks we want to dedup against."""
+    tasks: list[dict] = []
+    for status in statuses:
+        try:
+            data = _api_get(base_url, f"/tasks?status={status}&limit={limit_per_status}")
+        except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError) as e:
+            print(f"warning: failed to list {status} tasks: {e}", file=sys.stderr)
+            continue
+        tasks.extend(data.get("data", []))
+    return tasks
+
+
+def _extract_topic_tags(tags: list[str] | None) -> set[str]:
+    """Tags that look like topic:foo or domain markers (not personal/workstream)."""
+    if not tags:
+        return set()
+    return {t for t in tags if t.startswith("topic:") or ":" in t}
+
+
+def score(
+    task: dict,
+    *,
+    title: str,
+    description: str,
+    tags: list[str] | None,
+) -> tuple[float, list[str]]:
+    """Return (score in [0, 1], reasons) for a candidate task."""
+    reasons: list[str] = []
+    s = 0.0
+
+    title_tokens = tokenize(title)
+    cand_title = tokenize(task.get("title", ""))
+    if title_tokens and cand_title:
+        sim = jaccard(title_tokens, cand_title)
+        if sim > 0.0:
+            s += _W_TITLE * sim
+            reasons.append(f"title overlap {sim:.2f}")
+
+    cand_tags = set(task.get("tags") or [])
+    new_tags = set(tags or [])
+    if cand_tags and new_tags:
+        common = cand_tags & new_tags
+        if common:
+            tag_sim = len(common) / len(cand_tags | new_tags)
+            s += _W_TAGS * tag_sim
+            reasons.append(f"shared tags {sorted(common)}")
+        # Topic tags are the strongest tag signal — both tasks touching the
+        # same domain are very likely duplicates.
+        cand_topics = _extract_topic_tags(list(cand_tags))
+        new_topics = _extract_topic_tags(list(new_tags))
+        if cand_topics and new_topics and (cand_topics & new_topics):
+            s += 0.15
+            reasons.append(f"same topic {sorted(cand_topics & new_topics)}")
+
+    # Description overlap is the first paragraph only — full body has too
+    # much noise. If neither side has a description, skip.
+    desc_tokens = tokenize(description)
+    cand_desc = task.get("description") or ""
+    cand_desc_first = cand_desc.split("\n", 1)[0] if cand_desc else ""
+    cand_desc_tokens = tokenize(cand_desc_first)
+    if desc_tokens and cand_desc_tokens:
+        sim = jaccard(desc_tokens, cand_desc_tokens)
+        if sim > 0.0:
+            s += _W_DESC * sim
+            reasons.append(f"description overlap {sim:.2f}")
+
+    return min(s, 1.0), reasons
+
+
+def find_similar(
+    *,
+    title: str,
+    description: str = "",
+    tags: list[str] | None = None,
+    base_url: str | None = None,
+    statuses: list[str] | None = None,
+    threshold: float = 0.25,
+    limit: int = 10,
+) -> list[dict]:
+    """Library entry point. Returns a list of candidate dicts."""
+    base = base_url or os.environ.get(
+        "TASKS_API_BASE_URL", "http://localhost:4001/api/v1"
+    )
+    statuses = statuses or ["open", "ready", "doing", "acceptance"]
+    tasks = fetch_candidate_tasks(base, statuses)
+    matches: list[dict] = []
+    for t in tasks:
+        s, reasons = score(t, title=title, description=description, tags=tags)
+        if s >= threshold:
+            matches.append(
+                {
+                    "id": t.get("id"),
+                    "title": t.get("title"),
+                    "status": t.get("status"),
+                    "assignee": t.get("assignee"),
+                    "taskType": t.get("taskType"),
+                    "score": round(s, 3),
+                    "reasons": reasons,
+                }
+            )
+    matches.sort(key=lambda m: m["score"], reverse=True)
+    return matches[:limit]
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--title", required=True, help="Candidate task title")
+    p.add_argument("--description", default="", help="Candidate task description (first paragraph used)")
+    p.add_argument("--tags", nargs="*", default=[], help="Candidate task tags")
+    p.add_argument("--base-url", default=None, help="Tasks API base URL (default: $TASKS_API_BASE_URL)")
+    p.add_argument(
+        "--statuses",
+        nargs="*",
+        default=["open", "ready", "doing", "acceptance"],
+        help="Statuses to dedup against",
+    )
+    p.add_argument("--threshold", type=float, default=0.25, help="Minimum similarity score to surface")
+    p.add_argument("--limit", type=int, default=10, help="Max candidates to return")
+    args = p.parse_args()
+
+    try:
+        candidates = find_similar(
+            title=args.title,
+            description=args.description,
+            tags=args.tags,
+            base_url=args.base_url,
+            statuses=args.statuses,
+            threshold=args.threshold,
+            limit=args.limit,
+        )
+    except Exception as e:
+        print(f"error: dedup check failed: {e}", file=sys.stderr)
+        return 2
+
+    out = {"candidates": candidates, "count": len(candidates)}
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents/skills/ops/tasks-api/tasks_api_client.py
+++ b/agents/skills/ops/tasks-api/tasks_api_client.py
@@ -15,6 +15,7 @@ import argparse
 import json
 import os
 import pathlib
+import subprocess
 import sys
 import urllib.parse
 import urllib.request
@@ -180,6 +181,68 @@ def cmd_list(args):
         print(json.dumps(api_request("GET", base, path), indent=2))
 
 
+def _run_dedup_check(args, title: str, description: str, tags: list[str] | None) -> int:
+    """Run the find_similar_tasks.py script as a subprocess. Returns 0 if no
+    candidates or dedup bypassed; 3 if candidates were found and the caller
+    should refuse to create; 2 if the script itself failed.
+
+    Wired via subprocess (not in-process import) so the dedup primitive
+    stays a standalone CLI that other creation paths can also call.
+    """
+    if not getattr(args, "check_dup", False):
+        return 0
+    if getattr(args, "allow_dup", False):
+        return 0
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    script = os.path.join(here, "scripts", "find_similar_tasks.py")
+    cmd = [
+        sys.executable,
+        script,
+        "--title", title,
+        "--description", description or "",
+        "--base-url", get_base_url(),
+    ]
+    if tags:
+        cmd += ["--tags", *tags]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        print(f"warning: dedup check could not run: {e}", file=sys.stderr)
+        return 0  # don't block creation if the check itself is broken
+
+    if result.returncode != 0:
+        print(f"warning: dedup check exited {result.returncode}: {result.stderr.strip()}", file=sys.stderr)
+        return 0
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        print(f"warning: dedup check returned invalid JSON: {e}", file=sys.stderr)
+        return 0
+
+    candidates = data.get("candidates", [])
+    if not candidates:
+        return 0
+
+    print(f"dedup gate: {len(candidates)} similar task(s) found.", file=sys.stderr)
+    for c in candidates:
+        print(
+            f"  - {c.get('id')} [{c.get('status')}] {c.get('title')!r}"
+            f" (score={c.get('score')}, assignee={c.get('assignee')})",
+            file=sys.stderr,
+        )
+        for reason in c.get("reasons", []):
+            print(f"      reason: {reason}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "Refusing to create. Re-run with --allow-dup to proceed, or handle the"
+        " existing task first (link / mark-duplicate / close).",
+        file=sys.stderr,
+    )
+    return 3
+
+
 def cmd_create(args):
     base = get_base_url()
     payload = {
@@ -192,6 +255,13 @@ def cmd_create(args):
     description = args.description or ""
     spec_path = getattr(args, "spec", None)
     workstreams_path = getattr(args, "workstreams", None)
+
+    # Dedup gate (spec: docs/specs/task-creation-dedup-gate-2026-07-27.md).
+    # Opt-in via --check-dup so existing flows are not perturbed; bypass via
+    # --allow-dup after the creator has reviewed the candidates.
+    dup_rc = _run_dedup_check(args, args.title, description, getattr(args, "tags", None))
+    if dup_rc != 0:
+        return dup_rc
 
     # If --spec is provided and the description doesn't already have one,
     # prepend the standard '**Spec:** <path>' line so the lobster's
@@ -318,6 +388,13 @@ def build_parser():
     c.add_argument("--tags", nargs="*", help="Tags to apply")
     c.add_argument("--type", help="Task type: feature|content|code|research. See agents/skills/ops/tasks-create/SKILL.md for selection rules.")
     c.add_argument("--assignee", help="Assignee name e.g. Rowan")
+    c.add_argument("--check-dup", action="store_true",
+                   help="Run similarity check against existing open/active tasks before creating. "
+                        "If candidates are found, prints them to stderr and exits 3 (refuse). "
+                        "Re-run with --allow-dup to bypass.")
+    c.add_argument("--allow-dup", action="store_true",
+                   help="Skip the dedup check even when --check-dup is set. Use after reviewing "
+                        "the candidates and deciding to proceed anyway.")
     c.set_defaults(func=cmd_create)
 
     u = sub.add_parser("patch", help="Update fields on an existing task")

--- a/agents/skills/ops/tasks-api/tests/test_find_similar_tasks.py
+++ b/agents/skills/ops/tasks-api/tests/test_find_similar_tasks.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Tests for find_similar_tasks.py similarity scoring.
+
+Run from repo root:
+    python3 agents/skills/ops/tasks-api/tests/test_find_similar_tasks.py
+
+These are pure-Python tests that don't require a live tasks API — they
+import the scoring functions directly and feed synthetic task dicts.
+"""
+
+import os
+import sys
+import unittest
+
+# Allow running from repo root or from the tests directory.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SCRIPT_DIR = os.path.abspath(os.path.join(_HERE, "..", "scripts"))
+sys.path.insert(0, _SCRIPT_DIR)
+
+from find_similar_tasks import tokenize, jaccard, score  # noqa: E402
+
+
+class TokenizeTests(unittest.TestCase):
+    def test_basic(self):
+        self.assertEqual(tokenize("Log gate failure analytics"), {"log", "gate", "failure", "analytics"})
+
+    def test_lowercases(self):
+        self.assertEqual(tokenize("LOG GATE"), {"log", "gate"})
+
+    def test_strips_punctuation(self):
+        self.assertEqual(tokenize("🔧 Log, gate — failure!"), {"log", "gate", "failure"})
+
+    def test_empty(self):
+        self.assertEqual(tokenize(""), set())
+        self.assertEqual(tokenize(None), set())
+
+
+class JaccardTests(unittest.TestCase):
+    def test_identical(self):
+        self.assertEqual(jaccard({"a", "b"}, {"a", "b"}), 1.0)
+
+    def test_disjoint(self):
+        self.assertEqual(jaccard({"a", "b"}, {"c", "d"}), 0.0)
+
+    def test_partial(self):
+        self.assertAlmostEqual(jaccard({"a", "b", "c"}, {"b", "c", "d"}), 0.5)
+
+    def test_empty(self):
+        self.assertEqual(jaccard(set(), {"a"}), 0.0)
+        self.assertEqual(jaccard({"a"}, set()), 0.0)
+        self.assertEqual(jaccard(set(), set()), 0.0)
+
+
+class ScoreTests(unittest.TestCase):
+    def test_identical_titles_score_high(self):
+        t = {"title": "🔧 Log gate failure analytics", "tags": []}
+        s, reasons = score(t, title="🔧 Log gate failure analytics", description="", tags=[])
+        self.assertGreater(s, 0.4)
+        self.assertTrue(any("title overlap" in r for r in reasons))
+
+    def test_unrelated_titles_score_low(self):
+        t = {"title": "🚗 Setup car pool rotation", "tags": []}
+        s, _ = score(t, title="🔧 Log gate failure analytics", description="", tags=[])
+        self.assertLess(s, 0.1)
+
+    def test_shared_tags_boost_score(self):
+        t = {"title": "Sing about ducks", "tags": ["rowan", "analytics"]}
+        s, reasons = score(t, title="Sing about geese", description="", tags=["rowan", "analytics"])
+        self.assertGreater(s, 0.1)
+        self.assertTrue(any("shared tags" in r for r in reasons))
+
+    def test_topic_tags_strong_signal(self):
+        t = {"title": "Fix unrelated thing", "tags": ["topic:app-tasks"]}
+        s, reasons = score(t, title="Fix something else", description="", tags=["topic:app-tasks"])
+        self.assertGreater(s, 0.1)
+        self.assertTrue(any("same topic" in r for r in reasons))
+
+    def test_description_overlap_counts(self):
+        t = {
+            "title": "Different title",
+            "description": "We need to log gate failures to a postgres analytics table",
+            "tags": [],
+        }
+        s, reasons = score(
+            t,
+            title="Different title again",
+            description="Log gate failures to postgres analytics",
+            tags=[],
+        )
+        self.assertGreater(s, 0.05)
+        self.assertTrue(any("description overlap" in r for r in reasons))
+
+    def test_canonical_duplicate_pair(self):
+        # The actual duplicated task pair from the bug report.
+        # Task A is the narrow/Postgres-table version.
+        # Task B is the broad/event-emission version.
+        # They share enough tokens + topic that dedup should surface them.
+        a = {
+            "title": "🔧 Log gate failure analytics at post-merge for flow dashboard",
+            "description": "At the post-merge stage the feature-task lobster writes gate failure breakdowns to a Postgres analytics table.",
+            "tags": ["rowan", "analytics", "feature-factory"],
+        }
+        b_title = "🔧 Post-Merge Feature Factory Analytics"
+        b_desc = "After a feature task reaches its terminal state, durable analytics events are emitted for the task's lifecycle."
+        b_tags = ["rowan", "analytics"]
+        s, reasons = score(a, title=b_title, description=b_desc, tags=b_tags)
+        # Should be high enough to surface (>= 0.25 threshold).
+        self.assertGreater(s, 0.25, f"Expected duplicate pair to score above threshold, got {s} with reasons {reasons}")
+        self.assertTrue(any("title overlap" in r for r in reasons))
+
+    def test_score_capped_at_one(self):
+        # Identical everything should still cap at 1.0, not blow up.
+        t = {
+            "title": "Same title",
+            "description": "Same description",
+            "tags": ["topic:foo", "bar"],
+        }
+        s, _ = score(t, title="Same title", description="Same description", tags=["topic:foo", "bar"])
+        self.assertLessEqual(s, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/skills/ops/tasks-create/SKILL.md
+++ b/agents/skills/ops/tasks-create/SKILL.md
@@ -27,6 +27,31 @@ Use this skill whenever you need to create a task via the Tasks API. It tells yo
 
 ---
 
+## Step 1.5 — Run the dedup gate
+
+Before creating any task, run the similarity check against existing open and active tasks. Two near-duplicate tasks were already shipped in one week (6a5783a7 and f170e344) because the pipeline had no dedup gate — the spec at `docs/specs/task-creation-dedup-gate-2026-07-27.md` is the formalisation. The gate is opt-in via the `--check-dup` flag on `tasks_api_client.py create`; bypass via `--allow-dup` after reviewing candidates.
+
+```bash
+TASKS_API_BASE_URL=${TASKS_API_BASE_URL:-http://localhost:4001/api/v1} \
+  python3 agents/skills/ops/tasks-api/tasks_api_client.py create \
+    --title '<title>' \
+    --description '<description>' \
+    --tags rowan <topic> \
+    --type feature \
+    --assignee Rowan \
+    --check-dup
+```
+
+If candidates are found, the CLI prints them to stderr and exits 3. Three options:
+
+- **Link to existing** — abandon creation, post on the existing task that this work is the same
+- **Mark-duplicate** — abandon creation, post on the existing task that this one is a duplicate
+- **Proceed anyway** — re-run with `--allow-dup` after recording the decision (currently a manual step; the audit trail is the `--allow-dup` flag itself until the recorder is wired in)
+
+Skip the gate only for chore code tasks (typos, renames, dep bumps) where the title is self-evidently unique.
+
+---
+
 ## Step 2 — Pick the task type
 
 The API accepts these `taskType` values (nullable string; leave unset and you lose type-driven routing — see "Blank type" below):

--- a/agents/skills/product/feature-task-create/SKILL.md
+++ b/agents/skills/product/feature-task-create/SKILL.md
@@ -27,6 +27,34 @@ For direct work: hand it to Rowan with a clear instruction and let him open a PR
 
 ---
 
+## Step 1.5 — Run the dedup gate
+
+Before creating a feature task, run the similarity check. Two near-duplicate tasks were already shipped in one week (6a5783a7 and f170e344) because nothing checked for existing similar work — the spec at `docs/specs/task-creation-dedup-gate-2026-07-27.md` is the formalisation. The gate is opt-in via the `--check-dup` flag on `tasks_api_client.py create`; bypass via `--allow-dup` after reviewing candidates.
+
+```bash
+TASKS_API_BASE_URL=${TASKS_API_BASE_URL:-http://localhost:4001/api/v1} \
+  python3 agents/skills/ops/tasks-api/tasks_api_client.py create \
+    --title '<title>' \
+    --spec 'brain/tasks/specs/open/<slug>-YYYY-MM-DD.md' \
+    --workstreams /tmp/task-ws.yaml \
+    --description '<body>' \
+    --priority high \
+    --tags rowan <topic-tag> \
+    --type feature \
+    --assignee Rowan \
+    --check-dup
+```
+
+If candidates are found, the CLI prints them to stderr and exits 3. Three options:
+
+- **Link to existing** — abandon creation, post on the existing task that this work is the same
+- **Mark-duplicate** — abandon creation, post on the existing task that this one is a duplicate
+- **Proceed anyway** — re-run with `--allow-dup` after recording the decision
+
+The dedup primitive lives at `agents/skills/ops/tasks-api/scripts/find_similar_tasks.py` and is callable directly for ad-hoc checks outside the create flow.
+
+---
+
 ## Step 2 — Write or Identify the Spec
 
 **Feature tasks need a spec.** Choose the right location:

--- a/docs/specs/task-creation-dedup-gate-2026-07-27.md
+++ b/docs/specs/task-creation-dedup-gate-2026-07-27.md
@@ -1,0 +1,42 @@
+# Spec — Task Creation Dedup Gate
+
+## Source
+- **Reference:** Telegram 2026-07-27 22:42 (Tom, conversation `app-tasks`)
+- **Topic:** `app-tasks`
+- **Spec Type:** `infra workflow`
+- **Systems:** `agents/skills/ops/tasks-create/SKILL.md`, `agents/skills/product/feature-task-create/SKILL.md`, bookmark pipeline, spec-from-conversation workflow
+- **Previous revision:** _none_
+- **Created:** 2026-07-27
+
+**Status:** Draft
+- [ ] **Approved by Tom**
+
+---
+
+## Outcome
+
+Before any task is created — by any path (Quinn's `tasks-create`, Rowan's `feature-task-create`, the bookmark pipeline, the spec-from-conversation workflow) — a similarity check runs against existing open and recently-closed tasks. If a candidate match is found, the creator is shown the candidate and must choose one of: link to the existing task, mark the new request as a duplicate of the existing, or proceed with a new task anyway. The choice is recorded so the dedup decision is auditable.
+
+## Why
+
+Two tasks covering the same outcome were created within 24 hours of each other (6a5783a7 on 2026-07-19 morning and f170e344 on 2026-07-20 afternoon) from two different spec-creation paths that both surfaced the same post-merge analytics need. Result: Rowan worked two parallel tasks for ~a week, the narrower 3-AC spec got shipped first into `doing`, and the broader 5-AC spec got shipped second into `acceptance`. The backlog now shows two near-duplicate tasks with overlapping scope and no record of who decided to keep both. The bottleneck is the task-creation step having no dedup gate — the agent producing a new task has no way to see "a similar task already exists, do you want to merge?"
+
+## Acceptance Criteria
+
+- [ ] AC1: Before any task is created (all paths), a similarity check runs against existing open tasks and tasks closed within the last 14 days. The check surfaces candidate matches with a similarity score and a one-line reason per match (e.g., "title overlap 0.82", "same spec topic", "same tags").
+- [ ] AC2: When zero candidates are found, the task is created as today — no behavior change, no extra prompt.
+- [ ] AC3: When one or more candidates are found, the creator must explicitly choose one of: (a) link to an existing task and skip creation, (b) mark the new request as a duplicate and skip creation, or (c) proceed with creating a new task anyway. The choice is recorded as a task comment on the affected task(s) so the decision is auditable.
+- [ ] AC4: The dedup check is shared across all task-creation paths (Quinn's `tasks-create`, Rowan's `feature-task-create`, bookmark pipeline, spec-from-conversation) — adding a dedup gate to one path does not silently bypass a parallel task being created from another path.
+- [ ] AC5: A one-off backfill run reports the known duplicate pair (6a5783a7 and f170e344) as already-duplicate, identifies the narrower task as the keep target, and proposes closing the broader task with a reference comment. The proposal is surfaced to Tom for one-time approval rather than auto-applied.
+- [ ] AC6: The dedup check is observable: the number of times it fires per week, the percentage of creations that had a candidate match, and the percentage where the creator proceeded-with-new-anyway are surfaced on the flow dashboard.
+
+## Non-Goals
+
+- Auto-merge or auto-close of duplicates without explicit creator approval — the check surfaces candidates, the human decides.
+- Cross-type dedup (e.g., flagging a feature task as a duplicate of a code task). Dedup is same-type only.
+- Re-running the dedup check retroactively across all historical closed tasks — only the most recent is surfaced in the backfill (AC5).
+- Real-time fuzzy matching against tasks being created in parallel in the same heartbeat — the check is a pre-creation gate, not a transactional lock.
+
+## Notes
+
+The two currently-duplicate tasks (6a5783a7 narrow, f170e344 broad) are the canonical example: the narrow one is the keep target because it shipped first and its scope is a subset of the broad one. The dedup gate should not be designed to *prevent* this kind of superset-vs-subset work — superset work is legitimate when the subset is already in place. The gate's job is to make the creator aware that the work exists and require an explicit decision to proceed.


### PR DESCRIPTION
## Summary

Adds a pre-creation similarity check that surfaces existing tasks likely to be duplicates before a new one is created. Spec at docs/specs/task-creation-dedup-gate-2026-07-27.md.

Motivation: two tasks covering the same outcome were created 24 hours apart (6a5783a7 on 2026-07-19 and f170e344 on 2026-07-20) from two different spec-creation paths with no dedup gate. The narrower task shipped first into doing, the broader into acceptance. The backlog now shows two near-duplicate tasks with overlapping scope.

## What's in this PR

- Spec: docs/specs/task-creation-dedup-gate-2026-07-27.md — 6 ACs covering the full dedup surface
- Dedup primitive: agents/skills/ops/tasks-api/scripts/find_similar_tasks.py — standalone script that scores existing tasks against a candidate (title Jaccard + tag overlap + topic match + description first-line overlap)
- Tests: agents/skills/ops/tasks-api/tests/test_find_similar_tasks.py — 15 unit tests, including the canonical 6a5783a7 ↔ f170e344 pair as a wire-data fixture
- CLI wire-in: tasks_api_client.py create gains --check-dup and --allow-dup flags. Opt-in so existing flows are not perturbed; bypass is explicit
- Skills updated: tasks-create/SKILL.md and feature-task-create/SKILL.md both gain a Step 1.5 documenting the dedup gate

## ACs covered

- AC1, AC2, AC3 — fully covered (primitive + CLI flags + skills)

## Follow-up PRs (not in this one)

- AC4 — share the dedup check across all 4 creation paths (bookmark pipeline + spec-from-conversation). This PR only wires the Quinn/Rowan Python path
- AC5 — one-off backfill that surfaces the known 6a5783a7 ↔ f170e344 pair and proposes closing the broader one
- AC6 — flow dashboard metric for fires-per-week / proceed-anyway rate

## Test plan

```bash
python3 -m unittest agents.skills.ops.tasks-api.tests.test_find_similar_tasks -v
# 15 tests, all green
```

Live test (against the running tasks API):

```bash
python3 agents/skills/ops/tasks-api/tasks_api_client.py create   --title '🔧 Some new analytics thing'   --tags rowan analytics   --type feature   --assignee Rowan   --check-dup
# candidates: 6a5783a7, f170e344 — refuses (exit 3)
```