### PR TITLE
fix: make definitions sync launcher branch-independent

### DIFF
--- a/scripts/ops/sync-agent-definitions.sh
+++ b/scripts/ops/sync-agent-definitions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+REPO_ROOT=${SINDUSTRIES_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}
 WORKSPACE_ROOT=${OPENCLAW_WORKSPACE_ROOT:-"$HOME/.openclaw/workspace"}
 BACKUP_ROOT=${OPENCLAW_AGENT_DEFS_BACKUP_ROOT:-"$HOME/.openclaw/backups/agent-definitions"}
 LOCK_DIR=${OPENCLAW_AGENT_DEFS_LOCK_DIR:-"${TMPDIR:-/tmp}/openclaw-agent-definitions-sync.lock"}


### PR DESCRIPTION
## Summary

- allow the agent-definitions sync script to receive an explicit repository root
- lets the disabled cron load the script from `origin/main` rather than depending on the shared checkout branch containing it

## Verification

- `scripts/ops/tests/sync-agent-definitions.test.sh`
- `git diff --check`

## Rollout

Cron remains disabled pending review. After merge, its command will fetch `origin/main`, stage this script from Git, and execute it with `SINDUSTRIES_REPO_ROOT` pointing at the shared repository metadata.
