### PR TITLE
fix(content-tasks): harden PR routing inspection

### DIFF
--- a/agents/workflows/content-tasks/scripts/common.py
+++ b/agents/workflows/content-tasks/scripts/common.py
@@ -26,9 +26,12 @@ WEEKLY_CONTENT_TITLE_RE = re.compile(r"weekly\s+(review|content\s+updates?)", re
 AUTHOR = "Lobster"
 STATUS_ORDER = {"open": 0, "ready": 1, "doing": 2, "acceptance": 3, "done": 4}
 PR_URL_RE = re.compile(r"https?://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/pull/(\d+)", re.I)
-PR_HEADING_RE = re.compile(r"^\s{0,3}#{1,4}\s+.*\bPR\b.*$", re.I | re.M)
-OWNER_HEADING_RE = re.compile(r"^\s{0,3}#{1,4}\s+.*\b(Tom|Quinn)\b.*$", re.I | re.M)
-ANY_HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+", re.M)
+# Use horizontal whitespace for indentation. `\s` also matches newlines, so
+# with MULTILINE it can consume the line break before a heading and make the
+# match's first line appear empty to callers that inspect the heading text.
+PR_HEADING_RE = re.compile(r"^[ \t]{0,3}#{1,4}[ \t]+.*\bPR\b.*$", re.I | re.M)
+OWNER_HEADING_RE = re.compile(r"^[ \t]{0,3}#{1,4}[ \t]+.*\b(Tom|Quinn)\b.*$", re.I | re.M)
+ANY_HEADING_RE = re.compile(r"^[ \t]{0,3}(#{1,6})[ \t]+", re.M)
 CHECKBOX_RE = re.compile(r"^\s*-\s*\[([ xX])\]\s+(.+\S)\s*$", re.M)
 
 
@@ -364,7 +367,14 @@ def gh_pr_view(url: str, fields: list[str]) -> dict[str, Any]:
 
 def gh_pr_assignees(url: str) -> list[str]:
     """Return list of GitHub login names assigned to the PR."""
-    data = gh_pr_view(url, ["assignees"])
+    # Use REST here rather than `gh pr view --json assignees`. The GraphQL
+    # representation resolves organisation-backed user fields and can require
+    # `read:org`, while the workflow only needs the public login names.
+    parsed = parse_pr_url(url)
+    if parsed is None:
+        raise RuntimeError(f"Invalid GitHub PR URL: {url}")
+    owner, repo, number = parsed
+    data = gh_api(f"repos/{owner}/{repo}/pulls/{number}")
     assignees = data.get("assignees") or []
     return [a.get("login") for a in assignees if a.get("login")]
 
@@ -448,14 +458,19 @@ def gh_pr_review_decision(url: str) -> str:
 
 def gh_pr_reviewers(url: str) -> list[str]:
     """Return login names of all reviewers (requested + completed) for a PR."""
-    pr = gh_pr_view(url, ["reviewRequests", "reviews"])
+    parsed = parse_pr_url(url)
+    if parsed is None:
+        raise RuntimeError(f"Invalid GitHub PR URL: {url}")
+    owner, repo, number = parsed
+    requested = gh_api(f"repos/{owner}/{repo}/pulls/{number}/requested_reviewers")
+    reviews = gh_api(f"repos/{owner}/{repo}/pulls/{number}/reviews")
     logins: list[str] = []
-    for entry in pr.get("reviewRequests") or []:
-        login = entry.get("login")
+    for entry in (requested.get("users") if isinstance(requested, dict) else []) or []:
+        login = entry.get("login") if isinstance(entry, dict) else None
         if login and login not in logins:
             logins.append(login)
-    for review in pr.get("reviews") or []:
-        author = review.get("author")
+    for review in reviews if isinstance(reviews, list) else []:
+        author = review.get("user") if isinstance(review, dict) else None
         login = author.get("login") if isinstance(author, dict) else None
         if login and login not in logins:
             logins.append(login)

--- a/tests/test_content_task_workflow.py
+++ b/tests/test_content_task_workflow.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+content_scripts = os.path.join(os.path.dirname(__file__), "..", "agents/workflows/content-tasks/scripts")
+loaded_common = sys.modules.pop("common", None)
+loaded_path = sys.path[:]
+sys.path.insert(0, content_scripts)
+try:
+    import common as content_common  # noqa: E402
+    from common import ANY_HEADING_RE, OWNER_HEADING_RE, PR_HEADING_RE  # noqa: E402
+    from pr_transition import owner_heading_index, owner_sections  # noqa: E402
+finally:
+    sys.path[:] = loaded_path
+    sys.modules.pop("common", None)
+    if loaded_common is not None:
+        sys.modules["common"] = loaded_common
+
+
+DESCRIPTION = """**Source:** brain/content/sindustries-weekly-content/2026-07-31.md
+
+---
+
+## Quinn can execute
+[PR #337](https://github.com/Stoffer-Industries/sindustries/pull/337)
+- [x] ADD release — shipped update
+
+## Needs Tom approval
+[PR #338](https://github.com/Stoffer-Industries/sindustries/pull/338)
+- [ ] EDIT experiment/gymtrack — publish it
+"""
+
+
+class ContentTaskHeadingTests(unittest.TestCase):
+    def test_owner_sections_preserve_heading_text_after_a_preceding_newline(self):
+        sections = owner_sections(DESCRIPTION)
+
+        self.assertEqual(len(sections), 2)
+        self.assertEqual(sections[0][0].splitlines()[0], "## Quinn can execute")
+        self.assertEqual(sections[1][0].splitlines()[0], "## Needs Tom approval")
+
+    def test_explicit_owner_routes_map_to_their_headings(self):
+        self.assertEqual(owner_heading_index(DESCRIPTION, "quinn"), 0)
+        self.assertEqual(owner_heading_index(DESCRIPTION, "tom"), 1)
+
+    def test_heading_patterns_do_not_consume_preceding_newlines(self):
+        text = "intro\n\n## PR #337\n\n## Quinn can execute\n"
+
+        for pattern in (PR_HEADING_RE, OWNER_HEADING_RE, ANY_HEADING_RE):
+            match = pattern.search(text)
+            self.assertIsNotNone(match)
+            self.assertFalse(match.group(0).startswith("\n"))
+
+    @patch.object(content_common, "gh_api")
+    def test_pr_routing_uses_rest_user_endpoints(self, gh_api):
+        gh_api.side_effect = [
+            {"assignees": [{"login": "ivystoffer"}]},
+            {"users": [{"login": "stoff81"}]},
+            [{"user": {"login": "quinnstoffer"}}],
+        ]
+        url = "https://github.com/Stoffer-Industries/sindustries/pull/337"
+
+        self.assertEqual(content_common.gh_pr_assignees(url), ["ivystoffer"])
+        self.assertEqual(content_common.gh_pr_reviewers(url), ["stoff81", "quinnstoffer"])
+        self.assertEqual(
+            [call.args[0] for call in gh_api.call_args_list],
+            [
+                "repos/Stoffer-Industries/sindustries/pulls/337",
+                "repos/Stoffer-Industries/sindustries/pulls/337/requested_reviewers",
+                "repos/Stoffer-Industries/sindustries/pulls/337/reviews",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Make content-task heading matching line-safe so owner headings retain their actual first line when preceded by blank lines.
- Use GitHub REST endpoints for PR assignee and reviewer lookup, avoiding GraphQL `read:org` requirements that previously surfaced as misleading PR-routing failures.
- Add regression coverage for owner routing, heading matching, and REST-based reviewer inspection.

## System Spec
No system spec change — workflow-internal reliability fix; no product-facing behaviour change.

## Test plan
- [x] `python3 -m pytest -q tests/test_content_task_workflow.py` (4 passed)
- [x] `python3 -m unittest discover -s tests -p 'test_*.py' -q` (135 passed)
- [x] Replayed task `87f173aa-4f5d-4629-8c04-7307958ab246` through `pr_transition.py --dry-run --json`: `criteria_met: true`, `action_taken: dry_run_move_doing_to_acceptance`, no failures.

🤖 Generated with OpenClaw