### PR TITLE
fix(rowan): pass heartbeat summary flag correctly

### DIFF
--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -21,7 +21,7 @@ If no open PRs or no unresolved comments: skip the assignee part.
 ## Step 2 — Feature task work
 
 Query the Tasks API for active feature tasks assigned to me:
-`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/tasks_api_client.py list --assignee Rowan --status ready --status doing --status acceptance summary`
+`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/tasks_api_client.py list --assignee Rowan --status ready --status doing --status acceptance --summary`
 
 For each returned task, classify by state and follow `WORKFLOW.md` for the execution steps in that state. This file does not restate the workflow.
 


### PR DESCRIPTION
## Summary
- fix Rowan's heartbeat Tasks API command to pass `--summary` as an option instead of the invalid positional `summary`
- prevent the active-task query from exiting with code 2 before returning `ready`, `doing`, and `acceptance` tasks
- repo-wide sweep found no other malformed positional `summary` or `heartbeat` invocations

## System Spec
No system spec change — this corrects a heartbeat command typo without changing product or system behaviour.

## Test plan
- [x] Run the exact corrected heartbeat Tasks API command and confirm it reports grouped `READY`, `DOING`, and `ACCEPTANCE` results
- [x] Search agent definitions and cron prompts for positional `summary`/`heartbeat` arguments; no other malformed invocations found
- [x] Run `git diff --check`

🤖 Generated with OpenClaw
