### PR TITLE
fix(workflow): harden Ivy routing and tweet voice

### DIFF
--- a/agents/definitions/ivy/DoD.md
+++ b/agents/definitions/ivy/DoD.md
@@ -24,7 +24,8 @@ A content task is only Done when all are true:
    - Task comments updated with PR URLs
    - Quinn notified of completion
    - A `[ivy-prs]` task comment with the PR URL(s) has been posted, in the exact format the Lobster parses
-   - ACs from the task body appear in the PR description and are marked `- [x]` once satisfied
+   - Only the routed owner's ACs appear in each PR description, copied into `## Acceptance criteria` and marked `- [x]` once satisfied
+   - The `[ivy-prs]` task comment uses explicit `tom:` / `quinn:` labels; an unlabeled PR list is invalid
 
 ---
 

--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -87,6 +87,18 @@ Scan the week's signals and pick the single strongest arc — a story with a beg
   5. One idea per tweet. If a tweet needs a second sentence, split it into a follow-up bullet in the arc.
   6. Concrete over abstract: "shipped a 10-day calendar view in Mission Control" beats "improved our operating surface."
 
+### Tweet voice and formatting
+
+These tweets publish from Tom's X account, so write as Tom:
+
+- Use first-person singular: `I`, `me`, and `my`.
+- Do not use collective first person: never write `we`, `us`, or `our` unless quoting a source.
+- Do not describe Tom from the outside (for example, "Tom built...").
+- Avoid dense paragraph blocks. For any tweet with more than one sentence or idea, use line breaks and a readable structure: a short hook followed by one or two short lines, or `•` bullets / `1/2/3` steps when listing points.
+- Use plain text formatting that survives X; do not rely on Markdown tables, bold, or headings.
+- A one-line tweet is fine when the idea is genuinely one line. Formatting is there for readability, not decoration.
+- Count line breaks, bullets, and spaces in the 280-character limit.
+
 ### 4. Schedule the sequence
 
 - First tweet: **tomorrow** (today + 1) at `10:00 Pacific/Auckland`.

--- a/agents/definitions/ivy/WORKFLOW.md
+++ b/agents/definitions/ivy/WORKFLOW.md
@@ -103,8 +103,8 @@ GH_CONFIG_DIR=~/.config/gh-ivy gh pr create \
 ```
 
 PR description must:
-- Copy every AC from the task body
-- Mark ACs as `- [x]` once I have completed that work in the PR
+- Start from an explicit owner-to-AC manifest: `## Quinn can execute` belongs only in the Quinn PR, and `## Needs Tom approval` belongs only in the Tom PR. Never copy the other owner's ACs into a PR.
+- Copy the complete AC text for that owner into the PR's `## Acceptance criteria` section, and mark only those ACs as `- [x]` once I have completed that work in the PR.
 - Include the task ID in the PR body for traceability
 
 ### 5. Write PR URLs back to the task
