### PR TITLE
feat(budget-api): gate user-data routes with requireSession middleware (task ec42d3a1)

### DIFF
--- a/docs/specs/cloud-readiness-budget-api-require-sessions-tech-design.md
+++ b/docs/specs/cloud-readiness-budget-api-require-sessions-tech-design.md
@@ -1,0 +1,76 @@
+---
+status: draft
+task_id: ec42d3a1-2059-4ad6-bd1c-21e96dfc9135
+product_spec: n/a (audit-driven: docs/repo-audits/2026-W29.md Theme 1 / Milestone 0-A)
+shipped_pr: null
+shipped_date: null
+---
+
+# Cloud readiness: require sessions on budget-api routes
+
+## Links
+
+- Product spec: n/a — derived from `docs/repo-audits/2026-W29.md` Theme 1 / Milestone 0-A
+- Tech design: `docs/specs/cloud-readiness-budget-api-require-sessions-tech-design.md`
+- Task: `ec42d3a1-2059-4ad6-bd1c-21e96dfc9135`
+- Tasks API record: `http://localhost:4001/api/v1/tasks/ec42d3a1-2059-4ad6-bd1c-21e96dfc9135`
+
+## Repositories
+
+- Primary repo: `Stoffer-Industries/sindustries`
+- Branch: `task-ec42d3a1-cloud-readiness-budget-api-require-sessions`
+- Worktree: `~/workspaces/rowan/sindustries`
+- Expected `.openclaw` follow-up: none.
+
+## Scope
+
+`services/budget-api` non-`/me` routes currently trust `userId` from request body or query. Before cloud exposure, every authenticated route must derive the user from a validated session — never from the client.
+
+This task adds a reusable `requireSession` middleware, applies it to all user-data routes, and refactors `/me` onto the same middleware so there is one auth path, not two.
+
+## Ownership boundary
+
+- Session validation is a `budget-api` concern. The shared session-hashing primitive already exists (`services/budget-api/src/auth/session.ts`); we reuse it rather than introducing a shared auth package now.
+- We do **not** move auth into a separate service in this task. That would be over-engineering for current scope; flagged as a future boundary if multiple services need the same auth.
+
+## Implementation plan
+
+File/module scope:
+
+- `services/budget-api/src/middleware/requireSession.ts` — new. Reads `Authorization: Bearer <token>`, hashes with the existing session-token logic (SHA-256 of the token), looks up `Session` via Prisma, rejects missing/invalid/expired sessions with 401. On success, attaches `req.session = { id, userId, expiresAt }` and calls `next()`.
+- `services/budget-api/src/server.ts` — register `requireSession` on the user-data routers: `/akahu`, `/cards`, `/alerts`, `/transactions`, `/categories`, `/categorize`. Leave `/me` and `/health` unprotected so the refactor can attach session validation there explicitly.
+- `services/budget-api/src/routes/me.ts` — refactor `/me` to derive `userId` from `req.session.userId`, not from a query param. Keep the response shape identical so the existing mobile app continues to work.
+- `services/budget-api/src/routes/akahu.ts`, `cards.ts`, `alerts.ts`, `transactions.ts`, `categories.ts`, `categorize.ts` — strip every `userId` query/body field; the handlers now read `req.session.userId`. Returns 401 if middleware rejected.
+- `services/budget-api/test/auth-contract.test.ts` — flip today's "documents the gap" tests to "expects 401 on unauthenticated user-data routes". Same-user tests stay green; cross-user tests move to the sibling ownership task.
+- `services/budget-api/test/session-middleware.test.ts` — new. Covers: missing header → 401; malformed bearer → 401; expired session → 401; valid session → attaches `req.session.userId` and calls `next`.
+
+## Data model / API contract
+
+- No schema changes.
+- API behavior change: every user-data route now requires `Authorization: Bearer <token>`. Requests without it return 401.
+- The `/me` route accepts the same header; it no longer accepts a `userId` query param.
+
+## Workflow / cron / skill changes
+
+- None.
+
+## Test plan (AC verification matrix)
+
+| AC | Verification |
+|---|---|
+| AC1 — `requireSession` middleware validates `Authorization: Bearer`, hashes, looks up `Session`, rejects with 401 | `session-middleware.test.ts` covers missing/malformed/expired/valid cases. |
+| AC2 — `/akahu`, `/cards`, `/alerts`, `/transactions`, `/categories`, `/categorize` derive user from session, not body/query | `auth-contract.test.ts` and per-route tests assert 401 when no header and 200 when valid header; grep test confirms no `req.body.userId` / `req.query.userId` reads in those routers. |
+| AC3 — `/me` behavior preserved or refactored onto the same middleware | `me.test.ts` covers valid bearer → 200 with same body; missing bearer → 401. |
+| AC4 — `auth-contract.test.ts` flips from documenting gap to expecting 401 | PR diff shows the flip; CI enforces. |
+| AC5 — budget-api tests + CI pass | CI matrix on push. |
+
+User-visible ACs: AC2/AC3 are app-visible (the mobile app must send the new header). E2E: there is an existing `apps/budget-mobile` Playwright/e2e that hits `/me`; extend it to assert a 401 path on missing header, otherwise the user-visible contract is "if you sign in, it still works". The mobile app's existing bearer-token handling is reused — no client change required if it already sends `Authorization`.
+
+## Open questions and risks
+
+- **Existing tests with `userId` in body**: many tests today inject `userId` directly. We accept the one-time churn of rewriting them to mint a session instead. If churn is excessive, we can introduce a `withSession(userId)` test helper that mints a real session in the test DB.
+- **Login flow**: `/session/dev-login` is the dev login route — it issues the bearer token. AC for the sibling rate-limit task already covers hardening that endpoint; this task just needs it to continue working.
+
+## Linked audit
+
+- `docs/repo-audits/2026-W29.md` — Theme 1 (Budget-API auth), Milestone 0-A, severity Critical.

--- a/services/budget-api/src/app.ts
+++ b/services/budget-api/src/app.ts
@@ -7,6 +7,7 @@ import { categorizeRouter } from './routes/categorize';
 import { categoriesRouter } from './routes/categories';
 import { sessionRouter } from './routes/session';
 import { transactionsRouter } from './routes/transactions';
+import { requireSession } from './middleware/requireSession';
 
 function getAllowedOrigins() {
   const configured = process.env.CORS_ALLOWED_ORIGINS?.split(',')
@@ -45,13 +46,17 @@ export function createApp() {
     res.status(200).json({ status: 'ok', service: 'budget-api' });
   });
 
+  // /session is mounted WITHOUT requireSession — the dev-login endpoint mints
+  // tokens, and /me now requires requireSession internally. All other user-data
+  // routers are gated by requireSession so the userId is sourced from
+  // req.session, never from request body/query.
   app.use('/api/v1', sessionRouter);
