### PR TITLE
docs(agents): document cross-system identities

### DIFF
--- a/agents/definitions/ivy/TOOLS.md
+++ b/agents/definitions/ivy/TOOLS.md
@@ -39,6 +39,14 @@ Skills are shared. Your setup is yours. Keeping them apart means you can update 
 
 Add whatever helps you do your job. This is your cheat sheet.
 
+## Identities
+
+Ivy has different names in different systems — use the right one per system, not the GitHub login everywhere:
+
+- **GitHub login:** `ivystoffer` (`GH_CONFIG_DIR=~/.config/gh-ivy`)
+- **Tasks API `assignee` value:** `Ivy` (capitalized first name — NOT the GitHub login; e.g. `?assignee=Ivy`, not `?assignee=ivystoffer`)
+- **Telegram account:** not yet a dedicated bot account — if this changes, record it here
+
 ## GitHub
 
 - **Account:** ivystoffer

--- a/agents/definitions/lox/TOOLS.md
+++ b/agents/definitions/lox/TOOLS.md
@@ -31,6 +31,14 @@ Things like:
 - Default speaker: Kitchen HomePod
 ```
 
+## Identities
+
+Lox has different names in different systems — use the right one per system, not the GitHub login everywhere:
+
+- **GitHub login:** not yet configured (no `~/.config/gh-lox` set up) — if this changes, record the login + `GH_CONFIG_DIR` here
+- **Tasks API `assignee` value:** `Lox` (capitalized first name — NOT a GitHub login; e.g. `?assignee=Lox`)
+- **Telegram account:** `lox` (`channels.telegram.accounts.lox`)
+
 ## Why Separate?
 
 Skills are shared. Your setup is yours. Keeping them apart means you can update skills without losing your notes, and share skills without leaking your infrastructure.

--- a/agents/definitions/quinn/TOOLS.md
+++ b/agents/definitions/quinn/TOOLS.md
@@ -13,6 +13,14 @@ Things like:
 - Device nicknames
 - Anything environment-specific
 
+## Identities
+
+Quinn has different names in different systems — use the right one per system, not the GitHub login everywhere:
+
+- **GitHub login:** `quinnstoffer` (`GH_CONFIG_DIR=~/.config/gh-quinn`)
+- **Tasks API `assignee` value:** `Quinn` (capitalized first name — NOT the GitHub login; e.g. `?assignee=Quinn`, not `?assignee=quinnstoffer`)
+- **Telegram account:** `quinn` (default bot account in `channels.telegram.accounts.quinn`)
+
 ## Quinn's Accounts & Devices
 
 ### Identity

--- a/agents/definitions/rowan/TOOLS.md
+++ b/agents/definitions/rowan/TOOLS.md
@@ -32,6 +32,14 @@ Things like:
 - Default speaker: Kitchen HomePod
 ```
 
+## Identities
+
+Rowan has different names in different systems — use the right one per system, not the GitHub login everywhere:
+
+- **GitHub login:** `rowanstoffer` (`GH_CONFIG_DIR=~/.config/gh-rowan`)
+- **Tasks API `assignee` value:** `Rowan` (capitalized first name — NOT the GitHub login; e.g. `?assignee=Rowan`, not `?assignee=rowanstoffer`)
+- **Telegram account:** `rowan` (`channels.telegram.accounts.rowan`)
+
 ## GitHub
 
 - **Account:** rowanstoffer


### PR DESCRIPTION
## Summary
- Document the identity mapping each agent must use across GitHub, the Tasks API, and Telegram.
- Prevent silent false-empty task queries caused by confusing GitHub usernames with Tasks API assignee values.

## System Spec
No system spec change — documentation-only operational guidance.

## Test plan
- [x] Verify each agent has the correct GitHub login and Tasks API assignee mapping.
- [x] Verify the Telegram account mapping is recorded where a dedicated account exists.
- [x] Run `git diff --check`.

🤖 Generated with OpenClaw