@@ -125,6 +125,8 @@ or
 ```
 
 **The label (`tom:` / `quinn:`) is required** — it tells the Lobster which heading to inject the PR URL into. A URL without a label will be ignored.
+
+The labels are mandatory routing data, not presentation. The Lobster rejects unlabelled or positional PR lists rather than guessing which AC section a PR covers.
 
 Post this as a task comment immediately after opening the PR(s). The Lobster will pick it up on the next heartbeat and move the task from `doing` to `acceptance`.
 

--- a/agents/skills/content/sindustries-copy/SKILL.md
+++ b/agents/skills/content/sindustries-copy/SKILL.md
@@ -95,6 +95,22 @@ These are non-negotiable:
 
    Agent names (Ivy, Rowan, Quinn) are fine to use — they add personality. Describe what a system *does for the business*. Reference other published Systems or Stacks by their public names instead.
 
+### Social copy for Tom's account
+
+When this skill is used to draft a tweet or social post for Ivy's weekly
+campaign, the account voice is Tom's:
+
+- Write in first-person singular (`I`, `me`, `my`). Do not use `we`, `us`, or
+  `our` unless quoting source material.
+- Never refer to Tom as an outside subject. The post should sound like Tom is
+  saying it directly.
+- Do not return every tweet as one dense paragraph. For multi-sentence or
+  multi-point posts, use line breaks and plain-text structure such as `•`
+  bullets or numbered steps. Do not depend on Markdown styling that X will
+  not render.
+- Keep one-line posts when the idea is genuinely one line; do not add
+  decorative formatting just to satisfy a template.
+
 ---
 
 ## Images

--- a/agents/workflows/content-tasks/scripts/common.py
+++ b/agents/workflows/content-tasks/scripts/common.py
@@ -262,15 +262,64 @@ def task_acceptance_criteria(description: str) -> list[str]:
 
 
 def extract_ivy_pr_urls(task: dict[str, Any]) -> list[str]:
-    # Only read the most recent [ivy-prs] comment — newer comment supersedes older ones
-    latest = None
+    return list(extract_ivy_pr_routes(task).values())
+
+
+IVY_PR_ROUTE_RE = re.compile(
+    r"\b(?P<owner>tom|quinn)\s*:\s*(?P<url>https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+)",
+    re.I,
+)
+
+
+def latest_ivy_pr_comment(task: dict[str, Any]) -> str:
+    """Return the latest Ivy PR handoff comment, if any."""
+    latest = ""
     for comment in task_comments(task):
         text = comment_text(comment)
         if IVY_PRS_TAG in text:
             latest = text
-    if not latest:
-        return []
-    return list(dict.fromkeys(extract_pr_urls_from_text(latest)))
+    return latest
+
+
+def parse_ivy_pr_routes(comment: str) -> tuple[dict[str, str], list[str]]:
+    """Parse explicit approver-to-PR routing from an Ivy handoff comment.
+
+    Positional PR inference is deliberately not supported. A missing or
+    malformed owner label must block the task rather than silently attaching
+    a PR to the wrong acceptance-criteria section.
+    """
+    if not comment:
+        return {}, ["No `[ivy-prs]` task comment with a GitHub PR URL has been detected."]
+
+    routes: dict[str, str] = {}
+    errors: list[str] = []
+    labelled_urls: set[str] = set()
+    for match in IVY_PR_ROUTE_RE.finditer(comment):
+        owner = match.group("owner").lower()
+        url = match.group("url")
+        if owner in routes:
+            errors.append(f"`{owner}:` appears more than once in the latest `[ivy-prs]` comment.")
+        if url in labelled_urls:
+            errors.append(f"PR URL `{url}` is mapped to more than one approver.")
+        routes[owner] = url
+        labelled_urls.add(url)
+
+    all_urls = extract_pr_urls_from_text(comment)
+    unlabelled = [url for url in all_urls if url not in labelled_urls]
+    if unlabelled:
+        errors.append(
+            "Every PR URL in the latest `[ivy-prs]` comment must have an explicit `tom:` or `quinn:` label; "
+            f"unlabelled URL(s): {', '.join(unlabelled)}."
+        )
+    if not routes:
+        errors.append("Latest `[ivy-prs]` comment must use `tom: <url>` and/or `quinn: <url>` routing labels.")
+    return routes, errors
+
+
+def extract_ivy_pr_routes(task: dict[str, Any]) -> dict[str, str]:
+    """Return the latest explicit Ivy PR routing map, ignoring invalid entries."""
+    routes, _ = parse_ivy_pr_routes(latest_ivy_pr_comment(task))
+    return routes
 
 
 def task_is_weekly_content(task: dict[str, Any]) -> bool:

--- a/agents/workflows/content-tasks/scripts/pr_transition.py
+++ b/agents/workflows/content-tasks/scripts/pr_transition.py
@@ -10,7 +10,6 @@ from common import (
     CHECKBOX_RE,
     OWNER_HEADING_RE,
     dump_json,
-    extract_ivy_pr_urls,
     extract_pr_urls_from_text,
     gh_pr_body,
     gh_pr_assignees,
@@ -21,9 +20,11 @@ from common import (
     heading_level,
     is_at,
     is_past,
+    latest_ivy_pr_comment,
     move_task,
     next_heading_pos,
     owner_heading_block_url_failures,
+    parse_ivy_pr_routes,
     patch_task,
     read_first_json_value,
     refresh_task,
@@ -99,8 +100,15 @@ def checked_pr_acceptance_criteria(pr_body: str) -> set[str]:
 
 def checked_pr_ac_signatures(pr_body: str) -> set[str]:
     """Extract AC slugs from checked PR acceptance criteria."""
+    acceptance_heading = re.search(
+        r"^\s{0,3}#{1,6}\s+acceptance criteria\s*$", pr_body or "", re.I | re.M
+    )
+    if not acceptance_heading:
+        return set()
+    end = next_heading_pos(pr_body, acceptance_heading.end(), heading_level(acceptance_heading.group(0)))
+    acceptance_body = pr_body[acceptance_heading.end():end]
     checked: set[str] = set()
-    for match in re.finditer(r"^\s*-\s*\[[xX]\]\s+(.+\S)\s*$", pr_body or "", re.M):
+    for match in re.finditer(r"^\s*-\s*\[[xX]\]\s+(.+\S)\s*$", acceptance_body, re.M):
         checked.add(ac_signature(match.group(1)))
     return checked
 
@@ -109,125 +117,79 @@ def pr_heading_urls(task: dict) -> list[str]:
     return extract_pr_urls_from_text(task.get("description") or "")
 
 
-QUINN_LOGINS = {"quinnstoffer"}
-TOM_LOGINS = {"stoff81"}
 IVY_LOGINS = {"ivystoffer"}
 
 
-def _heading_index_for_assignees(assignees: list[str]) -> int | None:
-    """Return heading index based on PR assignees. Quinn=0, Tom=1, unknown=None."""
-    logins = {a.lower() for a in assignees if a}
-    if logins & QUINN_LOGINS:
-        return 0
-    if logins & TOM_LOGINS:
-        return 1
-    return None
-
-
-def _heading_index_for_pr(url: str) -> int | None:
-    """Return heading index for a PR.
-
-    Checks assignees first (legacy pattern where Quinn/Tom are assigned).
-    When Ivy self-assigns, falls back to reviewer logins to determine section.
-    Quinn reviewer → 0, Tom reviewer → 1.
-    """
-    try:
-        assignees = gh_pr_assignees(url)
-        idx = _heading_index_for_assignees(assignees)
-        if idx is not None:
+def owner_heading_index(description: str, owner: str) -> int | None:
+    """Return the actual owner-heading index for an explicit route label."""
+    owner = owner.lower()
+    for idx, (block, _) in enumerate(owner_sections(description)):
+        heading = block.splitlines()[0].lower() if block.splitlines() else ""
+        if owner in heading:
             return idx
-    except Exception:
-        pass
-    try:
-        reviewers = gh_pr_reviewers(url)
-        reviewer_logins = {r.lower() for r in reviewers if r}
-        if reviewer_logins & QUINN_LOGINS:
-            return 0
-        if reviewer_logins & TOM_LOGINS:
-            return 1
-    except Exception:
-        pass
     return None
 
 
-def url_to_heading_index(url: str, pr_urls: list[str], description: str = "") -> int | None:
+def url_to_heading_index(
+    url: str,
+    pr_urls: list[str],
+    description: str = "",
+    routes: dict[str, str] | None = None,
+) -> int | None:
     """Map a PR URL to its owner heading index.
 
-    Priority order:
-    1. Scan owner sections in the description (URL already injected).
-    2. Look up PR assignees (legacy) or reviewers (Ivy self-assign flow).
-    3. Fall back to reversed-position formula (fragile, last resort).
+    Explicit `tom:` / `quinn:` routing is authoritative. There is no
+    positional fallback: an unlabeled PR is unsafe to match to an AC set.
     """
     if not url or url not in pr_urls:
         return None
+    if routes:
+        for owner, routed_url in routes.items():
+            if routed_url == url:
+                return owner_heading_index(description, owner)
     if description:
         for idx, (block_text, _) in enumerate(owner_sections(description)):
             if url in block_text:
                 return idx
-    idx = _heading_index_for_pr(url)
-    if idx is not None:
-        return idx
-    pos = pr_urls.index(url)
-    return 1 - pos  # last resort: pr_urls[0] → Tom(1), pr_urls[1] → Quinn(0)
+    return None
 
 
-def inject_pr_urls_into_description(description: str, pr_urls: list[str]) -> str:
+def inject_pr_urls_into_description(description: str, routes: dict[str, str]) -> str:
     """Inject PR URLs as markdown links into the correct owner heading blocks.
 
-    Uses PR assignees to determine the target heading:
-    - quinnstoffer → ## Quinn can execute (idx 0)
-    - Stoff81 → ## Needs Tom approval (idx 1)
-    Falls back to positional ordering only when no assignee is set.
+    Explicit route labels are authoritative. Existing PR links are rewritten
+    so a previous positional guess cannot remain attached to the wrong ACs.
     """
-    if not pr_urls or not description:
+    if not routes or not description:
         return description
-    result = description
-    owner_matches = list(OWNER_HEADING_RE.finditer(result))
-    for url in pr_urls:
-        if url in result:
-            continue
-        pr_num_match = re.search(r"pull/(\d+)", url or "")
-        pr_label = f"PR #{pr_num_match.group(1)}" if pr_num_match else url
+    owner_matches = list(OWNER_HEADING_RE.finditer(description))
+    if not owner_matches:
+        return description
 
-        # Determine target heading by assignee/reviewer, fall back to first empty heading.
-        target_idx: int | None = _heading_index_for_pr(url)
-
-        if target_idx is not None:
-            # Inject into the assignee-matched heading if it doesn't already have a PR URL.
-            if target_idx < len(owner_matches):
-                match = owner_matches[target_idx]
-                start = match.end()
-                end = owner_matches[target_idx + 1].start() if target_idx + 1 < len(owner_matches) else next_heading_pos(
-                    result, start, heading_level(match.group(0))
-                )
-                block = result[start:end]
-                if not extract_pr_urls_from_text(match.group(0) + "\n" + block):
-                    result = result[:start] + f"\n[{pr_label}]({url})" + result[start:]
-                    owner_matches = list(OWNER_HEADING_RE.finditer(result))
-                    continue
-            # Heading already has a URL or index out of range — append at end.
-            result = result.rstrip() + f"\n\n[{pr_label}]({url})\n"
-        else:
-            # No assignee — fall back to first empty heading walking in reverse.
-            heading_idx = None
-            for h_idx in range(len(owner_matches) - 1, -1, -1):
-                match = owner_matches[h_idx]
-                start = match.end()
-                end = owner_matches[h_idx + 1].start() if h_idx + 1 < len(owner_matches) else next_heading_pos(
-                    result, start, heading_level(match.group(0))
-                )
-                block = result[start:end]
-                if not extract_pr_urls_from_text(match.group(0) + "\n" + block):
-                    heading_idx = h_idx
-                    break
-            if heading_idx is not None:
-                match = owner_matches[heading_idx]
-                start = match.end()
-                result = result[:start] + f"\n[{pr_label}]({url})" + result[start:]
-                owner_matches = list(OWNER_HEADING_RE.finditer(result))
-            else:
-                result = result.rstrip() + f"\n\n[{pr_label}]({url})\n"
-    return result
+    pieces: list[str] = []
+    cursor = 0
+    for idx, match in enumerate(owner_matches):
+        start = match.end()
+        end = owner_matches[idx + 1].start() if idx + 1 < len(owner_matches) else next_heading_pos(
+            description, start, heading_level(match.group(0))
+        )
+        pieces.append(description[cursor:start])
+        block = description[start:end]
+        cleaned = re.sub(
+            r"(?m)^[ \t]*\[[^\n\]]+\]\(https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+\)[ \t]*\n?",
+            "",
+            block,
+        )
+        owner = "quinn" if "quinn" in match.group(0).lower() else "tom"
+        url = routes.get(owner)
+        if url:
+            pr_num_match = re.search(r"pull/(\d+)", url)
+            pr_label = f"PR #{pr_num_match.group(1)}" if pr_num_match else url
+            cleaned = f"\n[{pr_label}]({url})\n" + cleaned.lstrip("\n")
+        pieces.append(cleaned)
+        cursor = end
+    pieces.append(description[cursor:])
+    return "".join(pieces)
 
 
 def ci_failures_for_pr(url: str) -> tuple[list[str], list[dict[str, str]]]:
@@ -267,7 +229,8 @@ def ac_failures_for_pr(url: str, heading_idx: int, task_acs: list[str], descript
     section_signatures = {ac_signature(ac) for ac in section_acs}
     checked_sigs = checked_pr_ac_signatures(gh_pr_body(url))
 
-    missing = [sig for sig in section_signatures if sig not in checked_sigs]
+    missing = sorted(sig for sig in section_signatures if sig not in checked_sigs)
+    unexpected = sorted(sig for sig in checked_sigs if sig not in section_signatures)
     checked_normalized = checked_pr_acceptance_criteria(gh_pr_body(url))
 
     details = {
@@ -277,9 +240,12 @@ def ac_failures_for_pr(url: str, heading_idx: int, task_acs: list[str], descript
         "sectionSignatures": sorted(section_signatures),
         "checkedSignatures": sorted(checked_sigs),
         "missingSignatures": missing,
+        "unexpectedSignatures": unexpected,
         "checkedAcceptanceCriteria": sorted(checked_normalized),
     }
-    return [f"{url} PR is missing AC: {sig}" for sig in missing], details
+    failures = [f"{url} PR is missing AC: {sig}" for sig in missing]
+    failures.extend(f"{url} PR contains AC for the wrong owner section: {sig}" for sig in unexpected)
+    return failures, details
 
 
 def main() -> int:
@@ -296,22 +262,23 @@ def main() -> int:
     state = dict(data.get("lobster_state") or {})
     description = task.get("description") or ""
 
-    detected = extract_ivy_pr_urls(task)
+    routes, route_failures = parse_ivy_pr_routes(latest_ivy_pr_comment(task))
     existing = [url for url in state.get("prUrls") or [] if isinstance(url, str)]
-    pr_urls = existing[:]
-    for url in detected:
-        if url not in pr_urls:
-            pr_urls.append(url)
+    # The latest labelled handoff is authoritative. Never merge it with the
+    # prior state or infer missing labels from URL order.
+    pr_urls = list(dict.fromkeys(routes.values()))
     state["prUrls"] = pr_urls
 
-    # Inject Ivy's PR URLs into the task description heading blocks if missing
-    updated_description = inject_pr_urls_into_description(description, pr_urls)
+    failures: list[str] = list(route_failures)
+
+    # Inject Ivy's explicitly routed PR URLs into the task description heading
+    # blocks. The route map, not URL position or PR assignee, decides placement.
+    updated_description = inject_pr_urls_into_description(description, routes)
     if updated_description != description and str(args.dry_run).lower() != "true":
         patch_task(str(task["id"]), {"description": updated_description})
         task = refresh_task(str(task["id"]))
         description = updated_description
 
-    failures: list[str] = []
     pr_heading_failures = owner_heading_block_url_failures(description)
     if pr_heading_failures:
         failures.extend(pr_heading_failures)
@@ -346,7 +313,7 @@ def main() -> int:
             pr_ci.append({"url": url, "error": str(exc)})
         if task_acs:
             try:
-                heading_idx = url_to_heading_index(url, pr_urls, description)
+                heading_idx = url_to_heading_index(url, pr_urls, description, routes)
                 if heading_idx is None:
                     failures.append(f"{url} has no mapped owner heading — cannot determine which ACs to validate.")
                     pr_ac_details.append({"url": url, "error": "no heading index"})
@@ -354,18 +321,19 @@ def main() -> int:
                     ac_fails, ac_details = ac_failures_for_pr(url, heading_idx, task_acs, description)
                     pr_ac_details.append(ac_details)
                     failures.extend(ac_fails)
-                    # Assignee check: heading_idx 0 = Quinn's section, 1 = Tom's section
                     assignees = gh_pr_assignees(url)
-                    # Accept ivy self-assign (new flow) or legacy approver-assign
-                    expected_assignees = {
-                        0: {"quinnstoffer"} | IVY_LOGINS,  # Quinn's PR → Quinn or Ivy
-                        1: {"Stoff81"} | IVY_LOGINS,       # Tom's PR → Tom or Ivy
-                    }
-                    expected = expected_assignees.get(heading_idx, set())
-                    if expected and not expected.intersection(set(assignees)):
+                    assignee_logins = {login.lower() for login in assignees if login}
+                    if assignee_logins != IVY_LOGINS:
                         failures.append(
-                            f"{url} is not assigned to one of {expected} — "
-                            f"PR must be assigned to Ivy (self-merge flow) or the owner ({'Quinn' if heading_idx == 0 else 'Tom'})."
+                            f"{url} must be assigned only to Ivy (`ivystoffer`), not to an approver; "
+                            f"actual assignees: {sorted(assignee_logins) or 'none'}."
+                        )
+                    expected_reviewer = "quinnstoffer" if heading_idx == 0 else "stoff81"
+                    reviewer_logins = {login.lower() for login in gh_pr_reviewers(url) if login}
+                    if expected_reviewer not in reviewer_logins:
+                        failures.append(
+                            f"{url} is routed to the {('Quinn' if heading_idx == 0 else 'Tom')} section but has no "
+                            f"matching reviewer (`{expected_reviewer}`)."
                         )
             except Exception as exc:
                 failures.append(f"Could not inspect PR description for {url}: {exc}")

--- a/docs/systems/content-factory.md
+++ b/docs/systems/content-factory.md
@@ -252,7 +252,7 @@ The `content-tasks/run.py` wrapper discovers active `content` tasks in `open`, `
 |---|---|
 | `open → ready` | Task body has a source `brain/...md` file or URL, plus one or more Tom/Quinn owner headings with checkbox ACs. Lobster assigns the task to Ivy. |
 | `ready → doing` | Task is assigned to Ivy and Ivy's current unblocked `doing` content task count is below the capacity limit (default: 1). |
