### PR TITLE
fix(tasks-api): default doing queue tasks to actionable

### DIFF
--- a/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
@@ -15,6 +15,7 @@ import importlib.util
 import json
 import os
 import pathlib
+import re
 import subprocess
 from typing import Any
 
@@ -53,6 +54,8 @@ QUEUE_KIND_ORDER = {
     "task": 4,
 }
 TASK_PRIORITY_ORDER = {"urgent": 0, "high": 1, "medium": 2, "low": 3}
+URL_RE = re.compile(r"https?://[^\s)>]+")
+GITHUB_PR_URL_RE = re.compile(r"^https://github\.com/[^/]+/[^/]+/pull/(\d+)(?:[/?#].*)?$")
 
 
 def _comment_texts(task: dict[str, Any]) -> list[str]:
@@ -66,11 +69,54 @@ def _has_prefix(texts: list[str], prefixes: tuple[str, ...]) -> bool:
     return any(text.lstrip().startswith(prefix) for text in texts for prefix in prefixes)
 
 
-def _latest_progress_comment(texts: list[str]) -> str:
+def _latest_tagged_comment(texts: list[str], prefixes: tuple[str, ...]) -> str:
     for text in reversed(texts):
-        if any(tag in text for tag in PROGRESS_TAGS):
+        stripped = text.lstrip()
+        if any(stripped.startswith(prefix) for prefix in prefixes):
             return text
     return ""
+
+
+def _latest_progress_comment(texts: list[str]) -> str:
+    return _latest_tagged_comment(texts, PROGRESS_TAGS)
+
+
+def _delivery_urls(texts: list[str]) -> list[str]:
+    comment = _latest_tagged_comment(texts, DELIVERY_TAGS)
+    if not comment:
+        return []
+    urls: list[str] = []
+    seen: set[str] = set()
+    for match in URL_RE.finditer(comment):
+        url = match.group(0).rstrip(".,)")
+        if url and url not in seen:
+            seen.add(url)
+            urls.append(url)
+    return urls
+
+
+def _task_agent(task: dict[str, Any]) -> str:
+    assignee = str(task.get("assignee") or "").strip()
+    return assignee if assignee.lower() in GITHUB_IDENTITIES else "Rowan"
+
+
+def _checks_pending(checks: list[dict[str, Any]]) -> bool:
+    return any(str(check.get("status") or "").lower() != "completed" for check in checks)
+
+
+def _checks_failing(checks: list[dict[str, Any]]) -> bool:
+    return any(
+        str(check.get("status") or "").lower() == "completed"
+        and str(check.get("conclusion") or "").lower() not in GREEN_CHECK_CONCLUSIONS
+        for check in checks
+    )
+
+
+def _pull_number_from_url(url: str) -> int | None:
+    match = GITHUB_PR_URL_RE.match(url)
+    if not match:
+        return None
+    return int(match.group(1))
 
 
 def _tech_design_approved(texts: list[str]) -> bool:
@@ -86,7 +132,94 @@ def _tech_design_approved(texts: list[str]) -> bool:
     return False
 
 
