### PR TITLE
feat(tasks-api): gate Content Scheduler publish with X_ACTOR_SECRET

### DIFF
--- a/services/tasks-api/.env.example
+++ b/services/tasks-api/.env.example
@@ -36,3 +36,12 @@ OTEL_ENVIRONMENT=dev
 # X_ACCESS_TOKEN=                 # Access Token
 # X_ACCESS_TOKEN_SECRET=          # Access Token Secret
 # X_HANDLE=sindustries
+
+# Cloud-readiness: when X_ACTOR_SECRET is set, POST /content-scheduler/items/:id/publish
+# requires a matching `x-actor-secret` header. Leave UNSET in local dev/test so the
+# single-user MVP flow keeps working without ceremony. In any cloud-exposed environment
+# (staging, prod), SET this to a long random string and supply the same value to the
+# only callers allowed to publish (Mission Control / scheduled jobs). The publish guard
+# returns 401 before any X API call is attempted when the secret is configured and the
+# header is missing/mismatched.
+# X_ACTOR_SECRET=

--- a/services/tasks-api/src/app.ts
+++ b/services/tasks-api/src/app.ts
@@ -61,7 +61,7 @@ export function createApp() {
     }
 
     res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-actor');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-actor, x-actor-secret');
 
     if (req.method === 'OPTIONS') {
       return res.sendStatus(204);

--- a/services/tasks-api/src/routes/contentScheduler.ts
+++ b/services/tasks-api/src/routes/contentScheduler.ts
@@ -24,6 +24,7 @@
 //              docs/specs/content-scheduler-auto-post-2026-07-16-tech-design.md
 
 import { Router } from 'express';
+import { timingSafeEqual } from 'node:crypto';
 import { prisma } from '../lib/prisma.ts';
 import { badRequest, notFound, sendError } from '../lib/http.ts';
 import {
@@ -53,6 +54,49 @@ function actor(req: any): string {
   return 'unknown';
 }
 
+/**
+ * Cloud-readiness guard for the publish endpoint.
+ *
+ * When X_ACTOR_SECRET is set in the environment, every publish request
+ * must present a matching `x-actor-secret` header. This prevents an
+ * unauthenticated caller from posting to X via the real client
+ * (`X_CLIENT=real`) once the service is exposed past localhost.
+ *
+ * When X_ACTOR_SECRET is unset (local dev/test), the guard is a no-op
+ * so existing single-user MVP flows continue to work without ceremony.
+ *
+ * Uses `crypto.timingSafeEqual` for the comparison so the secret isn't
+ * vulnerable to a timing side-channel attack. Length mismatch is
+ * detected first and short-circuits without invoking timingSafeEqual,
+ * which would otherwise throw on unequal-length buffers.
+ *
+ * Returns true if the request was rejected (and a response was sent),
+ * false if the request should continue to the publish logic.
+ */
+function requireActorSecret(req: any, res: any): boolean {
+  const expected = process.env.X_ACTOR_SECRET;
+  if (!expected) return false;
+  const provided = req.headers['x-actor-secret'];
+  if (typeof provided !== 'string') {
+    sendError(res, 401, 'MISSING_HEADER', 'x-actor-secret header is required when X_ACTOR_SECRET is configured');
+    return true;
+  }
+  const expectedBuf = Buffer.from(expected, 'utf8');
+  const providedBuf = Buffer.from(provided, 'utf8');
+  if (expectedBuf.length !== providedBuf.length || !timingSafeEqual(expectedBuf, providedBuf)) {
+    sendError(res, 401, 'MISMATCH', 'x-actor-secret header does not match X_ACTOR_SECRET');
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Apply the auto-post schedule decision after a write. Best-effort: if the
+ * adapter throws (e.g. Redis is down), we surface a 503 from the route so
+ * Tom sees the failure rather than silently dropping the schedule. The
+ * database write has already committed at this point, so the item state
+ * is the source of truth.
+ */
 async function applyAutoPostSchedule(
   itemId: string,
   prior: {
@@ -338,6 +382,10 @@ contentSchedulerRouter.post('/content-scheduler/items/:id/publish', async (req, 
   try {
     const id = parseId(req.params.id);
     if (!id) return badRequest(res, 'INVALID_ID', 'Invalid id');
+
+    // Cloud-readiness gate: when X_ACTOR_SECRET is configured, require a
+    // matching x-actor-secret header before any X API call is attempted.
+    if (requireActorSecret(req, res)) return;
 
     const result = await publishContentSchedulerItem(id, 'manual');
 

--- a/services/tasks-api/test/contentScheduler.test.ts
+++ b/services/tasks-api/test/contentScheduler.test.ts
@@ -320,6 +320,97 @@ describe('contentScheduler routes', () => {
     delete process.env.X_CLIENT;
   });
 
+  // --- Cloud-readiness: X_ACTOR_SECRET gate on /publish ------------------
+
+  it('POST /content-scheduler/items/:id/publish returns 401 when X_ACTOR_SECRET is set and x-actor-secret header is missing', async () => {
+    process.env.X_ACTOR_SECRET = 'cloud-secret-123';
+    const item = itemFixture({
+      id: 'eeee1111-1111-1111-1111-111111111111',
+      status: 'approved',
+      approvedAt: new Date()
+    });
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
+    const app = createApp();
+    const res = await request(app).post('/api/v1/content-scheduler/items/eeee1111-1111-1111-1111-111111111111/publish');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('MISSING_HEADER');
+    // No X API call should have been attempted — findUnique for the publish
+    // service path is mocked but the guard should fire before it gets hit
+    // (we still set up the mock for paranoia; the assertion below is the
+    // proof that no publish side-effects happened).
+    expect(prismaMock.contentSchedulerItem.update).not.toHaveBeenCalled();
+    delete process.env.X_ACTOR_SECRET;
+  });
+
+  it('POST /content-scheduler/items/:id/publish returns 401 when x-actor-secret header is wrong', async () => {
+    process.env.X_ACTOR_SECRET = 'cloud-secret-123';
+    const item = itemFixture({
+      id: 'eeee2222-2222-2222-2222-222222222222',
+      status: 'approved',
+      approvedAt: new Date()
+    });
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/content-scheduler/items/eeee2222-2222-2222-2222-222222222222/publish')
+      .set('x-actor-secret', 'wrong-secret');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('MISMATCH');
+    expect(prismaMock.contentSchedulerItem.update).not.toHaveBeenCalled();
+    delete process.env.X_ACTOR_SECRET;
+  });
+
+  it('POST /content-scheduler/items/:id/publish succeeds when x-actor-secret matches X_ACTOR_SECRET', async () => {
+    process.env.X_ACTOR_SECRET = 'cloud-secret-123';
+    process.env.X_CLIENT = 'fake';
+    const item = itemFixture({
+      id: 'eeee3333-3333-3333-3333-333333333333',
+      status: 'approved',
+      approvedAt: new Date()
+    });
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
+    prismaMock.contentSchedulerItem.update.mockResolvedValue({
+      ...item,
+      status: 'published',
+      publishedUrl: 'https://x.com/sindustries/status/abc',
+      publishedAt: new Date()
+    });
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/content-scheduler/items/eeee3333-3333-3333-3333-333333333333/publish')
+      .set('x-actor-secret', 'cloud-secret-123');
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('published');
+    delete process.env.X_ACTOR_SECRET;
+    delete process.env.X_CLIENT;
+  });
+
+  it('POST /content-scheduler/items/:id/publish works without x-actor-secret when X_ACTOR_SECRET is unset (dev/test mode)', async () => {
+    delete process.env.X_ACTOR_SECRET;
+    process.env.X_CLIENT = 'fake';
+    const item = itemFixture({
+      id: 'eeee4444-4444-4444-4444-444444444444',
+      status: 'approved',
+      approvedAt: new Date()
+    });
+    prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
+    prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
+    prismaMock.contentSchedulerItem.update.mockResolvedValue({
+      ...item,
+      status: 'published',
+      publishedUrl: 'https://x.com/sindustries/status/xyz',
+      publishedAt: new Date()
+    });
+    const app = createApp();
+    const res = await request(app).post('/api/v1/content-scheduler/items/eeee4444-4444-4444-4444-444444444444/publish');
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('published');
+    delete process.env.X_CLIENT;
+  });
+
   it('POST /content-scheduler/reorder writes positions in a transaction', async () => {
     const idA = 'aaaa1111-1111-1111-1111-111111111111';
     const idB = 'bbbb1111-1111-1111-1111-111111111111';


### PR DESCRIPTION
## Closed as duplicate of #314

This PR is closed in favour of [#314](https://github.com/Stoffer-Industries/sindustries/pull/314) (feat(tasks-api): gate manual X publish with x-actor-secret header), which implements the same 38d2ee65 task with the spec-aligned helper extraction (checkActorSecret in src/routes/contentSchedulerPublish.ts).

The implementation difference:

- **#314 (canonical)** — extracted checkActorSecret helper in a dedicated module, matching task WS1.
- **#315 (this PR, closed)** — inlined requireActorSecret in the route file. Functionally equivalent; kept the inline layout to keep the diff narrow, but spec asked for the extracted layout.

No review action needed on this PR. Task 38d2ee65 will move to acceptance after #314 merges and Tom posts [qa-ac-verified] true.
