### PR TITLE
docs(workflow): make PR assignee responsible for merge

### DIFF
--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -12,7 +12,7 @@ Read and follow the pr-process skill for both reviewer and assignee duties:
 `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/dev/pr-process/SKILL.md`
 
 - Review any PRs assigned to me for review.
-- Check all open PRs I authored for unresolved `CHANGES_REQUESTED` reviews. Address valid feedback and push. As PR owner, merge any PR where the required approval has been given and CI is green; do not wait for Tom to merge unless Tom is explicitly the required reviewer.
+- Check all open PRs I authored for unresolved `CHANGES_REQUESTED` reviews. Address valid feedback and push. As PR assignee, merge any PR where the required approval has been given and CI is green; do not wait for Tom to merge unless Tom is explicitly the required reviewer.
 
 If no open PRs or no unresolved comments: skip the assignee part.
 

--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -12,7 +12,7 @@ Read and follow the pr-process skill for both reviewer and assignee duties:
 `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/dev/pr-process/SKILL.md`
 
 - Review any PRs assigned to me for review.
-- Check all open PRs I authored for unresolved `CHANGES_REQUESTED` reviews. Address valid feedback and push. Merge any PR where all reviewers have approved and CI is green.
+- Check all open PRs I authored for unresolved `CHANGES_REQUESTED` reviews. Address valid feedback and push. As PR owner, merge any PR where the required approval has been given and CI is green; do not wait for Tom to merge unless Tom is explicitly the required reviewer.
 
 If no open PRs or no unresolved comments: skip the assignee part.
 

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -197,7 +197,7 @@ When all ACs are implemented and the PR is ready for review:
 - convert draft → ready-for-review
 - set yourself (`rowanstoffer`) as PR assignee; add **Quinn** (`quinnstoffer`) and **Tom** (`Stoff81`) as reviewers — Quinn is the blocking code reviewer, Tom is non-blocking (visibility only)
 - post `[implementer-prs] <url>` as a task comment
-- merge after Quinn approves and CI is green — do not wait for Tom's PR approval
+- as the PR owner, merge after the required approval has been given and CI is green — do not wait for Tom to merge or for Tom's PR approval unless Tom is the required reviewer for that PR
 - Tom tests post-merge in main; his sign-off is `[qa-ac-verified] true` on the task, not a PR review
 
 ---

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -197,7 +197,7 @@ When all ACs are implemented and the PR is ready for review:
 - convert draft → ready-for-review
 - set yourself (`rowanstoffer`) as PR assignee; add **Quinn** (`quinnstoffer`) and **Tom** (`Stoff81`) as reviewers — Quinn is the blocking code reviewer, Tom is non-blocking (visibility only)
 - post `[implementer-prs] <url>` as a task comment
-- as the PR owner, merge after the required approval has been given and CI is green — do not wait for Tom to merge or for Tom's PR approval unless Tom is the required reviewer for that PR
+- as the PR assignee, merge after the required approval has been given and CI is green — do not wait for Tom to merge or for Tom's PR approval unless Tom is the required reviewer for that PR
 - Tom tests post-merge in main; his sign-off is `[qa-ac-verified] true` on the task, not a PR review
 
 ---

--- a/agents/skills/dev/pr-process/SKILL.md
+++ b/agents/skills/dev/pr-process/SKILL.md
@@ -86,13 +86,13 @@ Labels are not mutually exclusive. A PR can be both `workflow-garden` and `direc
 
 ## Example role mappings
 
-This skill is role-based, not agent-based. Any agent can play any role on a given PR. The split is: one role owns the PR, one or more review it, and the PR owner is responsible for merging once the required approval(s) are given and CI is green.
+This skill is role-based, not agent-based. Any agent can play any role on a given PR. The split is: one assignee owns the PR, one or more review it, and the assignee is responsible for merging once the required approval(s) are given and CI is green.
 
 Concrete patterns in our workflows:
 
-- **Feature tasks:** The task implementer/assignee owns the PR and is the PR assignee. The blocking reviewer is Quinn; Tom may be added as a visibility-only reviewer for GitHub inbox visibility. The PR owner merges after the required approval (normally Quinn's) and CI is green — do not wait for Tom's PR approval or ask Tom to merge. Tom tests post-merge in main; his sign-off is the `[qa-ac-verified] true` task comment. The feature-task workflow is role-based: implementer owns/merges, reviewer reviews. Do not hardcode a specific agent into the workflow. Apply `--label feature-task` at PR creation.
-- **Content tasks:** PR owner opens (`--assignee <self>`, `--reviewer quinn,tomstoffer`, `--label content-task`). Quinn and Tom review. PR owner merges after the required approvals.
-- **Code-garden tasks:** PR owner opens with `--label code-garden`, reviewer reviews against the code-garden guardrail (no behavior change). PR owner merges after approval.
-- **Cross-repo PRs (workspace repo, infra scripts):** same pattern — PR owner opens, reviewer reviews, PR owner merges after approval.
+- **Feature tasks:** The task implementer is the PR assignee. The blocking reviewer is Quinn; Tom may be added as a visibility-only reviewer for GitHub inbox visibility. The assignee merges after the required approval (normally Quinn's) and CI is green — do not wait for Tom's PR approval or ask Tom to merge. Tom tests post-merge in main; his sign-off is the `[qa-ac-verified] true` task comment. The feature-task workflow is role-based: implementer is assignee/merger, reviewer reviews. Do not hardcode a specific agent into the workflow. Apply `--label feature-task` at PR creation.
+- **Content tasks:** Assignee opens (`--assignee <self>`, `--reviewer quinn,tomstoffer`, `--label content-task`). Quinn and Tom review. Assignee merges after the required approvals.
+- **Code-garden tasks:** Assignee opens with `--label code-garden`, reviewer reviews against the code-garden guardrail (no behavior change). Assignee merges after approval.
+- **Cross-repo PRs (workspace repo, infra scripts):** same pattern — assignee opens, reviewer reviews, assignee merges after approval.
 
-The reviewer never merges. The PR owner—normally the assignee/opener—owns getting the PR accepted and merged.
+The reviewer never merges. The assignee owns getting the PR accepted and merged.

--- a/agents/skills/dev/pr-process/SKILL.md
+++ b/agents/skills/dev/pr-process/SKILL.md
@@ -86,13 +86,13 @@ Labels are not mutually exclusive. A PR can be both `workflow-garden` and `direc
 
 ## Example role mappings
 
