### PR TITLE
fix(repo-audit-cron): require absolute cwd + add write/commit/push/PR completion gate

### DIFF
--- a/agents/crons/prompts/repo-audit-weekly.md
+++ b/agents/crons/prompts/repo-audit-weekly.md
@@ -1,6 +1,47 @@
 Read and execute the skill at:
 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/dev/repo-audit/SKILL.md
 
+## Working directory rule (HARD CONSTRAINT)
+
+This cron runs in an isolated session whose `cwd` is **NOT** the sindustries
+repo. Every shell command (Phase 1 exploration, Phase 4 git ops, anything
+that touches the repo) MUST either:
+
+1. Use absolute paths (`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/...`), OR
+2. Be prefixed with `cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries && ...`
+
+Do NOT rely on relative paths like `services/...`, `docs/...`, `apps/...`. They
+will resolve against the wrong cwd and fail with `exit 1` — this is the bug
+that broke the W31 audit (and probably W28–W30 silently).
+
+## Completion gate (HARD CONSTRAINT)
+
+A successful session MUST end with all four of these, in order, before the
+session ends:
+
+1. `docs/repo-audits/<YYYY-Www>.md` written to disk (not just planned in
+   the assistant text — actually written via `write` tool).
+2. `git add docs/repo-audits/<YYYY-Www>.md && git commit -m "..."` (or
+   the matching commit style).
+3. `git push -u origin <branch>` — the branch must land on the remote.
+4. PR opened via the pr-open skill (`cod—audit: ...` title, Executive Summary
+   body, `code-audit` label, `Stoff81` assignee, `tomstoffer` reviewer).
+
+If you reach the end of your session without all four landing, the audit
+is incomplete and the cron will record `consecutiveErrors++`. The W31
+trajectory showed the agent writing the planning text "Now I have
+everything I need. Let me write the audit document:" and then ending the
+session without a `write` call — that's exactly the failure mode this gate
+prevents.
+
+## Tool constraint
+
+The `toolsAllow` on the cron payload is set to:
+`read`, `exec`, `write`, `apply_patch`, `sessions_send`, `image`,
+`update_plan`, `web_search`, `web_fetch`, `message`. Do not attempt to
+invoke tools outside this list — they will fail and may not produce useful
+errors.
+
 # notify-soft-fails
 Read /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/notify-soft-fail/SKILL.md and follow it.
 If the output of this cron has soft failures or unacceptable errors, escalate that to Lox's main session.

--- a/agents/skills/dev/repo-audit/SKILL.md
+++ b/agents/skills/dev/repo-audit/SKILL.md
@@ -15,6 +15,15 @@ Ground every claim in actual files: cite file paths and line numbers. If you can
 
 **Phase 1 / Discovery & Mapping** (read before judging)
 
+> **Working-directory rule.** This audit runs in an isolated session whose
+> `cwd` is NOT the target repo. Every `exec` / `read` / `list` / `git` call
+> MUST use either absolute paths (`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/...`)
+> or be prefixed with `cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries && ...`.
+> Relative paths like `services/...`, `docs/...`, `apps/...` will resolve
+> against the wrong cwd and fail silently with `exit 1`. This is the bug
+> that broke the W31 audit (and may have been silently dropping findings
+> in W28–W30).
+
 Explore the repository systematically before forming any opinions:
 
 - Map the directory structure and identify the project type, language(s), frameworks, and runtime targets.
