### PR TITLE
chore(git): guard shared sindustries working tree to main only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ Use prodlike for final verification, smoke checks, and automation that should ta
 ## NEVER rules
 
 - **Never do implementation work directly on `main`.** Work on a branch and open a PR.
+- **Never check out a branch in the shared `codebases/sindustries` working tree.** This one checkout (the canonical path every agent's tooling reads from directly, e.g. sync scripts, TOOLS.md references) must always stay on `main`. For branch work, create an isolated worktree instead: `git worktree add ../../workspaces/<agent>/sindustries-<task> -b <branch>`. A `post-checkout` guardrail hook (`scripts/git-hooks/post-checkout`, installed via `scripts/git-hooks/install.sh` / `make bootstrap`) auto-reverts this checkout back to `main` if it drifts, but don't rely on it — use a worktree from the start.
 - **Never treat prodlike as your day-to-day dev environment.** Build and iterate in `dev`; validate in `prodlike`.
 - **Never seed or reset prodlike casually.** `scripts/dev/reset-db.sh` intentionally blocks prodlike seeding to protect the validation dataset.
 - **Never duplicate operational logic in ad-hoc commands when a repo script already exists.** Prefer `scripts/dev/*` and `make` wrappers.

--- a/scripts/dev/bootstrap.sh
+++ b/scripts/dev/bootstrap.sh
@@ -65,6 +65,9 @@ echo "📦 Installing npm dependencies..."
 (cd "$ROOT_DIR/services/tasks-api" && npm install)
 (cd "$ROOT_DIR/apps/tasks" && npm install)
 
+echo "🪝 Installing repo git hooks..."
+"$ROOT_DIR/scripts/git-hooks/install.sh"
+
 echo "✅ Bootstrap complete."
 echo "Next:"
 echo "  make up"

--- a/scripts/git-hooks/install.sh
+++ b/scripts/git-hooks/install.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Installs repo-local git hooks (scripts/git-hooks/*) into .git/hooks for the
+# current checkout. Safe to re-run. Idempotent.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOKS_SRC="$ROOT_DIR/scripts/git-hooks"
+HOOKS_DEST="$ROOT_DIR/.git/hooks"
+
+if [[ ! -d "$ROOT_DIR/.git" ]]; then
+  echo "not a git checkout (no .git dir) — skipping hook install: $ROOT_DIR" >&2
+  exit 0
+fi
+
+mkdir -p "$HOOKS_DEST"
+
+for hook in "$HOOKS_SRC"/*; do
+  name=$(basename "$hook")
+  [[ "$name" == "install.sh" ]] && continue
+  [[ -f "$hook" ]] || continue
+  cp "$hook" "$HOOKS_DEST/$name"
+  chmod +x "$HOOKS_DEST/$name"
+  echo "installed hook: $name"
+done

--- a/scripts/git-hooks/post-checkout
+++ b/scripts/git-hooks/post-checkout
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# post-checkout guardrail: the shared sindustries working tree must stay on main.
+#
+# Why: codebases/sindustries is a single shared checkout that every agent's
+# tooling (paths, sync scripts, etc.) reads from directly — it is not a
+# per-task worktree. Branch work directly in this checkout has repeatedly
+# drifted it off main (see reflog history 2026-08-03), which risks other
+# tooling silently reading stale/WIP content off disk.
+#
+# Scope: this hook only acts on the canonical shared checkout path below.
+# All other worktrees (workspaces/<agent>/sindustries-<task>, worktrees/*,
+# detached PR checkouts, etc.) are untouched — the hook no-ops for them.
+# This is a soft guardrail (auto-revert + warning), not a hard block: git
+# has no true pre-checkout hook that can abort a local checkout.
+set -euo pipefail
+
+CANONICAL_PATH="${OPENCLAW_WORKSPACE_ROOT:-$HOME/.openclaw/workspace}/codebases/sindustries"
+
+prev_head=${1:-}
+new_head=${2:-}
+is_branch_checkout=${3:-0}
+
+# Only branch checkouts matter (arg 3 == 1); file checkouts are unrelated.
+[[ "$is_branch_checkout" == "1" ]] || exit 0
+
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null || true)
+[[ -n "$toplevel" ]] || exit 0
+
+# Resolve symlinks on both sides so path comparison is robust.
+canonical_resolved=$(cd "$CANONICAL_PATH" 2>/dev/null && pwd -P || echo "$CANONICAL_PATH")
+toplevel_resolved=$(cd "$toplevel" 2>/dev/null && pwd -P || echo "$toplevel")
+
+[[ "$toplevel_resolved" == "$canonical_resolved" ]] || exit 0
+
+current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")
+
+if [[ "$current_branch" != "main" ]]; then
+  echo "" >&2
+  echo "⚠️  agent-defs-sync guardrail: $CANONICAL_PATH is the shared working tree." >&2
+  echo "    It must stay on 'main' — checkout of '$current_branch' detected here." >&2
+  echo "    Auto-reverting to main. For branch work, use an isolated worktree:" >&2
+  echo "      git worktree add ../../workspaces/<agent>/sindustries-<task> -b <branch>" >&2
+  echo "" >&2
+  git checkout main --quiet
+fi


### PR DESCRIPTION
## Why

The shared checkout at `codebases/sindustries` — the single working tree every agent's tooling reads from directly (paths, sync scripts, TOOLS.md references) — has repeatedly drifted onto feature branches during normal dev work, with commits/rebases happening directly on it (not just read-only checkouts). Reflog today:

```
main -> fix/agent-task-retrieval-classifier -> main -> pr-338-check -> fix/mission-control-bookmark-pipeline-test-drift
```

This surfaced while building today's agent-defs symlink fix (the fs-safe bootstrap-injection boundary was silently marking Rowan/Lox/Ivy's SOUL/HEARTBEAT/etc as missing — separate, already-merged issue, PR #343/#344). While verifying that fix I found the shared tree itself sitting on a stale feature branch, 2 commits behind main, which is a standing hygiene risk independent of that fix.

## What this does

- `scripts/git-hooks/post-checkout`: soft guardrail — detects a branch checkout specifically in the canonical shared path (`~/.openclaw/workspace/codebases/sindustries`) and auto-reverts to `main`. No-ops for every other worktree (`workspaces/<agent>/sindustries-*`, `worktrees/*`, detached PR checkouts, etc) — those are expected to be on branches.
- `scripts/git-hooks/install.sh`: installs repo-local hooks into `.git/hooks`. Wired into `scripts/dev/bootstrap.sh` so new setups pick it up automatically.
- `CONTRIBUTING.md`: documents the rule and the worktree-based branch workflow.

**Not a hard block.** Git has no true pre-checkout hook that can abort a local checkout — this is detect-and-revert after the fact, not prevent. The `CONTRIBUTING.md` policy is the primary guardrail; the hook is a backstop for when policy is missed (as it clearly was here).

## Status

Not run/enabled anywhere live — this is docs + an opt-in hook that only takes effect once `scripts/git-hooks/install.sh` is run (or `make bootstrap` re-run) in a checkout. Manually switched the shared tree back to `main` separately (not part of this PR — that was a one-off fix, not code).

Holding for Tom's review before merge — not urgent, filed for visibility while the related sync work gets tested.