### PR TITLE
fix(tasks): classify agent queues before heartbeat work

### DIFF
--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -24,10 +24,10 @@ I am a heartbeat agent. I check the Tasks API on a regular interval for content 
 1. **Discovery must run before any silent result.** Query the Tasks API through the shared classifier for every active task assigned to Ivy:
 
    ```
-   TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Ivy
+   TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Ivy --json
    ```
 
-   Do not return `NO_REPLY` or `HEARTBEAT_OK` before this query succeeds and its full result is classified.
+   Do not return `NO_REPLY` or `HEARTBEAT_OK` before this query succeeds and its full result is classified. Use `reviewRequests`, `authoredPrFeedback`, and `mergeCandidates` for PR discovery, following `agents/skills/dev/pr-process/SKILL.md` for all review, feedback, and merge actions. The queue is read-only and never submits a review or merges automatically.
 
 2. Follow `WORKFLOW.md` for the *how* — this file does not restate execution steps:
    - **`ACTIONABLE` + `doing`** → follow `WORKFLOW.md` sections 1–5. On weekly-content tasks, also run the **Weekly tweet campaign** below.

--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -27,7 +27,7 @@ I am a heartbeat agent. I check the Tasks API on a regular interval for content 
    TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Ivy --json
    ```
 
-   Do not return `NO_REPLY` or `HEARTBEAT_OK` before this query succeeds and its full result is classified. Use `reviewRequests`, `authoredPrFeedback`, and `mergeCandidates` for PR discovery, following `agents/skills/dev/pr-process/SKILL.md` for all review, feedback, and merge actions. The queue is read-only and never submits a review or merges automatically.
+   Do not return `NO_REPLY` or `HEARTBEAT_OK` before this query succeeds. The unified queue returns one deterministic `topCandidate` across task work, PR review requests, authored-PR feedback, and Ivy's own merge candidates. Action that candidate through `WORKFLOW.md` or `agents/skills/dev/pr-process/SKILL.md`. The queue is read-only and never comments, reviews, changes task state, or merges automatically.
 
 2. Follow `WORKFLOW.md` for the *how* — this file does not restate execution steps:
    - **`ACTIONABLE` + `doing`** → follow `WORKFLOW.md` sections 1–5. On weekly-content tasks, also run the **Weekly tweet campaign** below.

--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -21,20 +21,22 @@ I am a heartbeat agent. I check the Tasks API on a regular interval for content 
 
 ## Heartbeat Procedure
 
-1. Query the Tasks API for tasks assigned to Ivy:
+1. **Discovery must run before any silent result.** Query the Tasks API through the shared classifier for every active task assigned to Ivy:
 
    ```