-def classify_task(task: dict[str, Any]) -> tuple[str, str]:
+def _latest_reviews(reviews: list[dict[str, Any]]) -> dict[str, str]:
+    latest: dict[str, str] = {}
+    for review in sorted(reviews, key=lambda item: item.get("submitted_at") or ""):
+        login = str((review.get("user") or {}).get("login") or "").lower()
+        state = str(review.get("state") or "").upper()
+        if login and state not in {"COMMENTED", "PENDING"}:
+            latest[login] = state
+    return latest
+
+
+def _blocking_reviewers(agent: str, pr: dict[str, Any], latest: dict[str, str]) -> list[str]:
+    agent = agent.lower()
+    title = str(pr.get("title") or "").lower()
+    requested = {
+        str(item.get("login") or "").lower()
+        for item in pr.get("requested_reviewers") or []
+    }
+    if agent == "rowan":
+        return ["quinnstoffer"]
+    if agent == "ivy":
+        if "tom-approval" in title:
+            return ["stoff81"]
+        if "quinn-approval" in title:
+            return ["quinnstoffer"]
+        known = (requested | set(latest)) & {"quinnstoffer", "stoff81"}
+        return sorted(known)
+    own_login = GITHUB_IDENTITIES[agent][0]
+    non_self_requested = {login for login in requested if login != own_login}
+    if non_self_requested:
+        return sorted(non_self_requested)
+    # GitHub clears requested_reviewers after a review is submitted. Retain the
+    # non-self reviewer from latest review state so an approved Quinn-authored
+    # PR can become merge-eligible without ever accepting Quinn's own review.
+    return sorted(login for login in latest if login != own_login)
+
+
+def _classify_delivery_pr(agent: str, pr: dict[str, Any]) -> tuple[str, str]:
+    state = str(pr.get("state") or "").lower()
+    if state != "open":
+        if pr.get("merged_at") or pr.get("mergedAt"):
+            return (
+                "ACTIONABLE",
+                "linked implementation PR is already merged; waiting for promotion is not a verified blocker",
+            )
+        return "ACTIONABLE", "linked implementation PR is closed without merge; replacement PR required"
+
+    if pr.get("draft"):
+        return "ACTIONABLE", "linked implementation PR is still draft"
+
+    latest = _latest_reviews(pr.get("reviews") or [])
+    changes_requested_by = sorted(
+        reviewer for reviewer, state in latest.items() if state == "CHANGES_REQUESTED"
+    )
+    if changes_requested_by:
+        return "ACTIONABLE", "linked implementation PR has requested changes"
+
+    if pr.get("mergeable") is False:
+        return "ACTIONABLE", "linked implementation PR has merge conflicts"
+
+    checks = pr.get("check_runs") or []
+    if _checks_failing(checks):
+        return "ACTIONABLE", "linked implementation PR has failing CI"
+    if _checks_pending(checks):
+        return "WAITING_EXTERNAL", "linked implementation PR is waiting on CI"
+
+    requested = {
+        str(item.get("login") or "").lower()
+        for item in pr.get("requested_reviewers") or []
+    }
+    blocking = _blocking_reviewers(agent, pr, latest)
+    approvals_present = bool(blocking) and all(latest.get(reviewer) == "APPROVED" for reviewer in blocking)
+    waiting_on_review = any(reviewer in requested for reviewer in blocking)
+
+    if approvals_present and pr.get("mergeable") is True:
+        return "ACTIONABLE", "linked implementation PR is approved and ready to merge"
+    if waiting_on_review:
+        return "WAITING_EXTERNAL", "linked implementation PR is waiting on review"
+
+    return (
+        "ACTIONABLE",
+        "implementer delivery is posted but no verified current external blocker remains",
+    )
+
+
+def classify_task(
+    task: dict[str, Any],
+    delivery_prs: dict[str, dict[str, Any]] | None = None,
+) -> tuple[str, str]:
     """Return (classification, reason) for one full Tasks API task object."""
     if task.get("dependencyBlocked"):
         return "DEPENDENCY_BLOCKED", "one or more task dependencies are incomplete"
@@ -116,10 +249,28 @@ def classify_task(task: dict[str, Any]) -> tuple[str, str]:
             return "ACTIONABLE", "tech design or explicit waiver is missing"
         if not has_approval and not has_waiver:
             return "WAITING_EXTERNAL", "tech design is waiting for approval"
-        if _has_prefix(texts, DELIVERY_TAGS):
-            return "WAITING_EXTERNAL", "implementer delivery posted; verify PR review and CI state"
         if "missing `[implementer-prs]`" in latest_progress.lower():
             return "ACTIONABLE", "progress checklist says implementer delivery is missing"
+        delivery_urls = _delivery_urls(texts)
+        if delivery_urls:
+            actionable_reasons: list[str] = []
+            waiting_reasons: list[str] = []
+            for url in delivery_urls:
+                pr = (delivery_prs or {}).get(url)
+                if pr is None:
+                    actionable_reasons.append(
+                        "implementer delivery is posted but live PR state is unavailable"
+                    )
+                    continue
+                classification, reason = _classify_delivery_pr(_task_agent(task), pr)
+                if classification == "WAITING_EXTERNAL":
+                    waiting_reasons.append(reason)
+                else:
+                    actionable_reasons.append(reason)
+            if actionable_reasons:
+                return "ACTIONABLE", actionable_reasons[0]
+            if waiting_reasons:
+                return "WAITING_EXTERNAL", waiting_reasons[0]
         return "ACTIONABLE", "implementation PR delivery has not been posted"
 
     if status == "acceptance":
@@ -135,10 +286,13 @@ def classify_task(task: dict[str, Any]) -> tuple[str, str]:
     return "WAITING_EXTERNAL", f"task state {status or 'unknown'} has no agent action rule"
 
 
