### PR TITLE
fix(workflow): share code and feature delivery gate

### DIFF
--- a/agents/skills/ops/tasks-create/SKILL.md
+++ b/agents/skills/ops/tasks-create/SKILL.md
@@ -106,12 +106,22 @@ tasks_api_client.py create \
 **Acceptance Criteria**
 
 - [ ] AC1: <observable outcome>
-- [ ] AC2: <observable outcome>"
+- [ ] AC2: <observable outcome>
+
+---
+
+**Workstreams**
+
+- Owner: Rowan
+  ACs: AC1, AC2
+  Branch: (pending)
+  PR: (pending)"
 ```
 
 **Rules:**
 - Product spec is not required for code tasks
 - ACs are still required and observable
+- Use the same `**Workstreams**` section and `Owner` block as feature tasks
 - Attach a `docs/specs/<slug>-tech-design.md` when a code task changes service boundaries, moves data ownership, splits/merges services, adds migrations, touches cross-service API contracts, changes security posture, or is a non-trivial refactor
 - Tech designs for code tasks do not require Tom product sign-off by default; they require review/sign-off only when they introduce security risk, data-loss/migration risk, user-visible behavior changes, new external credentials, or architecture decisions that need Tom/Quinn judgement
 - Do not add prefix emoji manually; the Tasks UI renders type icons in the browser

--- a/agents/workflows/feature-task/code-task.lobster.yaml
+++ b/agents/workflows/feature-task/code-task.lobster.yaml
@@ -60,7 +60,7 @@ steps:
   - id: code_task_verify_delivery
     command: >-
       cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
-      code-task-verify-delivery --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+      verify-delivery --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
     stdin: $code_task_ready_checks.stdout
     condition: $code_task_ready_checks.json.criteriaMet
 

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -506,8 +506,8 @@ fn ready_checks(args: StageArgs) -> Result<Envelope> {
 
 // ---- Code-task stages (task f77b7a60) ----
 //
-// `code-task-tech-design-check` (task 3ba96b5e), `code-task-ready-checks`,
-// and `code-task-verify-delivery` mirror the feature-task stages for
+// `code-task-tech-design-check` (task 3ba96b5e) and `code-task-ready-checks`
+// mirror the feature-task stages for
 // `taskType: code` tasks. They:
 //   * Skip the spec-drift machinery entirely — code tasks have no
 //     `**Spec:**` line and no `specChecksum`.
@@ -522,9 +522,9 @@ fn ready_checks(args: StageArgs) -> Result<Envelope> {
 //     runs in `code-task-tech-design-check` (open → ready); the assignee
 //     + capacity gate runs in `code-task-ready-checks` (ready → doing).
 //
-// `feedback_aggregate` and `post_merge` are reused unchanged: their only
-// task-type-specific behaviour is reading `[implementer-prs]` and reviewing
-// PRs, both of which work identically for feature and code tasks.
+// `verify_delivery`, `feedback_aggregate`, and `post_merge` are shared with
+// feature tasks. Code tasks therefore use the same PR, AC, workstream, and
+// handoff contract once they reach implementation.
 
 fn code_task_tech_design_check(args: StageArgs) -> Result<Envelope> {
     let mut env = read_envelope()?;
@@ -622,84 +622,10 @@ fn code_task_ready_checks(args: StageArgs) -> Result<Envelope> {
 }
 
 fn code_task_verify_delivery(args: StageArgs) -> Result<Envelope> {
-    let mut env = read_envelope()?;
-    env.lobster_state.workflow = workflow_for_task(&env.task);
-    let manual_failures = manual_block_failures(&env.task);
-    if !manual_failures.is_empty() {
-        return block_with_manual_block(
-            &args,
-            env,
-            "code_task_verify_delivery",
-            manual_failures,
-            "[code-task-blocked]",
-        );
-    }
-    if is_past(&env.task, "doing") {
-        env.already_past = true;
-        env.criteria_met = true;
-        env.action_taken = "already_past_doing".to_string();
-        return Ok(env);
-    }
-    let mut failures = Vec::new();
-    let pr_urls = implementer_pr_urls(&env.task);
-    if pr_urls.is_empty() {
-        failures
-            .push("Missing `[implementer-prs]` task comment with at least one PR URL.".to_string());
-    }
-    env.lobster_state.pr_urls = pr_urls.clone();
-    let task_acs = task_description_acs(&env.task.description.clone().unwrap_or_default());
-    let latest_pr_url = pr_urls.iter().max_by_key(|url| pr_number(url)).cloned();
-    for url in &pr_urls {
-        let review = inspect_pr(url);
-        match review {
-            Ok(r) => {
-                if let Some(failure) = verify_delivery_review_failure(url, r) {
-                    failures.push(failure);
-                }
-            }
-            Err(err) => failures.push(format!("Could not inspect PR {url}: {err}.")),
-        }
-        if let Ok(body) = pr_body(url) {
-            if !body_has_checked_acceptance(&body) {
-                failures.push(format!(
-                    "PR {url} does not show checked acceptance criteria in its body."
-                ));
-            }
-            for ac_failure in verify_pr_acs_failures(&body) {
-                failures.push(format!("PR {url} — {ac_failure}"));
-            }
-        }
-    }
-    if let Some(url) = &latest_pr_url {
-        match pr_body(url) {
-            Ok(body) => {
-                for ac_failure in task_ac_vs_open_pr_failures(&env.task.id, &task_acs, &body, url) {
-                    failures.push(format!("PR {url} — {ac_failure}"));
-                }
-            }
-            Err(err) => {
-                failures.push(format!(
-                    "Could not read PR body for {url}: {err}. Cannot validate AC text."
-                ));
-            }
-        }
-    }
-    if workstreams(&env.task).is_empty() {
-        failures.push("Task description must include at least one workstream.".to_string());
-    }
-    if openclaw_needed(&env.task) && !openclaw_done(&env.task) {
-        failures
-            .push("`[openclaw-needed]` is present but `[openclaw-done]` is missing.".to_string());
-    }
-    transition_or_block(
-        &args,
-        env,
-        "acceptance",
-        "code_task_verify_delivery",
-        failures,
-        "[code-task-progress-checklist]",
-        "Code task workflow moved task to `acceptance`.",
-    )
+    // Backwards-compatible CLI alias. The code-task pipeline now calls the
+    // canonical feature-task delivery stage directly so both task types share
+    // exactly the same delivery contract.
+    verify_delivery(args)
 }
 
 fn verify_delivery(args: StageArgs) -> Result<Envelope> {

--- a/docs/specs/code-task-lobster-extension-tech-design.md
+++ b/docs/specs/code-task-lobster-extension-tech-design.md
@@ -42,7 +42,7 @@ Two concrete gaps motivated the task: an incident-action code task and a bookmar
 |---|---|---|
 | `spec_check` | **Skipped** | No product spec; no `specChecksum`; no spec drift |
 | `ready_checks` | `code-task-ready-checks` | Tech design gate optional (waivable); no spec-drift guard |
-| `verify_delivery` | `code-task-verify-delivery` | PR/AC checks reused; spec-drift check removed |
+| `verify_delivery` | `verify-delivery` | Shared PR/AC/workstream/handoff gate; code tasks have no `specChecksum`, so spec drift is a no-op |
 | `feedback_aggregate` | **Reused as-is** | PR review state logic is identical |
 | `post_merge` | **Reused as-is** | `archive_done_task_spec()` already no-ops without `**Spec:**` |
 
@@ -60,21 +60,11 @@ No spec-checksum guard. No spec-drift check. No `move_approved_chat_spec_if_need
 
 **New helper needed:** `tech_design_waived(task: &Task) -> bool` — checks for a comment starting with `[tech-design-not-required]` (same parsing pattern as `tagged_values()`).
 