-| `doing → acceptance` | Ivy has posted the latest `[ivy-prs]` comment; Lobster records the PR URLs, injects them under the owner headings if missing, verifies every owner heading has a PR URL, verifies PR CI is successful, verifies each PR body has checked AC signatures for that owner section, and verifies Quinn/Tom PRs are assigned to `quinnstoffer`/`Stoff81`. |
+| `doing → acceptance` | Ivy has posted the latest labelled `[ivy-prs]` comment; Lobster records the explicit `tom:` / `quinn:` route, injects each link under the matching owner heading (repairing misplaced links), rejects positional/unlabelled routing, verifies PR CI, verifies each PR body contains exactly the ACs for its routed owner section, and verifies Ivy is the sole assignee with the matching approver as reviewer. |
 | `acceptance → done` | All recorded PRs are merged to `main`. Before merge, the current implementation treats `CHANGES_REQUESTED`, `REVIEW_REQUIRED`, or any returned inline review comments on an unmerged PR as Ivy revision work and routes that feedback back to Ivy. |
 
 If earlier criteria regress, the Lobster moves the task backwards and posts a comment explaining why. While a task is in `acceptance`, the Lobster can also route PR review feedback back to Ivy by posting a task comment.
@@ -305,7 +305,7 @@ Immediately after opening PRs, Ivy posts a task comment:
 
 If both PRs exist, keep the order `tom` then `quinn`. If only one PR was opened, include just that labelled URL.
 