-def build_queue(tasks: list[dict[str, Any]]) -> dict[str, Any]:
+def build_queue(
+    tasks: list[dict[str, Any]],
+    delivery_prs: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     items = []
     for task in tasks:
-        classification, reason = classify_task(task)
+        classification, reason = classify_task(task, delivery_prs)
         items.append(
             {
                 "id": task.get("id"),
@@ -184,42 +338,6 @@ def _gh_api(config_dir: str, token_env: str, endpoint: str) -> Any:
         env=env,
     )
     return json.loads(result.stdout)
-
-
-def _latest_reviews(reviews: list[dict[str, Any]]) -> dict[str, str]:
-    latest: dict[str, str] = {}
-    for review in sorted(reviews, key=lambda item: item.get("submitted_at") or ""):
-        login = str((review.get("user") or {}).get("login") or "").lower()
-        state = str(review.get("state") or "").upper()
-        if login and state not in {"COMMENTED", "PENDING"}:
-            latest[login] = state
-    return latest
-
-
-def _blocking_reviewers(agent: str, pr: dict[str, Any], latest: dict[str, str]) -> list[str]:
-    agent = agent.lower()
-    title = str(pr.get("title") or "").lower()
-    requested = {
-        str(item.get("login") or "").lower()
-        for item in pr.get("requested_reviewers") or []
-    }
-    if agent == "rowan":
-        return ["quinnstoffer"]
-    if agent == "ivy":
-        if "tom-approval" in title:
-            return ["stoff81"]
-        if "quinn-approval" in title:
-            return ["quinnstoffer"]
-        known = (requested | set(latest)) & {"quinnstoffer", "stoff81"}
-        return sorted(known)
-    own_login = GITHUB_IDENTITIES[agent][0]
-    non_self_requested = {login for login in requested if login != own_login}
-    if non_self_requested:
-        return sorted(non_self_requested)
-    # GitHub clears requested_reviewers after a review is submitted. Retain the
-    # non-self reviewer from latest review state so an approved Quinn-authored
-    # PR can become merge-eligible without ever accepting Quinn's own review.
-    return sorted(login for login in latest if login != own_login)
 
 
 def classify_github_prs(agent: str, prs: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
@@ -332,6 +450,41 @@ def fetch_github_prs(agent: str) -> list[dict[str, Any]]:
     return hydrated
 
 
+def fetch_linked_delivery_prs(
+    agent: str,
+    tasks: list[dict[str, Any]],
+    github_prs: list[dict[str, Any]] | None = None,
+) -> dict[str, dict[str, Any]]:
+    _, config_dir, token_env = GITHUB_IDENTITIES[agent.lower()]
+    prs_by_url = {
+        str(pr.get("html_url")): pr for pr in (github_prs or []) if pr.get("html_url")
+    }
+    linked_urls = {
+        url
+        for task in tasks
+        for url in _delivery_urls(_comment_texts(task))
+    }
+    for url in sorted(linked_urls):
+        if url in prs_by_url:
+            continue
+        pr_number = _pull_number_from_url(url)
+        if pr_number is None:
+            continue
+        detail = _gh_api(config_dir, token_env, f"repos/{REPO}/pulls/{pr_number}")
+        detail["reviews"] = _gh_api(
+            config_dir, token_env, f"repos/{REPO}/pulls/{pr_number}/reviews?per_page=100"
+        )
+        checks = _gh_api(
+            config_dir,
+            token_env,
+            f"repos/{REPO}/commits/{detail['head']['sha']}/check-runs?per_page=100",
+        )
+        detail["check_runs"] = checks.get("check_runs") or []
+        if detail.get("html_url"):
+            prs_by_url[str(detail["html_url"])] = detail
+    return prs_by_url
+
+
 def build_unified_queue(
     task_items: list[dict[str, Any]],
     tech_design_approvals: list[dict[str, Any]],
@@ -386,8 +539,12 @@ def build_work_queue(
     agent: str,
     github_prs: list[dict[str, Any]] | None = None,
     tech_design_approvals: list[dict[str, Any]] | None = None,
+    delivery_prs: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    task_queue = build_queue(tasks)
+    task_queue = build_queue(
+        tasks,
+        delivery_prs or {str(pr.get("html_url")): pr for pr in (github_prs or []) if pr.get("html_url")},
+    )
     approvals = tech_design_approvals or []
     github_queue = classify_github_prs(agent, github_prs or [])
     queue = build_unified_queue(task_queue["items"], approvals, github_queue)
@@ -424,16 +581,25 @@ def main() -> None:
         raise SystemExit(f"unsupported agent {args.assignee!r}; expected Rowan, Ivy, or Quinn")
     tasks = fetch_agent_tasks(args.assignee)
     approvals = fetch_pending_tech_design_approvals() if agent_key == "quinn" else []
+    github_prs = fetch_github_prs(args.assignee)
+    delivery_prs = fetch_linked_delivery_prs(args.assignee, tasks, github_prs)
     queue = build_work_queue(
         tasks,
         args.assignee,
-        fetch_github_prs(args.assignee),
+        github_prs,
         approvals,
+        delivery_prs,
     )
     if args.json:
         print(json.dumps(queue, indent=2))
     else:
-        print_human(build_queue(tasks), args.assignee)
+        print_human(
+            {
+                "actionableCount": queue["actionableTaskCount"],
+                "items": queue["tasks"],
+            },
+            args.assignee,
+        )
         print(f"Tech-design approvals: {len(queue['techDesignApprovals'])}")
         print(f"Review requests: {len(queue['reviewRequests'])}")
         print(f"Authored PRs with requested changes: {len(queue['authoredPrFeedback'])}")

--- a/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
@@ -17,6 +17,7 @@ def task(**overrides):
         "taskType": "code",
         "status": "doing",
         "priority": "high",
+        "assignee": "Rowan",
         "blocked": False,
         "dependencyBlocked": False,
         "comments": [],
@@ -49,6 +50,9 @@ def pull_request(**overrides):
             {"status": "completed", "conclusion": "skipped"},
         ],
         "mergeable": True,
+        "state": "open",
+        "draft": False,
+        "merged_at": None,
     }
     value.update(overrides)
     return value
@@ -68,9 +72,16 @@ class AgentTaskQueueTest(unittest.TestCase):
     def test_missing_implementer_prs_is_actionable_for_feature_and_code(self):
         for task_type in ("feature", "code"):
             with self.subTest(task_type=task_type):
-                classification, reason = agent_task_queue.classify_task(implementation_task(taskType=task_type))
+                classification, reason = agent_task_queue.classify_task(
+                    implementation_task(taskType=task_type)
+                )
                 self.assertEqual(classification, "ACTIONABLE")
                 self.assertIn("delivery", reason)
+
+    def test_doing_task_missing_delivery_is_actionable(self):
+        classification, reason = agent_task_queue.classify_task(implementation_task(taskType="feature"))
+        self.assertEqual(classification, "ACTIONABLE")
+        self.assertIn("delivery", reason)
 
     def test_progress_checklist_missing_implementer_prs_is_not_external_wait(self):
         classification, _ = agent_task_queue.classify_task(
@@ -87,19 +98,42 @@ class AgentTaskQueueTest(unittest.TestCase):
         )
         self.assertEqual(classification, "ACTIONABLE")
 
-    def test_posted_implementer_prs_is_external_wait_candidate(self):
+    def test_closed_unmerged_implementer_pr_is_actionable(self):
+        pr_url = "https://github.com/acme/repo/pull/1"
         classification, reason = agent_task_queue.classify_task(
             implementation_task(
+                taskType="feature",
                 comments=[
                     {"text": "[tech-design] https://example.test/design"},
                     {"text": "[tech-design-approved] true"},
-                    {"text": "[code-task-progress-checklist]\nMissing `[implementer-prs]` task comment."},
-                    {"text": "[implementer-prs] https://github.com/acme/repo/pull/1"},
-                ]
-            )
+                    {"text": f"[implementer-prs] {pr_url}"},
+                ],
+            ),
+            {pr_url: pull_request(html_url=pr_url, state="closed", merged_at=None)},
+        )
+        self.assertEqual(classification, "ACTIONABLE")
+        self.assertIn("closed without merge", reason)
+
+    def test_open_review_requested_implementer_pr_is_waiting_external(self):
+        pr_url = "https://github.com/acme/repo/pull/1"
+        classification, reason = agent_task_queue.classify_task(
+            implementation_task(
+                taskType="feature",
+                comments=[
+                    {"text": "[tech-design] https://example.test/design"},
+                    {"text": "[tech-design-approved] true"},
+                    {"text": f"[implementer-prs] {pr_url}"},
+                ],
+            ),
+            {
+                pr_url: pull_request(
+                    html_url=pr_url,
+                    requested_reviewers=[{"login": "quinnstoffer"}],
+                )
+            },
         )
         self.assertEqual(classification, "WAITING_EXTERNAL")
-        self.assertIn("verify PR", reason)
+        self.assertIn("waiting on review", reason)
 
     def test_ready_without_tech_design_is_actionable(self):
         classification, reason = agent_task_queue.classify_task(task(status="ready"))
@@ -240,6 +274,7 @@ class AgentTaskQueueTest(unittest.TestCase):
         )
 
     def test_unified_queue_keeps_non_actionable_tasks_below_actionable_work(self):