-### `code-task-verify-delivery` (doing → acceptance)
+### Shared `verify-delivery` (doing → acceptance)
 
-Same checks as feature task `verify_delivery` with spec machinery removed:
+Code tasks use the feature-task `verify_delivery` implementation unchanged. This keeps PR review, checked-AC evidence, task-AC matching, workstream, system-handoff, and `[openclaw-needed]` checks identical across task types. Code tasks have no `specChecksum`, so the shared spec-drift check is a no-op for them.
 
-- `[rowan-prs]` comment with at least one PR URL.
-- PR review state: not `ChangesRequested`, not `ClosedUnmerged`.
-- PR body has at least one checked acceptance criterion.
-- Task ACs match PR body ACs (reuse `task_ac_vs_open_pr_failures()`).
-- At least one workstream in the task description.
-- System spec gate (reuse `system_spec_failures()`).
-- `[openclaw-needed]` without `[openclaw-done]` blocks.
-
-**Removed vs feature task `verify_delivery`:**
-- `block_on_spec_drift_fluid()` call — no spec drift for code tasks.
-- `LobsterState.workflow` is set to `"code-task-workflow"` (was hardcoded to `"feature-task-workflow"`).
+`LobsterState.workflow` remains `"code-task-workflow"` because the earlier code-task lifecycle stages set it before the shared delivery stage runs.
 
 ### `feedback_aggregate` and `post_merge` (reused unchanged)
 
