### PR TITLE
fix(bookmarks): fix run.py dedup check for pending approval lock

### DIFF
--- a/agents/workflows/bookmarks/run.py
+++ b/agents/workflows/bookmarks/run.py
@@ -28,6 +28,28 @@ def log_progress(message: str) -> None:
     print(f"[bookmark-review-cron] {message}", flush=True)
 
 
+def is_all_deduped(approval_result: dict) -> bool:
+    """True when request_topic_approval.py delivered no new approvals because
+    a global approval lock is already held (one topic outstanding blocks all
+    others per policy). Healthy/expected state — not an error.
+
+    Not every blocked package will carry this reason: packages beyond the
+    first ready one are blocked by the unrelated "single approval per run
+    policy" cap, so we check for *any* match rather than requiring *all* to
+    match. A prior version required all() to match a reason string
+    ("approval already pending for topic") that request_topic_approval.py
+    never emits (it emits "approval already pending globally"), so this
+    dedup path was unreachable whenever more than one ready package existed
+    — every run fell through to the ambiguous needs_approval branch with an
+    empty approvals list instead. See cron 1d8a3cf1 error streak, 2026-08-01.
+    """
+    new_approvals = approval_result.get("approvals") or []
+    blocked = approval_result.get("blockedPackages") or []
+    return not new_approvals and any(
+        b.get("reason") == "approval already pending globally" for b in blocked
+    )
+
+
 def _stream_reader(pipe, prefix: str, sink: list[str]) -> None:
     try:
         for line in iter(pipe.readline, ""):
@@ -188,14 +210,7 @@ def main() -> int:
                 "reason": "approval_pending items exist but one or more are missing approvalResumeToken",
             }))
             return 1
