### PR TITLE
feat(tasks-api): gate manual X publish with x-actor-secret header (task 38d2ee65)

### DIFF
--- a/services/tasks-api/.env.example
+++ b/services/tasks-api/.env.example
@@ -36,3 +36,13 @@ OTEL_ENVIRONMENT=dev
 # X_ACCESS_TOKEN=                 # Access Token
 # X_ACCESS_TOKEN_SECRET=          # Access Token Secret
 # X_HANDLE=sindustries
+
+# Cloud-readiness gate (task 38d2ee65) — protects the manual publish route
+# `POST /content-scheduler/items/:id/publish` when running with X_CLIENT=real.
+# When set, callers MUST send a matching `x-actor-secret` header or the
+# route returns 401 before any X API call is attempted.
+# When UNSET (dev / local / CI), the gate is pass-through and the manual
+# publish route behaves as before — so existing local workflows keep
+# working. The auto-post worker is not gated (it runs in-process).
+# Generate a strong random value: `openssl rand -hex 32`.
+# X_ACTOR_SECRET=                 # Required when X_CLIENT=real in cloud deploys

--- a/services/tasks-api/src/app.ts
+++ b/services/tasks-api/src/app.ts
@@ -61,7 +61,7 @@ export function createApp() {
     }
 
     res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-actor');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-actor, x-actor-secret');
 
     if (req.method === 'OPTIONS') {
       return res.sendStatus(204);

--- a/services/tasks-api/src/routes/contentScheduler.ts
+++ b/services/tasks-api/src/routes/contentScheduler.ts
@@ -30,6 +30,7 @@ import {
   guardPublish,
   getAucklandTodayParts,
   getXClient,
+  checkActorSecret,
   TERMINAL_STATUSES
 } from './contentSchedulerPublish.ts';
 import {
@@ -338,6 +339,23 @@ contentSchedulerRouter.post('/content-scheduler/items/:id/publish', async (req, 
   try {
     const id = parseId(req.params.id);
     if (!id) return badRequest(res, 'INVALID_ID', 'Invalid id');
+
+    // Cloud-readiness gate (task 38d2ee65): when X_ACTOR_SECRET is
+    // configured, require an `x-actor-secret` header that matches before
+    // any X API call is attempted. When unset, dev/local/CI stays usable.
+    const rawHeader = req.headers['x-actor-secret'];
+    const headerValue = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+    const actorGuard = checkActorSecret(headerValue);
+    if (actorGuard.ok === false) {
+      return sendError(
+        res,
+        401,
+        'UNAUTHORIZED',
+        actorGuard.reason === 'MISSING_HEADER'
+          ? 'Missing x-actor-secret header (X_ACTOR_SECRET is configured)'
+          : 'Invalid x-actor-secret header'
+      );
+    }
 
     const result = await publishContentSchedulerItem(id, 'manual');
 

--- a/services/tasks-api/src/routes/contentSchedulerPublish.ts
+++ b/services/tasks-api/src/routes/contentSchedulerPublish.ts
@@ -260,3 +260,58 @@ function startOfAucklandDay(now: Date): Date {
   // Fallback: return now (should never hit given bounded loop).
   return now;
 }
+
+/**
+ * Manual publish gate — protects `POST /content-scheduler/items/:id/publish`
+ * (the real-X write path) when `X_ACTOR_SECRET` is configured.
+ *
+ * Behavior matrix:
+ *  - X_ACTOR_SECRET unset → pass-through (dev / local / CI without the secret
+ *    stays usable; behavior documented in services/tasks-api/.env.example).
+ *  - X_ACTOR_SECRET set + header missing → 401 UNAUTHORIZED before any X call.
+ *  - X_ACTOR_SECRET set + header present + match → pass-through.
+ *  - X_ACTOR_SECRET set + header present + mismatch → 401 UNAUTHORIZED.
+ *
+ * Comparison uses `crypto.timingSafeEqual` on equal-length buffers to avoid
+ * leaking the secret via response-time differences. The header value and
+ * the env var are both normalized to UTF-8 before comparison.
+ *
+ * This gate is **only** applied to the manual publish route. The auto-post
+ * worker calls `publishContentSchedulerItem` directly with `actor='auto'`
+ * and is intentionally not gated here — the worker is an in-process queue
+ * consumer that already runs inside a trusted boundary.
+ *
+ * Task: 38d2ee65-a6c0-4952-a8ca-ad03d4856eb1
+ * Tech design: docs/specs/cloud-readiness-x-publish-actor-secret-tech-design.md
+ */
+export type ActorSecretGuard =
+  | { ok: true; configured: false }
+  | { ok: true; configured: true }
+  | { ok: false; reason: 'MISSING_HEADER' | 'MISMATCH' };
+
+/**
+ * Pure check. Reads the expected secret from `process.env.X_ACTOR_SECRET`
+ * and the provided header from the caller. Returns whether the gate should
+ * allow the request through.
+ *
+ * Pure (no Express coupling) so the unit tests can drive it without spinning
+ * up the app. The route wrapper below maps a `false` result to a 401.
+ */
+export function checkActorSecret(providedHeader: string | undefined | null): ActorSecretGuard {
+  const expected = process.env.X_ACTOR_SECRET;
+  if (!expected || expected.length === 0) {
+    // Dev / local / CI mode — gate is disabled by configuration.
+    return { ok: true, configured: false };
+  }
+  if (typeof providedHeader !== 'string' || providedHeader.length === 0) {
+    return { ok: false, reason: 'MISSING_HEADER' };
+  }
+  const expectedBuf = Buffer.from(expected, 'utf8');
+  const providedBuf = Buffer.from(providedHeader, 'utf8');
+  if (expectedBuf.length !== providedBuf.length) {
+    return { ok: false, reason: 'MISMATCH' };
+  }
+  const { timingSafeEqual } = require('node:crypto') as typeof import('node:crypto');
+  const equal = timingSafeEqual(expectedBuf, providedBuf);
+  return equal ? { ok: true, configured: true } : { ok: false, reason: 'MISMATCH' };
+}

--- a/services/tasks-api/test/contentScheduler.test.ts
+++ b/services/tasks-api/test/contentScheduler.test.ts
@@ -1,6 +1,12 @@
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { guardPublish, getXClient, FakeXClient, RealXClient } from '../src/routes/contentSchedulerPublish.ts';
+import {
+  guardPublish,
+  getXClient,
+  FakeXClient,
+  RealXClient,
+  checkActorSecret
+} from '../src/routes/contentSchedulerPublish.ts';
 
 // --- Prisma mock ---------------------------------------------------------
 
@@ -189,6 +195,55 @@ describe('getXClient', () => {
 
 // --- HTTP routes ----------------------------------------------------------
 
+describe('checkActorSecret (cloud-readiness x-actor-secret gate)', () => {
+  const originalSecret = process.env.X_ACTOR_SECRET;
+
+  beforeEach(() => {
+    delete process.env.X_ACTOR_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) delete process.env.X_ACTOR_SECRET;
+    else process.env.X_ACTOR_SECRET = originalSecret;
+  });
+
+  it('passes through when X_ACTOR_SECRET is unset (dev / local / CI)', () => {
+    delete process.env.X_ACTOR_SECRET;
+    const result = checkActorSecret(undefined);
+    expect(result).toEqual({ ok: true, configured: false });
+  });
+
+  it('passes through when X_ACTOR_SECRET is set to an empty string', () => {
+    process.env.X_ACTOR_SECRET = '';
+    const result = checkActorSecret('any-value');
+    expect(result).toEqual({ ok: true, configured: false });
+  });
+
+  it('refuses with MISSING_HEADER when secret is set and header is absent', () => {
+    process.env.X_ACTOR_SECRET = 's3cret-value';
+    expect(checkActorSecret(undefined)).toEqual({ ok: false, reason: 'MISSING_HEADER' });
+    expect(checkActorSecret(null)).toEqual({ ok: false, reason: 'MISSING_HEADER' });
+    expect(checkActorSecret('')).toEqual({ ok: false, reason: 'MISSING_HEADER' });
+  });
+
+  it('refuses with MISMATCH when secret is set and header is wrong', () => {
+    process.env.X_ACTOR_SECRET = 's3cret-value';
+    expect(checkActorSecret('wrong-value')).toEqual({ ok: false, reason: 'MISMATCH' });
+    // Different length always mismatches (no timingSafeEqual on different-length buffers).
+    expect(checkActorSecret('x')).toEqual({ ok: false, reason: 'MISMATCH' });
+  });
+
+  it('passes when secret is set and header matches exactly', () => {
+    process.env.X_ACTOR_SECRET = 's3cret-value';
+    expect(checkActorSecret('s3cret-value')).toEqual({ ok: true, configured: true });
+  });
+
+  it('passes when secret is set and header matches with non-ASCII (utf-8 normalized)', () => {
+    process.env.X_ACTOR_SECRET = 'π-secret';
+    expect(checkActorSecret('π-secret')).toEqual({ ok: true, configured: true });
+  });
+});
+
 describe('contentScheduler routes', () => {
   it('GET /api/v1/content-scheduler/items lists non-removed items', async () => {
     prismaMock.contentSchedulerItem.findMany.mockResolvedValue([itemFixture()]);
@@ -317,6 +372,86 @@ describe('contentScheduler routes', () => {
     const res = await request(app).post('/api/v1/content-scheduler/items/dddd1111-1111-1111-1111-111111111111/publish');
     expect(res.status).toBe(503);
     expect(res.body.error.code).toBe('MISSING_CREDENTIALS');
+    delete process.env.X_CLIENT;
+  });
+
+  // --- x-actor-secret gate (cloud-readiness task 38d2ee65) -------------
+
+  it('POST /content-scheduler/items/:id/publish returns 401 when X_ACTOR_SECRET is set and x-actor-secret header is missing', async () => {
+    process.env.X_ACTOR_SECRET = 'deploy-secret';
+    const itemId = 'eeee1111-1111-1111-1111-111111111111';
+    const item = itemFixture({ id: itemId, status: 'approved', approvedAt: new Date() });
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
+    const app = createApp();
+    const res = await request(app).post(`/api/v1/content-scheduler/items/${itemId}/publish`);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+    expect(res.body.error.message).toMatch(/Missing x-actor-secret/i);
+    // Gate fires before any DB load — prisma.findUnique is never called.
+    expect(prismaMock.contentSchedulerItem.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.contentSchedulerItem.update).not.toHaveBeenCalled();
+    delete process.env.X_ACTOR_SECRET;
+  });
+
+  it('POST /content-scheduler/items/:id/publish returns 401 when x-actor-secret header is wrong', async () => {
+    process.env.X_ACTOR_SECRET = 'deploy-secret';
+    const itemId = 'ffff1111-1111-1111-1111-111111111111';
+    const item = itemFixture({ id: itemId, status: 'approved', approvedAt: new Date() });
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
+    const app = createApp();
+    const res = await request(app)
+      .post(`/api/v1/content-scheduler/items/${itemId}/publish`)
+      .set('x-actor-secret', 'not-the-right-value');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+    expect(res.body.error.message).toMatch(/Invalid x-actor-secret/i);
+    expect(prismaMock.contentSchedulerItem.findUnique).not.toHaveBeenCalled();
+    delete process.env.X_ACTOR_SECRET;
+  });
+
+  it('POST /content-scheduler/items/:id/publish succeeds when x-actor-secret header matches', async () => {
+    process.env.X_ACTOR_SECRET = 'deploy-secret';
+    process.env.X_CLIENT = 'fake';
+    const itemId = 'aaaa2222-1111-1111-1111-111111111111';
+    const item = itemFixture({ id: itemId, status: 'approved', approvedAt: new Date() });
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
+    prismaMock.contentSchedulerItem.update.mockResolvedValue({
+      ...item,
+      status: 'published',
+      publishedUrl: 'https://x.com/sindustries/status/abc',
+      publishedAt: new Date()
+    });
+    const app = createApp();
+    const res = await request(app)
+      .post(`/api/v1/content-scheduler/items/${itemId}/publish`)
+      .set('x-actor-secret', 'deploy-secret');
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('published');
+    delete process.env.X_ACTOR_SECRET;
+    delete process.env.X_CLIENT;
+  });
+
+  it('POST /content-scheduler/items/:id/publish gate stays pass-through when X_ACTOR_SECRET is unset (dev/local/CI)', async () => {
+    delete process.env.X_ACTOR_SECRET;
+    process.env.X_CLIENT = 'fake';
+    const itemId = 'bbbb2222-1111-1111-1111-111111111111';
+    const item = itemFixture({ id: itemId, status: 'approved', approvedAt: new Date() });
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
+    prismaMock.contentSchedulerItem.update.mockResolvedValue({
+      ...item,
+      status: 'published',
+      publishedUrl: 'https://x.com/sindustries/status/abc',
+      publishedAt: new Date()
+    });
+    const app = createApp();
+    // No x-actor-secret header sent — should still succeed because the gate is disabled.
+    const res = await request(app).post(`/api/v1/content-scheduler/items/${itemId}/publish`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('published');
     delete process.env.X_CLIENT;
   });
 


### PR DESCRIPTION
## Summary

Closes task **38d2ee65-a6c0-4952-a8ca-ad03d4856eb1** (Cloud readiness: gate Content Scheduler X publish with actor secret). The manual Content Scheduler publish route is currently the only path that can post to real X with `X_CLIENT=real`, and it was guarded only by an unauthenticated `x-actor` label. This change adds an `x-actor-secret` header gate that fires before any X API call when `X_ACTOR_SECRET` is configured, while keeping dev/local/CI pass-through behavior intact when the env var is unset.

Source: `docs/repo-audits/2026-W29.md` Theme 3 / Milestone 0-C.

## Acceptance Criteria

- [x] AC1: `POST /content-scheduler/items/:id/publish` (or current publish route) validates an `x-actor-secret` header against `process.env.X_ACTOR_SECRET` when the env var is set. (🧪 testID: content-scheduler-actor-secret-gate)
- [x] AC2: Missing or mismatched `x-actor-secret` returns 401 before any X API call is attempted. (🧪 testID: content-scheduler-actor-secret-401)
- [x] AC3: Local/dev/test mode remains usable when `X_ACTOR_SECRET` is intentionally unset, with the behavior documented. (🧪 testID: content-scheduler-actor-secret-pass-through)
- [x] AC4: `services/tasks-api/.env.example` documents `X_ACTOR_SECRET` alongside `X_CLIENT`, `X_API_BEARER_TOKEN`, and `X_HANDLE` if not already present. (📄 not code: services/tasks-api/.env.example)
- [x] AC5: CI coverage proves unauthenticated publish is blocked when the secret is configured. (🧪 testID: content-scheduler-actor-secret-suite)

## Workstreams (from task description)

- **WS1 — Gate helper** (`checkActorSecret` in `src/routes/contentSchedulerPublish.ts`): pure function, `crypto.timingSafeEqual` on equal-length UTF-8 buffers, returns a discriminated union `{ ok: true; configured: boolean } | { ok: false; reason: 'MISSING_HEADER' | 'MISMATCH' }`. (AC1, AC2, AC3)
- **WS2 — Route wiring** (`src/routes/contentScheduler.ts` `/items/:id/publish`): invoke `checkActorSecret` after `parseId`, map `false` to `401 UNAUTHORIZED` via the shared `sendError` helper. Manual route only — auto-post worker is intentionally not gated (in-process trusted boundary). (AC1, AC2)
- **WS3 — CORS** (`src/app.ts`): extend `Access-Control-Allow-Headers` to include `x-actor-secret`. (AC1)
- **WS4 — Env doc** (`services/tasks-api/.env.example`): add `X_ACTOR_SECRET` line under the Content Scheduler X section with pass-through docs and `openssl rand -hex 32` hint. (AC3, AC4)
- **WS5 — CI coverage** (`test/contentScheduler.test.ts`): pure unit tests + route-level tests including explicit "no DB call on 401" assertion. (AC5)

## Diff stats

```
 services/tasks-api/.env.example                    |  10 ++
 services/tasks-api/src/app.ts                      |   2 +-
 services/tasks-api/src/routes/contentScheduler.ts  |  18 +++
 services/tasks-api/src/routes/contentSchedulerPublish.ts |  55 +++++++++
 services/tasks-api/test/contentScheduler.test.ts   | 137 ++++++++++++++++++++-
 5 files changed, 220 insertions(+), 2 deletions(-)
```

## Test plan

- `cd services/tasks-api && npm test` — all 139 tests pass, including 10 new cases for this change.
- `npx tsc --noEmit` — no new type errors introduced (matches pre-existing baseline of 89 errors on `main`; the remaining errors are pre-existing in `featureTaskAnalytics.ts`, `db-integration.test.ts`, etc., and are unrelated to this PR).
- Manual smoke (when `X_ACTOR_SECRET=test-secret` is set in env):
  - `curl -X POST .../content-scheduler/items/<id>/publish` → `401 UNAUTHORIZED` (no `x-actor-secret` header).
  - `curl -X POST -H 'x-actor-secret: wrong' .../publish` → `401 UNAUTHORIZED`.
  - `curl -X POST -H 'x-actor-secret: test-secret' .../publish` → proceeds to publish.
- Manual smoke (when `X_ACTOR_SECRET` is unset, e.g. local dev): all publish calls behave as before (pass-through).

## Security notes

- Constant-time comparison via `crypto.timingSafeEqual` on equal-length UTF-8 buffers prevents response-time leaks of the secret.
- The auto-post worker calls `publishContentSchedulerItem(id, 'auto')` directly (not via the HTTP route), so it is intentionally not gated here. The worker is an in-process queue consumer that already runs inside a trusted boundary; gating it would break scheduled publishes without adding security.
- CORS allow-list extension is the minimal change (`x-actor-secret` only); existing `x-actor` and `Authorization` headers are unchanged.

## Task lifecycle

- Task status: still `doing`; will move to `acceptance` after `[qa-ac-verified] true` from Tom.
- Branch: `feat/cloud-readiness-x-publish-actor-secret` (1 commit, ready for review).

Co-Authored-By: Rowan <rowanstoffer@gmail.com>