@@ -92,7 +82,7 @@ CodeTaskVerifyDelivery(StageArgs),
 
 Two new top-level functions:
 - `code_task_ready_checks(args: StageArgs) -> Result<Envelope>`
-- `code_task_verify_delivery(args: StageArgs) -> Result<Envelope>`
+- `code_task_verify_delivery(args: StageArgs) -> Result<Envelope>` (retained as a backwards-compatible alias for `verify_delivery`)
 
 One new helper:
 - `tech_design_waived(task: &Task) -> bool`
@@ -101,7 +91,7 @@ Wired into `main()` in the pattern already established for the other subcommands
 
 ### 2. `agents/workflows/feature-task/code-task.lobster.yaml` (new)
 
-Mirrors `feature-task.lobster.yaml` but with `code_task_ready_checks` and `code_task_verify_delivery` instead of `spec_check` / `ready_checks` / `verify_delivery`. Same `feedback_aggregate` and `post_merge` stages, same args (`taskId`, `tasksApiBaseUrl`, `sindustriesRepo`, `workspaceRoot`, `dryRun`).
+Mirrors `feature-task.lobster.yaml` but with the code-task lifecycle stages before the shared `verify-delivery`, `feedback_aggregate`, and `post_merge` stages. Same args (`taskId`, `tasksApiBaseUrl`, `sindustriesRepo`, `workspaceRoot`, `dryRun`).
 
 ### 3. `agents/workflows/feature-task/run.py`
 
@@ -142,7 +132,7 @@ The known open code tasks in the 2026-W29 audit cloud-readiness sweep will need 
 |---|---|---|
 | AC1 | `run.py` discovers `taskType: code` tasks and routes them through `code-task.lobster.yaml`. | `run.py` unit test asserting code-task dispatch; integration test with sample code task in `open` status. |
 | AC2 | `code-task-ready-checks` gates on `[tech-design]`+`[tech-design-approved]` OR `[tech-design-not-required]`, plus assignee + capacity. | Unit test for each gate failure path and the happy path. |
-| AC3 | `code-task-verify-delivery` reuses AC text/evidence checks and system spec gate, removes spec-drift logic. | Unit test asserting spec-drift is not evaluated; same AC evidence checks as feature-task tests. |
+| AC3 | Code tasks use the shared `verify-delivery` AC/evidence/workstream/handoff gate; their absent `specChecksum` makes spec-drift a no-op. | Existing delivery-gate tests plus a dry-run code-task pipeline check. |
 | AC4 | `feedback_aggregate` and `post_merge` unchanged; `archive_done_task_spec()` no-ops without `**Spec:**`. | Unit test asserting `archive_done_task_spec()` returns `post_merge_no_spec_to_archive` for code tasks. |
 | AC5 | Existing open code tasks are picked up on first run; blocked at `code-task-ready-checks` with checklist if missing prerequisites. | Integration test with sample code task missing tech-design → expect `criteriaMet: false` + checklist comment. |
 | AC6 | `LobsterState.workflow` set to `"code-task-workflow"` for code task state comments. | Unit test asserting `lobster_state.workflow == "code-task-workflow"` after `code-task-ready-checks`. |