+        waiting_pr_url = "https://github.com/acme/repo/pull/99"
         queue = agent_task_queue.build_work_queue(
             [
                 implementation_task(
@@ -247,12 +282,19 @@ class AgentTaskQueueTest(unittest.TestCase):
                     comments=[
                         {"text": "[tech-design] https://example.test/design"},
                         {"text": "[tech-design-approved] true"},
-                        {"text": "[implementer-prs] https://example.test/pr"},
+                        {"text": f"[implementer-prs] {waiting_pr_url}"},
                     ],
                 ),
                 implementation_task(title="Action now"),
             ],
             "Rowan",
+            [
+                pull_request(
+                    number=99,
+                    html_url=waiting_pr_url,
+                    requested_reviewers=[{"login": "quinnstoffer"}],
+                )
+            ],
         )
         self.assertEqual("Action now", queue["topCandidate"]["title"])
         self.assertTrue(queue["queue"][0]["actionable"])

--- a/docs/systems/tasks.md
+++ b/docs/systems/tasks.md
@@ -1,7 +1,7 @@
 # Tasks
 
 **Type:** System reference (data plane + workflows)
-**Last updated:** 2026-07-26
+**Last updated:** 2026-08-04
 **Owner:** Rowan (engineering) · Quinn (workflow orchestration) · Tom (product)
 **Repos:** `Stoffer-Industries/sindustries`
 **App spec:** `apps/tasks/SPEC.md`
