### PR TITLE
test(mission-control): pin inScopeItem / inScopeTransition tests to fixture NOW

### DIFF
--- a/apps/mission-control/src/bookmarkPipeline.test.js
+++ b/apps/mission-control/src/bookmarkPipeline.test.js
@@ -125,9 +125,9 @@ describe('cutoffFromWindow', () => {
 describe('inScopeItem / inScopeTransition', () => {
   it('respects the topic filter', () => {
     const item = makeItem({ topic: 'infra' });
-    expect(inScopeItem(item, { topic: 'all' })).toBe(true);
-    expect(inScopeItem(item, { topic: 'infra' })).toBe(true);
-    expect(inScopeItem(item, { topic: 'brain' })).toBe(false);
+    expect(inScopeItem(item, { topic: 'all', now: NOW })).toBe(true);
+    expect(inScopeItem(item, { topic: 'infra', now: NOW })).toBe(true);
+    expect(inScopeItem(item, { topic: 'brain', now: NOW })).toBe(false);
   });
 
   it('respects the time window', () => {
@@ -140,9 +140,9 @@ describe('inScopeItem / inScopeTransition', () => {
 
   it('inScopeTransition filters by topic of the referenced item', () => {
     const byKey = new Map([['a', makeItem({ topic: 'infra' })]]);
-    expect(inScopeTransition({ key: 'a', at: isoDaysAgo(1) }, byKey, { topic: 'all' })).toBe(true);
-    expect(inScopeTransition({ key: 'a', at: isoDaysAgo(1) }, byKey, { topic: 'brain' })).toBe(false);
-    expect(inScopeTransition({ key: 'unknown', at: isoDaysAgo(1) }, byKey, { topic: 'brain' })).toBe(false);
+    expect(inScopeTransition({ key: 'a', at: isoDaysAgo(1) }, byKey, { topic: 'all', now: NOW })).toBe(true);
+    expect(inScopeTransition({ key: 'a', at: isoDaysAgo(1) }, byKey, { topic: 'brain', now: NOW })).toBe(false);
+    expect(inScopeTransition({ key: 'unknown', at: isoDaysAgo(1) }, byKey, { topic: 'brain', now: NOW })).toBe(false);
   });
 });
 


### PR DESCRIPTION
PR unblocks the mission-control tests job on main by restoring green on the broken `bookmarkPipeline.test.js > inScopeItem / inScopeTransition > respects the topic filter` test.

## Root cause

The `inScopeItem` / `inScopeTransition` tests in `apps/mission-control/src/bookmarkPipeline.test.js` construct items with `lastUpdatedAt` (and transition events with `at`) relative to a fixed `NOW` constant (**2026-07-04T12:00:00.000Z**) but did not pass `now` to the helper invocations. The helpers default `now = new Date()`, so the 30-day window cutoff derived from real time drifted past the fixture timestamps as real time advanced, and the topic-filter test started failing on main roughly 30 days after the fixtures were written.

The adjacent `it('respects the time window', ...)` test in the same describe block already passes `now: NOW` — the broken tests just didn't.

## Fix

Pass `now: NOW` through every call in the `inScopeItem / inScopeTransition` describe block (6 lines total). No source changes; the production code is correct, the test fixtures were leaky.

## Scope

- `apps/mission-control/src/bookmarkPipeline.test.js` — 6 lines changed, all test fixture invocation sites.
- No content files touched (per Ivy's PR #338 instructions).
- No source changes in `bookmarkPipeline.js`.

## Verification

- `npm run test -- src/bookmarkPipeline.test.js` → 50/50 pass (was 49/50).
- `npm run test` (full mission-control suite) → 175/175 pass across 11 files.

## Why this is a PR on its own

Per Tom (via Quinn): the broken test is pre-existing on main and unrelated to the content diff in PR #338. Branch protection requires all CI checks green to merge, so PR #338 is blocked until this lands on main. Quinn will rebase PR #338 once this is merged.