-        # Dedup case: all packages blocked because an approval is already pending
-        # for each topic. No new delivery needed; healthy state, waiting on reply.
-        new_approvals = approval_result.get("approvals") or []
-        blocked = approval_result.get("blockedPackages") or []
-        all_deduped = not new_approvals and all(
-            b.get("reason") == "approval already pending for topic" for b in blocked
-        )
-        if all_deduped:
+        if is_all_deduped(approval_result):
             print(json.dumps({
                 "ok": True,
                 "status": "waiting_on_approval",

--- a/agents/workflows/bookmarks/tests/test_run_dedup.py
+++ b/agents/workflows/bookmarks/tests/test_run_dedup.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Regression test for run.py's is_all_deduped() dedup detection.
+
+Bug history: run.py previously required *every* blockedPackages entry to
+carry the reason string "approval already pending for topic" for the dedup
+(waiting_on_approval) path to trigger. But:
+  1. request_topic_approval.py never emits that string \u2014 it emits
+     "approval already pending globally".
+  2. Even after fixing the string, requiring all() to match is wrong: when
+     more than one ready package exists, only the *first* is blocked with
+     "approval already pending globally" \u2014 the rest are blocked with the
+     unrelated "single approval per run policy" reason.
+
+Both defects combined meant the dedup path was unreachable whenever a
+global approval lock was held and more than one package was ready. Every
+cron run instead fell through to the ambiguous needs_approval branch with
+an empty approvals list, which sent the (MiniMax) cron agent into a long
+reasoning loop trying to reconcile "needs_approval" against an empty
+approvals array \u2014 causing the 2026-08-01 Bookmark Review Lobster error
+streak (cron 1d8a3cf1, 3 consecutive "Agent couldn't generate a response").
+
+Fix: is_all_deduped() now uses any() instead of all(), and checks the
+reason string request_topic_approval.py actually emits.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+WORKFLOW_DIR = THIS_DIR.parent
+if str(WORKFLOW_DIR) not in sys.path:
+    sys.path.insert(0, str(WORKFLOW_DIR))
+
+import unittest
+
+from run import is_all_deduped  # noqa: E402
+
+
+class TestIsAllDeduped(unittest.TestCase):
+    def test_single_blocked_package_matches(self):
+        approval_result = {
+            "approvals": [],
+            "blockedPackages": [
+                {"reason": "approval already pending globally"},
+            ],
+        }
+        self.assertTrue(is_all_deduped(approval_result))
+
+    def test_mixed_blocked_reasons_still_dedups(self):
+        """Reproduces the real 2026-08-01 payload shape: one package blocked
+        globally, others blocked by the unrelated single-approval-per-run cap.
+        Prior code (all()) failed this case."""
+        approval_result = {
+            "approvals": [],
+            "blockedPackages": [
+                {"reason": "single approval per run policy"},
+                {"reason": "approval already pending globally"},
+            ],
+        }
+        self.assertTrue(is_all_deduped(approval_result))
+
+    def test_new_approvals_present_is_not_deduped(self):
+        approval_result = {
+            "approvals": [{"topic": "outreach"}],
+            "blockedPackages": [
+                {"reason": "approval already pending globally"},
+            ],
+        }
+        self.assertFalse(is_all_deduped(approval_result))
+
+    def test_no_global_lock_reason_is_not_deduped(self):
+        approval_result = {
+            "approvals": [],
+            "blockedPackages": [
+                {"reason": "single approval per run policy"},
+                {"reason": "no spec docs — spec needs to be written before approval can be requested"},
+            ],
+        }
+        self.assertFalse(is_all_deduped(approval_result))
+
+    def test_stale_reason_string_no_longer_matches(self):
+        """The old (wrong) reason string request_topic_approval.py never emits
+        should NOT match \u2014 guards against silently reintroducing the bug."""
+        approval_result = {
+            "approvals": [],
+            "blockedPackages": [
+                {"reason": "approval already pending for topic"},
+            ],
+        }
+        self.assertFalse(is_all_deduped(approval_result))
+
+    def test_empty_blocked_packages(self):
+        approval_result = {"approvals": [], "blockedPackages": []}
+        self.assertFalse(is_all_deduped(approval_result))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixed a real bug in `run.py`'s dedup check for pending bookmark approvals: it checked `blockedPackages` entries for the reason string `"approval already pending for topic"`, but `request_topic_approval.py` has only ever emitted `"approval already pending globally"` — the two files diverged at authoring time.
- Fixed a second, compounding bug: the check required `all()` blocked packages to match the reason, but when more than one package is ready, only the first is blocked by the global lock — the rest are blocked by the unrelated "single approval per run policy" cap. Switched to `any()`.
- Together these bugs made the healthy `waiting_on_approval` short-circuit unreachable whenever a prior approval was stuck and new packages were ready — exactly the combination that caused the Bookmark Review Lobster cron (`1d8a3cf1`) to error 3 consecutive runs on 2026-08-01 (`"Agent couldn't generate a response"` — the cron agent burned its full output-token budget reasoning over an ambiguous `needs_approval` + empty `approvals` payload).
- Extracted the check into a small pure function `is_all_deduped()` and added a regression test covering the exact bug shape (mixed blocked reasons, stale reason string guard).
- Verified live against the real stuck state (a "brain" topic approval pending since 2026-07-30, Telegram msg 17364 in thread 75) — `run.py` now correctly reports `status: "waiting_on_approval"` instead of falling through to the ambiguous branch.

## System Spec
No system spec change — internal cron script bug fix, no user-facing behaviour beyond restoring the intended dedup short-circuit. The stuck "brain" topic approval itself (msg 17364) is a separate, real item still awaiting Tom's reply and is unaffected by this fix.

## Test plan
- [x] `python3 -m pytest agents/workflows/bookmarks/` — 52 passed (46 existing + 6 new in `test_run_dedup.py`)
- [x] Ran `python3 codebases/sindustries/agents/workflows/bookmarks/run.py` live against the real stuck state (bookmarkKey `96c892bc962c0f71`, approvalId `ap2826840d`) — confirmed output changed from the buggy fallthrough to `{"ok": true, "status": "waiting_on_approval", ...}`

🤖 Generated with Claude Code