@@ -189,6 +189,7 @@ Agent tooling always targets **prodlike** (`4001`). The dev stack (`4000`) is fo
 - **Dependency appears blocked but `blocked` is false:** check `dependencyBlocked` — this is expected when an unfinished dependency exists. The two signals are independent.
 - **PATCH rejects a dependency update:** inspect error code for self-reference, archived dependency, missing task ID, invalid UUID, or direct circular dependency.
 - **Stale task comments mention an old PR:** read the latest task comments; lobster state may retain old `prUrls`. Current task comments and workstream fields are the source of truth.
+- **Rowan queue says a `doing` implementation task is waiting externally:** that should only happen when the latest `[implementer-prs]` delivery still points exclusively at live open PRs that are genuinely waiting on review or CI. Closed-unmerged delivery comments remain `ACTIONABLE` until Rowan opens a replacement PR.
 - **Malformed UUID on any path parameter:** `GET` / `PATCH` / `DELETE /tasks/:id` and `POST /tasks/:id/comments` now return `400 INVALID_TASK_ID` (PR #271). Pass full 36-char UUIDs; the 8-char lobster prefix is display-only.
 
 ---


### PR DESCRIPTION
## Summary
- Make unblocked `doing` tasks actionable by default instead of trusting stale delivery comments.
- Verify linked implementation PR state before classifying a task as externally waiting.
- Treat closed-unmerged, draft, conflicted, failing-CI, or unverifiable deliveries as actionable work for the implementer.
- Add regression coverage for the exact `1474d515` failure mode and document the queue rule.

## System Spec
`docs/systems/tasks.md`

## Test plan
- [x] Closed-unmerged implementation PR requires a replacement PR and remains actionable.
- [x] Open PR genuinely awaiting review/CI remains `WAITING_EXTERNAL`.
- [x] A `doing` task with no delivery remains actionable.
- [x] Explicit and dependency blocks retain precedence.
- [x] `python3 -m unittest agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py` — 26 tests passed.
- [x] `git diff --check` passed.

## Original ask
Tom identified that `doing` tasks `1474d515` and `f39a20a7` were skipped because the queue trusted stale `[implementer-prs]` state. This makes live task/PR state authoritative so that failure does not recur.
