### PR TITLE
fix(content-tasks): resolve dotenv path via Path.home() not parents[4]

### DIFF
--- a/agents/workflows/content-tasks/run.py
+++ b/agents/workflows/content-tasks/run.py
@@ -42,7 +42,7 @@ def run_workflow(task_id: str, capacity_limit: int) -> dict:
     log_debug("starting content-task pass for " + task_id)
     env = os.environ.copy()
     if not env.get("GH_TOKEN") and not env.get("GITHUB_TOKEN"):
-        dotenv = Path(__file__).parents[4] / ".openclaw" / ".env"
+        dotenv = Path.home() / ".openclaw" / ".env"
         try:
             for line in dotenv.read_text().splitlines():
                 if line.startswith("QUINN_GITHUB_TOKEN="):


### PR DESCRIPTION
## Summary
- Fixed content-tasks lobster (`agents/workflows/content-tasks/run.py:47`) dotenv path bug: `Path(__file__).parents[4]` resolved to a nonexistent `codebases/.openclaw/.env`, so the cron subprocess never picked up `GH_TOKEN`, and `gh pr view` calls returned unauthenticated 401s from the GitHub GraphQL API — surfacing as "no mapped owner heading" downstream in the lobster's PR-inspection step (task 87f173aa, PRs #337/#338, cron `3c2fa067` at 2026-08-03 14:55 NZST).
- Mirrors the already-correct pattern in the sibling `feature-task/run.py`'s `_load_dotenv_token()`, which uses `Path.home() / ".openclaw" / ".env"`.
- Root-caused and fix identified by Lox (cross-agent reliability check); implemented and opened by Quinn per the opener-identity policy (content-tasks is a Quinn-owned workflow).

## System Spec
No system spec change — one-line path fix, no user-facing behaviour change. Root-cause analysis and fix options documented in `infra/runbooks/content-tasks-lobster-gh-token-401.md`.

## Test plan
- [x] Verified `Path.home() / ".openclaw" / ".env"` resolves to `/Users/quinnstoffer/.openclaw/.env` and exists, containing `QUINN_GITHUB_TOKEN`.
- [x] Confirmed `gh pr view` succeeds with `GH_TOKEN=$QUINN_GITHUB_TOKEN` set (PR #337 merged, #338 open — both readable).
- [ ] Next Task Lobsters cron run (3c2fa067, ~2h cadence) should show no "no mapped owner heading" / 401 diagnostics on the content-task branch — will confirm post-merge per runbook verification steps.

🤖 Generated with Claude Code