### PR TITLE
fix(content-workflow): let weekly tasks queue tweets before acceptance

### DIFF
--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -35,8 +35,8 @@ I am a heartbeat agent. I check the Tasks API on a regular interval for content 
    - **`blocked`** → do not attempt to resolve. Post a message to Quinn's session escalating the block. Do not change the `blocked` flag.
 
 3. Cadence rules — the heartbeat's only per-state opinions, layered on top of `WORKFLOW.md`:
-   - Do not re-do work on a `doing` task if a valid `[ivy-prs]` comment already exists with at least one open PR. The Lobster handles the move to `acceptance`.
-   - On weekly-content tasks in `doing`, both `[ivy-prs]` **and** `[ivy-tweets-queued]` are required before the Lobster transitions to `acceptance` (see the Weekly tweet campaign section below).
+   - For non-weekly content tasks, do not re-do work if a valid `[ivy-prs]` comment already exists with at least one open PR. The Lobster handles the move to `acceptance`.
+   - For weekly-content tasks, an existing `[ivy-prs]` comment suppresses only the PR-authoring work. If `[ivy-tweets-queued]` is missing, continue with the Weekly tweet campaign below; both comments are required before the Lobster transitions to `acceptance`.
    - On `acceptance`, only push new commits when there are unresolved review comments or CI failures.
 
 ---
@@ -46,6 +46,8 @@ I am a heartbeat agent. I check the Tasks API on a regular interval for content 
 **Only applies when the task title contains `weekly review` or `weekly content updates`.**
 
 Alongside my usual PR work, I drive a themed 5–7 tweet arc into the Content Scheduler for the coming week. One theme per week, one tweet per day. Tom approves each in Mission Control; auto-post fires at `scheduledFor`.
+
+This campaign must run while the task is still `doing`, even when the task already has one or more open PRs. Existing PRs suppress duplicate PR authoring only; they do not satisfy or suppress the `[ivy-tweets-queued]` gate.
 
 The scheduler primitive lives in `agents/skills/content/schedule-tweets/SKILL.md` — that skill queues one tweet. This section owns the *campaign* logic: theme, arc, sequencing, traceability.
 

--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -35,7 +35,6 @@ I am a heartbeat agent. I check the Tasks API on a regular interval for content 
    - **`blocked`** → do not attempt to resolve. Post a message to Quinn's session escalating the block. Do not change the `blocked` flag.
 
 3. Cadence rules — the heartbeat's only per-state opinions, layered on top of `WORKFLOW.md`:
-   - For non-weekly content tasks, do not re-do work if a valid `[ivy-prs]` comment already exists with at least one open PR. The Lobster handles the move to `acceptance`.
    - For weekly-content tasks still in `doing`, an existing `[ivy-prs]` comment suppresses only the PR-authoring work. While `[ivy-tweets-queued]` is missing, continue with the Weekly tweet campaign below; both comments are required before the Lobster transitions to `acceptance`.
    - On `acceptance`, only push new commits when there are unresolved review comments or CI failures.
 

--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -36,14 +36,14 @@ I am a heartbeat agent. I check the Tasks API on a regular interval for content 
 
 3. Cadence rules — the heartbeat's only per-state opinions, layered on top of `WORKFLOW.md`:
    - For non-weekly content tasks, do not re-do work if a valid `[ivy-prs]` comment already exists with at least one open PR. The Lobster handles the move to `acceptance`.
-   - For weekly-content tasks, an existing `[ivy-prs]` comment suppresses only the PR-authoring work. If `[ivy-tweets-queued]` is missing, continue with the Weekly tweet campaign below; both comments are required before the Lobster transitions to `acceptance`.
+   - For weekly-content tasks still in `doing`, an existing `[ivy-prs]` comment suppresses only the PR-authoring work. While `[ivy-tweets-queued]` is missing, continue with the Weekly tweet campaign below; both comments are required before the Lobster transitions to `acceptance`.
    - On `acceptance`, only push new commits when there are unresolved review comments or CI failures.
 
 ---
 
 ## Weekly tweet campaign (weekly-content tasks in `doing`)
 
-**Only applies when the task title contains `weekly review` or `weekly content updates`.**
+**Only applies when the task is still `doing`, the title contains `weekly review` or `weekly content updates`, and `[ivy-tweets-queued]` is missing.**
 
 Alongside my usual PR work, I drive a themed 5–7 tweet arc into the Content Scheduler for the coming week. One theme per week, one tweet per day. Tom approves each in Mission Control; auto-post fires at `scheduledFor`.
 


### PR DESCRIPTION
## Summary
- Clarify Ivy's heartbeat idempotence rule so existing weekly-content PRs suppress only duplicate PR authoring.
- Require the weekly tweet campaign to run while the task is still `doing` when `[ivy-tweets-queued]` is missing.
- Preserve the existing Lobster gate that requires both `[ivy-prs]` and `[ivy-tweets-queued]` before acceptance.

## System Spec
No system spec change — this is a focused agent operating-procedure fix; the content-task workflow gate remains the source of truth.

## Test plan
- [x] Run `git diff --check`.
- [x] Run `python3 -m unittest tests.test_pr_transition_headings -v` (4 tests passing).
- [ ] Confirm the next weekly-content heartbeat queues tweets when open PRs already exist but `[ivy-tweets-queued]` is absent.

🤖 Generated with Claude Code
