### PR TITLE
ops: sync agent definitions from origin main

### DIFF
--- a/scripts/ops/sync-agent-definitions.sh
+++ b/scripts/ops/sync-agent-definitions.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+WORKSPACE_ROOT=${OPENCLAW_WORKSPACE_ROOT:-"$HOME/.openclaw/workspace"}
+BACKUP_ROOT=${OPENCLAW_AGENT_DEFS_BACKUP_ROOT:-"$HOME/.openclaw/backups/agent-definitions"}
+LOCK_DIR=${OPENCLAW_AGENT_DEFS_LOCK_DIR:-"${TMPDIR:-/tmp}/openclaw-agent-definitions-sync.lock"}
+SOURCE_ROOT=agents/definitions
+AGENTS=(quinn rowan lox ivy)
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  echo "agent-definitions sync already running; skipping"
+  exit 0
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+
+git -C "$REPO_ROOT" fetch --quiet origin main
+
+backup_stamp="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+backup_dir="$BACKUP_ROOT/$backup_stamp"
+changed=0
+
+for agent in "${AGENTS[@]}"; do
+  source_dir="$SOURCE_ROOT/$agent"
+  if ! git -C "$REPO_ROOT" cat-file -e "origin/main:$source_dir" 2>/dev/null; then
+    echo "missing source directory on origin/main: $source_dir" >&2
+    exit 1
+  fi
+
+  if [[ "$agent" == quinn ]]; then
+    destination_dir="$WORKSPACE_ROOT"
+  else
+    destination_dir="$WORKSPACE_ROOT/agents/$agent"
+  fi
+  mkdir -p "$destination_dir"
+
+  while IFS= read -r source_path; do
+    filename=${source_path##*/}
+    [[ "$filename" == "AGENTS.md" ]] && continue
+    destination="$destination_dir/$filename"
+    staged=$(mktemp "${TMPDIR:-/tmp}/agent-definition.XXXXXX")
+    git -C "$REPO_ROOT" show "origin/main:$source_path" > "$staged"
+
+    if [[ -f "$destination" ]] && cmp -s "$staged" "$destination"; then
+      rm -f "$staged"
+      continue
+    fi
+
+    if [[ -e "$destination" ]]; then
+      mkdir -p "$backup_dir/$agent"
+      cp -p "$destination" "$backup_dir/$agent/$filename"
+    fi
+    install -m 0644 "$staged" "$destination"
+    rm -f "$staged"
+    echo "synced $source_path -> $destination"
+    changed=$((changed + 1))
+  done < <(git -C "$REPO_ROOT" ls-tree -r --name-only origin/main -- "$source_dir" | grep -E '\.md$')
+done
+
+echo "agent-definitions sync complete: $changed file(s) changed"
+if [[ -d "$backup_dir" ]]; then
+  echo "backups: $backup_dir"
+fi

--- a/scripts/ops/tests/sync-agent-definitions.test.sh
+++ b/scripts/ops/tests/sync-agent-definitions.test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/sync-agent-definitions.sh
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+export OPENCLAW_WORKSPACE_ROOT="$TMP/workspace"
+export OPENCLAW_AGENT_DEFS_BACKUP_ROOT="$TMP/backups"
+export OPENCLAW_AGENT_DEFS_LOCK_DIR="$TMP/lock"
+mkdir -p "$OPENCLAW_WORKSPACE_ROOT/agents/rowan"
+printf 'keep me\n' > "$OPENCLAW_WORKSPACE_ROOT/AGENTS.md"
+printf 'old soul\n' > "$OPENCLAW_WORKSPACE_ROOT/agents/rowan/SOUL.md"
+
+"$SCRIPT" >/dev/null
+cmp <(git -C "$(cd "$(dirname "$SCRIPT")/../.." && pwd)" show origin/main:agents/definitions/rowan/SOUL.md) "$OPENCLAW_WORKSPACE_ROOT/agents/rowan/SOUL.md"
+[[ "$(cat "$OPENCLAW_WORKSPACE_ROOT/AGENTS.md")" == "keep me" ]]
+backup=$(find "$OPENCLAW_AGENT_DEFS_BACKUP_ROOT" -path '*/rowan/SOUL.md' -type f -print -quit)
+[[ -n "$backup" ]]
+[[ "$(cat "$backup")" == "old soul" ]]
+
+before=$(find "$OPENCLAW_AGENT_DEFS_BACKUP_ROOT" -type f | wc -l | tr -d ' ')
+"$SCRIPT" >/dev/null
+after=$(find "$OPENCLAW_AGENT_DEFS_BACKUP_ROOT" -type f | wc -l | tr -d ' ')
+[[ "$before" == "$after" ]]
+echo "sync-agent-definitions: ok"


### PR DESCRIPTION
## Summary

- sync each agent's bootstrap Markdown directly from `origin/main`
- leave the shared working tree and `AGENTS.md` untouched
- back up changed destination files before atomic overwrite
- serialize overlapping runs with a lock directory
- add an isolated test covering sync, backup, idempotence, and `AGENTS.md` preservation

## Verification

- `scripts/ops/tests/sync-agent-definitions.test.sh`
- `git diff --cached --check`

## Rollout

The 5-minute command cron will remain disabled until Quinn's sanity-check and this PR is merged.