-   TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/tasks_api_client.py list --assignee Ivy --status doing
-   TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/tasks_api_client.py list --assignee Ivy --status acceptance
-   TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/tasks_api_client.py list --assignee Ivy --blocked true
+   TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Ivy
    ```
 
-2. Classify each returned task and follow `WORKFLOW.md` for the *how* — this file does not restate execution steps:
-   - **`doing`** → follow `WORKFLOW.md` sections 1–5. On weekly-content tasks, also run the **Weekly tweet campaign** below.
-   - **`acceptance`** → follow `WORKFLOW.md` section 6.
-   - **`blocked`** → do not attempt to resolve. Post a message to Quinn's session escalating the block. Do not change the `blocked` flag.
+   Do not return `NO_REPLY` or `HEARTBEAT_OK` before this query succeeds and its full result is classified.
 
-3. Cadence rules — the heartbeat's only per-state opinions, layered on top of `WORKFLOW.md`:
+2. Follow `WORKFLOW.md` for the *how* — this file does not restate execution steps:
+   - **`ACTIONABLE` + `doing`** → follow `WORKFLOW.md` sections 1–5. On weekly-content tasks, also run the **Weekly tweet campaign** below.
+   - **`acceptance`** → follow `WORKFLOW.md` section 6. It remains an external wait unless review feedback or CI creates new implementer work.
+   - **`BLOCKED` or `DEPENDENCY_BLOCKED`** → do not attempt to resolve. Post a message to Quinn's session when the blocker is new or newly evidenced. Do not change the `blocked` flag or dependency state.
+
+3. **Actionability contract:** if discovery returns any `ACTIONABLE` item, this pass must produce tangible progress on at least one: read the linked source and create/update a draft, commit or PR work, queue the required tweets, post a required task comment, or record a newly evidenced concrete blocker. Existing state summaries and repeated “waiting” notes are not progress. Do not silently return `NO_REPLY` or `HEARTBEAT_OK` while actionable work remains.
+
+4. Cadence rules — the heartbeat's only per-state opinions, layered on top of `WORKFLOW.md`:
    - For weekly-content tasks still in `doing`, an existing `[ivy-prs]` comment suppresses only the PR-authoring work. While `[ivy-tweets-queued]` is missing, continue with the Weekly tweet campaign below; both comments are required before the Lobster transitions to `acceptance`.
    - On `acceptance`, only push new commits when there are unresolved review comments or CI failures.
 

--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -6,18 +6,17 @@
 
 ASSIGNED ACTIVE TASK DISCOVERY — RUN FIRST
 
-Before any specialised section or silent-success decision, run both mandatory preflight queries:
+Before any specialised section or silent-success decision, fetch the unified read-only queue once:
 
-1. Classify every active task assigned to Quinn:
-   `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Quinn --json`
-2. Discover the global tech-design approval queue across all feature/code tasks, regardless of assignee:
-   `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py --json`
+`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Quinn --json`
 
-The shared queue also returns read-only `reviewRequests`, `authoredPrFeedback`, and `mergeCandidates`; the **PR REVIEW** section owns every action through `pr-process`. It never auto-submits Quinn's reviews or merges. Quinn must never approve her own PR, and a self-authored PR is never a merge candidate based on Quinn's own review.
+The queue combines assigned active tasks, Quinn's **global** tech-design approval scan across all feature/code tasks regardless of assignee, review requests, authored-PR feedback, and role-safe merge candidates. It returns one deterministic `topCandidate`. Action that candidate through the matching specialised section and existing workflow/PR skill; the queue itself never mutates tasks or GitHub.
 
-The assignee classifier covers Quinn's assigned `ready`, `doing`, and `acceptance` tasks and distinguishes actionable work from explicit blockers, dependency blockers, and external waits. **It is not the tech-design approval queue:** Quinn's delegated approval responsibility is global, so only `pending_tech_design_approvals.py` supplies that preflight result. The classifier also does not replace the separate **QUINN OPS TASKS** query for open tasks with no `taskType`; that query must still run in its section because open untyped ops tasks are outside the classifier's active-state query.
+Quinn must never approve her own PR, and a self-authored PR is never a merge candidate based on Quinn's own review. The queue's assigned-task classifier is not used as a substitute for global approval discovery: `techDesignApprovals` is populated with the exact parser and global scan from `pending_tech_design_approvals.py`.
 
-**Actionability gate:** if either preflight query identifies actionable work, or later discovery finds an actionable handoff, ops task, or PR review, take a concrete action in this pass. Concrete action means implementation or document progress, an approval/review, an applied handoff, a required task comment, or a newly evidenced blocker/escalation. Repeating existing state is not action. Do not return `HEARTBEAT_OK` or otherwise finish silently before both preflight queries and the open no-taskType ops query run, and do not return silent success while an actionable item remains untouched.
+The queue does not replace the separate **QUINN OPS TASKS** query for open tasks with no `taskType`; that query must still run because open untyped ops tasks are outside the active-task query.
+
+**Actionability gate:** if `topCandidate` exists, take a concrete action on it in this pass. Later specialised discovery may still surface an actionable handoff or open ops task. Concrete action means implementation or document progress, an approval/review, an applied handoff, a required task comment, or a newly evidenced blocker/escalation. Repeating existing state is not action. Do not return `HEARTBEAT_OK` before the unified queue and open no-taskType ops query run, and do not return silent success while an actionable item remains untouched.
 
 The top-level silence rule still applies after all required discovery and action: report only the action taken or genuinely new input needed.
 
@@ -28,9 +27,7 @@ TECH DESIGN APPROVAL
 Quinn approves tech designs on behalf of Tom during heartbeat. Tom has delegated this.
 
 Each heartbeat:
-1. Find feature tasks with a `[tech-design]` comment but no proper `[tech-design-approved] true` comment:
-   `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py --json`
-   The script mirrors the lobster's parser (`tagged_values` + `tech_design_approved` in `agents/workflows/feature-task/src/main.rs`): a comment counts as approval only if its trimmed text STARTS WITH the tag and the first whitespace-separated token after the tag is `true` (case-insensitive). Substring matches in the lobster's progress-checklist complaints (e.g. `Missing task comment [tech-design-approved] true`) are intentionally NOT counted.
+1. Use `techDesignApprovals` from the unified queue. It is populated by the global `pending_tech_design_approvals.py` scan and mirrors the lobster's parser (`tagged_values` + `tech_design_approved` in `agents/workflows/feature-task/src/main.rs`): a comment counts as approval only if its trimmed text STARTS WITH the tag and the first whitespace-separated token after the tag is `true` (case-insensitive). Substring matches in the lobster's progress-checklist complaints (e.g. `Missing task comment [tech-design-approved] true`) are intentionally NOT counted.
 2. **If 0 pending: skip this section entirely. No output.**
 3. For each pending task:
    - Read the design at the linked path.

--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -4,6 +4,20 @@
 
 ---
 
+ASSIGNED ACTIVE TASK DISCOVERY — RUN FIRST
+
+Before any specialised section or silent-success decision, classify every active task assigned to Quinn:
+
+`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Quinn`
+
+This read-only classifier covers assigned `ready`, `doing`, and `acceptance` tasks and distinguishes actionable work from explicit blockers, dependency blockers, and external waits. It does not replace the separate **QUINN OPS TASKS** query for open tasks with no `taskType`; that query must still run in its section because open untyped ops tasks are outside the classifier's active-state query.
+
+**Actionability gate:** if this query identifies an `ACTIONABLE` assigned task, or later discovery finds an actionable handoff, tech-design approval, ops task, or PR review, take a concrete action in this pass. Concrete action means implementation or document progress, an approval/review, an applied handoff, a required task comment, or a newly evidenced blocker/escalation. Repeating existing state is not action. Do not return `HEARTBEAT_OK` or otherwise finish silently before required discovery runs, and do not return silent success while an actionable item remains untouched.
+
+The top-level silence rule still applies after all required discovery and action: report only the action taken or genuinely new input needed.
+
+---
+
 TECH DESIGN APPROVAL
 
 Quinn approves tech designs on behalf of Tom during heartbeat. Tom has delegated this.

--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -6,13 +6,16 @@
 
 ASSIGNED ACTIVE TASK DISCOVERY — RUN FIRST
 
-Before any specialised section or silent-success decision, classify every active task assigned to Quinn:
+Before any specialised section or silent-success decision, run both mandatory preflight queries:
 
-`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Quinn`
+1. Classify every active task assigned to Quinn:
+   `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Quinn`
+2. Discover the global tech-design approval queue across all feature/code tasks, regardless of assignee:
+   `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py --json`
 
-This read-only classifier covers assigned `ready`, `doing`, and `acceptance` tasks and distinguishes actionable work from explicit blockers, dependency blockers, and external waits. It does not replace the separate **QUINN OPS TASKS** query for open tasks with no `taskType`; that query must still run in its section because open untyped ops tasks are outside the classifier's active-state query.
+The assignee classifier covers Quinn's assigned `ready`, `doing`, and `acceptance` tasks and distinguishes actionable work from explicit blockers, dependency blockers, and external waits. **It is not the tech-design approval queue:** Quinn's delegated approval responsibility is global, so only `pending_tech_design_approvals.py` supplies that preflight result. The classifier also does not replace the separate **QUINN OPS TASKS** query for open tasks with no `taskType`; that query must still run in its section because open untyped ops tasks are outside the classifier's active-state query.
 
-**Actionability gate:** if this query identifies an `ACTIONABLE` assigned task, or later discovery finds an actionable handoff, tech-design approval, ops task, or PR review, take a concrete action in this pass. Concrete action means implementation or document progress, an approval/review, an applied handoff, a required task comment, or a newly evidenced blocker/escalation. Repeating existing state is not action. Do not return `HEARTBEAT_OK` or otherwise finish silently before required discovery runs, and do not return silent success while an actionable item remains untouched.
+**Actionability gate:** if either preflight query identifies actionable work, or later discovery finds an actionable handoff, ops task, or PR review, take a concrete action in this pass. Concrete action means implementation or document progress, an approval/review, an applied handoff, a required task comment, or a newly evidenced blocker/escalation. Repeating existing state is not action. Do not return `HEARTBEAT_OK` or otherwise finish silently before both preflight queries and the open no-taskType ops query run, and do not return silent success while an actionable item remains untouched.
 
 The top-level silence rule still applies after all required discovery and action: report only the action taken or genuinely new input needed.
 

--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -9,9 +9,11 @@ ASSIGNED ACTIVE TASK DISCOVERY — RUN FIRST
 Before any specialised section or silent-success decision, run both mandatory preflight queries:
 
 1. Classify every active task assigned to Quinn:
-   `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Quinn`
+   `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Quinn --json`
 2. Discover the global tech-design approval queue across all feature/code tasks, regardless of assignee:
    `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py --json`
+
+The shared queue also returns read-only `reviewRequests`, `authoredPrFeedback`, and `mergeCandidates`; the **PR REVIEW** section owns every action through `pr-process`. It never auto-submits Quinn's reviews or merges. Quinn must never approve her own PR, and a self-authored PR is never a merge candidate based on Quinn's own review.
 
 The assignee classifier covers Quinn's assigned `ready`, `doing`, and `acceptance` tasks and distinguishes actionable work from explicit blockers, dependency blockers, and external waits. **It is not the tech-design approval queue:** Quinn's delegated approval responsibility is global, so only `pending_tech_design_approvals.py` supplies that preflight result. The classifier also does not replace the separate **QUINN OPS TASKS** query for open tasks with no `taskType`; that query must still run in its section because open untyped ops tasks are outside the classifier's active-state query.
 
@@ -80,7 +82,7 @@ Do not apply `.openclaw` changes speculatively. Only act on explicit `[openclaw-
 
 PR REVIEW
 
-Process any PRs that need your attention.
+Process the shared queue's `reviewRequests` and any `authoredPrFeedback`. Treat `mergeCandidates` as assignee-only: Quinn may merge only a PR she authored after a non-Quinn blocking reviewer approved and CI is green; she never self-approves. Rowan and Ivy own merging their own eligible PRs.
 
 Read and follow the reviewer section of:
 `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/dev/pr-process/SKILL.md`

--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -21,9 +21,9 @@ If no open PRs or no unresolved comments: skip the assignee part.
 ## Step 2 — Task work (feature + code)
 
 Query the Tasks API through the shared agent queue classifier for all active tasks assigned to me, regardless of `taskType`:
-`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Rowan --capacity 2`
+`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Rowan`
 
-The classifier is blocker-aware: an explicit or dependency-blocked `doing` task does not consume active capacity. It also treats a missing implementation delivery (`[implementer-prs]`) as `ACTIONABLE`, never as a request or wait for Quinn.
+The classifier distinguishes explicit and dependency blocks from actionable work. Capacity and state admission remain entirely owned by Lobster. A missing implementation delivery (`[implementer-prs]`) is `ACTIONABLE`, never a request or wait for Quinn.
 
 For each returned task, follow `WORKFLOW.md` for the execution steps in that state. If the queue contains any `ACTIONABLE` task, the pass must materially progress one before finishing: create/update a branch, commit, PR, validation result, required task comment, or a newly evidenced concrete blocker. A pass with actionable work and no such progress is a failed heartbeat and must follow **Escalate on Failure** below.
 

--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -4,6 +4,11 @@
 
 Each heartbeat pass does two things in order: handle all PR work (review assigned PRs and address feedback on my own), then pick code-garden work.
 
+Before Step 1, run the shared read-only work queue once:
+`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Rowan --json`
+
+Use `reviewRequests`, `authoredPrFeedback`, and `mergeCandidates` for PR discovery, and `tasks` for Step 2. The queue never reviews or merges automatically; every action still follows `pr-process` with Rowan's own GitHub identity.
+
 ---
 
 ## Step 1 — PR work
@@ -20,8 +25,7 @@ If no open PRs or no unresolved comments: skip the assignee part.
 
 ## Step 2 — Task work (feature + code)
 
-Query the Tasks API through the shared agent queue classifier for all active tasks assigned to me, regardless of `taskType`:
-`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Rowan`
+Use the `tasks` returned by the shared queue for all active tasks assigned to me, regardless of `taskType`.
 
 The classifier distinguishes explicit and dependency blocks from actionable work. Capacity and state admission remain entirely owned by Lobster. A missing implementation delivery (`[implementer-prs]`) is `ACTIONABLE`, never a request or wait for Quinn.
 

--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -20,10 +20,12 @@ If no open PRs or no unresolved comments: skip the assignee part.
 
 ## Step 2 — Task work (feature + code)
 
-Query the Tasks API for all active tasks assigned to me, regardless of `taskType`:
-`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/tasks_api_client.py list --assignee Rowan --status ready --status doing --status acceptance --summary`
+Query the Tasks API through the shared agent queue classifier for all active tasks assigned to me, regardless of `taskType`:
+`TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Rowan --capacity 2`
 
-For each returned task, classify by state and follow `WORKFLOW.md` for the execution steps in that state. This file does not restate the workflow.
+The classifier is blocker-aware: an explicit or dependency-blocked `doing` task does not consume active capacity. It also treats a missing implementation delivery (`[implementer-prs]`) as `ACTIONABLE`, never as a request or wait for Quinn.
+
+For each returned task, follow `WORKFLOW.md` for the execution steps in that state. If the queue contains any `ACTIONABLE` task, the pass must materially progress one before finishing: create/update a branch, commit, PR, validation result, required task comment, or a newly evidenced concrete blocker. A pass with actionable work and no such progress is a failed heartbeat and must follow **Escalate on Failure** below.
 
 **Heartbeat cadence rule — the only per-pass opinion layered on top of `WORKFLOW.md`:**
 

--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -7,7 +7,7 @@ Each heartbeat pass does two things in order: handle all PR work (review assigne
 Before Step 1, run the shared read-only work queue once:
 `TASKS_API_BASE_URL=http://localhost:4001/api/v1 python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Rowan --json`
 
-Use `reviewRequests`, `authoredPrFeedback`, and `mergeCandidates` for PR discovery, and `tasks` for Step 2. The queue never reviews or merges automatically; every action still follows `pr-process` with Rowan's own GitHub identity.
+The queue combines task and PR work and returns one deterministic `topCandidate`. Action that candidate in this pass through the matching workflow or `pr-process` skill with Rowan's own identity. The queue never reviews, comments, changes task state, or merges automatically.
 
 ---
 
@@ -16,8 +16,7 @@ Use `reviewRequests`, `authoredPrFeedback`, and `mergeCandidates` for PR discove
 Read and follow the pr-process skill for both reviewer and assignee duties:
 `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/dev/pr-process/SKILL.md`
 
-- Review any PRs assigned to me for review.
-- Check all open PRs I authored for unresolved `CHANGES_REQUESTED` reviews. Address valid feedback and push. As PR assignee, merge any PR where the required approval has been given and CI is green; do not wait for Tom to merge unless Tom is explicitly the required reviewer.
+When `topCandidate.kind` is `reviewRequest`, `authoredPrFeedback`, or `mergeCandidate`, process that one candidate through the matching reviewer or assignee path. Rowan merges only his own eligible PR after Quinn's blocking approval and green CI; Tom remains visibility-only unless explicitly required.
 
 If no open PRs or no unresolved comments: skip the assignee part.
 
@@ -25,7 +24,7 @@ If no open PRs or no unresolved comments: skip the assignee part.
 
 ## Step 2 — Task work (feature + code)
 
-Use the `tasks` returned by the shared queue for all active tasks assigned to me, regardless of `taskType`.
+When `topCandidate.kind` is `task`, use that task as the active work item. The `tasks` list retains all assigned active tasks for blocker/context checks.
 
 The classifier distinguishes explicit and dependency blocks from actionable work. Capacity and state admission remain entirely owned by Lobster. A missing implementation delivery (`[implementer-prs]`) is `ACTIONABLE`, never a request or wait for Quinn.
 

--- a/agents/skills/ops/tasks-api/SKILL.md
+++ b/agents/skills/ops/tasks-api/SKILL.md
@@ -42,14 +42,15 @@ Programmatic use: import `get_task`, `list_tasks`, and `get_base_url` from `task
 
 Agent heartbeat queue (recommended):
 ```bash
-python3 scripts/agent_task_queue.py --assignee Rowan --capacity 2
-python3 scripts/agent_task_queue.py --assignee Rowan --capacity 2 --json
+python3 scripts/agent_task_queue.py --assignee Rowan
+python3 scripts/agent_task_queue.py --assignee Rowan --json
 ```
 
 This read-only adapter retrieves full active tasks and classifies them as
-`ACTIONABLE`, `WAITING_EXTERNAL`, `DEPENDENCY_BLOCKED`, or `BLOCKED`. Capacity
-counts only unblocked `doing` tasks. For feature and code tasks, a missing
-`[implementer-prs]` is implementer work and therefore `ACTIONABLE`; a posted
+`ACTIONABLE`, `WAITING_EXTERNAL`, `DEPENDENCY_BLOCKED`, or `BLOCKED`. Lobster
+remains the sole owner of capacity and state admission. For feature and code
+tasks, a missing `[implementer-prs]` is implementer work and therefore
+`ACTIONABLE`; a posted
 delivery is an external-wait candidate whose PR/review state must still be
 verified.
 

--- a/agents/skills/ops/tasks-api/SKILL.md
+++ b/agents/skills/ops/tasks-api/SKILL.md
@@ -40,7 +40,20 @@ Programmatic use: import `get_task`, `list_tasks`, and `get_base_url` from `task
 
 ## Common patterns
 
-Agent task view (grouped by status with blockers):
+Agent heartbeat queue (recommended):
+```bash
+python3 scripts/agent_task_queue.py --assignee Rowan --capacity 2
+python3 scripts/agent_task_queue.py --assignee Rowan --capacity 2 --json
+```
+
+This read-only adapter retrieves full active tasks and classifies them as
+`ACTIONABLE`, `WAITING_EXTERNAL`, `DEPENDENCY_BLOCKED`, or `BLOCKED`. Capacity
+counts only unblocked `doing` tasks. For feature and code tasks, a missing
+`[implementer-prs]` is implementer work and therefore `ACTIONABLE`; a posted
+delivery is an external-wait candidate whose PR/review state must still be
+verified.
+
+Raw agent task view (grouped by status):
 ```bash
 python3 tasks_api_client.py list --assignee Rowan --status ready --status doing --status acceptance --summary
 ```

--- a/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
@@ -95,13 +95,10 @@ def classify_task(task: dict[str, Any]) -> tuple[str, str]:
     return "WAITING_EXTERNAL", f"task state {status or 'unknown'} has no agent action rule"
 
 
-def build_queue(tasks: list[dict[str, Any]], capacity: int) -> dict[str, Any]:
+def build_queue(tasks: list[dict[str, Any]]) -> dict[str, Any]:
     items = []
-    active_doing = 0
     for task in tasks:
         classification, reason = classify_task(task)
-        if task.get("status") == "doing" and classification not in {"BLOCKED", "DEPENDENCY_BLOCKED"}:
-            active_doing += 1
         items.append(
             {
                 "id": task.get("id"),
@@ -117,7 +114,6 @@ def build_queue(tasks: list[dict[str, Any]], capacity: int) -> dict[str, Any]:
     order = {"ACTIONABLE": 0, "WAITING_EXTERNAL": 1, "DEPENDENCY_BLOCKED": 2, "BLOCKED": 3}
     items.sort(key=lambda item: (order.get(item["classification"], 99), item.get("title") or ""))
     return {
-        "capacity": {"activeDoing": active_doing, "limit": capacity, "available": max(0, capacity - active_doing)},
         "actionableCount": sum(item["classification"] == "ACTIONABLE" for item in items),
         "items": items,
     }
@@ -135,11 +131,7 @@ def fetch_agent_tasks(assignee: str, base_url: str | None = None) -> list[dict[s
 
 
 def print_human(queue: dict[str, Any], assignee: str) -> None:
-    capacity = queue["capacity"]
-    print(
-        f"{assignee} active capacity: {capacity['activeDoing']}/{capacity['limit']} "
-        f"({capacity['available']} available); actionable: {queue['actionableCount']}"
-    )
+    print(f"{assignee} actionable tasks: {queue['actionableCount']}")
     for item in queue["items"]:
         print(
             f"{item['classification']:18} [{str(item['id'])[:8]}] "
@@ -150,14 +142,13 @@ def print_human(queue: dict[str, Any], assignee: str) -> None:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--assignee", required=True, help="Tasks API assignee name, e.g. Rowan")
-    parser.add_argument("--capacity", type=int, default=2, help="Unblocked doing-task capacity (default: 2)")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     return parser
 
 
 def main() -> None:
     args = build_parser().parse_args()
-    queue = build_queue(fetch_agent_tasks(args.assignee), args.capacity)
+    queue = build_queue(fetch_agent_tasks(args.assignee))
     if args.json:
         print(json.dumps(queue, indent=2))
     else:

--- a/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
@@ -23,7 +23,7 @@ SPEC.loader.exec_module(tasks_api_client)
 IMPLEMENTATION_TYPES = {"feature", "code"}
 DELIVERY_TAGS = ("[implementer-prs]", "[rowan-prs]")
 TECH_DESIGN_TAG = "[tech-design]"
-TECH_DESIGN_APPROVAL_TAG = "[tech-design-approved] true"
+TECH_DESIGN_APPROVAL_TAG = "[tech-design-approved]"
 TECH_DESIGN_WAIVER_TAG = "[tech-design-not-required]"
 PROGRESS_TAGS = ("[feature-task-progress-checklist]", "[code-task-progress-checklist]")
 
@@ -46,6 +46,19 @@ def _latest_progress_comment(texts: list[str]) -> str:
     return ""
 
 
+def _tech_design_approved(texts: list[str]) -> bool:
+    """Mirror Lobster's starts-with tag and exact first-token approval rule."""
+    for text in texts:
+        stripped = text.strip()
+        if not stripped.startswith(TECH_DESIGN_APPROVAL_TAG):
+            continue
+        value = stripped[len(TECH_DESIGN_APPROVAL_TAG):].strip()
+        token = value.split(maxsplit=1)[0] if value else ""
+        if token.lower() == "true":
+            return True
+    return False
+
+
 def classify_task(task: dict[str, Any]) -> tuple[str, str]:
     """Return (classification, reason) for one full Tasks API task object."""
     if task.get("dependencyBlocked"):
@@ -60,7 +73,7 @@ def classify_task(task: dict[str, Any]) -> tuple[str, str]:
 
     if status == "ready" and task_type in IMPLEMENTATION_TYPES:
         has_design = _has_prefix(texts, (TECH_DESIGN_TAG,))
-        has_approval = any(TECH_DESIGN_APPROVAL_TAG in text.lower() for text in texts)
+        has_approval = _tech_design_approved(texts)
         has_waiver = _has_prefix(texts, (TECH_DESIGN_WAIVER_TAG,))
         if not has_design and not has_waiver:
             return "ACTIONABLE", "tech design or explicit waiver is missing"
@@ -70,7 +83,7 @@ def classify_task(task: dict[str, Any]) -> tuple[str, str]:
 
     if status == "doing" and task_type in IMPLEMENTATION_TYPES:
         has_design = _has_prefix(texts, (TECH_DESIGN_TAG,))
-        has_approval = any(TECH_DESIGN_APPROVAL_TAG in text.lower() for text in texts)
+        has_approval = _tech_design_approved(texts)
         has_waiver = _has_prefix(texts, (TECH_DESIGN_WAIVER_TAG,))
         if not has_design and not has_waiver:
             return "ACTIONABLE", "tech design or explicit waiver is missing"

--- a/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Retrieve and classify an agent's active task queue.
+
+The Tasks API and Lobster remain the source of truth for task state. This
+read-only adapter makes task state useful to heartbeat agents by distinguishing
+work that can be advanced now from dependency blocks and external waits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import pathlib
+from typing import Any
+
+CLIENT_PATH = pathlib.Path(__file__).parents[1] / "tasks_api_client.py"
+SPEC = importlib.util.spec_from_file_location("tasks_api_client", CLIENT_PATH)
+tasks_api_client = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(tasks_api_client)
+
+IMPLEMENTATION_TYPES = {"feature", "code"}
+DELIVERY_TAGS = ("[implementer-prs]", "[rowan-prs]")
+TECH_DESIGN_TAG = "[tech-design]"
+TECH_DESIGN_APPROVAL_TAG = "[tech-design-approved] true"
+TECH_DESIGN_WAIVER_TAG = "[tech-design-not-required]"
+PROGRESS_TAGS = ("[feature-task-progress-checklist]", "[code-task-progress-checklist]")
+
+
+def _comment_texts(task: dict[str, Any]) -> list[str]:
+    return [
+        str(comment.get("text") or comment.get("body") or "").strip()
+        for comment in task.get("comments") or []
+    ]
+
+
+def _has_prefix(texts: list[str], prefixes: tuple[str, ...]) -> bool:
+    return any(text.lstrip().startswith(prefix) for text in texts for prefix in prefixes)
+
+
+def _latest_progress_comment(texts: list[str]) -> str:
+    for text in reversed(texts):
+        if any(tag in text for tag in PROGRESS_TAGS):
+            return text
+    return ""
+
+
+def classify_task(task: dict[str, Any]) -> tuple[str, str]:
+    """Return (classification, reason) for one full Tasks API task object."""
+    if task.get("dependencyBlocked"):
+        return "DEPENDENCY_BLOCKED", "one or more task dependencies are incomplete"
+    if task.get("blocked"):
+        return "BLOCKED", "task blocked flag is set"
+
+    status = str(task.get("status") or "").lower()
+    task_type = str(task.get("taskType") or "").lower()
+    texts = _comment_texts(task)
+    latest_progress = _latest_progress_comment(texts)
+
+    if status == "ready" and task_type in IMPLEMENTATION_TYPES:
+        has_design = _has_prefix(texts, (TECH_DESIGN_TAG,))
+        has_approval = any(TECH_DESIGN_APPROVAL_TAG in text.lower() for text in texts)
+        has_waiver = _has_prefix(texts, (TECH_DESIGN_WAIVER_TAG,))
+        if not has_design and not has_waiver:
+            return "ACTIONABLE", "tech design or explicit waiver is missing"
+        if has_approval or has_waiver:
+            return "WAITING_EXTERNAL", "delivery is ready for Lobster promotion to doing"
+        return "WAITING_EXTERNAL", "tech design is waiting for approval"
+
+    if status == "doing" and task_type in IMPLEMENTATION_TYPES:
+        has_design = _has_prefix(texts, (TECH_DESIGN_TAG,))
+        has_approval = any(TECH_DESIGN_APPROVAL_TAG in text.lower() for text in texts)
+        has_waiver = _has_prefix(texts, (TECH_DESIGN_WAIVER_TAG,))
+        if not has_design and not has_waiver:
+            return "ACTIONABLE", "tech design or explicit waiver is missing"
+        if not has_approval and not has_waiver:
+            return "WAITING_EXTERNAL", "tech design is waiting for approval"
+        if _has_prefix(texts, DELIVERY_TAGS):
+            return "WAITING_EXTERNAL", "implementer delivery posted; verify PR review and CI state"
+        if "missing `[implementer-prs]`" in latest_progress.lower():
+            return "ACTIONABLE", "progress checklist says implementer delivery is missing"
+        return "ACTIONABLE", "implementation PR delivery has not been posted"
+
+    if status == "acceptance":
+        if task_type in IMPLEMENTATION_TYPES and _has_prefix(texts, DELIVERY_TAGS):
+            return "WAITING_EXTERNAL", "implementer delivery posted; verify review, QA, and post-merge state"
+        if "missing `[implementer-prs]`" in latest_progress.lower():
+            return "ACTIONABLE", "progress checklist says implementer delivery is missing"
+        return "WAITING_EXTERNAL", "task is in acceptance; verify review, QA, and post-merge state"
+
+    if status in {"ready", "doing"}:
+        return "ACTIONABLE", f"{task_type or 'task'} task is in {status}"
+
+    return "WAITING_EXTERNAL", f"task state {status or 'unknown'} has no agent action rule"
+
+
+def build_queue(tasks: list[dict[str, Any]], capacity: int) -> dict[str, Any]:
+    items = []
+    active_doing = 0
+    for task in tasks:
+        classification, reason = classify_task(task)
+        if task.get("status") == "doing" and classification not in {"BLOCKED", "DEPENDENCY_BLOCKED"}:
+            active_doing += 1
+        items.append(
+            {
+                "id": task.get("id"),
+                "title": task.get("title"),
+                "taskType": task.get("taskType"),
+                "status": task.get("status"),
+                "priority": task.get("priority"),
+                "classification": classification,
+                "reason": reason,
+            }
+        )
+
+    order = {"ACTIONABLE": 0, "WAITING_EXTERNAL": 1, "DEPENDENCY_BLOCKED": 2, "BLOCKED": 3}
+    items.sort(key=lambda item: (order.get(item["classification"], 99), item.get("title") or ""))
+    return {
+        "capacity": {"activeDoing": active_doing, "limit": capacity, "available": max(0, capacity - active_doing)},
+        "actionableCount": sum(item["classification"] == "ACTIONABLE" for item in items),
+        "items": items,
+    }
+
+
+def fetch_agent_tasks(assignee: str, base_url: str | None = None) -> list[dict[str, Any]]:
+    base = base_url or tasks_api_client.get_base_url()
+    summaries = tasks_api_client.list_tasks(
+        limit=50,
+        status=["ready", "doing", "acceptance"],
+        assignee=assignee,
+        base_url=base,
+    )
+    return [tasks_api_client.get_task(task["id"], base_url=base) for task in summaries]
+
+
+def print_human(queue: dict[str, Any], assignee: str) -> None:
+    capacity = queue["capacity"]
+    print(
+        f"{assignee} active capacity: {capacity['activeDoing']}/{capacity['limit']} "
+        f"({capacity['available']} available); actionable: {queue['actionableCount']}"
+    )
+    for item in queue["items"]:
+        print(
+            f"{item['classification']:18} [{str(item['id'])[:8]}] "
+            f"{item['status']}/{item['taskType']}: {item['title']} — {item['reason']}"
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--assignee", required=True, help="Tasks API assignee name, e.g. Rowan")
+    parser.add_argument("--capacity", type=int, default=2, help="Unblocked doing-task capacity (default: 2)")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    queue = build_queue(fetch_agent_tasks(args.assignee), args.capacity)
+    if args.json:
+        print(json.dumps(queue, indent=2))
+    else:
+        print_human(queue, args.assignee)
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
@@ -45,6 +45,14 @@ GITHUB_IDENTITIES = {
     "quinn": ("quinnstoffer", "~/.config/gh-quinn", "QUINN_GITHUB_TOKEN"),
 }
 GREEN_CHECK_CONCLUSIONS = {"success", "skipped", "neutral"}
+QUEUE_KIND_ORDER = {
+    "authoredPrFeedback": 0,
+    "mergeCandidate": 1,
+    "reviewRequest": 2,
+    "techDesignApproval": 3,
+    "task": 4,
+}
+TASK_PRIORITY_ORDER = {"urgent": 0, "high": 1, "medium": 2, "low": 3}
 
 
 def _comment_texts(task: dict[str, Any]) -> list[str]:
@@ -324,6 +332,55 @@ def fetch_github_prs(agent: str) -> list[dict[str, Any]]:
     return hydrated
 
 
+def build_unified_queue(
+    task_items: list[dict[str, Any]],
+    tech_design_approvals: list[dict[str, Any]],
+    github_queue: dict[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    """Normalize every read-only heartbeat input into one deterministic queue."""
+    items: list[dict[str, Any]] = []
+    for item in github_queue["authoredPrFeedback"]:
+        items.append({"kind": "authoredPrFeedback", "actionable": True, **item})
+    for item in github_queue["mergeCandidates"]:
+        items.append({"kind": "mergeCandidate", "actionable": True, **item})
+    for item in github_queue["reviewRequests"]:
+        items.append({"kind": "reviewRequest", "actionable": True, **item})
+    for item in tech_design_approvals:
+        items.append(
+            {
+                "kind": "techDesignApproval",
+                "actionable": True,
+                "id": item.get("id"),
+                "title": item.get("title"),
+                "url": item.get("techDesignUrl"),
+                "status": item.get("status"),
+                "assignee": item.get("assignee"),
+            }
+        )
+    for item in task_items:
+        items.append(
+            {
+                "kind": "task",
+                "actionable": item.get("classification") == "ACTIONABLE",
+                **item,
+            }
+        )
+
+    def sort_key(item: dict[str, Any]) -> tuple[Any, ...]:
+        actionable_rank = 0 if item.get("actionable") else 1
+        kind_rank = QUEUE_KIND_ORDER.get(str(item.get("kind")), 99)
+        task_priority = TASK_PRIORITY_ORDER.get(str(item.get("priority") or "").lower(), 99)
+        return (
+            actionable_rank,
+            kind_rank,
+            task_priority,
+            str(item.get("title") or ""),
+            str(item.get("id") or item.get("number") or ""),
+        )
+
+    return sorted(items, key=sort_key)
+
+
 def build_work_queue(
     tasks: list[dict[str, Any]],
     agent: str,
@@ -331,11 +388,15 @@ def build_work_queue(
     tech_design_approvals: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     task_queue = build_queue(tasks)
+    approvals = tech_design_approvals or []
     github_queue = classify_github_prs(agent, github_prs or [])
+    queue = build_unified_queue(task_queue["items"], approvals, github_queue)
     return {
+        "queue": queue,
+        "topCandidate": next((item for item in queue if item["actionable"]), None),
         "tasks": task_queue["items"],
         "actionableTaskCount": task_queue["actionableCount"],
-        "techDesignApprovals": tech_design_approvals or [],
+        "techDesignApprovals": approvals,
         **github_queue,
     }
 

--- a/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
@@ -2,8 +2,10 @@
 """Retrieve and classify an agent's active task queue.
 
 The Tasks API and Lobster remain the source of truth for task state. This
-read-only adapter makes task state useful to heartbeat agents by distinguishing
-work that can be advanced now from dependency blocks and external waits.
+read-only adapter makes task and GitHub state useful to heartbeat agents by
+distinguishing work that can be advanced now from dependency blocks and external
+waits. It never submits reviews, edits PRs, or merges; agents invoke the explicit
+role-specific PR skills for every mutation.
 """
 
 from __future__ import annotations
@@ -11,7 +13,9 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
 import pathlib
+import subprocess
 from typing import Any
 
 CLIENT_PATH = pathlib.Path(__file__).parents[1] / "tasks_api_client.py"
@@ -20,12 +24,27 @@ tasks_api_client = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 SPEC.loader.exec_module(tasks_api_client)
 
+APPROVALS_PATH = pathlib.Path(__file__).with_name("pending_tech_design_approvals.py")
+APPROVALS_SPEC = importlib.util.spec_from_file_location(
+    "pending_tech_design_approvals", APPROVALS_PATH
+)
+pending_approvals = importlib.util.module_from_spec(APPROVALS_SPEC)
+assert APPROVALS_SPEC.loader is not None
+APPROVALS_SPEC.loader.exec_module(pending_approvals)
+
 IMPLEMENTATION_TYPES = {"feature", "code"}
 DELIVERY_TAGS = ("[implementer-prs]", "[rowan-prs]")
 TECH_DESIGN_TAG = "[tech-design]"
 TECH_DESIGN_APPROVAL_TAG = "[tech-design-approved]"
 TECH_DESIGN_WAIVER_TAG = "[tech-design-not-required]"
 PROGRESS_TAGS = ("[feature-task-progress-checklist]", "[code-task-progress-checklist]")
+REPO = "Stoffer-Industries/sindustries"
+GITHUB_IDENTITIES = {
+    "rowan": ("rowanstoffer", "~/.config/gh-rowan", "ROWAN_GITHUB_TOKEN"),
+    "ivy": ("ivystoffer", "~/.config/gh-ivy", "IVY_GITHUB_TOKEN"),
+    "quinn": ("quinnstoffer", "~/.config/gh-quinn", "QUINN_GITHUB_TOKEN"),
+}
+GREEN_CHECK_CONCLUSIONS = {"success", "skipped", "neutral"}
 
 
 def _comment_texts(task: dict[str, Any]) -> list[str]:
@@ -143,6 +162,184 @@ def fetch_agent_tasks(assignee: str, base_url: str | None = None) -> list[dict[s
     return [tasks_api_client.get_task(task["id"], base_url=base) for task in summaries]
 
 
+def _gh_api(config_dir: str, token_env: str, endpoint: str) -> Any:
+    env = os.environ.copy()
+    env["GH_CONFIG_DIR"] = os.path.expanduser(config_dir)
+    token = env.get(token_env)
+    if token:
+        env["GH_TOKEN"] = token
+    result = subprocess.run(
+        ["gh", "api", endpoint],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return json.loads(result.stdout)
+
+
+def _latest_reviews(reviews: list[dict[str, Any]]) -> dict[str, str]:
+    latest: dict[str, str] = {}
+    for review in sorted(reviews, key=lambda item: item.get("submitted_at") or ""):
+        login = str((review.get("user") or {}).get("login") or "").lower()
+        state = str(review.get("state") or "").upper()
+        if login and state not in {"COMMENTED", "PENDING"}:
+            latest[login] = state
+    return latest
+
+
+def _blocking_reviewers(agent: str, pr: dict[str, Any], latest: dict[str, str]) -> list[str]:
+    agent = agent.lower()
+    title = str(pr.get("title") or "").lower()
+    requested = {
+        str(item.get("login") or "").lower()
+        for item in pr.get("requested_reviewers") or []
+    }
+    if agent == "rowan":
+        return ["quinnstoffer"]
+    if agent == "ivy":
+        if "tom-approval" in title:
+            return ["stoff81"]
+        if "quinn-approval" in title:
+            return ["quinnstoffer"]
+        known = (requested | set(latest)) & {"quinnstoffer", "stoff81"}
+        return sorted(known)
+    own_login = GITHUB_IDENTITIES[agent][0]
+    non_self_requested = {login for login in requested if login != own_login}
+    if non_self_requested:
+        return sorted(non_self_requested)
+    # GitHub clears requested_reviewers after a review is submitted. Retain the
+    # non-self reviewer from latest review state so an approved Quinn-authored
+    # PR can become merge-eligible without ever accepting Quinn's own review.
+    return sorted(login for login in latest if login != own_login)
+
+
+def classify_github_prs(agent: str, prs: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Build read-only review, feedback, and merge queues from hydrated PR data."""
+    login = GITHUB_IDENTITIES[agent.lower()][0].lower()
+    review_requests = []
+    authored_feedback = []
+    merge_candidates = []
+
+    for pr in prs:
+        author = str((pr.get("user") or {}).get("login") or "").lower()
+        requested = {
+            str(item.get("login") or "").lower()
+            for item in pr.get("requested_reviewers") or []
+        }
+        summary = {
+            "number": pr.get("number"),
+            "title": pr.get("title"),
+            "url": pr.get("html_url"),
+        }
+        if login in requested and author != login:
+            review_requests.append(summary)
+        if author != login:
+            continue
+
+        latest = _latest_reviews(pr.get("reviews") or [])
+        changes_requested_by = sorted(
+            reviewer for reviewer, state in latest.items() if state == "CHANGES_REQUESTED"
+        )
+        if changes_requested_by:
+            authored_feedback.append({**summary, "changesRequestedBy": changes_requested_by})
+
+        blocking = _blocking_reviewers(agent, pr, latest)
+        checks = pr.get("check_runs") or []
+        ci_green = bool(checks) and all(
+            check.get("status") == "completed"
+            and str(check.get("conclusion") or "").lower() in GREEN_CHECK_CONCLUSIONS
+            for check in checks
+        )
+        approvals_present = bool(blocking) and all(
+            latest.get(reviewer) == "APPROVED" for reviewer in blocking
+        )
+        if (
+            approvals_present
+            and ci_green
+            and pr.get("mergeable") is True
+            and not changes_requested_by
+        ):
+            merge_candidates.append({**summary, "blockingApprovals": blocking})
+
+    return {
+        "reviewRequests": review_requests,
+        "authoredPrFeedback": authored_feedback,
+        "mergeCandidates": merge_candidates,
+    }
+
+
+def fetch_pending_tech_design_approvals(base_url: str | None = None) -> list[dict[str, Any]]:
+    """Return Quinn's global approval queue, independent of task assignee."""
+    base = (base_url or tasks_api_client.get_base_url()).rstrip("/")
+    candidates = [
+        task
+        for task in pending_approvals.list_tasks(base, [])
+        if pending_approvals.needs_tech_design_review(task)
+    ]
+    approvals = []
+    for summary in candidates:
+        task = pending_approvals.fetch_task_detail(base, summary["id"])
+        url = pending_approvals.tech_design_url(task)
+        if not url or pending_approvals.tech_design_approved(task):
+            continue
+        approvals.append(
+            {
+                "id": task.get("id"),
+                "title": task.get("title"),
+                "status": task.get("status"),
+                "assignee": task.get("assignee"),
+                "techDesignUrl": url,
+            }
+        )
+    return approvals
+
+
+def fetch_github_prs(agent: str) -> list[dict[str, Any]]:
+    """Read open PR state with the agent's own GitHub credentials; never mutate."""
+    _, config_dir, token_env = GITHUB_IDENTITIES[agent.lower()]
+    prs = _gh_api(config_dir, token_env, f"repos/{REPO}/pulls?state=open&per_page=100")
+    hydrated = []
+    for summary in prs:
+        author = str((summary.get("user") or {}).get("login") or "").lower()
+        requested = {
+            str(item.get("login") or "").lower()
+            for item in summary.get("requested_reviewers") or []
+        }
+        login = GITHUB_IDENTITIES[agent.lower()][0].lower()
+        if author != login and login not in requested:
+            continue
+        number = summary["number"]
+        detail = _gh_api(config_dir, token_env, f"repos/{REPO}/pulls/{number}")
+        detail["reviews"] = _gh_api(
+            config_dir, token_env, f"repos/{REPO}/pulls/{number}/reviews?per_page=100"
+        )
+        checks = _gh_api(
+            config_dir,
+            token_env,
+            f"repos/{REPO}/commits/{detail['head']['sha']}/check-runs?per_page=100",
+        )
+        detail["check_runs"] = checks.get("check_runs") or []
+        hydrated.append(detail)
+    return hydrated
+
+
+def build_work_queue(
+    tasks: list[dict[str, Any]],
+    agent: str,
+    github_prs: list[dict[str, Any]] | None = None,
+    tech_design_approvals: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    task_queue = build_queue(tasks)
+    github_queue = classify_github_prs(agent, github_prs or [])
+    return {
+        "tasks": task_queue["items"],
+        "actionableTaskCount": task_queue["actionableCount"],
+        "techDesignApprovals": tech_design_approvals or [],
+        **github_queue,
+    }
+
+
 def print_human(queue: dict[str, Any], assignee: str) -> None:
     print(f"{assignee} actionable tasks: {queue['actionableCount']}")
     for item in queue["items"]:
@@ -161,11 +358,25 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = build_parser().parse_args()
-    queue = build_queue(fetch_agent_tasks(args.assignee))
+    agent_key = args.assignee.lower()
+    if agent_key not in GITHUB_IDENTITIES:
+        raise SystemExit(f"unsupported agent {args.assignee!r}; expected Rowan, Ivy, or Quinn")
+    tasks = fetch_agent_tasks(args.assignee)
+    approvals = fetch_pending_tech_design_approvals() if agent_key == "quinn" else []
+    queue = build_work_queue(
+        tasks,
+        args.assignee,
+        fetch_github_prs(args.assignee),
+        approvals,
+    )
     if args.json:
         print(json.dumps(queue, indent=2))
     else:
-        print_human(queue, args.assignee)
+        print_human(build_queue(tasks), args.assignee)
+        print(f"Tech-design approvals: {len(queue['techDesignApprovals'])}")
+        print(f"Review requests: {len(queue['reviewRequests'])}")
+        print(f"Authored PRs with requested changes: {len(queue['authoredPrFeedback'])}")
+        print(f"Merge candidates: {len(queue['mergeCandidates'])}")
 
 
 if __name__ == "__main__":

--- a/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
@@ -1,6 +1,7 @@
 import importlib.util
 import pathlib
 import unittest
+from unittest.mock import patch
 
 MODULE_PATH = pathlib.Path(__file__).with_name("agent_task_queue.py")
 SPEC = importlib.util.spec_from_file_location("agent_task_queue", MODULE_PATH)
@@ -100,6 +101,51 @@ class AgentTaskQueueTest(unittest.TestCase):
         )
         self.assertEqual(classification, "WAITING_EXTERNAL")
         self.assertIn("Lobster", reason)
+
+    def test_content_task_doing_remains_actionable_with_delivery_comment(self):
+        classification, reason = agent_task_queue.classify_task(
+            task(
+                taskType="content",
+                status="doing",
+                comments=[{"text": "[ivy-prs] https://github.com/acme/repo/pull/1"}],
+            )
+        )
+        self.assertEqual(classification, "ACTIONABLE")
+        self.assertIn("content task", reason)
+
+    def test_content_task_acceptance_is_external_wait(self):
+        classification, reason = agent_task_queue.classify_task(
+            task(taskType="content", status="acceptance")
+        )
+        self.assertEqual(classification, "WAITING_EXTERNAL")
+        self.assertIn("acceptance", reason)
+
+    def test_untyped_doing_task_is_actionable_for_quinn(self):
+        classification, reason = agent_task_queue.classify_task(
+            task(taskType=None, status="doing")
+        )
+        self.assertEqual(classification, "ACTIONABLE")
+        self.assertIn("task is in doing", reason)
+
+    def test_untyped_acceptance_task_is_external_wait(self):
+        classification, reason = agent_task_queue.classify_task(
+            task(taskType=None, status="acceptance")
+        )
+        self.assertEqual(classification, "WAITING_EXTERNAL")
+        self.assertIn("acceptance", reason)
+
+    def test_fetch_keeps_open_untyped_ops_tasks_outside_active_classifier(self):
+        with (
+            patch.object(agent_task_queue.tasks_api_client, "list_tasks", return_value=[]) as list_tasks,
+            patch.object(agent_task_queue.tasks_api_client, "get_base_url", return_value="http://test/api/v1"),
+        ):
+            agent_task_queue.fetch_agent_tasks("Quinn")
+
+        self.assertEqual(
+            list_tasks.call_args.kwargs["status"],
+            ["ready", "doing", "acceptance"],
+        )
+        self.assertNotIn("open", list_tasks.call_args.kwargs["status"])
 
 
 if __name__ == "__main__":

--- a/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
@@ -95,6 +95,37 @@ class AgentTaskQueueTest(unittest.TestCase):
         self.assertEqual(classification, "WAITING_EXTERNAL")
         self.assertIn("approval", reason)
 
+    def test_tech_design_approval_matches_lobster_exact_token_rule(self):
+        accepted = (
+            "[tech-design-approved] true",
+            "  [tech-design-approved] TRUE rationale follows",
+        )
+        rejected = (
+            "Missing task comment `[tech-design-approved] true`.",
+            "[tech-design-approved] false",
+            "[tech-design-approved] trueish",
+            "[tech-design-approved]",
+        )
+        for text in accepted:
+            with self.subTest(accepted=text):
+                self.assertTrue(agent_task_queue._tech_design_approved([text]))
+        for text in rejected:
+            with self.subTest(rejected=text):
+                self.assertFalse(agent_task_queue._tech_design_approved([text]))
+
+    def test_checklist_approval_substring_does_not_promote_doing_task(self):
+        classification, reason = agent_task_queue.classify_task(
+            task(
+                status="doing",
+                comments=[
+                    {"text": "[tech-design] https://example.test/design"},
+                    {"text": "Missing task comment `[tech-design-approved] true`."},
+                ],
+            )
+        )
+        self.assertEqual(classification, "WAITING_EXTERNAL")
+        self.assertIn("approval", reason)
+
     def test_code_task_waiver_waits_for_lobster_promotion(self):
         classification, reason = agent_task_queue.classify_task(
             task(status="ready", comments=[{"text": "[tech-design-not-required] small fix"}])

--- a/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
@@ -206,6 +206,8 @@ class AgentTaskQueueTest(unittest.TestCase):
         self.assertEqual(
             set(queue),
             {
+                "queue",
+                "topCandidate",
                 "tasks",
                 "actionableTaskCount",
                 "techDesignApprovals",
@@ -214,6 +216,47 @@ class AgentTaskQueueTest(unittest.TestCase):
                 "mergeCandidates",
             },
         )
+
+    def test_unified_queue_selects_one_deterministic_top_candidate(self):
+        feedback_pr = pull_request(
+            reviews=[
+                {
+                    "user": {"login": "quinnstoffer"},
+                    "state": "CHANGES_REQUESTED",
+                    "submitted_at": "2026-01-01T00:00:00Z",
+                }
+            ]
+        )
+        queue = agent_task_queue.build_work_queue(
+            [implementation_task(priority="urgent")],
+            "Rowan",
+            [feedback_pr],
+            [{"id": "approval", "title": "Review design", "techDesignUrl": "https://design"}],
+        )
+        self.assertEqual("authoredPrFeedback", queue["topCandidate"]["kind"])
+        self.assertEqual(
+            ["authoredPrFeedback", "techDesignApproval", "task"],
+            [item["kind"] for item in queue["queue"]],
+        )
+
+    def test_unified_queue_keeps_non_actionable_tasks_below_actionable_work(self):
+        queue = agent_task_queue.build_work_queue(
+            [
+                implementation_task(
+                    title="Waiting",
+                    comments=[
+                        {"text": "[tech-design] https://example.test/design"},
+                        {"text": "[tech-design-approved] true"},
+                        {"text": "[implementer-prs] https://example.test/pr"},
+                    ],
+                ),
+                implementation_task(title="Action now"),
+            ],
+            "Rowan",
+        )
+        self.assertEqual("Action now", queue["topCandidate"]["title"])
+        self.assertTrue(queue["queue"][0]["actionable"])
+        self.assertFalse(queue["queue"][-1]["actionable"])
 
     def test_review_requests_exclude_self_review(self):
         other = pull_request(

--- a/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
@@ -36,23 +36,14 @@ def implementation_task(**overrides):
 
 
 class AgentTaskQueueTest(unittest.TestCase):
-    def test_dependency_blocked_doing_does_not_consume_capacity(self):
+    def test_dependency_blocked_doing_is_classified(self):
         queue = agent_task_queue.build_queue(
-            [
-                implementation_task(id="blocked", dependencyBlocked=True),
-                implementation_task(id="active-1"),
-                implementation_task(id="active-2"),
-            ],
-            capacity=2,
+            [implementation_task(id="blocked", dependencyBlocked=True)]
         )
+        self.assertEqual(queue["items"][0]["classification"], "DEPENDENCY_BLOCKED")
 
-        self.assertEqual(queue["capacity"], {"activeDoing": 2, "limit": 2, "available": 0})
-        blocked = next(item for item in queue["items"] if item["id"] == "blocked")
-        self.assertEqual(blocked["classification"], "DEPENDENCY_BLOCKED")
-
-    def test_explicitly_blocked_doing_does_not_consume_capacity(self):
-        queue = agent_task_queue.build_queue([implementation_task(blocked=True)], capacity=2)
-        self.assertEqual(queue["capacity"]["activeDoing"], 0)
+    def test_explicitly_blocked_doing_is_classified(self):
+        queue = agent_task_queue.build_queue([implementation_task(blocked=True)])
         self.assertEqual(queue["items"][0]["classification"], "BLOCKED")
 
     def test_missing_implementer_prs_is_actionable_for_feature_and_code(self):

--- a/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
@@ -1,0 +1,115 @@
+import importlib.util
+import pathlib
+import unittest
+
+MODULE_PATH = pathlib.Path(__file__).with_name("agent_task_queue.py")
+SPEC = importlib.util.spec_from_file_location("agent_task_queue", MODULE_PATH)
+agent_task_queue = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(agent_task_queue)
+
+
+def task(**overrides):
+    value = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "title": "Example",
+        "taskType": "code",
+        "status": "doing",
+        "priority": "high",
+        "blocked": False,
+        "dependencyBlocked": False,
+        "comments": [],
+    }
+    value.update(overrides)
+    return value
+
+
+def implementation_task(**overrides):
+    value = task(
+        comments=[
+            {"text": "[tech-design] https://example.test/design"},
+            {"text": "[tech-design-approved] true"},
+        ]
+    )
+    value.update(overrides)
+    return value
+
+
+class AgentTaskQueueTest(unittest.TestCase):
+    def test_dependency_blocked_doing_does_not_consume_capacity(self):
+        queue = agent_task_queue.build_queue(
+            [
+                implementation_task(id="blocked", dependencyBlocked=True),
+                implementation_task(id="active-1"),
+                implementation_task(id="active-2"),
+            ],
+            capacity=2,
+        )
+
+        self.assertEqual(queue["capacity"], {"activeDoing": 2, "limit": 2, "available": 0})
+        blocked = next(item for item in queue["items"] if item["id"] == "blocked")
+        self.assertEqual(blocked["classification"], "DEPENDENCY_BLOCKED")
+
+    def test_explicitly_blocked_doing_does_not_consume_capacity(self):
+        queue = agent_task_queue.build_queue([implementation_task(blocked=True)], capacity=2)
+        self.assertEqual(queue["capacity"]["activeDoing"], 0)
+        self.assertEqual(queue["items"][0]["classification"], "BLOCKED")
+
+    def test_missing_implementer_prs_is_actionable_for_feature_and_code(self):
+        for task_type in ("feature", "code"):
+            with self.subTest(task_type=task_type):
+                classification, reason = agent_task_queue.classify_task(implementation_task(taskType=task_type))
+                self.assertEqual(classification, "ACTIONABLE")
+                self.assertIn("delivery", reason)
+
+    def test_progress_checklist_missing_implementer_prs_is_not_external_wait(self):
+        classification, _ = agent_task_queue.classify_task(
+            implementation_task(
+                comments=[
+                    {"text": "[tech-design] https://example.test/design"},
+                    {"text": "[tech-design-approved] true"},
+                    {
+                        "text": "[code-task-progress-checklist]\n"
+                        "Missing `[implementer-prs]` task comment with at least one PR URL."
+                    },
+                ]
+            )
+        )
+        self.assertEqual(classification, "ACTIONABLE")
+
+    def test_posted_implementer_prs_is_external_wait_candidate(self):
+        classification, reason = agent_task_queue.classify_task(
+            implementation_task(
+                comments=[
+                    {"text": "[tech-design] https://example.test/design"},
+                    {"text": "[tech-design-approved] true"},
+                    {"text": "[code-task-progress-checklist]\nMissing `[implementer-prs]` task comment."},
+                    {"text": "[implementer-prs] https://github.com/acme/repo/pull/1"},
+                ]
+            )
+        )
+        self.assertEqual(classification, "WAITING_EXTERNAL")
+        self.assertIn("verify PR", reason)
+
+    def test_ready_without_tech_design_is_actionable(self):
+        classification, reason = agent_task_queue.classify_task(task(status="ready"))
+        self.assertEqual(classification, "ACTIONABLE")
+        self.assertIn("tech design", reason)
+
+    def test_ready_with_design_waits_for_approval(self):
+        classification, reason = agent_task_queue.classify_task(
+            task(status="ready", comments=[{"text": "[tech-design] https://example.test/design"}])
+        )
+        self.assertEqual(classification, "WAITING_EXTERNAL")
+        self.assertIn("approval", reason)
+
+    def test_code_task_waiver_waits_for_lobster_promotion(self):
+        classification, reason = agent_task_queue.classify_task(
+            task(status="ready", comments=[{"text": "[tech-design-not-required] small fix"}])
+        )
+        self.assertEqual(classification, "WAITING_EXTERNAL")
+        self.assertIn("Lobster", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
@@ -36,6 +36,24 @@ def implementation_task(**overrides):
     return value
 
 
+def pull_request(**overrides):
+    value = {
+        "number": 42,
+        "title": "feat: example",
+        "html_url": "https://github.com/acme/repo/pull/42",
+        "user": {"login": "rowanstoffer"},
+        "requested_reviewers": [],
+        "reviews": [],
+        "check_runs": [
+            {"status": "completed", "conclusion": "success"},
+            {"status": "completed", "conclusion": "skipped"},
+        ],
+        "mergeable": True,
+    }
+    value.update(overrides)
+    return value
+
+
 class AgentTaskQueueTest(unittest.TestCase):
     def test_dependency_blocked_doing_is_classified(self):
         queue = agent_task_queue.build_queue(
@@ -177,6 +195,119 @@ class AgentTaskQueueTest(unittest.TestCase):
             ["ready", "doing", "acceptance"],
         )
         self.assertNotIn("open", list_tasks.call_args.kwargs["status"])
+
+    def test_work_queue_exposes_all_read_only_queue_keys(self):
+        queue = agent_task_queue.build_work_queue(
+            [implementation_task()],
+            "Rowan",
+            [],
+            [{"id": "approval"}],
+        )
+        self.assertEqual(
+            set(queue),
+            {
+                "tasks",
+                "actionableTaskCount",
+                "techDesignApprovals",
+                "reviewRequests",
+                "authoredPrFeedback",
+                "mergeCandidates",
+            },
+        )
+
+    def test_review_requests_exclude_self_review(self):
+        other = pull_request(
+            user={"login": "ivystoffer"},
+            requested_reviewers=[{"login": "quinnstoffer"}],
+        )
+        own = pull_request(
+            user={"login": "quinnstoffer"},
+            requested_reviewers=[{"login": "quinnstoffer"}],
+        )
+        queue = agent_task_queue.classify_github_prs("Quinn", [other, own])
+        self.assertEqual([42], [item["number"] for item in queue["reviewRequests"]])
+
+    def test_latest_changes_requested_review_drives_authored_feedback(self):
+        pr = pull_request(
+            reviews=[
+                {
+                    "user": {"login": "quinnstoffer"},
+                    "state": "APPROVED",
+                    "submitted_at": "2026-01-01T00:00:00Z",
+                },
+                {
+                    "user": {"login": "quinnstoffer"},
+                    "state": "CHANGES_REQUESTED",
+                    "submitted_at": "2026-01-02T00:00:00Z",
+                },
+            ]
+        )
+        queue = agent_task_queue.classify_github_prs("Rowan", [pr])
+        self.assertEqual(["quinnstoffer"], queue["authoredPrFeedback"][0]["changesRequestedBy"])
+        self.assertEqual([], queue["mergeCandidates"])
+
+    def test_rowan_merge_candidate_requires_quinn_approval_and_green_ci(self):
+        approved = pull_request(
+            reviews=[
+                {
+                    "user": {"login": "quinnstoffer"},
+                    "state": "APPROVED",
+                    "submitted_at": "2026-01-01T00:00:00Z",
+                }
+            ]
+        )
+        queue = agent_task_queue.classify_github_prs("Rowan", [approved])
+        self.assertEqual([42], [item["number"] for item in queue["mergeCandidates"]])
+
+        approved["check_runs"][0]["conclusion"] = "failure"
+        self.assertEqual(
+            [],
+            agent_task_queue.classify_github_prs("Rowan", [approved])["mergeCandidates"],
+        )
+
+    def test_ivy_merge_candidate_uses_pr_specific_blocking_reviewer(self):
+        pr = pull_request(
+            title="content: weekly updates (Tom-approval)",
+            user={"login": "ivystoffer"},
+            reviews=[
+                {
+                    "user": {"login": "Stoff81"},
+                    "state": "APPROVED",
+                    "submitted_at": "2026-01-01T00:00:00Z",
+                }
+            ],
+        )
+        queue = agent_task_queue.classify_github_prs("Ivy", [pr])
+        self.assertEqual(["stoff81"], queue["mergeCandidates"][0]["blockingApprovals"])
+
+    def test_quinn_cannot_self_approve_a_merge_candidate(self):
+        pr = pull_request(
+            user={"login": "quinnstoffer"},
+            requested_reviewers=[{"login": "quinnstoffer"}],
+            reviews=[
+                {
+                    "user": {"login": "quinnstoffer"},
+                    "state": "APPROVED",
+                    "submitted_at": "2026-01-01T00:00:00Z",
+                }
+            ],
+        )
+        queue = agent_task_queue.classify_github_prs("Quinn", [pr])
+        self.assertEqual([], queue["mergeCandidates"])
+
+    def test_quinn_authored_pr_can_merge_after_non_self_approval(self):
+        pr = pull_request(
+            user={"login": "quinnstoffer"},
+            reviews=[
+                {
+                    "user": {"login": "Stoff81"},
+                    "state": "APPROVED",
+                    "submitted_at": "2026-01-01T00:00:00Z",
+                }
+            ],
+        )
+        queue = agent_task_queue.classify_github_prs("Quinn", [pr])
+        self.assertEqual(["stoff81"], queue["mergeCandidates"][0]["blockingApprovals"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a reusable, read-only agent task retrieval layer parameterized by assignee
- classify active tasks as actionable, externally waiting, explicitly blocked, or dependency blocked
- treat missing `[implementer-prs]` on feature/code tasks as implementer action, while ignoring stale checklist comments after delivery is posted
- wire Rowan, Ivy, and Quinn heartbeat discovery to the shared queue and require tangible progress whenever actionable work exists
- normalize task work, global Quinn approvals, review requests, authored PR feedback, and role-aware merge candidates into one deterministic read-only `queue` with a single `topCandidate`; all mutations remain in explicit workflow/PR skills
- preserve Ivy's content-specific doing/acceptance and tweet-campaign rules, plus Quinn's global tech-design approval scan, separate open no-taskType ops query, and specialised heartbeat sections

## Original ask
Tom asked in chat to keep the Lobster unchanged and make blocker-aware retrieval/actionability logic reusable across agents without creating a task or spec. Follow-up scope extends the heartbeat execution guardrail from Rowan to Ivy and Quinn without changing models, cadence, Lobster, or capacity logic.

## System Spec
No system spec change — this is a read-only heartbeat retrieval adapter and workflow guardrail; it does not change Tasks API or Lobster behavior.

## Test plan
- [x] Unit tests cover explicit and dependency blocker classification.
- [x] Unit tests cover feature/code `[implementer-prs]` behavior, including stale checklist comments.
- [x] Unit tests cover ready-task tech-design and waiver classification.
- [x] Unit tests verify tech-design approvals use Lobster's starts-with tag and exact first-token `true` rule, rejecting checklist substring false positives.
- [x] Unit tests cover content-task doing/acceptance semantics, including content work remaining actionable after an Ivy delivery comment.
- [x] Unit tests cover Quinn untyped active-task classification and verify open no-taskType ops tasks remain outside the active classifier query.
- [x] Unit tests cover review requests, latest CHANGES_REQUESTED state, green-CI/mergeability gates, Rowan/Quinn/Ivy blocking-reviewer rules, and Quinn self-approval prohibition.
- [x] Unit tests cover deterministic unified-queue ordering, one `topCandidate`, and actionable work sorting above external waits/blockers.
- [x] Live prodlike queries validate read-only Tasks API and GitHub discovery for Rowan and Quinn without mutating PR state or duplicating Lobster capacity logic.

Validation:
- `python3 -m unittest agents.skills.ops.tasks-api.tests.test_tasks_api_client agents.skills.ops.tasks-api.scripts.test_agent_task_queue` (37 tests passed)
- `python3 -m py_compile agents/skills/ops/tasks-api/scripts/agent_task_queue.py agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py`
- `git diff --check`

Note: the broader `test_pending_tech_design_approvals` suite currently has four unrelated pre-existing failures because `pending_tech_design_approvals.py` lacks `is_feature_task`; this PR does not touch that module.