@@ -109,11 +118,34 @@ When the implementation lands, its PR updates the same audit finding line with `
 
 If a task is created after the audit PR has already merged, open a tiny docs-only audit-ledger PR to add the task link. If the task is created before the audit PR merges, include the task link directly in the audit PR.
 
+## Completion gate (HARD CONSTRAINT)
+
+A successful audit session MUST end with all four of these gates firing, in order, before the session ends:
+
+1. **Write** — `docs/repo-audits/<YYYY-Www>.md` exists on disk (not just
+   planned in the assistant text — actually written via the `write` tool).
+2. **Commit** — `git add docs/repo-audits/<YYYY-Www>.md && git commit -m "..."` (or the matching commit style).
+3. **Push** — `git push -u origin <branch>` lands the branch on the remote.
+4. **PR** — PR opened via the pr-open skill (`cod—audit: ...` title, Executive Summary body, `code-audit` label, `Stoff81` assignee, `tomstoffer` reviewer).
+
+If the session ends without all four landing, the audit is incomplete and
+the cron will record `consecutiveErrors++`. The W31 trajectory showed the
+agent generating the planning text "Now I have everything I need. Let me
+write the audit document:" and then ending the session with no `write` tool
+call — that's exactly the failure mode this gate prevents. **Do not stop
+after planning; do the write, commit, push, and PR.**
+
 ## Runbook
 
 Target repo: `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`
 
 **1. Audit** — run the four-phase prompt above against the target repo. Produce the audit document in memory.
+
+**1a. Verify cwd before any execution.** Run `pwd` first; if it does not
+print `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`, then
+prefix every subsequent command with `cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries && ...`
+or use absolute paths. This is a one-time check at the start of each Phase 1
+exploration to surface the cwd-mismatch bug if it ever recurs.
 
 **2. Determine the current ISO week:**
 


### PR DESCRIPTION
## Summary

The SIndustries Weekly Repo Audit cron (`9f874f51`) has been failing for 3 consecutive weeks (W28, W29, W30 silent, W31 explicit) due to two compounding bugs in `agents/crons/prompts/repo-audit-weekly.md` and `agents/skills/dev/repo-audit/SKILL.md`:

- **Bug 1 — cwd mismatch in Phase 1 exploration.** The cron runs in an isolated session whose `cwd` is `agents/rowan`, not the sindustries repo. Phase 1 used relative paths (`services/...`, `docs/...`, `apps/...`) which resolved against the wrong cwd and failed with `exit 1`. W31 trajectory confirmed this on the very first exploration call. Every other exec in the run had the right `cd ... &&` prefix; this one dropped it.
- **Bug 2 — no-write silent end of session.** The W31 trajectory showed the agent generating the planning text *"Now I have everything I need. Let me write the audit document:"* and then ending the session with no `write` tool call. Session status was `success` with 81/81 tool calls, but `docs/repo-audits/2026-W31.md` was never written.

## Acceptance Criteria

- [x] AC1: `agents/crons/prompts/repo-audit-weekly.md` documents the working-directory rule (HARD CONSTRAINT: absolute paths or `cd ... &&` prefix on every shell call). (🧪 testID: read top of file — `## Working directory rule (HARD CONSTRAINT)` block names the rule and the two accepted forms.)
- [x] AC2: `agents/skills/dev/repo-audit/SKILL.md` Phase 1 / Discovery & Mapping section has a working-directory callout making the cwd rule explicit at the start of every exploration. (🧪 testID: read `Phase 1 / Discovery & Mapping` block — first paragraph is now the working-directory rule.)
- [x] AC3: `agents/skills/dev/repo-audit/SKILL.md` has a "Completion gate (HARD CONSTRAINT)" section before the Runbook, listing all four required end-of-session steps (write, commit, push, PR) with the exact failure mode the gate prevents. (🧪 testID: read `## Completion gate (HARD CONSTRAINT)` section — 4 items + W31 reference.)
- [x] AC4: `agents/skills/dev/repo-audit/SKILL.md` Runbook has a `1a. Verify cwd before any execution` step at the start of the runbook so future agents surface the cwd-mismatch bug if it ever recurs. (🧪 testID: read Runbook section — `1a.` step appears between `## Runbook` and the existing `1. Audit` item.)
- [x] AC5: Cron payload `toolsAllow` is set on `9f874f51` with the verified-working tool list (`read`, `exec`, `write`, `apply_patch`, `sessions_send`, `image`, `update_plan`, `web_search`, `web_fetch`, `message`). (🔗 pr: this is the change — applied via `openclaw cron edit 9f874f51 --tools ...` outside the repo, verified via `openclaw cron get 9f874f51` showing `payload.toolsAllow: [...]`.)

## Test plan

1. `openclaw cron run 9f874f51-4d50-4db1-99e7-843699dd06db` to manually verify the patch:
   - cwd-relative `ls` calls in Phase 1 should now succeed (no exit 1)
   - completion gate should fire — `docs/repo-audits/2026-W31.md` should land on disk
   - branch should push and PR should open
2. Inspect `docs/repo-audits/2026-W31.md` for the canonical 6-section structure (Executive Summary, Repo Map, Audit Report, Improvement Strategy, Task Plan, Open Questions).
3. Verify the PR body matches the pr-open skill template.

## Out-of-scope flags for Quinn FYI (separate from this PR)

These are real issues that surfaced during the trajectory analysis but are out of scope for the cron-prompt fix. Submitting them as separate items:

- **Model override.** Cron payload `model: "anthropic/claude-opus-4-8"` is set, but the W31 trajectory shows the actual run was `minimax-portal/MiniMax-M3`. The 60s idle timeout in attempt 1 is consistent with `MiniMax-M3` going unresponsive, not `opus-4-8`. Either `payload.model` is not honored for cron runs or there's a routing layer rewriting `anthropic → minimax-portal`. Three weeks of audit data may have been generated under MiniMax-M3. **Worth Quinn's eyes on the model-allowlist precedence layer.**
- **W29/W30 attribution inconsistency.** W28's audit says `**Auditor:** Rowan (Staff Engineer)`. W29 and W30 say `**Auditor:** Quinn (Chief of Staff)`. The cron always runs as `agentId: "rowan"`, so "Quinn" attribution is LLM-shaped prose, not factual. Most likely the model-override is leaking through into the prose — worth eyeballing W30 vs the W25-W28 shape for attribution consistency.

## Related

- Cron `9f874f51-4d50-4db1-99e7-843699dd06db` (SIndustries Weekly Repo Audit)
- Last-run trajectory: session `64cfd0cb`, 2026-07-30T04:03:39Z → 04:06:01Z (142s)
- Per-cron root-cause analysis via Lox (inter-session)