-The Lobster parses the latest `[ivy-prs]` comment on the next pass, records the URLs in Lobster state, injects the links into the task description owner sections when needed, and advances the task to `acceptance` once all `doing → acceptance` criteria pass.
+The Lobster parses the latest labelled `[ivy-prs]` comment on the next pass, records the explicit owner-to-PR mapping in Lobster state, injects links into the matching task-description owner sections, and advances the task to `acceptance` only when routing, PR metadata, CI, and exact per-owner AC coverage all pass. It never infers routing from URL order.
 
 ### Review iteration
 

--- a/tests/test_pr_transition_headings.py
+++ b/tests/test_pr_transition_headings.py
@@ -106,5 +106,73 @@ class WeeklyContentTweetGateTests(unittest.TestCase):
         self.assertFalse(common_module.has_ivy_tweets_queued(normal))
 
 
+class IvyPrRoutingTests(unittest.TestCase):
+    def test_latest_handoff_requires_explicit_owner_labels(self):
+        common_module = load_common_module()
+        url1 = "https://github.com/Stoffer-Industries/sindustries/pull/319"
+        url2 = "https://github.com/Stoffer-Industries/sindustries/pull/320"
+
+        routes, errors = common_module.parse_ivy_pr_routes(f"[ivy-prs] tom: {url1}, quinn: {url2}")
+        self.assertEqual(routes, {"tom": url1, "quinn": url2})
+        self.assertEqual(errors, [])
+
+        routes, errors = common_module.parse_ivy_pr_routes(f"[ivy-prs] {url1} {url2}")
+        self.assertEqual(routes, {})
+        self.assertTrue(any("explicit `tom:` or `quinn:`" in error for error in errors))
+
+    def test_explicit_routes_repair_reversed_task_links(self):
+        module = load_content_task_modules()
+        url1 = "https://github.com/Stoffer-Industries/sindustries/pull/319"
+        url2 = "https://github.com/Stoffer-Industries/sindustries/pull/320"
+        description = (
+            "## Quinn can execute\n"
+            f"[PR #319]({url1})\n"
+            "- [ ] ADD system/quinn - factual update\n\n"
+            "## Needs Tom approval\n"
+            f"[PR #320]({url2})\n"
+            "- [ ] EDIT story/tom - approval required\n"
+        )
+
+        updated = module.inject_pr_urls_into_description(
+            description, {"quinn": url2, "tom": url1}
+        )
+        quinn_start = updated.index("## Quinn can execute")
+        tom_start = updated.index("## Needs Tom approval")
+        self.assertLess(updated.index(url2), tom_start)
+        self.assertGreater(updated.index(url1), quinn_start)
+        self.assertGreater(updated.index(url1), tom_start)
+
+    def test_pr_ac_signatures_ignore_test_plan_checkboxes(self):
+        module = load_content_task_modules()
+        body = (
+            "## Test plan\n"
+            "- [x] Validate JSON\n\n"
+            "## Acceptance criteria\n"
+            "- [x] ADD system/example - publish the page\n"
+        )
+
+        self.assertEqual(module.checked_pr_ac_signatures(body), {"add system/example"})
+
+    def test_pr_with_other_owner_ac_is_rejected(self):
+        module = load_content_task_modules()
+        url = "https://github.com/Stoffer-Industries/sindustries/pull/1"
+        description = (
+            "## Quinn can execute\n"
+            "- [ ] ADD system/quinn - factual update\n\n"
+            "## Needs Tom approval\n"
+            "- [ ] EDIT story/tom - approval required\n"
+        )
+        module.gh_pr_body = lambda _url: (
+            "## Acceptance criteria\n"
+            "- [x] EDIT story/tom - approval required\n"
+        )
+
+        failures, details = module.ac_failures_for_pr(url, 0, [], description)
+
+        self.assertTrue(any("missing AC: add system/quinn" in failure for failure in failures))
+        self.assertTrue(any("wrong owner section: edit story/tom" in failure for failure in failures))
+        self.assertEqual(details["unexpectedSignatures"], ["edit story/tom"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Make Ivy's explicit `tom:` / `quinn:` PR handoff labels authoritative; reject unlabelled or positional routing instead of guessing.
- Require exact per-owner AC coverage, Ivy-only PR assignment, and the matching approver reviewer so wrong AC/PR pairings block before acceptance.
- Update Ivy's tweet guidance to use Tom's first-person singular voice and readable plain-text formatting.

## System Spec
Updated `docs/systems/content-factory.md` with the routing and acceptance gates.

## Test plan
- [x] `python3 -m pytest -q tests/test_pr_transition_headings.py` (8 passed)
- [x] `python3 -m py_compile agents/workflows/content-tasks/scripts/common.py agents/workflows/content-tasks/scripts/pr_transition.py`
- [x] `git diff --check`
- [ ] Full repository suite: 5 unrelated pre-existing failures; 234 tests passed.