@@ -158,7 +148,7 @@ The known open code tasks in the 2026-W29 audit cloud-readiness sweep will need 
 
 - **Q1 — Capacity accounting.** Code tasks share Rowan's doing capacity with feature tasks. Should high-priority code tasks be allowed to preempt a lower-priority feature task? Current design: no, single-threaded. If a code task is genuinely urgent (security fix), Tom or Quinn can manually intervene.
 - **Q2 — Spec-required escape hatch.** Some code tasks may eventually grow product-style criteria. The current design treats `[tech-design-not-required]` as the waiving mechanism, but should a `taskType: code` task that needs spec machinery be promoted to a feature task instead? Current recommendation: yes — promotion is cleaner than bolting spec machinery into code tasks.
-- **Q3 — Backwards compatibility.** Existing code tasks with `[openclaw-needed]` but no `[openclaw-done]` will block at `code-task-verify-delivery` exactly like feature tasks. No escape hatch — must complete the handoff before acceptance.
+- **Q3 — Backwards compatibility.** Existing code tasks with `[openclaw-needed]` but no `[openclaw-done]` will block at the shared `verify-delivery` gate exactly like feature tasks. No escape hatch — the handoff must complete before acceptance.
 
 ## Companion doc updates
 

--- a/docs/systems/tasks.md
+++ b/docs/systems/tasks.md
@@ -368,6 +368,8 @@ check
 
 The lobster dispatches `taskType: code` tasks through `agents/workflows/feature-task/code-task.lobster.yaml`. The same Rust binary that runs the feature-task pipeline is reused; the YAML selects a smaller set of subcommands.
 
+After the code-task lifecycle-specific gates, delivery verification uses the same `verify-delivery` stage as feature tasks. Code and feature tasks therefore share the same PR, acceptance-criteria, workstream, and handoff contract; only the product-spec lifecycle and optional tech-design gate differ.
+
 The `open → ready → doing` jump is split into two stages so the tech-design gate and the assignee/capacity gate are visible separately (task `3ba96b5e`):
 
 - `code-task-tech-design-check` gates `open → ready`. It only checks the tech design (or explicit waiver). A task with no assignee still advances to `ready` once its tech design is approved.
@@ -381,7 +383,7 @@ The comment prefix on each stage is the signal that names which gate is open: `[
 |---|---|---|
 | `code-task-tech-design-check` | `ready_checks` (tech-design portion) | New stage (task `3ba96b5e`). Splits the old single `open → doing` jump into `open → ready → doing`. Only checks the tech design (or waiver). Transitions to `ready`. |
 | `code-task-ready-checks` | `ready_checks` (assignee + capacity portion) | Tech-design check removed (moved to the preceding stage). Now only checks assignee + capacity. Transitions to `doing`. |
-| `code-task-verify-delivery` | `verify_delivery` | Spec drift check removed; no `specChecksum` writes |
+| `verify-delivery` | `verify_delivery` | Shared delivery gate; code tasks have no `specChecksum`, so the spec-drift check is a no-op |
 | `feedback_aggregate` | `feedback_aggregate` | Reused unchanged |
 | `post_merge` | `post_merge` | Reused unchanged; `archive_done_task_spec()` no-ops when no `**Spec:**` is present |
 
@@ -419,6 +421,7 @@ A code task must include:
 - source link if created from an audit finding;
 - why it is not code-garden-safe, when applicable;
 - observable acceptance criteria;
+- the standard `**Workstreams**` section used by feature tasks;
 - assignee and relevant tags.
 
 A product spec is not required.


### PR DESCRIPTION
## Summary
- Route code-task delivery through the canonical feature-task `verify-delivery` stage instead of maintaining a duplicate verifier.
- Document and enforce the same standard Workstreams contract for code tasks.
- Retain the old `code-task-verify-delivery` CLI as a compatibility alias while the pipeline uses the shared command.

## System Spec
docs/systems/tasks.md

## Test plan
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml --bin feature-task` — 186 passed.
- [x] `git diff --check` — clean.
- [x] Code-task dry-run for `38d2ee65` with the normalized task/PR contract — `would_move_to_acceptance`, zero failures.

## Operational follow-up
- Normalized task `38d2ee65` to the standard Owner-based Workstreams contract without changing its ACs.
- Updated merged PR #314's AC section with verbatim task ACs and parser-compatible evidence annotations.

Co-Authored-By: Tom Stoffer <tomstoffer@gmail.com>