### PR TITLE
chore(gymtrack): add CI/CD deploy pipeline for Supabase + Vercel prod

### DIFF
--- a/.github/workflows/gymtrack-deploy.yml
+++ b/.github/workflows/gymtrack-deploy.yml
@@ -1,0 +1,88 @@
+name: GymTrack Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/gymtrack/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/gymtrack-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '22'
+
+jobs:
+  deploy:
+    name: Deploy gymtrack (Supabase + Vercel prod)
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.GYMTRACK_VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_REF: johwddosiwcxytfbtdyx
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Ensure Rollup Linux native binary is present
+        run: npm install --no-save @rollup/rollup-linux-x64-gnu@4.59.0 --workspace apps/gymtrack
+
+      - name: Test gymtrack
+        run: npm test --workspace apps/gymtrack
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link Supabase project
+        working-directory: apps/gymtrack
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Push Supabase migrations
+        working-directory: apps/gymtrack
+        run: supabase db push --linked --yes
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@54.2.0
+
+      - name: Pull Vercel environment
+        working-directory: apps/gymtrack
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Build Vercel output
+        working-directory: apps/gymtrack
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+
+      - name: Deploy to Vercel
+        id: deploy
+        working-directory: apps/gymtrack
+        run: |
+          DEPLOY_URL=$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")
+          echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
+          {
+            echo "### GymTrack deployment"
+            echo ""
+            echo "- Target: production"
+            echo "- Branch: ${GITHUB_REF_NAME}"
+            echo "- URL: $DEPLOY_URL"
+            echo "- Production URL: https://gymtrack-sigma-pied.vercel.app"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/agents/crons/prompts/repo-audit-weekly.md
+++ b/agents/crons/prompts/repo-audit-weekly.md
@@ -25,7 +25,7 @@ session ends:
    the matching commit style).
 3. `git push -u origin <branch>` — the branch must land on the remote.
 4. PR opened via the pr-open skill (`cod—audit: ...` title, Executive Summary
-   body, `code-audit` label, `Stoff81` assignee, `tomstoffer` reviewer).
+   body, `code-audit` label, `Stoff81` assignee, `Stoff81` reviewer).
 
 If you reach the end of your session without all four landing, the audit
 is incomplete and the cron will record `consecutiveErrors++`. The W31

--- a/agents/skills/dev/pr-process/SKILL.md
+++ b/agents/skills/dev/pr-process/SKILL.md
@@ -91,7 +91,7 @@ This skill is role-based, not agent-based. Any agent can play any role on a give
 Concrete patterns in our workflows:
 
 - **Feature tasks:** The task implementer is the PR assignee. The blocking reviewer is Quinn; Tom may be added as a visibility-only reviewer for GitHub inbox visibility. The assignee merges after the required approval (normally Quinn's) and CI is green — do not wait for Tom's PR approval or ask Tom to merge. Tom tests post-merge in main; his sign-off is the `[qa-ac-verified] true` task comment. The feature-task workflow is role-based: implementer is assignee/merger, reviewer reviews. Do not hardcode a specific agent into the workflow. Apply `--label feature-task` at PR creation.
-- **Content tasks:** Assignee opens (`--assignee <self>`, `--reviewer quinn,tomstoffer`, `--label content-task`). Quinn and Tom review. Assignee merges after the required approvals.
+- **Content tasks:** Assignee opens (`--assignee <self>`, `--reviewer quinn,Stoff81`, `--label content-task`). Quinn and Tom review. Assignee merges after the required approvals.
 - **Code-garden tasks:** Assignee opens with `--label code-garden`, reviewer reviews against the code-garden guardrail (no behavior change). Assignee merges after approval.
 - **Cross-repo PRs (workspace repo, infra scripts):** same pattern — assignee opens, reviewer reviews, assignee merges after approval.
 

--- a/agents/skills/dev/repo-audit/SKILL.md
+++ b/agents/skills/dev/repo-audit/SKILL.md
@@ -126,7 +126,7 @@ A successful audit session MUST end with all four of these gates firing, in orde
    planned in the assistant text — actually written via the `write` tool).
 2. **Commit** — `git add docs/repo-audits/<YYYY-Www>.md && git commit -m "..."` (or the matching commit style).
 3. **Push** — `git push -u origin <branch>` lands the branch on the remote.
-4. **PR** — PR opened via the pr-open skill (`cod—audit: ...` title, Executive Summary body, `code-audit` label, `Stoff81` assignee, `tomstoffer` reviewer).
+4. **PR** — PR opened via the pr-open skill (`cod—audit: ...` title, Executive Summary body, `code-audit` label, `Stoff81` assignee, `Stoff81` reviewer).
 
 If the session ends without all four landing, the audit is incomplete and
 the cron will record `consecutiveErrors++`. The W31 trajectory showed the
@@ -172,4 +172,4 @@ git push -u origin code-garden/sindustries/<YYYY-Www> --force-with-lease
 - Body: the `## Executive Summary` section from the audit document, followed by a link to the full audit file (`docs/repo-audits/<YYYY-Www>.md`)
 - Label: `code-audit`
 - Assignee: `Stoff81`
-- Reviewer: `tomstoffer`
+- Reviewer: `Stoff81`


### PR DESCRIPTION
## Summary
- gymtrack had no deploy pipeline: `ci.yml` only ran tests, and the Vercel project isn't Git-linked, so merges to `main` never shipped. PR #333 sat merged-but-not-live for ~13h until manually deployed today.
- Adds `.github/workflows/gymtrack-deploy.yml`, mirroring `website-deploy.yml`: on push to `main` touching `apps/gymtrack/**`, it runs tests, links + pushes Supabase migrations (`supabase db push --linked`), then builds and deploys to Vercel prod (`vercel deploy --prebuilt --prod`).
- No staging environment for gymtrack (per Tom), so this deploys straight to prod on every main merge — same posture as the manual step it replaces.
- New secrets added to the repo: `SUPABASE_ACCESS_TOKEN` (Supabase PAT) and `GYMTRACK_VERCEL_PROJECT_ID` (existing `VERCEL_ORG_ID`/`VERCEL_TOKEN` secrets are reused).
- Also updates docs that referenced the stale `tomstoffer` GitHub handle to the correct `Stoff81` (repo-audit skill, pr-process skill, repo-audit-weekly cron prompt) — Tom's actual GitHub username, confirmed in chat.

## System Spec
No `docs/systems/*.md` change — this is CI/CD-only, no user-facing behaviour change. `apps/gymtrack/SPEC.md` is unaffected (deploy mechanics, not app flow).

## Test plan
- [x] Manually ran the equivalent steps locally today (`supabase db push --linked`, `vercel deploy --prod`) to unblock #333 — both succeeded and are live at https://gymtrack-sigma-pied.vercel.app.
- [ ] First push to `main` touching `apps/gymtrack/**` after merge will exercise the new workflow end-to-end — verify the Actions run is green and the Vercel deployment summary shows the expected URL.

🤖 Generated with Claude Code