-This skill is role-based, not agent-based. Any agent can play any role on a given PR. The split is: one role opens the PR, one or more review it, the opener merges after all approvals + green CI.
+This skill is role-based, not agent-based. Any agent can play any role on a given PR. The split is: one role owns the PR, one or more review it, and the PR owner is responsible for merging once the required approval(s) are given and CI is green.
 
 Concrete patterns in our workflows:
 
-- **Feature tasks:** The task implementer/assignee opens the PR and is the PR assignee. The blocking reviewer is Quinn; Tom may be added as a visibility-only reviewer for GitHub inbox visibility. The opener/assignee merges after Quinn approves and CI is green — do not wait for Tom's PR approval. Tom tests post-merge in main; his sign-off is the `[qa-ac-verified] true` task comment. The feature-task workflow is role-based: implementer opens/merges, reviewer reviews. Do not hardcode a specific agent into the workflow. Apply `--label feature-task` at PR creation.
-- **Content tasks:** opener opens (`--assignee <self>`, `--reviewer quinn,tomstoffer`, `--label content-task`). Quinn and Tom review. Opener merges after both approvals.
-- **Code-garden tasks:** opener opens with `--label code-garden`, reviewer reviews against the code-garden guardrail (no behavior change). Opener merges after approval.
-- **Cross-repo PRs (workspace repo, infra scripts):** same pattern — opener opens, reviewer reviews, opener merges.
+- **Feature tasks:** The task implementer/assignee owns the PR and is the PR assignee. The blocking reviewer is Quinn; Tom may be added as a visibility-only reviewer for GitHub inbox visibility. The PR owner merges after the required approval (normally Quinn's) and CI is green — do not wait for Tom's PR approval or ask Tom to merge. Tom tests post-merge in main; his sign-off is the `[qa-ac-verified] true` task comment. The feature-task workflow is role-based: implementer owns/merges, reviewer reviews. Do not hardcode a specific agent into the workflow. Apply `--label feature-task` at PR creation.
+- **Content tasks:** PR owner opens (`--assignee <self>`, `--reviewer quinn,tomstoffer`, `--label content-task`). Quinn and Tom review. PR owner merges after the required approvals.
+- **Code-garden tasks:** PR owner opens with `--label code-garden`, reviewer reviews against the code-garden guardrail (no behavior change). PR owner merges after approval.
+- **Cross-repo PRs (workspace repo, infra scripts):** same pattern — PR owner opens, reviewer reviews, PR owner merges after approval.
 
-The reviewer never merges. The assignee/opener owns getting the PR accepted and merged.
+The reviewer never merges. The PR owner—normally the assignee/opener—owns getting the PR accepted and merged.


### PR DESCRIPTION
## Summary
- Make the cross-workflow rule explicit: the PR owner is responsible for merging once required approval has been given and CI is green.
- Clarify Rowan's heartbeat and workflow instructions so Tom is not treated as the default merger for Rowan-owned PRs.

## System Spec
No system spec change — this is an internal workflow/documentation clarification.

## Test plan
- [x] `git diff --check`
- [x] Confirm Rowan HEARTBEAT and WORKFLOW both state the PR-owner merge responsibility.
- [x] Confirm `pr-process` uses the same rule for feature, content, code-garden, and cross-repo PRs.