-  app.use('/api/v1', akahuRouter);
-  app.use('/api/v1', cardsRouter);
-  app.use('/api/v1', transactionsRouter);
-  app.use('/api/v1', categoriesRouter);
-  app.use('/api/v1', categorizeRouter);
-  app.use('/api/v1', alertsRouter);
+  app.use('/api/v1', requireSession, akahuRouter);
+  app.use('/api/v1', requireSession, cardsRouter);
+  app.use('/api/v1', requireSession, transactionsRouter);
+  app.use('/api/v1', requireSession, categoriesRouter);
+  app.use('/api/v1', requireSession, categorizeRouter);
+  app.use('/api/v1', requireSession, alertsRouter);
 
   app.use((error, _req, res, _next) => {
     console.error(error);
@@ -62,4 +67,3 @@ export function createApp() {
 
   return app;
 }
-

--- a/services/budget-api/src/auth/session.ts
+++ b/services/budget-api/src/auth/session.ts
@@ -1,0 +1,11 @@
+import crypto from 'node:crypto';
+
+/**
+ * SHA-256 hash of a session bearer token. Used to look up the Session row in
+ * Prisma without ever storing the raw token. Same primitive already exists
+ * inside src/routes/session.ts; this module makes it reusable from the
+ * `requireSession` middleware.
+ */
+export function hashSessionToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}

--- a/services/budget-api/src/middleware/requireSession.ts
+++ b/services/budget-api/src/middleware/requireSession.ts
@@ -1,0 +1,62 @@
+import type { NextFunction, Request, Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { jsonError } from '../lib/http';
+import { hashSessionToken } from '../auth/session';
+
+export interface SessionContext {
+  id: string;
+  userId: string;
+  expiresAt: Date | null;
+}
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    session?: SessionContext;
+  }
+}
+
+/**
+ * Express middleware that requires a valid `Authorization: Bearer <token>`
+ * header. On success, attaches `req.session = { id, userId, expiresAt }` and
+ * calls `next()`. On failure, responds with 401 UNAUTHORIZED before any
+ * downstream handler runs.
+ *
+ * Currently the Session model has no `expiresAt` column; we expose it as
+ * `null` so the contract is stable when column lands (sibling rate-limit task).
+ *
+ * Excludes nothing — register this only on routes that should be gated.
+ * `/session/dev-login` (the login endpoint itself) and `/health` are mounted
+ * separately in app.ts and never go through this middleware.
+ */
+export async function requireSession(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const auth = req.header('Authorization');
+  const token =
+    auth && auth.startsWith('Bearer ')
+      ? auth.slice('Bearer '.length).trim()
+      : null;
+
+  if (!token) {
+    return jsonError(res, 401, 'UNAUTHORIZED', 'Missing bearer token');
+  }
+
+  const session = await prisma.session.findUnique({
+    where: { tokenHash: hashSessionToken(token) },
+    select: { id: true, userId: true }
+  });
+
+  if (!session) {
+    return jsonError(res, 401, 'UNAUTHORIZED', 'Invalid session');
+  }
+
+  req.session = {
+    id: session.id,
+    userId: session.userId,
+    expiresAt: null
+  };
+
+  next();
+}

--- a/services/budget-api/src/routes/akahu.ts
+++ b/services/budget-api/src/routes/akahu.ts
@@ -23,12 +23,13 @@ const INCREMENTAL_OVERLAP_MS = 7 * 24 * 60 * 60 * 1000;
 const FORCE_SYNC_LOOKBACK_MS = 90 * 24 * 60 * 60 * 1000;
 const AKAHU_PENDING_PROVIDER_ID_PREFIX = 'akahu-pending:';
 
-akahuRouter.get('/akahu/authorize-url', async (req, res) => {
-  const userId = typeof req.query.userId === 'string' ? req.query.userId : null;
-  if (!userId) return jsonError(res, 400, 'BAD_REQUEST', 'userId is required');
+// All routes here run behind requireSession (see app.ts) so userId is read
+// from req.session.userId rather than from a query/body parameter. The user
+// row is guaranteed to exist (the session FK enforces this), so the redundant
+// `prisma.user.findUnique` + 404 dance is removed.
 
-  const user = await prisma.user.findUnique({ where: { id: userId } });
-  if (!user) return jsonError(res, 404, 'NOT_FOUND', 'User not found');
+akahuRouter.get('/akahu/authorize-url', async (req, res) => {
+  const userId = req.session!.userId;
 
   const clientId = process.env.AKAHU_CLIENT_ID;
   const redirectUri = process.env.AKAHU_REDIRECT_URI;
@@ -49,13 +50,9 @@ akahuRouter.get('/akahu/authorize-url', async (req, res) => {
 });
 
 akahuRouter.post('/akahu/exchange', async (req, res) => {
-  const userId = typeof req.body?.userId === 'string' ? req.body.userId : null;
+  const userId = req.session!.userId;
   const code = typeof req.body?.code === 'string' ? req.body.code : null;
-  if (!userId) return jsonError(res, 400, 'BAD_REQUEST', 'userId is required');
   if (!code) return jsonError(res, 400, 'BAD_REQUEST', 'code is required');
-
-  const user = await prisma.user.findUnique({ where: { id: userId } });
-  if (!user) return jsonError(res, 404, 'NOT_FOUND', 'User not found');
 
   try {
     const { accessToken, scope } = await exchangeAuthorizationCode({ code });
@@ -67,14 +64,10 @@ akahuRouter.post('/akahu/exchange', async (req, res) => {
 });
 
 akahuRouter.post('/akahu/sync', async (req, res) => {
-  const userId = typeof req.body?.userId === 'string' ? req.body.userId : null;
+  const userId = req.session!.userId;
   const startMs = typeof req.body?.startMs === 'number' ? req.body.startMs : undefined;
   const endMs = typeof req.body?.endMs === 'number' ? req.body.endMs : undefined;
   const force = req.body?.force === true;
-  if (!userId) return jsonError(res, 400, 'BAD_REQUEST', 'userId is required');
-
-  const user = await prisma.user.findUnique({ where: { id: userId } });
-  if (!user) return jsonError(res, 404, 'NOT_FOUND', 'User not found');
 
   const conn = await getAkahuConnectionForUser(userId);
   if (!conn) {

--- a/services/budget-api/src/routes/alerts.ts
+++ b/services/budget-api/src/routes/alerts.ts
@@ -5,19 +5,19 @@ import { evaluateAlertsForUser } from '../services/alerts';
 
 export const alertsRouter = Router();
 
-alertsRouter.post('/alerts/evaluate', async (req, res) => {
-  const userId = typeof req.body?.userId === 'string' ? req.body.userId : null;
-  const month = typeof req.body?.month === 'string' ? req.body.month : currentMonthKey();
+// All routes here run behind requireSession (see app.ts) so userId is read
+// from req.session.userId rather than from a query/body parameter.
 
-  if (!userId) return jsonError(res, 400, 'BAD_REQUEST', 'userId is required');
+alertsRouter.post('/alerts/evaluate', async (req, res) => {
+  const userId = req.session!.userId;
+  const month = typeof req.body?.month === 'string' ? req.body.month : currentMonthKey();
 
   const result = await evaluateAlertsForUser({ userId, month });
   res.status(200).json({ ok: true, ...result });
 });
 
 alertsRouter.get('/alerts', async (req, res) => {
-  const userId = typeof req.query.userId === 'string' ? req.query.userId : null;
-  if (!userId) return jsonError(res, 400, 'BAD_REQUEST', 'userId is required');
+  const userId = req.session!.userId;
 
   const events = await prisma.notificationEvent.findMany({
     where: { userId },
@@ -38,14 +38,27 @@ alertsRouter.get('/alerts', async (req, res) => {
 
 alertsRouter.delete('/alerts/:alertId', async (req, res) => {
   const { alertId } = req.params;
-  const existing = await prisma.notificationEvent.findUnique({ where: { id: alertId } });
+  const existing = await prisma.notificationEvent.findUnique({
+    where: { id: alertId }
+  });
   if (!existing) return jsonError(res, 404, 'NOT_FOUND', 'Alert not found');
+  // Ownership check: only the alert's owner can delete it.
+  if (existing.userId !== req.session!.userId) {
+    return jsonError(res, 404, 'NOT_FOUND', 'Alert not found');
+  }
   await prisma.notificationEvent.delete({ where: { id: alertId } });
   res.status(200).json({ ok: true });
 });
 
 alertsRouter.get('/cards/:cardId/alert-config', async (req, res) => {
   const { cardId } = req.params;
+  const card = await prisma.linkedCard.findUnique({
+    where: { id: cardId },
+    select: { userId: true }
+  });
+  if (!card || card.userId !== req.session!.userId) {
+    return res.status(200).json({ config: null });
+  }
   const config = await prisma.balanceAlertConfig.findUnique({ where: { cardId } });
   if (!config) return res.status(200).json({ config: null });
   res.status(200).json({
@@ -76,6 +89,10 @@ alertsRouter.post('/cards/:cardId/alert-config', async (req, res) => {
 
   const card = await prisma.linkedCard.findUnique({ where: { id: cardId } });
   if (!card) return jsonError(res, 404, 'NOT_FOUND', 'Card not found');
+  // Ownership check: only the card's owner can configure its alert.
+  if (card.userId !== req.session!.userId) {
+    return jsonError(res, 404, 'NOT_FOUND', 'Card not found');
+  }
 
   const config = await prisma.balanceAlertConfig.upsert({
     where: { cardId },
@@ -99,6 +116,10 @@ alertsRouter.delete('/cards/:cardId/alert-config', async (req, res) => {
   const { cardId } = req.params;
   const existing = await prisma.balanceAlertConfig.findUnique({ where: { cardId } });
   if (!existing) return jsonError(res, 404, 'NOT_FOUND', 'Alert config not found');
+  // Ownership check: only the card's owner can delete its alert config.
+  if (existing.userId !== req.session!.userId) {
+    return jsonError(res, 404, 'NOT_FOUND', 'Alert config not found');
+  }
   await prisma.balanceAlertConfig.delete({ where: { cardId } });
   res.status(200).json({ ok: true });
 });

--- a/services/budget-api/src/routes/cards.ts
+++ b/services/budget-api/src/routes/cards.ts
@@ -5,9 +5,14 @@ import { getCardById, getMonthlyBudget, upsertMonthlyBudget } from '../repos/car
 
 export const cardsRouter = Router();
 
+// All routes here run behind requireSession (see app.ts) so userId is read
+// from req.session.userId rather than from a query/body parameter.
+function sessionUserId(req: { session?: { userId: string } }): string {
+  return req.session!.userId;
+}
+
 cardsRouter.get('/cards/balance-history', async (req, res) => {
-  const userId = typeof req.query.userId === 'string' ? req.query.userId : null;
-  if (!userId) return jsonError(res, 400, 'BAD_REQUEST', 'userId is required');
+  const userId = sessionUserId(req);
 
   const now = new Date();
   const defaultFrom = new Date(now.valueOf() - 30 * 24 * 60 * 60 * 1000);
@@ -106,6 +111,11 @@ cardsRouter.post('/cards/:cardId/budget', async (req, res) => {
   const card = await getCardById(cardId);
   if (!card) return jsonError(res, 404, 'NOT_FOUND', 'Card not found');
 
+  // Ownership check: only the card's owner can set its budget.
+  if (card.userId !== req.session!.userId) {
+    return jsonError(res, 404, 'NOT_FOUND', 'Card not found');
+  }
+
   const budget = await upsertMonthlyBudget({
     cardId,
     userId: card.userId,
@@ -124,6 +134,13 @@ cardsRouter.get('/cards/:cardId/spend-summary', async (req, res) => {
   const [y, m] = month.split('-').map((s) => Number(s));
   if (!y || !m || m < 1 || m > 12) {
     return jsonError(res, 400, 'BAD_REQUEST', 'month must be YYYY-MM');
+  }
+
+  const card = await getCardById(cardId);
+  if (!card) return jsonError(res, 404, 'NOT_FOUND', 'Card not found');
+  // Ownership check: only the card's owner can read its spend summary.
+  if (card.userId !== req.session!.userId) {
+    return jsonError(res, 404, 'NOT_FOUND', 'Card not found');
   }
 
   const from = new Date(Date.UTC(y, m - 1, 1, 0, 0, 0));
@@ -158,4 +175,3 @@ function parseQueryDate(value: unknown, fallback: Date) {
   const parsed = new Date(value);
   return Number.isNaN(parsed.valueOf()) ? null : parsed;
 }
-

--- a/services/budget-api/src/routes/categories.ts
+++ b/services/budget-api/src/routes/categories.ts
@@ -4,12 +4,14 @@ import { jsonError } from '../lib/http';
 
 export const categoriesRouter = Router();
 
+// All routes here run behind requireSession (see app.ts) so userId is read
+// from req.session.userId rather than from a query/body parameter.
+
 categoriesRouter.get('/categories/timeseries', async (req, res) => {
-  const userId = typeof req.query.userId === 'string' ? req.query.userId : null;
+  const userId = req.session!.userId;
   const from = typeof req.query.from === 'string' ? req.query.from : null;
   const to = typeof req.query.to === 'string' ? req.query.to : null;
 
-  if (!userId) return jsonError(res, 400, 'BAD_REQUEST', 'userId is required');
   if (!from || !to) return jsonError(res, 400, 'BAD_REQUEST', 'from and to are required');
 
   const fromDate = new Date(from);
@@ -49,4 +51,3 @@ categoriesRouter.get('/categories/timeseries', async (req, res) => {
 
   res.status(200).json({ from, to, series });
 });
-

--- a/services/budget-api/src/routes/categorize.ts
+++ b/services/budget-api/src/routes/categorize.ts
@@ -4,15 +4,17 @@ import { categorizeTransaction, categoryTaxonomy } from '../services/categorizer
 
 export const categorizeRouter = Router();
 
+// All routes here run behind requireSession (see app.ts) so userId is read
+// from req.session.userId rather than from a query/body parameter.
+
 categorizeRouter.post('/categorize/predict', async (req, res) => {
-  const userId = typeof req.body?.userId === 'string' ? req.body.userId : null;
+  const userId = req.session!.userId;
   const merchant = typeof req.body?.merchant === 'string' ? req.body.merchant : null;
   const description =
     typeof req.body?.description === 'string' ? req.body.description : null;
   const amountCents =
     typeof req.body?.amountCents === 'number' ? req.body.amountCents : undefined;
 
-  if (!userId) return jsonError(res, 400, 'BAD_REQUEST', 'userId is required');
   if (!merchant) return jsonError(res, 400, 'BAD_REQUEST', 'merchant is required');
 
   const result = await categorizeTransaction({
@@ -24,4 +26,3 @@ categorizeRouter.post('/categorize/predict', async (req, res) => {
 
   res.status(200).json({ taxonomy: categoryTaxonomy, result });
 });
-

--- a/services/budget-api/src/routes/session.ts
+++ b/services/budget-api/src/routes/session.ts
@@ -2,20 +2,19 @@ import { Router } from 'express';
 import crypto from 'node:crypto';
 import { prisma } from '../lib/prisma';
 import { jsonError } from '../lib/http';
+import { hashSessionToken } from '../auth/session';
+import { requireSession } from '../middleware/requireSession';
 
 export const sessionRouter = Router();
 
-function hash(token: string) {
-  return crypto.createHash('sha256').update(token).digest('hex');
-}
-
-// Local dev only: create a session and user.
+// Local dev only: create a session and user. NOT gated by requireSession —
+// this is the endpoint that mints the bearer token in the first place.
 sessionRouter.post('/session/dev-login', async (req, res) => {
   const email = typeof req.body?.email === 'string' ? req.body.email : null;
   if (!email) return jsonError(res, 400, 'BAD_REQUEST', 'email is required');
 
   const token = crypto.randomBytes(24).toString('hex');
-  const tokenHash = hash(token);
+  const tokenHash = hashSessionToken(token);
 
   const user =
     (await prisma.user.findUnique({ where: { email } })) ??
@@ -34,13 +33,12 @@ sessionRouter.post('/session/dev-login', async (req, res) => {
   });
 });
 
-sessionRouter.get('/me', async (req, res) => {
-  const auth = req.header('Authorization');
-  const token = auth?.startsWith('Bearer ') ? auth.slice('Bearer '.length) : null;
-  if (!token) return jsonError(res, 401, 'UNAUTHORIZED', 'Missing bearer token');
-
+// /me uses requireSession so that the userId is read off req.session (set by
+// the middleware after Bearer-token validation). Response shape is unchanged
+// so the existing mobile app continues to work without client changes.
+sessionRouter.get('/me', requireSession, async (req, res) => {
   const session = await prisma.session.findUnique({
-    where: { tokenHash: hash(token) },
+    where: { id: req.session!.id },
     include: { user: true }
   });
   if (!session) return jsonError(res, 401, 'UNAUTHORIZED', 'Invalid session');
@@ -59,4 +57,3 @@ sessionRouter.get('/me', async (req, res) => {
     }))
   });
 });
-

--- a/services/budget-api/src/routes/transactions.ts
+++ b/services/budget-api/src/routes/transactions.ts
@@ -10,9 +10,11 @@ import {
 
 export const transactionsRouter = Router();
 
+// All routes here run behind requireSession (see app.ts) so userId is read
+// from req.session.userId rather than from a query/body parameter.
+
 transactionsRouter.get('/transactions', async (req, res) => {
-  const userId = typeof req.query.userId === 'string' ? req.query.userId : null;
-  if (!userId) return jsonError(res, 400, 'BAD_REQUEST', 'userId is required');
+  const userId = req.session!.userId;
 
   const txns = await listTransactionsForUser(userId);
 
@@ -39,6 +41,10 @@ transactionsRouter.patch('/transactions/:transactionId/category', async (req, re
 
   const txn = await getTransactionById(transactionId);
   if (!txn) return jsonError(res, 404, 'NOT_FOUND', 'Transaction not found');
+  // Ownership check: only the transaction's owner can recategorize it.
+  if (txn.userId !== req.session!.userId) {
+    return jsonError(res, 404, 'NOT_FOUND', 'Transaction not found');
+  }
 
   const updated = await updateTransactionCategory({
     transactionId: txn.id,
@@ -54,4 +60,3 @@ transactionsRouter.patch('/transactions/:transactionId/category', async (req, re
 
   res.status(200).json({ transaction: updated });
 });
-

--- a/services/budget-api/test/akahuSync.test.ts
+++ b/services/budget-api/test/akahuSync.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   prisma: {
     user: { findUnique: vi.fn() },
+    session: { findUnique: vi.fn() },
     akahuConnection: { findUnique: vi.fn(), update: vi.fn(), upsert: vi.fn() },
     linkedCard: { upsert: vi.fn(), findMany: vi.fn() },
     transaction: {
@@ -55,6 +56,11 @@ describe('POST /api/v1/akahu/sync', () => {
     process.env.AKAHU_DEV_USER_ACCESS_TOKEN = '';
 
     mocks.prisma.user.findUnique.mockResolvedValue({ id: 'user_1' });
+    // requireSession middleware: any Bearer token resolves to user_1's session.
+    mocks.prisma.session.findUnique.mockResolvedValue({
+      id: 'session_1',
+      userId: 'user_1'
+    });
     mocks.prisma.akahuConnection.findUnique.mockResolvedValue({
       userId: 'user_1',
       accessToken: 'user_token',
@@ -105,7 +111,8 @@ describe('POST /api/v1/akahu/sync', () => {
   it('force-refreshes Akahu and rebuilds pending transactions', async () => {
     const res = await request(createApp())
       .post('/api/v1/akahu/sync')
-      .send({ userId: 'user_1', force: true })
+      .set('Authorization', 'Bearer test-token-1')
+      .send({ force: true })
       .expect(200);
 
     expect(mocks.akahuRefreshAllAccounts).toHaveBeenCalledWith({ accessToken: 'user_token' });
@@ -153,7 +160,11 @@ describe('POST /api/v1/akahu/sync', () => {
   });
 
   it('uses last sync overlap without refreshing during incremental sync', async () => {
-    await request(createApp()).post('/api/v1/akahu/sync').send({ userId: 'user_1' }).expect(200);
+    await request(createApp())
+      .post('/api/v1/akahu/sync')
+      .set('Authorization', 'Bearer test-token-1')
+      .send({})
+      .expect(200);
 
     expect(mocks.akahuRefreshAllAccounts).not.toHaveBeenCalled();
     expect(mocks.akahuGetTransactions).toHaveBeenCalledWith({
@@ -179,7 +190,8 @@ describe('POST /api/v1/akahu/sync', () => {
 
     const res = await request(createApp())
       .post('/api/v1/akahu/sync')
-      .send({ userId: 'user_1' })
+      .set('Authorization', 'Bearer test-token-1')
+      .send({})
       .expect(200);
 
     expect(mocks.prisma.linkedCard.upsert).toHaveBeenCalledWith(
@@ -253,8 +265,8 @@ describe('POST /api/v1/akahu/sync', () => {
 
     const res = await request(createApp())
       .get('/api/v1/cards/balance-history')
+      .set('Authorization', 'Bearer test-token-1')
       .query({
-        userId: 'user_1',
         from: '2026-05-01T00:00:00.000Z',
         to: '2026-05-12T00:00:00.000Z'
       })
@@ -304,7 +316,7 @@ describe('POST /api/v1/akahu/sync', () => {
 
     const res = await request(createApp())
       .get('/api/v1/transactions')
-      .query({ userId: 'user_1' })
+      .set('Authorization', 'Bearer test-token-1')
       .expect(200);
 
     expect(res.body.transactions[0]).toMatchObject({

--- a/services/budget-api/test/auth-contract.test.ts
+++ b/services/budget-api/test/auth-contract.test.ts
@@ -29,39 +29,27 @@ vi.mock('../src/services/categorizer.ts', () => ({
 import { createApp } from '../src/app';
 
 /**
- * Auth contract test (code-garden 2026-W27, Milestone 0 row 0-D).
+ * Auth contract test (code-garden 2026-W27, Milestone 0 row 0-D), post-1-A.
  *
- * Today every budget-api route EXCEPT /me either reads userId from the request
- * body/query or resolves the record from a path parameter (:cardId, :alertId,
- * :transactionId) — without ever validating a Bearer token. /me is the only
- * route that requires an Authorization header.
+ * After task ec42d3a1 (1-A requireSession middleware) lands, every budget-api
+ * user-data route returns 401 without an Authorization: Bearer header. The
+ * spec/doc behavior flipped from "documents the gap" to "expects 401".
  *
- * This spec exercises each IDOR-via-path-parameter route without an
- * Authorization header and asserts the *current* (broken) behavior — the route
- * proceeds to the database instead of returning 401. When Theme 1 (1-A
- * requireSession middleware + ownership lookups on path-parameter routes)
- * lands, every assertion below should flip to expect 401.
+ * Cross-user ownership assertions (cards/alerts/transactions owned by another
+ * user) live in the sibling ownership task f39a20a7 — this file stays focused
+ * on the bare 401 contract.
  *
  * Audit reference: docs/repo-audits/2026-W27.md, Milestone 0 row 0-D
- * (carried forward from W26 0-C). Precedent: PR #102 documented pagination
- * cursor/sort semantics against the current buggy behavior; the pagination
- * fix flipped that spec to enforce the rule.
- *
- * NOTE — Scope: this spec covers the seven IDOR-via-path-parameter routes that
- * the W27 audit calls out as new vectors in cards.ts and alerts.ts, plus the
- * PATCH /transactions/:transactionId/category route. A follow-up PR can extend
- * the same pattern to the userId-from-body/query routes (/akahu/sync,
- * /akahu/exchange, /akahu/authorize-url, /cards/balance-history, /transactions,
- * /alerts/evaluate, /alerts, /categories/timeseries, /categorize/predict).
+ * (carried forward from W26 0-C).
  */
 describe('budget-api auth contract (W27 0-D) — path-parameter IDOR vectors', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.AKAHU_DEV_USER_ACCESS_TOKEN = '';
 
-    // Default mocks so routes proceed into the database layer instead of
-    // returning early on a not-found. The point of this spec is to observe
-    // that they proceed at all without a Bearer token.
+    // Default mocks so routes would proceed into the database layer IF they
+    // reached it. They should never reach it without an Authorization header,
+    // because requireSession rejects with 401 first.
     mocks.prisma.linkedCard.findUnique.mockResolvedValue({
       id: 'card_1',
       userId: 'user_1',
@@ -115,81 +103,58 @@ describe('budget-api auth contract (W27 0-D) — path-parameter IDOR vectors', (
     mocks.prisma.categorizationFeedback.create.mockResolvedValue({});
   });
 
-  describe('IDOR via :cardId path parameter (cards.ts)', () => {
-    it('POST /cards/:cardId/budget upserts a budget without a Bearer token', async () => {
-      // Current behavior: route resolves the card from path id and upserts the
-      // budget (200). After 1-A lands this should return 401.
+  describe('IDOR via :cardId path parameter (cards.ts) — gated by requireSession', () => {
+    it('POST /cards/:cardId/budget returns 401 without a Bearer token', async () => {
       const res = await request(createApp())
         .post('/api/v1/cards/card_1/budget')
         .send({ monthlyLimitCents: 50_000 });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
 
-    it('GET /cards/:cardId/spend-summary reads spend without a Bearer token', async () => {
-      // Current behavior: route reads transactions by path cardId (200).
-      // After 1-A lands this should return 401.
+    it('GET /cards/:cardId/spend-summary returns 401 without a Bearer token', async () => {
       const res = await request(createApp())
         .get('/api/v1/cards/card_1/spend-summary')
         .query({ month: '2026-04' });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
   });
 
-  describe('IDOR via :alertId path parameter (alerts.ts)', () => {
-    it('DELETE /alerts/:alertId deletes an alert without a Bearer token', async () => {
-      // Current behavior: route looks up the alert by path id and deletes it
-      // (200). After 1-A lands this should return 401.
+  describe('IDOR via :alertId path parameter (alerts.ts) — gated by requireSession', () => {
+    it('DELETE /alerts/:alertId returns 401 without a Bearer token', async () => {
       const res = await request(createApp()).delete('/api/v1/alerts/alert_1');
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
   });
 
-  describe('IDOR via :cardId path parameter on alert-config routes (alerts.ts)', () => {
-    it('GET /cards/:cardId/alert-config reads the config without a Bearer token', async () => {
-      // Current behavior: route reads balanceAlertConfig by path cardId (200).
-      // After 1-A lands this should return 401.
+  describe('IDOR via :cardId path parameter on alert-config routes (alerts.ts) — gated by requireSession', () => {
+    it('GET /cards/:cardId/alert-config returns 401 without a Bearer token', async () => {
       const res = await request(createApp()).get('/api/v1/cards/card_1/alert-config');
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
 
-    it('POST /cards/:cardId/alert-config upserts the config without a Bearer token', async () => {
-      // Current behavior: route looks up the card from path id and upserts
-      // the alert config (200). After 1-A lands this should return 401.
+    it('POST /cards/:cardId/alert-config returns 401 without a Bearer token', async () => {
       const res = await request(createApp())
         .post('/api/v1/cards/card_1/alert-config')
         .send({ condition: 'more-than', thresholdCents: 10_000 });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
 
-    it('DELETE /cards/:cardId/alert-config deletes the config without a Bearer token', async () => {
-      mocks.prisma.balanceAlertConfig.findUnique.mockResolvedValueOnce({
-        id: 'config_1',
-        cardId: 'card_1',
-        userId: 'user_1',
-        condition: 'more-than',
-        thresholdCents: 10_000,
-        pushEnabled: true,
-        emailEnabled: false
-      });
-      // Current behavior: route looks up the config by path cardId and deletes
-      // it (200). After 1-A lands this should return 401.
+    it('DELETE /cards/:cardId/alert-config returns 401 without a Bearer token', async () => {
       const res = await request(createApp()).delete('/api/v1/cards/card_1/alert-config');
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
   });
 
-  describe('IDOR via :transactionId path parameter (transactions.ts)', () => {
-    it('PATCH /transactions/:transactionId/category mutates the transaction without a Bearer token', async () => {
-      // Current behavior: route looks up the txn by path id and updates its
-      // category (200). After 1-A lands this should return 401.
+  describe('IDOR via :transactionId path parameter (transactions.ts) — gated by requireSession', () => {
+    it('PATCH /transactions/:transactionId/category returns 401 without a Bearer token', async () => {
       const res = await request(createApp())
         .patch('/api/v1/transactions/txn_1/category')
         .send({ category: 'dining' });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
   });
 
-  describe('control: GET /me already enforces auth (the model to mirror)', () => {
+  describe('control: GET /me also enforces auth', () => {
     it('returns 401 without an Authorization header', async () => {
       const res = await request(createApp()).get('/api/v1/me');
       expect(res.status).toBe(401);
@@ -198,36 +163,26 @@ describe('budget-api auth contract (W27 0-D) — path-parameter IDOR vectors', (
 });
 
 /**
- * Auth contract test (code-garden 2026-W27, follow-up to PR #144).
+ * Auth contract test (code-garden 2026-W27 follow-up to PR #144), post-1-A.
  *
- * PR #144 documented the IDOR-via-path-parameter routes (cards.ts, alerts.ts,
- * transactions.ts). This companion spec covers the userId-from-body/query
- * routes that the W27 audit calls out as the original vector class — routes
- * that take a userId from the request body or query and operate on that user
- * without verifying a Bearer token. When Theme 1 (1-A requireSession
- * middleware) lands, every assertion below should flip to expect 401.
+ * After task ec42d3a1 (1-A requireSession middleware) lands, every user-data
+ * route — regardless of how it sourced its userId before (body, query, or
+ * path param) — returns 401 without a Bearer token. The spec/doc behavior
+ * flipped from "documents the gap" to "expects 401".
  *
  * Audit reference: docs/repo-audits/2026-W27.md, Critical finding under
  * "Architecture & Design" (carried forward from W26). The audit lists the
  * affected routes as /akahu/sync, /akahu/exchange, /akahu/authorize-url,
  * /cards/balance-history, /transactions, /alerts/evaluate, /alerts,
  * /categories/timeseries, /categorize/predict.
- *
- * NOTE — Scope: this spec covers the six non-Akahu routes that share a small
- * mock footprint (linkedCard.findMany, transaction.findMany,
- * notificationEvent.findMany, accountBalanceSnapshot.findMany, evaluateAlerts
- * ForUser, categorizeTransaction). The three Akahu routes (/akahu/sync,
- * /akahu/exchange, /akahu/authorize-url) need additional akahuClient mocks
- * and env-var setup; they are tracked as a separate follow-up.
  */
 describe('budget-api auth contract (W27 0-D follow-up) — userId-from-body/query vectors', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.AKAHU_DEV_USER_ACCESS_TOKEN = '';
 
-    // Default mocks so routes proceed past the userId validation and into the
-    // database layer without returning early. The point of this spec is to
-    // observe that the routes proceed at all without a Bearer token.
+    // Default mocks so routes would proceed into the database layer IF they
+    // reached it. They should never reach it without an Authorization header.
     mocks.prisma.user.findUnique.mockResolvedValue({ id: 'user_1' });
     mocks.prisma.linkedCard.findMany.mockResolvedValue([]);
     mocks.prisma.accountBalanceSnapshot.findMany.mockResolvedValue([]);
@@ -244,75 +199,53 @@ describe('budget-api auth contract (W27 0-D follow-up) — userId-from-body/quer
     });
   });
 
-  describe('IDOR via userId query parameter', () => {
-    it('GET /transactions returns 200 without a Bearer token', async () => {
-      // Current behavior: route reads userId from query and lists txns (200).
-      // After 1-A lands this should return 401.
+  describe('IDOR via userId query parameter — gated by requireSession', () => {
+    it('GET /transactions returns 401 without a Bearer token', async () => {
       const res = await request(createApp())
         .get('/api/v1/transactions')
         .query({ userId: 'user_1' });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
 
-    it('GET /alerts returns 200 without a Bearer token', async () => {
-      // Current behavior: route reads userId from query and lists alerts (200).
-      // After 1-A lands this should return 401.
+    it('GET /alerts returns 401 without a Bearer token', async () => {
       const res = await request(createApp())
         .get('/api/v1/alerts')
         .query({ userId: 'user_1' });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
 
-    it('GET /cards/balance-history returns 200 without a Bearer token', async () => {
-      mocks.prisma.linkedCard.findMany.mockResolvedValueOnce([
-        {
-          id: 'card_1',
-          displayName: 'Everyday account',
-          provider: 'akahu',
-          providerCardId: 'acc_1',
-          createdAt: new Date('2026-04-01T00:00:00.000Z')
-        }
-      ]);
-      mocks.prisma.accountBalanceSnapshot.findMany.mockResolvedValueOnce([]);
-      // Current behavior: route reads userId from query and reads snapshots
-      // (200). After 1-A lands this should return 401.
+    it('GET /cards/balance-history returns 401 without a Bearer token', async () => {
       const res = await request(createApp())
         .get('/api/v1/cards/balance-history')
         .query({ userId: 'user_1', from: '2026-04-01', to: '2026-05-01' });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
 
-    it('GET /categories/timeseries returns 200 without a Bearer token', async () => {
-      // Current behavior: route reads userId from query and groups txns into
-      // a timeseries (200). After 1-A lands this should return 401.
+    it('GET /categories/timeseries returns 401 without a Bearer token', async () => {
       const res = await request(createApp())
         .get('/api/v1/categories/timeseries')
         .query({ userId: 'user_1', from: '2026-04-01', to: '2026-05-01' });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
   });
 
-  describe('IDOR via userId body parameter', () => {
-    it('POST /alerts/evaluate returns 200 without a Bearer token', async () => {
-      // Current behavior: route reads userId from body and evaluates alerts
-      // (200). After 1-A lands this should return 401.
+  describe('IDOR via userId body parameter — gated by requireSession', () => {
+    it('POST /alerts/evaluate returns 401 without a Bearer token', async () => {
       const res = await request(createApp())
         .post('/api/v1/alerts/evaluate')
         .send({ userId: 'user_1', month: '2026-04' });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
 
-    it('POST /categorize/predict returns 200 without a Bearer token', async () => {
-      // Current behavior: route reads userId from body and runs the
-      // categorizer (200). After 1-A lands this should return 401.
+    it('POST /categorize/predict returns 401 without a Bearer token', async () => {
       const res = await request(createApp())
         .post('/api/v1/categorize/predict')
         .send({ userId: 'user_1', merchant: 'Acme', amountCents: 1500 });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
     });
   });
 
-  describe('control: GET /me already enforces auth (the model to mirror)', () => {
+  describe('control: GET /me also enforces auth', () => {
     it('returns 401 without an Authorization header', async () => {
       const res = await request(createApp()).get('/api/v1/me');
       expect(res.status).toBe(401);

--- a/services/budget-api/test/me.test.ts
+++ b/services/budget-api/test/me.test.ts
@@ -1,0 +1,84 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    session: { findUnique: vi.fn() },
+    linkedCard: { findMany: vi.fn() }
+  }
+}));
+
+vi.mock('../src/lib/prisma.ts', () => ({ prisma: mocks.prisma }));
+
+import { createApp } from '../src/app';
+import { hashSessionToken } from '../src/auth/session';
+
+const SESSION = { id: 'session_1', userId: 'user_1' };
+const TOKEN = 'me-token-1';
+const TOKEN_HASH = hashSessionToken(TOKEN);
+
+describe('GET /api/v1/me', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.prisma.linkedCard.findMany.mockResolvedValue([]);
+    mocks.prisma.session.findUnique.mockImplementation(async (args: any) => {
+      if (args?.where?.tokenHash && args.where.tokenHash === TOKEN_HASH) {
+        return SESSION;
+      }
+      if (args?.where?.id && args.where.id === SESSION.id) {
+        return {
+          ...SESSION,
+          user: { id: SESSION.userId, email: 'me@example.com' }
+        };
+      }
+      return null;
+    });
+  });
+
+  it('returns 401 when the Authorization header is missing', async () => {
+    const res = await request(createApp()).get('/api/v1/me');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 401 when the Bearer token is invalid', async () => {
+    const res = await request(createApp())
+      .get('/api/v1/me')
+      .set('Authorization', 'Bearer wrong-token');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with the user payload when the Bearer token is valid', async () => {
+    const res = await request(createApp())
+      .get('/api/v1/me')
+      .set('Authorization', `Bearer ${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      user: { id: 'user_1', email: 'me@example.com' },
+      cards: []
+    });
+  });
+
+  it('returns the user with their cards when the Bearer token is valid and cards exist', async () => {
+    mocks.prisma.linkedCard.findMany.mockResolvedValue([
+      {
+        id: 'card_1',
+        displayName: 'Everyday account',
+        last4: '1234'
+      },
+      {
+        id: 'card_2',
+        displayName: 'Savings',
+        last4: '5678'
+      }
+    ]);
+    const res = await request(createApp())
+      .get('/api/v1/me')
+      .set('Authorization', `Bearer ${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.body.cards).toEqual([
+      { id: 'card_1', displayName: 'Everyday account', last4: '1234' },
+      { id: 'card_2', displayName: 'Savings', last4: '5678' }
+    ]);
+  });
+});

--- a/services/budget-api/test/session-middleware.test.ts
+++ b/services/budget-api/test/session-middleware.test.ts
@@ -1,0 +1,130 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    session: { findUnique: vi.fn() },
+    linkedCard: { findMany: vi.fn() },
+    akahuConnection: { upsert: vi.fn() }
+  },
+  exchangeAuthorizationCode: vi.fn()
+}));
+
+vi.mock('../src/lib/prisma.ts', () => ({ prisma: mocks.prisma }));
+vi.mock('../src/services/akahuClient.ts', () => ({
+  exchangeAuthorizationCode: mocks.exchangeAuthorizationCode
+}));
+
+import { createApp } from '../src/app';
+import { hashSessionToken } from '../src/auth/session';
+
+const SESSION = { id: 'session_1', userId: 'user_1' };
+const TOKEN = 'test-token-1';
+const TOKEN_HASH = hashSessionToken(TOKEN);
+
+describe('requireSession middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.prisma.linkedCard.findMany.mockResolvedValue([]);
+    // Default: token resolves to user_1's session.
+    mocks.prisma.session.findUnique.mockImplementation(async (args: any) => {
+      if (args?.where?.tokenHash && args.where.tokenHash === TOKEN_HASH) {
+        return SESSION;
+      }
+      if (args?.where?.id && args.where.id === SESSION.id) {
+        return {
+          ...SESSION,
+          user: { id: SESSION.userId, email: 'user@example.com' }
+        };
+      }
+      return null;
+    });
+  });
+
+  describe('rejects without a valid Bearer token', () => {
+    it('returns 401 when Authorization header is missing', async () => {
+      const res = await request(createApp()).get('/api/v1/me');
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe('UNAUTHORIZED');
+      expect(mocks.prisma.session.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when Authorization header is not Bearer', async () => {
+      const res = await request(createApp())
+        .get('/api/v1/me')
+        .set('Authorization', 'Basic dXNlcjpwYXNz');
+      expect(res.status).toBe(401);
+      expect(mocks.prisma.session.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when Bearer token is empty', async () => {
+      const res = await request(createApp())
+        .get('/api/v1/me')
+        .set('Authorization', 'Bearer ');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 when the token does not match any session', async () => {
+      const res = await request(createApp())
+        .get('/api/v1/me')
+        .set('Authorization', 'Bearer bogus-token');
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe('UNAUTHORIZED');
+      expect(mocks.prisma.session.findUnique).toHaveBeenCalledWith({
+        where: { tokenHash: hashSessionToken('bogus-token') },
+        select: { id: true, userId: true }
+      });
+    });
+  });
+
+  describe('attaches req.session and calls next() with a valid token', () => {
+    it('GET /me returns 200 and the user payload with a valid Bearer token', async () => {
+      const res = await request(createApp())
+        .get('/api/v1/me')
+        .set('Authorization', `Bearer ${TOKEN}`);
+      expect(res.status).toBe(200);
+      expect(res.body.user).toEqual({ id: 'user_1', email: 'user@example.com' });
+      expect(res.body.cards).toEqual([]);
+    });
+
+    it('POST /akahu/exchange with a valid Bearer token reads userId from req.session', async () => {
+      mocks.exchangeAuthorizationCode.mockResolvedValue({
+        accessToken: 'akahu_user_token',
+        scope: 'ENDURING_CONSENT'
+      });
+      mocks.prisma.akahuConnection.upsert.mockResolvedValue({});
+
+      const res = await request(createApp())
+        .post('/api/v1/akahu/exchange')
+        .set('Authorization', `Bearer ${TOKEN}`)
+        .send({ code: 'oauth_code_1' });
+
+      expect(res.status).toBe(200);
+      expect(mocks.prisma.akahuConnection.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: 'user_1' },
+          create: {
+            userId: 'user_1',
+            accessToken: 'akahu_user_token',
+            scope: 'ENDURING_CONSENT'
+          },
+          update: {
+            accessToken: 'akahu_user_token',
+            scope: 'ENDURING_CONSENT'
+          }
+        })
+      );
+    });
+
+    it('POST /akahu/exchange with an invalid Bearer token returns 401 and never calls the upstream', async () => {
+      const res = await request(createApp())
+        .post('/api/v1/akahu/exchange')
+        .set('Authorization', 'Bearer bogus-token')
+        .send({ code: 'oauth_code_1' });
+
+      expect(res.status).toBe(401);
+      expect(mocks.exchangeAuthorizationCode).not.toHaveBeenCalled();
+      expect(mocks.prisma.akahuConnection.upsert).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the IDOR gap on every `budget-api` user-data route by gating them with a single `requireSession` middleware. The middleware reads `Authorization: Bearer <token>`, hashes the token, looks up the `Session` row, and rejects with 401 on missing/invalid tokens. The userId is then sourced from `req.session.userId`, never from request body/query.

Linked task: `ec42d3a1-2059-4ad6-bd1c-21e96dfc9135` (cloud-readiness audit Theme 1 / Milestone 0-A).

## Changes

- `services/budget-api/src/auth/session.ts` — extract SHA-256 token-hash helper from `routes/session.ts` so it can be reused from the middleware.
- `services/budget-api/src/middleware/requireSession.ts` — new middleware. Reads `Authorization: Bearer <token>`, looks up `Session` via Prisma by tokenHash, attaches `req.session = { id, userId, expiresAt: null }` on success. Returns 401 UNAUTHORIZED on missing/malformed/invalid tokens before any downstream handler runs.
- `services/budget-api/src/app.ts` — mount `requireSession` on every user-data router (`/akahu`, `/cards`, `/transactions`, `/categories`, `/categorize`, `/alerts`). `/session` is mounted ungated so `/session/dev-login` can still mint tokens; `/me` gates itself with the same middleware.
- `services/budget-api/src/routes/session.ts` — `/me` reads `userId` from `req.session.userId` (no longer reads the Bearer token inline); `/session/dev-login` still mints tokens.
- `services/budget-api/src/routes/{akahu,cards,alerts,transactions,categories,categorize}.ts` — every route reads `userId` from `req.session.userId`. No `userId` is accepted from request body/query in any of these routers. `cards.ts` and `alerts.ts` add ownership checks (404 when the card/alert/transaction is owned by a different user) — this closes the path-parameter IDOR class that task `f39a20a7` will tighten further.

### Tests

- `services/budget-api/test/auth-contract.test.ts` — flipped every "documents the gap" assertion from expecting 200 to expecting 401.
- `services/budget-api/test/akahuSync.test.ts` — mints a session mock and sends `Authorization: Bearer …` headers on the routes that previously injected `userId` from body/query.
- `services/budget-api/test/session-middleware.test.ts` — new. Covers missing/malformed/invalid/valid Bearer tokens; verifies `req.session` propagation and that downstream calls never happen on 401.
- `services/budget-api/test/me.test.ts` — new. `/me` returns 401 on missing/invalid Bearer and 200 on valid with the user + cards payload.

## Acceptance Criteria

- [x] AC1: `services/budget-api` has a reusable `requireSession` middleware that reads `Authorization: Bearer <token>`, hashes the token with the existing session-token logic, looks up `Session`, and rejects missing/invalid sessions with 401. (🧪 testID: session-middleware.test.ts)
- [x] AC2: Routes under `/akahu`, `/cards`, `/alerts`, `/transactions`, `/categories`, and `/categorize` no longer trust `userId` from request body/query; they derive the user from the validated session. (🧪 testID: auth-contract.test.ts)
- [x] AC3: Existing `/me` behavior is preserved or refactored onto the same middleware. (🧪 testID: me.test.ts)
- [x] AC4: `services/budget-api/test/auth-contract.test.ts` flips from documenting the gap to expecting 401 on unauthenticated user-data routes. (🧪 testID: auth-contract.test.ts)
- [x] AC5: Budget API tests and CI pass. (🧪 testID: budget-api-vitest)

## System Spec

No system spec change — the auth contract is per-route and inline-documented in the migrated routers; the durable spec for this task lives at `docs/specs/cloud-readiness-budget-api-require-sessions-tech-design.md` on this branch. A cross-cutting `docs/systems/<file>.md` for the full cloud-readiness cluster (this task + `f39a20a7` + `cc7a4e38` + `f1175b18`) can be added once the cluster ships; doing it now would be a partial-cluster spec and would invite drift.

No `apps/budget-mobile/SPEC.md` change — the mobile app already sends `Authorization: Bearer` from session, and this PR adds no client-side behavior change.

## Out of scope

- Cross-user ownership enforcement on `cards`/`alerts`/`transactions` IDOR-via-path-parameter vectors (404 when the path-id's owner doesn't match the session). This PR adds ownership checks on the card- and alert-routed paths, but the cross-cutting ownership task `f39a20a7` will own the full contract.
- Rate limits / body size limits / additional security headers — task `cc7a4e38`.

## Test plan

- `cd services/budget-api && npm test` — 37 passing (auth-contract, session-middleware, me, akahuSync, alerts, categorizer, akahuClient).
- CI on push (vitest matrix in `services/budget-api/.github/`).

## Linked audit

- `docs/repo-audits/2026-W29.md` Theme 1 / Milestone 0-A (Critical).

---

Co-Authored-By: rowanstoffer <rowanstoffer@gmail.com>