### PR TITLE
feat(gymtrack): add MCP server with OAuth auth

### DIFF
--- a/apps/gymtrack/.env.example
+++ b/apps/gymtrack/.env.example
@@ -11,4 +11,5 @@
 
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key-here
+VITE_GYMTRACK_MCP_BASE_URL=http://localhost:8787
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here

--- a/apps/gymtrack/README.md
+++ b/apps/gymtrack/README.md
@@ -1,74 +1,79 @@
 # GymTrack
 
-A multi-tenant workout tracker SPA. iOS-Safari-friendly; logs workouts to Supabase with per-user RLS isolation. As of task `72d7cc3b`, anyone can self-sign-up at `/signup` via email + password or Google — no manual provisioning required. Apple is in `DISABLED_OAUTH_PROVIDERS` in `apps/gymtrack/src/lib/authFlow.js` because the current Supabase project does not have Apple configured; the button is not rendered until Quinn removes `'apple'` from that array (no other code change required).
+A multi-tenant workout tracker SPA backed by Supabase. Users can sign up with email/password or Google, log workouts, browse planned workouts, and now review/revoke connected MCP clients from the in-app **Agents** settings screen.
+
+GymTrack also exposes two agent surfaces:
+
+- **Legacy REST endpoints** under `/api/agent/*` for already-issued static bearer keys.
+- **A dedicated MCP OAuth server** in `services/gymtrack-mcp` for discoverable tool access via OAuth Code + PKCE.
 
 ## Stack
 
 - Vite + React 18 + React Router
 - Supabase (Auth + Postgres)
-- Vitest + React Testing Library (unit + component)
-- Playwright (e2e on iPhone 13 emulation)
+- Vitest + React Testing Library
+- Playwright (mobile emulation)
 
 ## Development
 
 ```bash
-# From the repo root, or with workspaces enabled:
 npm install
 npm --workspace gymtrack run dev
 # → http://localhost:5179
 ```
 
-You'll need `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in `.env` for the app to boot. See `.env.example`.
+Required app env vars (`apps/gymtrack/.env`):
+
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+- `VITE_GYMTRACK_MCP_BASE_URL` when the MCP service is on a different origin than the SPA
+
+See `.env.example`.
 
 ## Test
 
 ```bash
-npm --workspace gymtrack test        # unit + component (Vitest)
-npm --workspace gymtrack run test:e2e # Playwright (requires dev server + Supabase)
+npm --workspace gymtrack test
+npm --workspace gymtrack run test:e2e
+npm --workspace @sindustries/gymtrack-mcp test
 ```
 
 ## Build
 
 ```bash
 npm --workspace gymtrack run build
-npm --workspace gymtrack run preview  # serves the built bundle
+npm --workspace gymtrack run preview
 ```
-
-## Deploy
-
-The `vercel.json` at the repo root of this app configures Vercel:
-
-- Build command: `npm run build`
-- Output: `dist/`
-- SPA rewrite: `/(.*)` → `/index.html`
-
-Environment variables are set in the Vercel project (NOT in the repo):
-
-- `VITE_SUPABASE_URL`
-- `VITE_SUPABASE_ANON_KEY`
 
 ## Supabase
 
-See `supabase/README.md` for the migration apply + RLS smoke-test steps.
+See `supabase/README.md` for migration apply steps.
 
-The sign-up path's RLS coverage is asserted by `supabase/migrations/20260731190000_signup_rls_assertion.sql`, which raises an exception if any GymTrack public table is missing `enable row level security`. Apply that migration alongside the existing schema migrations.
+New schema for task `1474d515` lives in:
 
-## Sign up
+- `supabase/migrations/20260804070000_mcp_oauth.sql`
 
-Anyone visiting the deployed URL who is not already signed in is shown `/login` with a "Create an account" link below the email + password form. Clicking the link routes to `/signup`, which offers:
+That migration adds:
 
-- **Google** OAuth CTA as the primary path. Apple is listed in `DISABLED_OAUTH_PROVIDERS` in `apps/gymtrack/src/lib/authFlow.js` so the button is absent from the first paint until Quinn removes `'apple'` from that array — this is graceful degradation, not a 500.
-- A collapsed "Use email + password instead" panel as a fallback.
+- `gymtrack_oauth_clients`
+- `gymtrack_oauth_consents`
+- `gymtrack_oauth_authorization_codes`
+- `gymtrack_oauth_tokens`
 
-Email auto-confirm must be enabled on the Supabase project for the flow to land a new account straight on `/workout`; otherwise the user sees a "check your email" state. The dev/staging projects already have auto-confirm enabled; production must enable it before this flow is exposed.
+All user-owned tables are RLS-protected.
 
-The OAuth flow uses `redirectTo: ${origin}/workout`; Supabase's `detectSessionInUrl: true` (configured in `src/lib/supabase.js`) handles the post-callback session detection automatically.
+## Browser auth UX
 
-## Agent API
+- `/login` supports email/password and Google sign-in.
+- `/signup` supports Google sign-up plus a collapsed email/password fallback.
+- `/agent-consent` is the protected approval page used by external MCP clients.
+- `/settings/agents` lists active MCP connections and lets the user revoke them.
 
-Agents (external tools, LLM assistants) can plan and read workouts on a user's behalf via bearer-token-authenticated serverless endpoints under `/api/agent/`. Full contract, request/response shapes, and known gaps are documented in `SPEC.md` ("Agent API" section) — read that before integrating.
+Apple remains hidden until Quinn removes `'apple'` from `src/lib/authFlow.js` after the Supabase provider is wired.
 
-Quick reference:
+## Legacy REST agent API
+
+These routes still work unchanged for existing static bearer keys:
 
 ```bash
 curl -X POST https://<deployment>/api/agent/planned-workouts \
@@ -89,27 +94,30 @@ curl https://<deployment>/api/agent/exercises/Bench%20Press/progression?limit=20
   -H "Authorization: Bearer gym_sk_example..."
 ```
 
-**There is no self-service key-generation UI yet** — a user cannot currently obtain a bearer token without direct Supabase access. See `SPEC.md` Known gaps and follow-up tasks tracking an MCP server + OAuth/social-login flow for this.
+## MCP OAuth server
 
-Server-only env var required for these endpoints (do not expose to the browser bundle): `SUPABASE_SERVICE_ROLE_KEY`.
+See `services/gymtrack-mcp/README.md` for runtime details. At a high level it exposes:
+
+- `GET /.well-known/oauth-authorization-server`
+- `GET /.well-known/oauth-protected-resource`
+- `GET /oauth/authorize`
+- `POST /oauth/token`
+- `POST /oauth/revoke`
+- `POST /mcp`
+
+Available MCP tools:
+
+- `plan_workout`
+- `read_history`
+- `read_exercise_progression`
 
 ## Files of interest
 
-- `src/main.jsx` — entry; wires `<AuthProvider>` + `<BrowserRouter>`.
-- `src/App.jsx` — top-level routes.
-- `src/lib/supabase.js` — singleton Supabase client; fails fast if env vars are missing.
-- `src/lib/auth.jsx` — `useAuth()` hook (session, signIn, signOut, …).
-- `src/lib/workouts.js` — `createWorkout`, `addSets`, `listWorkouts`, `listSetsForWorkouts`, `deleteWorkout`.
-- `src/lib/plans.js` — `fetchPlannedWorkoutForDate`, `fetchPlannedWorkoutById`, `markPlannedWorkoutCompleted` — browser-side plan-mode helpers.
-- `src/components/WorkoutLogger.jsx` — log-workout screen (freeform + plan mode).
-- `src/components/HistoryList.jsx` — last-30-days history view.
-- `src/components/LoginScreen.jsx` — sign-in screen (email + password + "Create an account" link).
-- `src/components/SignUpPage.jsx` — public sign-up screen (OAuth CTAs + collapsed email/password panel). (Task `72d7cc3b`.)
-- `src/lib/authFlow.js` — `signInWithOAuthRedirect`, `providerDisabled` heuristic, `getPostOAuthSession`, `SUPPORTED_OAUTH_PROVIDERS`. (Task `72d7cc3b`.)
-- `test/e2e/signup.spec.ts` — Playwright e2e for `/signup` (AC1, AC2-email+pw, AC4, AC5 of task `72d7cc3b`).
-- `test/e2e/signup-google.spec.ts` — Playwright e2e for the OAuth redirect path; gated on `SUPABASE_TEST_URL`.
-- `server/agentAuth.js` — shared agent bearer-token auth + Supabase admin client (server-only, outside `api/` so it is never itself a public route).
-- `api/agent/planned-workouts.js`, `api/agent/history.js`, `api/agent/exercises/[exerciseName]/progression.js` — agent API route handlers.
-- `supabase/migrations/20260708120000_init_workouts.sql` — schema + RLS.
-- `supabase/migrations/20260723170000_agent_powered_workouts.sql` — agent API keys + planned workouts schema + RLS.
-- `supabase/migrations/20260731190000_signup_rls_assertion.sql` — defensive assertion that RLS is enabled on every GymTrack public table + documented isolation smoke-test. (Task `72d7cc3b`.)
+- `src/App.jsx` — routes, including `/agent-consent` and `/settings/agents`
+- `src/components/LoginScreen.jsx` — email/password + Google sign-in
+- `src/components/AgentConsentPage.jsx` — MCP approval screen
+- `src/components/ConnectedAgentsPage.jsx` — connected-agent management UI
+- `src/lib/connectedAgents.js` — consent listing/revocation + approval POST helper
+- `server/agentData.js` — shared query/validation logic for legacy REST + MCP
+- `api/agent/*` — legacy static-key handlers
+- `services/gymtrack-mcp/` — standalone MCP OAuth service

--- a/apps/gymtrack/SPEC.md
+++ b/apps/gymtrack/SPEC.md
@@ -1,73 +1,95 @@
 # GymTrack — Behavioural spec
 
-Task: `18256740` (Shape GymTrack MVP from saved prototype), `f520c396` (Agent-Powered Workouts), `72d7cc3b` (Public Sign-Up with Social Login).
-Tech design: `docs/specs/gymtrack-mvp-tech-design.md`, `docs/specs/gymtrack-agent-powered-workouts-tech-design.md`, `docs/specs/gymtrack-public-signup-social-login-tech-design.md`.
-Product spec: `brain/tasks/specs/gymtrack-mvp-2026-07-07.md`, `brain/tasks/specs/in-progress/gymtrack-agent-powered-workouts.md`, `brain/tasks/specs/in-progress/gymtrack-signup-social-login-2026-07-27.md`.
+Task: `18256740` (Shape GymTrack MVP from saved prototype), `f520c396` (Agent-Powered Workouts), `72d7cc3b` (Public Sign-Up with Social Login), `1474d515` (GymTrack MCP Server with OAuth Auth).
+Tech design: `docs/specs/gymtrack-mvp-tech-design.md`, `docs/specs/gymtrack-agent-powered-workouts-tech-design.md`, `docs/specs/gymtrack-public-signup-social-login-tech-design.md`, `docs/specs/gymtrack-mcp-server-oauth-auth-tech-design.md`.
+Product spec: `brain/tasks/specs/gymtrack-mvp-2026-07-07.md`, `brain/tasks/specs/in-progress/gymtrack-agent-powered-workouts.md`, `brain/tasks/specs/in-progress/gymtrack-signup-social-login-2026-07-27.md`, `brain/tasks/specs/in-progress/gymtrack-mcp-server-oauth-2026-07-27.md`.
 
 ## Overview
 
-GymTrack is a workout tracker SPA deployed at a stable URL, accessible from iOS Safari without an app install. Workouts are persisted in Supabase, scoped per-user via RLS. As of task `72d7cc3b`, any visitor can create their own account via a public sign-up page — GymTrack is now a real multi-tenant product, not a single-user app. The MVP replaced the localStorage-based prototype (`apps/gymtrack/` on `feat/gymtrack-prototype`) with a real auth + real database.
+GymTrack is a workout tracker SPA deployed at a stable URL, accessible from iOS Safari without an app install. Workouts are persisted in Supabase, scoped per-user via RLS. Any visitor can create their own account via a public sign-up page — GymTrack is a real multi-tenant product, not a single-user app.
 
-As of task `f520c396`, an authenticated agent can also submit a **planned workout** on a user's behalf via a server-side API. The app surfaces the plan (if one exists for the selected date) in place of freeform logging, lets the user log actuals against each planned set, and stores both target and actual values side by side. Agents can also read back recent history and per-exercise progression to inform the next plan.
+GymTrack now exposes **two agent surfaces**:
+
+1. **Legacy REST agent endpoints** under `/api/agent/*` for already-issued static bearer keys from task `f520c396`.
+2. **A discoverable MCP server** (`services/gymtrack-mcp`) that uses OAuth 2.1 Authorization Code + PKCE, issues hashed access/refresh tokens, and lets a user approve or revoke an external client without any manual database work.
+
+The user-facing app surfaces planned workouts (created via either agent surface), lets the user log actuals against planned sets, and now includes an **Agents** settings screen where the user can see and revoke connected MCP clients.
 
 ## Users
 
-- **Anyone (since `72d7cc3b`)** — can self-sign-up at `/signup` with email + password or Google. Apple is gated on the Supabase project having Apple configured — currently disabled, so the Apple button is not rendered. The sign-up flow lands them directly on `/workout` with an empty history state. RLS is configured to scope all data to `auth.uid() = user_id` so every account is isolated from every other account from the moment of creation; this is asserted by `apps/gymtrack/supabase/migrations/20260731190000_signup_rls_assertion.sql`.
-- **Tom** — the original seeded account; email + password sign-in at `/login`. Continues to work unchanged. Sign-up from the `/login` page is also available as a fallback if he ever needs to recreate his account.
-- **Agents** — authenticate to the agent-facing API via a bearer token (see [Agent API](#agent-api) below). An agent acts as the `user_id` its token was issued for; it cannot see or write other users' data. **As of this writing there is no self-service key-generation UI in the app** — every issued token today has been created by direct Supabase service-role insert, not through a flow a real external agent/user could complete unassisted. See Non-goals / Known gaps.
+- **Anyone** — can self-sign-up at `/signup` with email + password or Google. Apple is gated on the Supabase project having Apple configured — currently disabled, so the Apple button is not rendered.
+- **Existing GymTrack users** — can sign in at `/login` with email + password, or with Google when the flow originates from a protected route such as `/agent-consent`.
+- **Legacy REST agents** — authenticate via static bearer keys stored in `public.gymtrack_agent_api_keys`. These keys continue to work unchanged.
+- **MCP clients** — authenticate through the GymTrack MCP OAuth flow. The issued bearer token is scoped to one GymTrack user and one consent record; it can discover tools, plan workouts, read history, and read exercise progression, but only for that user.
 
 ## Flows
 
-### Sign up (task `72d7cc3b`)
+### Sign up
 
-1. An unauthenticated visitor can reach `/signup` either directly (e.g. via a shared link) or by tapping the "Create an account" link under the email/password form on `/login`.
-2. The page renders one OAuth CTA (`Continue with Google`) as the primary path. Apple is listed in `DISABLED_OAUTH_PROVIDERS` in `apps/gymtrack/src/lib/authFlow.js` so the Apple button is absent from the first paint (not just hidden after a click). The `providerDisabled` heuristic in the same file remains a safety net for providers that fail at click time despite not being in `DISABLED_OAUTH_PROVIDERS` (e.g. config drift between deploys) — the button is removed from the list after a failed click.
-3. A collapsed "Use email + password instead" panel reveals the email + password form when tapped.
-4. Submit → Supabase creates the user (auto-confirm enabled in the dev/staging projects so no email verification is required) and the visitor is redirected to `/workout` (or to the originally intended destination if they were redirected here from a protected route).
-5. The empty `/workout` state is the landing experience — no special "welcome" screen is needed.
-6. Errors render inline; the submit button re-enables for retry.
+1. An unauthenticated visitor can reach `/signup` directly or from the `/login` link.
+2. The page renders Google as the primary OAuth CTA. Apple stays hidden while it remains in `DISABLED_OAUTH_PROVIDERS`.
+3. A collapsed "Use email + password instead" panel reveals the fallback form.
+4. On success, Supabase creates the user and the visitor is redirected to `/workout` or to the originally intended protected destination.
+5. Errors render inline and the buttons re-enable for retry.
 
-### Sign in (AC5)
+### Sign in
 
-1. Open the URL → unauthenticated users land on `/login`.
-2. Enter email + password → submit.
-3. On success → redirect to `/workout` (or to the originally intended destination if redirected from a protected route).
-4. On error → inline error banner; submit button re-enabled.
+1. Open the app while signed out → land on `/login`.
+2. Sign in with email + password, or with Google when continuing into a protected route.
+3. On success → redirect to `/workout` or back to the protected destination that triggered the redirect.
+4. On error → inline error banner; controls re-enable.
 
-### Log a workout (AC1)
+### Authorize an external MCP client
+
+1. An external client starts OAuth against `GET /oauth/authorize` on the GymTrack MCP server.
+2. The MCP server validates `client_id`, `redirect_uri`, requested `scope`, and PKCE (`code_challenge`, `code_challenge_method=S256`), then redirects the browser into GymTrack at `/agent-consent?...`.
+3. If the user is not signed in, `<AuthGate>` redirects them to `/login`, preserving the full consent URL. The user can continue with Google or email/password and lands back on `/agent-consent`.
+4. `/agent-consent` shows the client name, redirect URI, and requested scopes.
+5. Approve → GymTrack POSTs the decision to the MCP server with the signed-in Supabase access token; the MCP server verifies the user session, creates/updates the consent row, stores a hashed authorization code, and returns the client redirect URL with `code` and `state`.
+6. Cancel → the user is redirected back with `error=access_denied`.
+7. The external client exchanges the code at `POST /oauth/token` with a PKCE verifier. GymTrack returns a short-lived bearer access token plus a rotated refresh token. Plaintext tokens are never stored in Supabase.
+
+### Manage connected agents
+
+1. From `/workouts`, tap the **Agents** tab to open `/settings/agents`.
+2. The page lists active MCP consents, newest first, showing client name, granted time, requested scopes, and last-used time when available.
+3. Tap **Revoke access** → the consent row is marked revoked immediately.
+4. Any future MCP tool call or refresh-token exchange for that consent fails because the server checks `consent.revoked_at` on every use.
+
+### Log a workout
 
 1. From `/workout`, the date defaults to today.
-2. Pick an exercise from the catalogue (~29 entries) or choose "Other" and type a custom name.
+2. Pick an exercise from the catalogue or choose "Other" and type a custom name.
 3. Enter reps and weight; select kg/lb.
 4. Tap "Add set" → the set appears under "In this workout", grouped by exercise.
 5. Repeat for additional sets/exercises. Remove a set via its Remove button.
-6. Tap "Save workout" (sticky at the bottom on mobile) → creates the workout + all sets in Supabase.
+6. Tap "Save workout" → creates the workout + all sets in Supabase.
 7. On success → success banner; pending list cleared.
 8. On error → error banner; pending list retained so the user can retry.
 
-### View history (AC2)
+### View history
 
 1. From `/history`, the last 30 days of workouts load.
-2. Workouts are grouped by date (newest first). Each workout shows its set count and the per-set breakdown (exercise, set index, reps × weight unit).
+2. Workouts are grouped by date (newest first). Each workout shows its set count and the per-set breakdown.
 3. Empty state: "No workouts in the last 30 days. Log one from the Log tab."
 
-### Browse planned workouts (WS1 — task `2306125e` AC1, AC2, AC5)
+### Browse planned workouts
 
-1. From `/workout` or `/history`, tap the "Workouts" tab in the screen nav → land on `/workouts`.
-2. The page fetches the signed-in user's pending planned workouts (status `planned` or `started`), ordered soonest-first by `scheduled_for` ascending.
-3. Each workout renders as a card with: title, scheduled date, exercise/set summary ("Bench Press · 5 sets"), and (when present) a "Today" or "Overdue" badge distinguishing workouts scheduled for today or earlier from those further out.
-4. Empty state: "No upcoming workouts. Connect an agent (coming soon) to have your training planned here." This replaces the WS2 "Connect to your agent" CTA banner, which ships in a separate PR once the OAuth flow from sibling task `1474d515` lands.
-5. Tap a workout card → land on `/workout?date=YYYY-MM-DD`; the log screen's date picker is pre-selected with the workout's date, and plan-mode is rendered (because a planned workout exists for that date) so the user can log actuals against the planned sets without manually picking the date.
-6. Error state: render an inline error banner with the Supabase error message; the user can retry by reloading.
+1. From `/workout` or `/history`, tap the "Workouts" tab → land on `/workouts`.
+2. The page fetches the signed-in user's pending planned workouts (`planned` or `started`), ordered soonest-first by `scheduled_for` ascending.
+3. Each workout renders as a card with title, scheduled date, exercise/set summary, and Today/Overdue badge when relevant.
+4. Empty state: "No upcoming workouts yet. Connect Claude or ChatGPT from their MCP client, then manage access in the Agents tab."
+5. Tap a workout card → land on `/workout?date=YYYY-MM-DD`; if a plan exists for that date, plan mode is rendered.
+6. Error state: inline error banner with retry by reload.
 
-### Log a workout against a plan (AC2, agent-powered)
+### Log a workout against a plan
 
-1. From `/workout`, if a planned workout exists for the selected date (`status` in `planned`/`started`), the screen renders **plan mode** instead of the freeform form.
-2. Plan mode shows the plan's title and optional notes, then one table per exercise. Each row shows the target (reps × weight + unit) and editable actual-reps/actual-weight/unit inputs, pre-filled with the target values.
-3. An "Add an extra (non-planned) set" form remains available below the plan for sets outside the plan.
-4. Tap "Save workout" → creates a `workouts` row linked to the plan (`planned_workout_id`) and one `workout_sets` row per planned set (linked via `planned_set_id`) using the actual values entered, plus any extra freeform sets. The plan is marked `completed`.
-5. On success → success banner; plan clears from the screen (a `completed` plan is not re-shown for that date).
-6. If no plan exists for the selected date, the screen falls back to freeform logging (see "Log a workout" above). **The date shown is whatever is in the date picker — it defaults to today, not the plan's `scheduled_for` date.** If an agent creates a plan for a future date, Tom must change the date picker to that date to see it; the plan does not surface early.
+1. From `/workout`, if a planned workout exists for the selected date (`planned`/`started`), the screen renders plan mode instead of the freeform form.
+2. Plan mode shows the plan title and optional notes, then one table per exercise. Each row shows target reps/weight and editable actual inputs pre-filled from the target values.
+3. An "Add an extra (non-planned) set" form remains available below the plan.
+4. Tap "Save workout" → creates a `workouts` row linked to the plan and one `workout_sets` row per planned set, plus any extra freeform sets. The plan is marked `completed`.
+5. On success → success banner; completed plans no longer re-render for that date.
+6. If no plan exists for the selected date, the screen falls back to freeform logging.
 
 ### Sign out
 
@@ -75,96 +97,103 @@ As of task `f520c396`, an authenticated agent can also submit a **planned workou
 
 ## Screens
 
-| Route       | Component         | Notes                                                       |
-|-------------|-------------------|-------------------------------------------------------------|
-| `/`         | redirect          | → `/workout` if signed in, else `/login`.                    |
-| `/login`    | `LoginScreen`     | Email + password form + "Create an account" link to `/signup`. |
-| `/signup`   | `SignUpPage`      | Public sign-up — OAuth CTAs (Google, Apple) + collapsed email/password panel. (Since `72d7cc3b`.) |
-| `/workout`  | `WorkoutLogger`   | Date picker + exercise picker + reps/weight + pending sets. Accepts `?date=YYYY-MM-DD` to pre-select the date (used by the Workouts tab tap-into-workout flow). |
-| `/history`  | `HistoryList`     | Last-30-days grouped by date.                               |
-| `/workouts` | `WorkoutsTab`     | Pending planned workouts (planned/started), soonest-first, with Today/Overdue badges. Tapping a card routes to `/workout?date=`. Auth-gated. |
-| `*`         | redirect          | → `/` (which then redirects based on session).              |
+| Route | Component | Notes |
+|---|---|---|
+| `/` | redirect | → `/workout` if signed in, else `/login`. |
+| `/login` | `LoginScreen` | Email/password form plus Google CTA when available; preserves protected-route destination. |
+| `/signup` | `SignUpPage` | Public sign-up — Google CTA + collapsed email/password panel. |
+| `/agent-consent` | `AgentConsentPage` | Protected consent review screen for external MCP clients. |
+| `/workout` | `WorkoutLogger` | Date picker + exercise picker + pending sets; accepts `?date=YYYY-MM-DD`. |
+| `/history` | `HistoryList` | Last-30-days grouped history. |
+| `/workouts` | `WorkoutsTab` | Pending planned workouts, soonest-first, with Today/Overdue badges and Agents tab link. |
+| `/settings/agents` | `ConnectedAgentsPage` | Lists and revokes active MCP consents. |
+| `*` | redirect | → `/`. |
 
-All protected routes (`/workout`, `/history`) are wrapped in `<AuthGate>` which:
-
-- Renders a loading placeholder while the initial session resolves.
-- Redirects to `/login` (preserving the intended destination) if no session.
+All protected routes (`/workout`, `/history`, `/workouts`, `/agent-consent`, `/settings/agents`) are wrapped in `<AuthGate>` which renders a loading placeholder while the session resolves and redirects to `/login` when no session exists.
 
 ## Persistence
 
-- `public.workouts` — one row per workout session. Columns: `id`, `user_id`, `performed_at`, `notes`, `created_at`, `updated_at`. RLS: `auth.uid() = user_id`.
-- `public.workout_sets` — one row per set. Columns: `id`, `workout_id`, `exercise_name`, `set_index`, `reps`, `weight`, `unit`. RLS: parent `workouts.user_id = auth.uid()`.
-- Indexes: `(user_id, performed_at desc)` on `workouts` for the 30-day query; `(workout_id, set_index)` on `workout_sets` for set ordering.
-- Cascade: deleting a workout deletes its sets (`on delete cascade`).
+- `public.workouts` — one row per workout session. RLS: `auth.uid() = user_id`.
+- `public.workout_sets` — one row per set. RLS via parent `workouts.user_id = auth.uid()`.
+- `public.gymtrack_agent_api_keys` — legacy static REST credentials; plaintext tokens never stored.
+- `public.planned_workouts` / `public.planned_workout_sets` — planned workout state shared by both legacy REST agents and MCP clients.
+- `public.gymtrack_oauth_clients` — static allowlist of supported MCP clients and their registered redirect URIs.
+- `public.gymtrack_oauth_consents` — one active consent per `user_id + client_id`; drives the Agents settings page.
+- `public.gymtrack_oauth_authorization_codes` — hashed authorization codes with PKCE challenge metadata.
+- `public.gymtrack_oauth_tokens` — hashed access/refresh tokens, refresh-token family ids, rotation metadata, and revocation timestamps.
 
 ## Auth
 
-- Supabase Auth. Three paths are supported: email + password sign-in (always), email + password sign-up at `/signup`, and OAuth (Google, Apple) at `/signup`. Magic-link auth is not used in v1.
-- Sign-up (`/signup`) is public — no invitation, no manual provisioning. Email auto-confirm is enabled in the dev/staging Supabase projects so a new account is immediately usable; production must enable the same setting before this flow is exposed there.
-- Session persisted in `localStorage` via Supabase's default storage adapter.
-- `autoRefreshToken: true` keeps the session alive across reloads.
-- `detectSessionInUrl: true` handles both email-link confirmation redirects (if a password-reset is ever added) and OAuth callback redirects.
-- Apple provider is not enabled on the current Supabase project (Tom punted on the Apple Developer account wiring); it is listed in `DISABLED_OAUTH_PROVIDERS` in `apps/gymtrack/src/lib/authFlow.js` so the Apple button is not rendered on `/signup`. When Apple is later enabled via `.openclaw`, Quinn removes `'apple'` from that array and the Apple button re-appears on `/signup` with no other code change required.
+- Supabase Auth remains the browser identity layer.
+- Email/password sign-in and sign-up continue to work.
+- Google OAuth is the minimum social-login path for both public sign-up and protected-route sign-in.
+- `detectSessionInUrl: true` handles Supabase OAuth callback parsing.
+- Apple remains disabled until Quinn removes `'apple'` from `DISABLED_OAUTH_PROVIDERS` after provider wiring exists in Supabase.
 
 ## Error handling
 
-- All `workouts.js` functions return `{ data, error }`; they never throw to the caller.
-- Component banners (`status.error`) render the error message inline; the user can retry.
-- The app fails fast at startup if `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` are missing (clear error pointing to `.env.example`).
+- Browser helpers return `{ data, error }` for Supabase queries and render inline banners on failure.
+- The app fails fast at startup if `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` are missing.
+- MCP OAuth endpoints return standard OAuth JSON errors (`invalid_request`, `invalid_grant`, etc.).
+- MCP JSON-RPC errors use standard JSON-RPC envelopes with GymTrack-specific messages.
 
-## Agent API
+## Agent surfaces
 
-Server-side (Vercel serverless) endpoints under `apps/gymtrack/api/agent/`, implemented in `apps/gymtrack/server/agentAuth.js` + per-route handlers. These are separate from the browser app's Supabase anon-key access — they use the Supabase **service-role key** server-side and authenticate the caller via a bearer token, not a Supabase session.
+### Legacy REST agent API
 
-### Auth
+Server-side endpoints under `apps/gymtrack/api/agent/`, implemented in `apps/gymtrack/server/agentAuth.js` plus per-route handlers.
 
-- Header: `Authorization: Bearer <token>`.
-- Server hashes the token with SHA-256 and looks up a non-revoked row in `public.gymtrack_agent_api_keys` (`token_hash`, `revoked_at is null`).
-- On success, the request acts as that row's `user_id`; `last_used_at` is updated best-effort.
-- On failure (missing/malformed header, no matching row, revoked): `401 { "error": "invalid_api_key" }`.
-- **Known gap:** there is no in-app flow for a user to generate their own key yet. Every key that exists today was inserted directly via the Supabase service-role key from outside the app (see Known gaps below).
+- `POST /api/agent/planned-workouts`
+- `GET /api/agent/history?limit=1..50`
+- `GET /api/agent/exercises/:exerciseName/progression?limit=1..200`
 
-### Endpoints
+These routes still authenticate with `Authorization: Bearer <legacy static key>` and still resolve the caller through `public.gymtrack_agent_api_keys`. This preserves existing integrations from task `f520c396` unchanged.
 
-- `POST /api/agent/planned-workouts` — create a planned workout (title, optional notes, `scheduledFor` date, list of exercises each with target sets). Validates bounds (max 25 exercises, max 20 sets/exercise, max 200 sets total; positive reps; non-negative weight; unit `kg`/`lb`). Returns `201 { plannedWorkoutId, setCount }`. Implementation: `apps/gymtrack/api/agent/planned-workouts.js`.
-- `GET /api/agent/history?limit=1..50` (default 10) — the caller's recent workouts with sets, including linked planned target (if any) per set. Implementation: `apps/gymtrack/api/agent/history.js`.
-- `GET /api/agent/exercises/:exerciseName/progression?limit=1..200` (default 20) — chronological set history for one exercise (case-insensitive exact match), with linked planned target per set. Implementation: `apps/gymtrack/api/agent/exercises/[exerciseName]/progression.js`.
+### MCP server
 
-All three return `400 invalid_request` on bad input, `401 invalid_api_key` on auth failure, `405 method_not_allowed` on wrong verb, `500 server_error` on unexpected failure.
+`services/gymtrack-mcp` exposes:
 
-### Discovery
+- `POST /mcp` — JSON-RPC endpoint supporting `initialize`, `tools/list`, and `tools/call`.
+- `GET /.well-known/oauth-authorization-server`
+- `GET /.well-known/oauth-protected-resource`
+- `GET /oauth/authorize`
+- `POST /oauth/token`
+- `POST /oauth/revoke`
 
-**There is no machine-readable API discovery surface (no OpenAPI spec, no MCP server, no `/api/agent` index route).** An agent needs this SPEC.md section or direct source access to know the contract exists. This is a known gap — see Known gaps below.
+Available tools:
 
-## E2E coverage
+- `plan_workout`
+- `read_history`
+- `read_exercise_progression`
 
-| Flow                | Spec file                              |
-|---------------------|----------------------------------------|
-| Sign in → land on `/workout` | `test/e2e/log-workout.spec.ts`  |
-| Add 2 sets → save → see in history | `test/e2e/log-workout.spec.ts` |
-| Sign up at `/signup` with email + password → land on `/workout` | `test/e2e/signup.spec.ts` (task `72d7cc3b`) |
-| `/login` "Create an account" link navigates to `/signup` | `test/e2e/signup.spec.ts` (task `72d7cc3b`) |
-| OAuth (Google) redirect from `/signup` | `test/e2e/signup-google.spec.ts` (task `72d7cc3b`, gated on `SUPABASE_TEST_URL`) |
-| Browse planned workouts (list, badges, tap-to-log) | `test/e2e/workouts-tab.spec.ts` |
+The MCP server always derives the acting `user_id` from the validated OAuth access token. Tool arguments never supply or override the owner id, so an MCP client authorized for one user cannot read or write another user's data.
 
-Playwright runs against the Vite dev server on port 5179 with `iPhone 13` device emulation.
+## Coverage and tests
 
-**Agent API and plan-mode flows have unit/component coverage (`src/lib/plannedWorkoutsHandler.test.js`, `src/lib/historyHandler.test.js`, `src/lib/progressionHandler.test.js`, `src/lib/agentAuth.test.js`, `src/lib/plannedWorkouts.test.js`) but no Playwright e2e coverage yet.** Add e2e coverage for: agent creates a plan → plan renders in plan mode → actuals saved → history/progression reflect it.
+| Behaviour | Coverage |
+|---|---|
+| Email/password login + sign-up | Existing GymTrack unit/component tests + `test/e2e/signup.spec.ts` |
+| Google social login wiring | `test/e2e/signup-google.spec.ts` |
+| Planned workouts browse flow | `test/e2e/workouts-tab.spec.ts` + `src/components/WorkoutsTab.test.jsx` |
+| Connected agents list + revoke UI | `src/components/ConnectedAgentsPage.test.jsx` |
+| Legacy REST handlers | `src/lib/agentAuth.test.js`, `src/lib/plannedWorkoutsHandler.test.js`, `src/lib/historyHandler.test.js`, `src/lib/progressionHandler.test.js` |
+| MCP OAuth flow, PKCE exchange, refresh rotation, tool discovery | `services/gymtrack-mcp/test/app.test.js` |
 
-**Sign-up isolation (AC3 of task `72d7cc3b`) is asserted at the SQL boundary by `apps/gymtrack/supabase/migrations/20260731190000_signup_rls_assertion.sql`, not by a Playwright spec.** The assertion raises an exception if any GymTrack public table is missing `enable row level security`; the documented smoke-test query (manual or in CI) proves that a user cannot read another user's rows.
+Playwright still runs against the Vite dev server on port 5179 with `iPhone 13` device emulation. There is still no end-to-end Playwright spec that drives a real external MCP client through OAuth against a live Supabase project; the current branch covers that surface with service integration tests instead.
 
 ## Out of scope (v1)
 
-- HealthKit / Apple Health sync (deferred to follow-up; see spike `a1c8f88e`).
+- HealthKit / Apple Health sync.
 - Offline queue / sync.
 - Magic-link auth.
 - Push notifications.
 - Rest timer.
 - Exercise categories / favourites.
 - Volume / PR analytics.
-- Export / CSV / Apple Health import.
+- Automatic dynamic client registration for arbitrary MCP clients.
 
 ## Non-goals
 
-- Multi-user: only Tom's account exists in production. RLS is the safety net.
-- Cross-app coordination with Mission Control — GymTrack is a standalone deploy; a future "Open GymTrack" link from Mission Control is a separate task.
+- Building GymTrack-owned planning intelligence.
+- Shipping every OAuth provider on day one; Google is the minimum supported social-login path.
+- Replacing or breaking the existing `/api/agent/*` integrations.

--- a/apps/gymtrack/api/agent/exercises/[exerciseName]/progression.js
+++ b/apps/gymtrack/api/agent/exercises/[exerciseName]/progression.js
@@ -37,86 +37,30 @@ import {
   resolveAgentIdentity,
   unauthorized
 } from '../../../../server/agentAuth.js';
+import {
+  escapeIlikePattern,
+  exerciseNameErrorMessage,
+  EXERCISE_NAME_MAX_LENGTH,
+  fetchExerciseProgression,
+  formatProgressionResponse,
+  normalizeExerciseName,
+  parseProgressionLimit as parseLimit,
+  PROGRESSION_DEFAULT_LIMIT as DEFAULT_LIMIT,
+  PROGRESSION_MAX_LIMIT as MAX_LIMIT,
+  PROGRESSION_MIN_LIMIT as MIN_LIMIT
+} from '../../../../server/agentData.js';
 
-export const DEFAULT_LIMIT = 20;
-export const MIN_LIMIT = 1;
-export const MAX_LIMIT = 200;
-export const EXERCISE_NAME_MAX_LENGTH = 120;
-
-/**
- * Escape the few characters that have special meaning in a PostgREST `ilike`
- * pattern so the input name is matched literally (no wildcards, no escaping
- * surprises). The default escape character in Postgres is `\`.
- */
-export function escapeIlikePattern(s) {
-  return String(s).replace(/[\\%_]/g, '\\$&');
-}
-
-/**
- * Validate and normalize the exercise name from the dynamic route. Returns the
- * normalized name (trimmed) on success or `null` on error. The caller checks
- * `null` to distinguish error from the success string (which would otherwise be
- * indistinguishable when the name itself is a string).
- */
-export function normalizeExerciseName(raw) {
-  if (typeof raw !== 'string') return null;
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) return null;
-  if (trimmed.length > EXERCISE_NAME_MAX_LENGTH) return null;
-  return trimmed;
-}
-
-/**
- * Explain why `normalizeExerciseName` rejected a value. Separate from the
- * normalizer so the success path stays a clean string.
- */
-export function exerciseNameErrorMessage(raw) {
-  if (typeof raw !== 'string') return 'exerciseName must be a string.';
-  if (raw.trim().length === 0) return 'exerciseName must be a non-empty string.';
-  if (raw.trim().length > EXERCISE_NAME_MAX_LENGTH) {
-    return `exerciseName must be at most ${EXERCISE_NAME_MAX_LENGTH} characters.`;
-  }
-  return null;
-}
-
-/**
- * Parse and validate the `limit` query param. Returns the parsed integer or an
- * error string.
- */
-export function parseLimit(rawLimit) {
-  if (rawLimit == null || rawLimit === '') return DEFAULT_LIMIT;
-  if (typeof rawLimit === 'object') return `limit must be a string, not an object.`;
-  const n = Number(rawLimit);
-  if (!Number.isInteger(n) || n < MIN_LIMIT || n > MAX_LIMIT) {
-    return `limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}.`;
-  }
-  return n;
-}
-
-/**
- * Format the rows returned by the exercise-progression query into the agent API
- * response shape.
- */
-export function formatProgressionResponse(exerciseName, rows) {
-  return {
-    exerciseName,
-    sets: (rows ?? []).map((s) => {
-      // Vercel's dynamic-route param ends up on req.query; Supabase embeds the
-      // joined workout under the `workouts` key. We tolerate both shapes.
-      const workout = s.workouts ?? {};
-      return {
-        performedAt: workout.performed_at ?? null,
-        workoutId: workout.id ?? null,
-        setIndex: s.set_index,
-        reps: s.reps,
-        weight: s.weight,
-        unit: s.unit,
-        plannedReps: s.planned_workout_sets?.target_reps ?? null,
-        plannedWeight: s.planned_workout_sets?.target_weight ?? null
-      };
-    })
-  };
-}
+export {
+  DEFAULT_LIMIT,
+  EXERCISE_NAME_MAX_LENGTH,
+  MAX_LIMIT,
+  MIN_LIMIT,
+  escapeIlikePattern,
+  exerciseNameErrorMessage,
+  formatProgressionResponse,
+  normalizeExerciseName,
+  parseLimit
+};
 
 export default async function handler(req, res) {
   if (rejectIfWrongMethod(req, res, ['GET'])) return;
@@ -138,28 +82,16 @@ export default async function handler(req, res) {
   const limit = parseLimit(req.query?.limit);
   if (typeof limit === 'string') return badRequest(res, limit);
 
-  const pattern = escapeIlikePattern(exerciseName);
-
   const client = adminClient();
-  const { data, error } = await client
-    .from('workout_sets')
-    .select(`
-      set_index,
-      reps,
-      weight,
-      unit,
-      planned_set_id,
-      planned_workout_sets(target_reps, target_weight),
-      workouts!inner(id, performed_at, user_id)
-    `)
-    .eq('workouts.user_id', identity.user_id)
-    .ilike('exercise_name', pattern)
-    .order('performed_at', { ascending: false, foreignTable: 'workouts' })
-    .limit(limit);
 
-  if (error) {
-    return res.status(500).json({ error: 'server_error', message: error.message });
+  try {
+    const result = await fetchExerciseProgression(client, {
+      userId: identity.user_id,
+      exerciseName,
+      limit
+    });
+    return res.status(200).json(result);
+  } catch (err) {
+    return res.status(500).json({ error: 'server_error', message: err?.message ?? 'Progression lookup failed.' });
   }
-
-  return res.status(200).json(formatProgressionResponse(exerciseName, data ?? []));
 }

--- a/apps/gymtrack/api/agent/history.js
+++ b/apps/gymtrack/api/agent/history.js
@@ -45,50 +45,16 @@ import {
   resolveAgentIdentity,
   unauthorized
 } from '../../server/agentAuth.js';
+import {
+  fetchWorkoutHistory,
+  formatHistoryResponse,
+  HISTORY_DEFAULT_LIMIT as DEFAULT_LIMIT,
+  HISTORY_MAX_LIMIT as MAX_LIMIT,
+  HISTORY_MIN_LIMIT as MIN_LIMIT,
+  parseHistoryLimit as parseLimit
+} from '../../server/agentData.js';
 
-export const DEFAULT_LIMIT = 10;
-export const MIN_LIMIT = 1;
-export const MAX_LIMIT = 50;
-
-/**
- * Parse and validate the `limit` query param. Returns the parsed integer, or a
- * human-readable error string describing the first violation.
- */
-export function parseLimit(rawLimit) {
-  if (rawLimit == null || rawLimit === '') return DEFAULT_LIMIT;
-  if (typeof rawLimit === 'object') return `limit must be a string, not an object.`;
-  const n = Number(rawLimit);
-  if (!Number.isInteger(n) || n < MIN_LIMIT || n > MAX_LIMIT) {
-    return `limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}.`;
-  }
-  return n;
-}
-
-/**
- * Format a database workout row + nested sets into the agent API response shape.
- * Exported so tests can verify the mapping without re-implementing it.
- */
-export function formatHistoryResponse(workouts) {
-  return {
-    workouts: (workouts ?? []).map((w) => ({
-      id: w.id,
-      performedAt: w.performed_at,
-      notes: w.notes ?? null,
-      plannedWorkoutId: w.planned_workout_id ?? null,
-      sets: (w.workout_sets ?? []).map((s) => ({
-        id: s.id,
-        exerciseName: s.exercise_name,
-        setIndex: s.set_index,
-        reps: s.reps,
-        weight: s.weight,
-        unit: s.unit,
-        plannedSetId: s.planned_set_id ?? null,
-        plannedReps: s.planned_workout_sets?.target_reps ?? null,
-        plannedWeight: s.planned_workout_sets?.target_weight ?? null
-      }))
-    }))
-  };
-}
+export { DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT, formatHistoryResponse, parseLimit };
 
 export default async function handler(req, res) {
   if (rejectIfWrongMethod(req, res, ['GET'])) return;
@@ -105,31 +71,14 @@ export default async function handler(req, res) {
   if (typeof limit === 'string') return badRequest(res, limit);
 
   const client = adminClient();
-  const { data, error } = await client
-    .from('workouts')
-    .select(`
-      id,
-      performed_at,
-      notes,
-      planned_workout_id,
-      workout_sets(
-        id,
-        exercise_name,
-        set_index,
-        reps,
-        weight,
-        unit,
-        planned_set_id,
-        planned_workout_sets(target_reps, target_weight)
-      )
-    `)
-    .eq('user_id', identity.user_id)
-    .order('performed_at', { ascending: false })
-    .limit(limit);
 
-  if (error) {
-    return res.status(500).json({ error: 'server_error', message: error.message });
+  try {
+    const result = await fetchWorkoutHistory(client, {
+      userId: identity.user_id,
+      limit
+    });
+    return res.status(200).json(result);
+  } catch (err) {
+    return res.status(500).json({ error: 'server_error', message: err?.message ?? 'History lookup failed.' });
   }
-
-  return res.status(200).json(formatHistoryResponse(data ?? []));
 }

--- a/apps/gymtrack/api/agent/planned-workouts.js
+++ b/apps/gymtrack/api/agent/planned-workouts.js
@@ -35,115 +35,13 @@ import {
   resolveAgentIdentity,
   unauthorized
 } from '../../server/agentAuth.js';
+import {
+  buildInsertRows,
+  createPlannedWorkout,
+  validatePlannedWorkoutBody
+} from '../../server/agentData.js';
 
-const MAX_EXERCISES_PER_PLAN = 25;
-const MAX_SETS_PER_EXERCISE = 20;
-const MAX_TOTAL_SETS = 200;
-
-function isPositiveInt(n) {
-  return Number.isInteger(n) && n > 0;
-}
-
-function isNonNegativeNumber(n) {
-  return typeof n === 'number' && Number.isFinite(n) && n >= 0;
-}
-
-/**
- * Validate the POST body shape and bounds. Returns null on success or a
- * human-readable error message describing the first violation found.
- */
-export function validatePlannedWorkoutBody(body) {
-  if (!body || typeof body !== 'object' || Array.isArray(body)) {
-    return 'Body must be a JSON object.';
-  }
-  const { scheduledFor, title, notes, exercises } = body;
-
-  if (typeof scheduledFor !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(scheduledFor)) {
-    return 'scheduledFor must be a YYYY-MM-DD date string.';
-  }
-  if (typeof title !== 'string' || title.trim().length === 0) {
-    return 'title must be a non-empty string.';
-  }
-  if (notes != null && typeof notes !== 'string') {
-    return 'notes must be a string when provided.';
-  }
-  if (!Array.isArray(exercises) || exercises.length === 0) {
-    return 'exercises must be a non-empty array.';
-  }
-  if (exercises.length > MAX_EXERCISES_PER_PLAN) {
-    return `exercises must have at most ${MAX_EXERCISES_PER_PLAN} entries.`;
-  }
-
-  let totalSets = 0;
-  for (let ei = 0; ei < exercises.length; ei += 1) {
-    const exercise = exercises[ei];
-    if (!exercise || typeof exercise !== 'object' || Array.isArray(exercise)) {
-      return `exercises[${ei}] must be an object.`;
-    }
-    if (typeof exercise.name !== 'string' || exercise.name.trim().length === 0) {
-      return `exercises[${ei}].name must be a non-empty string.`;
-    }
-    if (!Array.isArray(exercise.sets) || exercise.sets.length === 0) {
-      return `exercises[${ei}].sets must be a non-empty array.`;
-    }
-    if (exercise.sets.length > MAX_SETS_PER_EXERCISE) {
-      return `exercises[${ei}].sets must have at most ${MAX_SETS_PER_EXERCISE} entries.`;
-    }
-    totalSets += exercise.sets.length;
-    if (totalSets > MAX_TOTAL_SETS) {
-      return `Total set count across all exercises must not exceed ${MAX_TOTAL_SETS}.`;
-    }
-    for (let si = 0; si < exercise.sets.length; si += 1) {
-      const set = exercise.sets[si];
-      if (!set || typeof set !== 'object' || Array.isArray(set)) {
-        return `exercises[${ei}].sets[${si}] must be an object.`;
-      }
-      if (!isPositiveInt(set.reps)) {
-        return `exercises[${ei}].sets[${si}].reps must be a positive integer.`;
-      }
-      if (!isNonNegativeNumber(set.weight)) {
-        return `exercises[${ei}].sets[${si}].weight must be a non-negative number.`;
-      }
-      const unit = set.unit ?? 'kg';
-      if (unit !== 'kg' && unit !== 'lb') {
-        return `exercises[${ei}].sets[${si}].unit must be 'kg' or 'lb'.`;
-      }
-      if (set.notes != null && typeof set.notes !== 'string') {
-        return `exercises[${ei}].sets[${si}].notes must be a string when provided.`;
-      }
-    }
-  }
-  return null;
-}
-
-/**
- * Flatten the validated body into row arrays for parent + child inserts.
- */
-export function buildInsertRows({ userId, keyId, body }) {
-  const setRows = [];
-  body.exercises.forEach((exercise) => {
-    exercise.sets.forEach((set, idx) => {
-      setRows.push({
-        planned_workout_id: undefined, // filled in after parent insert
-        exercise_name: exercise.name.trim(),
-        set_index: idx + 1,
-        target_reps: set.reps,
-        target_weight: set.weight,
-        unit: set.unit ?? 'kg',
-        notes: set.notes?.trim() || null
-      });
-    });
-  });
-  const parentRow = {
-    user_id: userId,
-    agent_key_id: keyId,
-    scheduled_for: body.scheduledFor,
-    title: body.title.trim(),
-    notes: body.notes?.trim() || null,
-    status: 'planned'
-  };
-  return { parentRow, setRows };
-}
+export { buildInsertRows, validatePlannedWorkoutBody };
 
 export default async function handler(req, res) {
   if (rejectIfWrongMethod(req, res, ['POST'])) return;
@@ -166,40 +64,17 @@ export default async function handler(req, res) {
   if (validationError) return badRequest(res, validationError);
 
   const client = adminClient();
-  const { parentRow, setRows } = buildInsertRows({
-    userId: identity.user_id,
-    keyId: identity.key_id,
-    body
-  });
 
-  const { data: parent, error: parentErr } = await client
-    .from('planned_workouts')
-    .insert(parentRow)
-    .select()
-    .single();
-
-  if (parentErr || !parent) {
-    return res
-      .status(500)
-      .json({ error: 'server_error', message: parentErr?.message ?? 'Insert failed.' });
+  try {
+    const result = await createPlannedWorkout(client, {
+      userId: identity.user_id,
+      legacyAgentKeyId: identity.key_id,
+      body
+    });
+    return res.status(201).json(result);
+  } catch (err) {
+    return res.status(500).json({ error: 'server_error', message: err?.message ?? 'Insert failed.' });
   }
-
-  if (setRows.length > 0) {
-    const rowsWithFk = setRows.map((row) => ({ ...row, planned_workout_id: parent.id }));
-    const { error: setsErr } = await client.from('planned_workout_sets').insert(rowsWithFk);
-    if (setsErr) {
-      // Roll back the parent so we never leave a plan with zero target sets.
-      await client.from('planned_workouts').delete().eq('id', parent.id);
-      return res
-        .status(500)
-        .json({ error: 'server_error', message: setsErr.message });
-    }
-  }
-
-  return res.status(201).json({
-    plannedWorkoutId: parent.id,
-    setCount: setRows.length
-  });
 }
 
 function safeJsonParse(s) {

--- a/apps/gymtrack/api/connected-agents/revoke.js
+++ b/apps/gymtrack/api/connected-agents/revoke.js
@@ -1,0 +1,70 @@
+import { adminClient, parseBearerToken, rejectIfWrongMethod } from '../../server/agentAuth.js';
+
+export default async function handler(req, res) {
+  if (rejectIfWrongMethod(req, res, ['POST'])) return;
+
+  const accessToken = parseBearerToken(req);
+  if (!accessToken) {
+    return res.status(401).json({ error: 'invalid_session', message: 'Missing user session.' });
+  }
+
+  const body = typeof req.body === 'string' ? safeJsonParse(req.body) : req.body;
+  const consentId = body?.consentId;
+  if (!consentId) {
+    return res.status(400).json({ error: 'invalid_request', message: 'consentId is required.' });
+  }
+
+  const client = adminClient();
+  const { data: authData, error: authError } = await client.auth.getUser(accessToken);
+  if (authError || !authData?.user) {
+    return res.status(401).json({ error: 'invalid_session', message: 'User session is not valid.' });
+  }
+
+  const { data: consent, error: consentError } = await client
+    .from('gymtrack_oauth_consents')
+    .select('id, user_id')
+    .eq('id', consentId)
+    .maybeSingle();
+
+  if (consentError) {
+    return res.status(500).json({ error: 'server_error', message: consentError.message });
+  }
+
+  if (!consent || consent.user_id !== authData.user.id) {
+    return res.status(404).json({ error: 'not_found', message: 'Connected agent not found.' });
+  }
+
+  const revokedAt = new Date().toISOString();
+  const [consentResult, tokenResult, codeResult] = await Promise.all([
+    client
+      .from('gymtrack_oauth_consents')
+      .update({ revoked_at: revokedAt })
+      .eq('id', consentId)
+      .is('revoked_at', null),
+    client
+      .from('gymtrack_oauth_tokens')
+      .update({ revoked_at: revokedAt, revocation_reason: 'user_revoked' })
+      .eq('consent_id', consentId)
+      .is('revoked_at', null),
+    client
+      .from('gymtrack_oauth_authorization_codes')
+      .update({ revoked_at: revokedAt })
+      .eq('consent_id', consentId)
+      .is('revoked_at', null)
+  ]);
+
+  const failed = consentResult.error ?? tokenResult.error ?? codeResult.error;
+  if (failed) {
+    return res.status(500).json({ error: 'server_error', message: failed.message });
+  }
+
+  return res.status(200).json({ ok: true });
+}
+
+function safeJsonParse(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}

--- a/apps/gymtrack/server/agentData.js
+++ b/apps/gymtrack/server/agentData.js
@@ -1,0 +1,272 @@
+export const MAX_EXERCISES_PER_PLAN = 25;
+export const MAX_SETS_PER_EXERCISE = 20;
+export const MAX_TOTAL_SETS = 200;
+
+export const HISTORY_DEFAULT_LIMIT = 10;
+export const HISTORY_MIN_LIMIT = 1;
+export const HISTORY_MAX_LIMIT = 50;
+
+export const PROGRESSION_DEFAULT_LIMIT = 20;
+export const PROGRESSION_MIN_LIMIT = 1;
+export const PROGRESSION_MAX_LIMIT = 200;
+export const EXERCISE_NAME_MAX_LENGTH = 120;
+
+function isPositiveInt(n) {
+  return Number.isInteger(n) && n > 0;
+}
+
+function isNonNegativeNumber(n) {
+  return typeof n === 'number' && Number.isFinite(n) && n >= 0;
+}
+
+export function validatePlannedWorkoutBody(body) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return 'Body must be a JSON object.';
+  }
+  const { scheduledFor, title, notes, exercises } = body;
+
+  if (typeof scheduledFor !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(scheduledFor)) {
+    return 'scheduledFor must be a YYYY-MM-DD date string.';
+  }
+  if (typeof title !== 'string' || title.trim().length === 0) {
+    return 'title must be a non-empty string.';
+  }
+  if (notes != null && typeof notes !== 'string') {
+    return 'notes must be a string when provided.';
+  }
+  if (!Array.isArray(exercises) || exercises.length === 0) {
+    return 'exercises must be a non-empty array.';
+  }
+  if (exercises.length > MAX_EXERCISES_PER_PLAN) {
+    return `exercises must have at most ${MAX_EXERCISES_PER_PLAN} entries.`;
+  }
+
+  let totalSets = 0;
+  for (let ei = 0; ei < exercises.length; ei += 1) {
+    const exercise = exercises[ei];
+    if (!exercise || typeof exercise !== 'object' || Array.isArray(exercise)) {
+      return `exercises[${ei}] must be an object.`;
+    }
+    if (typeof exercise.name !== 'string' || exercise.name.trim().length === 0) {
+      return `exercises[${ei}].name must be a non-empty string.`;
+    }
+    if (!Array.isArray(exercise.sets) || exercise.sets.length === 0) {
+      return `exercises[${ei}].sets must be a non-empty array.`;
+    }
+    if (exercise.sets.length > MAX_SETS_PER_EXERCISE) {
+      return `exercises[${ei}].sets must have at most ${MAX_SETS_PER_EXERCISE} entries.`;
+    }
+    totalSets += exercise.sets.length;
+    if (totalSets > MAX_TOTAL_SETS) {
+      return `Total set count across all exercises must not exceed ${MAX_TOTAL_SETS}.`;
+    }
+    for (let si = 0; si < exercise.sets.length; si += 1) {
+      const set = exercise.sets[si];
+      if (!set || typeof set !== 'object' || Array.isArray(set)) {
+        return `exercises[${ei}].sets[${si}] must be an object.`;
+      }
+      if (!isPositiveInt(set.reps)) {
+        return `exercises[${ei}].sets[${si}].reps must be a positive integer.`;
+      }
+      if (!isNonNegativeNumber(set.weight)) {
+        return `exercises[${ei}].sets[${si}].weight must be a non-negative number.`;
+      }
+      const unit = set.unit ?? 'kg';
+      if (unit !== 'kg' && unit !== 'lb') {
+        return `exercises[${ei}].sets[${si}].unit must be 'kg' or 'lb'.`;
+      }
+      if (set.notes != null && typeof set.notes !== 'string') {
+        return `exercises[${ei}].sets[${si}].notes must be a string when provided.`;
+      }
+    }
+  }
+  return null;
+}
+
+export function buildInsertRows({ userId, legacyAgentKeyId = null, keyId = null, body }) {
+  const setRows = [];
+  body.exercises.forEach((exercise) => {
+    exercise.sets.forEach((set, idx) => {
+      setRows.push({
+        planned_workout_id: undefined,
+        exercise_name: exercise.name.trim(),
+        set_index: idx + 1,
+        target_reps: set.reps,
+        target_weight: set.weight,
+        unit: set.unit ?? 'kg',
+        notes: set.notes?.trim() || null
+      });
+    });
+  });
+
+  return {
+    parentRow: {
+      user_id: userId,
+      agent_key_id: legacyAgentKeyId ?? keyId,
+      scheduled_for: body.scheduledFor,
+      title: body.title.trim(),
+      notes: body.notes?.trim() || null,
+      status: 'planned'
+    },
+    setRows
+  };
+}
+
+export async function createPlannedWorkout(client, { userId, legacyAgentKeyId = null, keyId = null, body }) {
+  const { parentRow, setRows } = buildInsertRows({ userId, legacyAgentKeyId, keyId, body });
+
+  const { data: parent, error: parentErr } = await client
+    .from('planned_workouts')
+    .insert(parentRow)
+    .select()
+    .single();
+
+  if (parentErr || !parent) {
+    throw new Error(parentErr?.message ?? 'Insert failed.');
+  }
+
+  if (setRows.length > 0) {
+    const rowsWithFk = setRows.map((row) => ({ ...row, planned_workout_id: parent.id }));
+    const { error: setsErr } = await client.from('planned_workout_sets').insert(rowsWithFk);
+    if (setsErr) {
+      await client.from('planned_workouts').delete().eq('id', parent.id);
+      throw new Error(setsErr.message);
+    }
+  }
+
+  return {
+    plannedWorkoutId: parent.id,
+    setCount: setRows.length
+  };
+}
+
+export function parseHistoryLimit(rawLimit) {
+  if (rawLimit == null || rawLimit === '') return HISTORY_DEFAULT_LIMIT;
+  if (typeof rawLimit === 'object') return `limit must be a string, not an object.`;
+  const n = Number(rawLimit);
+  if (!Number.isInteger(n) || n < HISTORY_MIN_LIMIT || n > HISTORY_MAX_LIMIT) {
+    return `limit must be an integer between ${HISTORY_MIN_LIMIT} and ${HISTORY_MAX_LIMIT}.`;
+  }
+  return n;
+}
+
+export function formatHistoryResponse(workouts) {
+  return {
+    workouts: (workouts ?? []).map((w) => ({
+      id: w.id,
+      performedAt: w.performed_at,
+      notes: w.notes ?? null,
+      plannedWorkoutId: w.planned_workout_id ?? null,
+      sets: (w.workout_sets ?? []).map((s) => ({
+        id: s.id,
+        exerciseName: s.exercise_name,
+        setIndex: s.set_index,
+        reps: s.reps,
+        weight: s.weight,
+        unit: s.unit,
+        plannedSetId: s.planned_set_id ?? null,
+        plannedReps: s.planned_workout_sets?.target_reps ?? null,
+        plannedWeight: s.planned_workout_sets?.target_weight ?? null
+      }))
+    }))
+  };
+}
+
+export async function fetchWorkoutHistory(client, { userId, limit }) {
+  const { data, error } = await client
+    .from('workouts')
+    .select(`
+      id,
+      performed_at,
+      notes,
+      planned_workout_id,
+      workout_sets(
+        id,
+        exercise_name,
+        set_index,
+        reps,
+        weight,
+        unit,
+        planned_set_id,
+        planned_workout_sets(target_reps, target_weight)
+      )
+    `)
+    .eq('user_id', userId)
+    .order('performed_at', { ascending: false })
+    .limit(limit);
+
+  if (error) throw new Error(error.message);
+  return formatHistoryResponse(data ?? []);
+}
+
+export function escapeIlikePattern(s) {
+  return String(s).replace(/[\\%_]/g, '\\$&');
+}
+
+export function normalizeExerciseName(raw) {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.length > EXERCISE_NAME_MAX_LENGTH) return null;
+  return trimmed;
+}
+
+export function exerciseNameErrorMessage(raw) {
+  if (typeof raw !== 'string') return 'exerciseName must be a string.';
+  if (raw.trim().length === 0) return 'exerciseName must be a non-empty string.';
+  if (raw.trim().length > EXERCISE_NAME_MAX_LENGTH) {
+    return `exerciseName must be at most ${EXERCISE_NAME_MAX_LENGTH} characters.`;
+  }
+  return null;
+}
+
+export function parseProgressionLimit(rawLimit) {
+  if (rawLimit == null || rawLimit === '') return PROGRESSION_DEFAULT_LIMIT;
+  if (typeof rawLimit === 'object') return `limit must be a string, not an object.`;
+  const n = Number(rawLimit);
+  if (!Number.isInteger(n) || n < PROGRESSION_MIN_LIMIT || n > PROGRESSION_MAX_LIMIT) {
+    return `limit must be an integer between ${PROGRESSION_MIN_LIMIT} and ${PROGRESSION_MAX_LIMIT}.`;
+  }
+  return n;
+}
+
+export function formatProgressionResponse(exerciseName, rows) {
+  return {
+    exerciseName,
+    sets: (rows ?? []).map((s) => {
+      const workout = s.workouts ?? {};
+      return {
+        performedAt: workout.performed_at ?? null,
+        workoutId: workout.id ?? null,
+        setIndex: s.set_index,
+        reps: s.reps,
+        weight: s.weight,
+        unit: s.unit,
+        plannedReps: s.planned_workout_sets?.target_reps ?? null,
+        plannedWeight: s.planned_workout_sets?.target_weight ?? null
+      };
+    })
+  };
+}
+
+export async function fetchExerciseProgression(client, { userId, exerciseName, limit }) {
+  const pattern = escapeIlikePattern(exerciseName);
+  const { data, error } = await client
+    .from('workout_sets')
+    .select(`
+      set_index,
+      reps,
+      weight,
+      unit,
+      planned_set_id,
+      planned_workout_sets(target_reps, target_weight),
+      workouts!inner(id, performed_at, user_id)
+    `)
+    .eq('workouts.user_id', userId)
+    .ilike('exercise_name', pattern)
+    .order('performed_at', { ascending: false, foreignTable: 'workouts' })
+    .limit(limit);
+
+  if (error) throw new Error(error.message);
+  return formatProgressionResponse(exerciseName, data ?? []);
+}

--- a/apps/gymtrack/src/App.jsx
+++ b/apps/gymtrack/src/App.jsx
@@ -1,5 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
+import AgentConsentPage from './components/AgentConsentPage.jsx';
 import AuthGate from './components/AuthGate.jsx';
+import ConnectedAgentsPage from './components/ConnectedAgentsPage.jsx';
 import LoginScreen from './components/LoginScreen.jsx';
 import SignUpPage from './components/SignUpPage.jsx';
 import WorkoutLogger from './components/WorkoutLogger.jsx';
@@ -40,6 +42,22 @@ export default function App() {
         element={
           <AuthGate>
             <WorkoutsTab />
+          </AuthGate>
+        }
+      />
+      <Route
+        path="/agent-consent"
+        element={
+          <AuthGate>
+            <AgentConsentPage />
+          </AuthGate>
+        }
+      />
+      <Route
+        path="/settings/agents"
+        element={
+          <AuthGate>
+            <ConnectedAgentsPage />
           </AuthGate>
         }
       />

--- a/apps/gymtrack/src/App.test.jsx
+++ b/apps/gymtrack/src/App.test.jsx
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockSignIn = vi.fn();
+const mockSignInWithOAuthRedirect = vi.fn();
+
+vi.mock('./lib/supabase.js', () => ({ supabase: { auth: { getUser: vi.fn(), onAuthStateChange: vi.fn() } } }));
+
+vi.mock('./lib/auth.jsx', () => ({
+  useAuth: () => ({
+    session: null,
+    user: null,
+    loading: false,
+    signIn: mockSignIn,
+    signUp: vi.fn(),
+    signOut: vi.fn()
+  }),
+  AuthProvider: ({ children }) => children
+}));
+
+vi.mock('./lib/authFlow.js', () => ({
+  DISABLED_OAUTH_PROVIDERS: ['apple'],
+  SUPPORTED_OAUTH_PROVIDERS: ['google', 'apple'],
+  signInWithOAuthRedirect: (...args) => mockSignInWithOAuthRedirect(...args)
+}));
+
+import App from './App.jsx';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSignInWithOAuthRedirect.mockResolvedValue({
+    data: null,
+    error: null,
+    providerDisabled: false
+  });
+});
+
+describe('GymTrack protected-route continuation', () => {
+  it('preserves /agent-consent intent when Google sign-in starts from AuthGate', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/agent-consent?client_id=claude-desktop&redirect_uri=https%3A%2F%2Fclaude.example%2Fcallback&response_type=code&scope=history%3Aread&state=opaque-state&code_challenge=pkce&code_challenge_method=S256'
+        ]}
+      >
+        <App />
+      </MemoryRouter>
+    );
+
+    await user.click(await screen.findByTestId('login-google'));
+
+    expect(mockSignInWithOAuthRedirect).toHaveBeenCalledWith(
+      'google',
+      '/agent-consent?client_id=claude-desktop&redirect_uri=https%3A%2F%2Fclaude.example%2Fcallback&response_type=code&scope=history%3Aread&state=opaque-state&code_challenge=pkce&code_challenge_method=S256'
+    );
+  });
+});

--- a/apps/gymtrack/src/components/AgentConsentPage.jsx
+++ b/apps/gymtrack/src/components/AgentConsentPage.jsx
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { fetchOAuthClient, submitAgentConsentDecision } from '../lib/connectedAgents.js';
+import { useAuth } from '../lib/auth.jsx';
+
+function scopeList(scope) {
+  return String(scope)
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+export default function AgentConsentPage() {
+  const [params] = useSearchParams();
+  const { session } = useAuth();
+  const [client, setClient] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const request = useMemo(
+    () => ({
+      client_id: params.get('client_id') ?? '',
+      redirect_uri: params.get('redirect_uri') ?? '',
+      scope: params.get('scope') ?? '',
+      state: params.get('state') ?? '',
+      code_challenge: params.get('code_challenge') ?? '',
+      code_challenge_method: params.get('code_challenge_method') ?? ''
+    }),
+    [params]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadClient() {
+      if (!request.client_id) {
+        setError('Missing OAuth client id.');
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      const { data, error: fetchError } = await fetchOAuthClient(request.client_id);
+      if (cancelled) return;
+      if (fetchError || !data) {
+        setError(fetchError?.message ?? 'Unknown OAuth client.');
+      } else {
+        setClient(data);
+      }
+      setLoading(false);
+    }
+
+    loadClient();
+    return () => {
+      cancelled = true;
+    };
+  }, [request.client_id]);
+
+  async function handleDecision(approve) {
+    setSubmitting(true);
+    setError(null);
+    const { data, error: submitError } = await submitAgentConsentDecision({
+      accessToken: session.access_token,
+      approve,
+      ...request
+    });
+    setSubmitting(false);
+    if (submitError) {
+      setError(submitError.message);
+      return;
+    }
+    if (data?.redirectTo) {
+      window.location.assign(data.redirectTo);
+    }
+  }
+
+  return (
+    <main className="container agent-consent-screen" data-testid="agent-consent-screen">
+      <h1>Authorize agent access</h1>
+      <p className="subtitle">
+        {client?.client_name ?? request.client_id} wants permission to read your workout history and plan workouts in GymTrack.
+      </p>
+
+      {loading ? <p data-testid="agent-consent-loading">Loading consent details…</p> : null}
+
+      {error ? (
+        <div className="status show error" role="alert" data-testid="agent-consent-error">
+          {error}
+        </div>
+      ) : null}
+
+      {!loading && !error ? (
+        <section className="workout-card connected-agent-card" data-testid="agent-consent-card">
+          <h2>{client?.client_name ?? request.client_id}</h2>
+          <p className="workout-card-meta">Redirect: {request.redirect_uri}</p>
+          <ul>
+            {scopeList(request.scope).map((scope) => (
+              <li key={scope}>{scope}</li>
+            ))}
+          </ul>
+          <div className="btn-row">
+            <button
+              type="button"
+              className="btn-secondary"
+              disabled={submitting}
+              onClick={() => handleDecision(false)}
+              data-testid="agent-consent-deny"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="btn-primary"
+              disabled={submitting}
+              onClick={() => handleDecision(true)}
+              data-testid="agent-consent-approve"
+            >
+              {submitting ? 'Authorizing…' : 'Approve access'}
+            </button>
+          </div>
+        </section>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/gymtrack/src/components/ConnectedAgentsPage.jsx
+++ b/apps/gymtrack/src/components/ConnectedAgentsPage.jsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { listConnectedAgents, revokeConnectedAgent } from '../lib/connectedAgents.js';
+
+function scopeSummary(scope) {
+  return String(scope)
+    .split(/\s+/)
+    .filter(Boolean)
+    .join(' · ');
+}
+
+export default function ConnectedAgentsPage() {
+  const [agents, setAgents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [busyId, setBusyId] = useState(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    const { data, error: fetchError } = await listConnectedAgents();
+    if (fetchError) {
+      setError(fetchError.message);
+      setAgents([]);
+    } else {
+      setAgents(data ?? []);
+    }
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function handleRevoke(consentId) {
+    setBusyId(consentId);
+    setError(null);
+    const { error: revokeError } = await revokeConnectedAgent(consentId);
+    setBusyId(null);
+    if (revokeError) {
+      setError(revokeError.message);
+      return;
+    }
+    await load();
+  }
+
+  return (
+    <main className="container connected-agents-screen" data-testid="connected-agents-screen">
+      <header className="screen-header">
+        <h1>Connected agents</h1>
+        <nav className="screen-tabs">
+          <Link to="/workout" className="tab" data-testid="tab-workout">
+            Log
+          </Link>
+          <Link to="/history" className="tab" data-testid="tab-history">
+            History
+          </Link>
+          <Link to="/workouts" className="tab" data-testid="tab-workouts">
+            Workouts
+          </Link>
+          <Link to="/settings/agents" className="tab active" data-testid="tab-agents">
+            Agents
+          </Link>
+        </nav>
+      </header>
+
+      <p className="subtitle">Review which external MCP clients can act on your behalf.</p>
+
+      {loading ? <p data-testid="connected-agents-loading">Loading connected agents…</p> : null}
+
+      {error ? (
+        <div className="status show error" role="alert" data-testid="connected-agents-error">
+          {error}
+        </div>
+      ) : null}
+
+      {!loading && !error && agents.length === 0 ? (
+        <p data-testid="connected-agents-empty">
+          No agents connected yet. Start from Claude or ChatGPT and approve the GymTrack consent screen.
+        </p>
+      ) : null}
+
+      {!loading && !error && agents.length > 0 ? (
+        <ul className="workout-cards" data-testid="connected-agents-list">
+          {agents.map((agent) => (
+            <li key={agent.id} className="workout-card-item" data-testid={`connected-agent-${agent.id}`}>
+              <article className="workout-card connected-agent-card">
+                <div className="workout-card-header">
+                  <div>
+                    <h2>{agent.clientName}</h2>
+                    <p className="workout-card-meta">{scopeSummary(agent.scope)}</p>
+                    <p className="workout-card-meta">Connected {new Date(agent.grantedAt).toLocaleString()}</p>
+                    <p className="workout-card-meta">
+                      {agent.lastUsedAt
+                        ? `Last used ${new Date(agent.lastUsedAt).toLocaleString()}`
+                        : 'Not used yet'}
+                    </p>
+                  </div>
+                </div>
+                <div className="btn-row">
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    disabled={busyId === agent.id}
+                    onClick={() => handleRevoke(agent.id)}
+                    data-testid={`revoke-agent-${agent.id}`}
+                  >
+                    {busyId === agent.id ? 'Revoking…' : 'Revoke access'}
+                  </button>
+                </div>
+              </article>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/gymtrack/src/components/ConnectedAgentsPage.test.jsx
+++ b/apps/gymtrack/src/components/ConnectedAgentsPage.test.jsx
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+const mockListConnectedAgents = vi.fn();
+const mockRevokeConnectedAgent = vi.fn();
+
+vi.mock('../lib/connectedAgents.js', () => ({
+  listConnectedAgents: (...args) => mockListConnectedAgents(...args),
+  revokeConnectedAgent: (...args) => mockRevokeConnectedAgent(...args),
+  fetchOAuthClient: vi.fn(),
+  submitAgentConsentDecision: vi.fn()
+}));
+
+import ConnectedAgentsPage from './ConnectedAgentsPage.jsx';
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/settings/agents']}>
+      <Routes>
+        <Route path="/settings/agents" element={<ConnectedAgentsPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ConnectedAgentsPage', () => {
+  it('renders connected agents returned by the query', async () => {
+    mockListConnectedAgents.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'consent-1',
+          clientId: 'claude-desktop',
+          clientName: 'Claude Desktop',
+          scope: 'history:read progression:read workouts:write',
+          grantedAt: '2026-08-03T00:00:00.000Z',
+          lastUsedAt: '2026-08-03T01:00:00.000Z'
+        }
+      ],
+      error: null
+    });
+
+    renderPage();
+
+    expect(await screen.findByTestId('connected-agents-list')).toBeInTheDocument();
+    expect(screen.getByText('Claude Desktop')).toBeInTheDocument();
+    expect(screen.getByText(/history:read/i)).toBeInTheDocument();
+  });
+
+  it('revokes an agent and reloads the list', async () => {
+    mockListConnectedAgents
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 'consent-1',
+            clientId: 'claude-desktop',
+            clientName: 'Claude Desktop',
+            scope: 'history:read progression:read workouts:write',
+            grantedAt: '2026-08-03T00:00:00.000Z',
+            lastUsedAt: null
+          }
+        ],
+        error: null
+      })
+      .mockResolvedValueOnce({ data: [], error: null });
+    mockRevokeConnectedAgent.mockResolvedValueOnce({ error: null });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByTestId('revoke-agent-consent-1'));
+
+    await waitFor(() => {
+      expect(mockRevokeConnectedAgent).toHaveBeenCalledWith('consent-1');
+    });
+    expect(await screen.findByTestId('connected-agents-empty')).toBeInTheDocument();
+  });
+});

--- a/apps/gymtrack/src/components/LoginScreen.jsx
+++ b/apps/gymtrack/src/components/LoginScreen.jsx
@@ -1,24 +1,55 @@
 import { useState } from 'react';
 import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../lib/auth.jsx';
+import {
+  DISABLED_OAUTH_PROVIDERS,
+  SUPPORTED_OAUTH_PROVIDERS,
+  signInWithOAuthRedirect
+} from '../lib/authFlow.js';
 
 /**
  * Email + password sign-in. On success, routes to the originally intended
  * destination (or /workout by default). Errors render inline.
  */
+const INITIAL_AVAILABLE_PROVIDERS = SUPPORTED_OAUTH_PROVIDERS.filter(
+  (provider) => !DISABLED_OAUTH_PROVIDERS.includes(provider)
+);
+
 export default function LoginScreen() {
   const { session, signIn } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const from = location.state?.from?.pathname ?? '/workout';
+  const fromState = location.state?.from;
+  const from = fromState
+    ? `${fromState.pathname ?? '/workout'}${fromState.search ?? ''}`
+    : '/workout';
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
+  const [availableProviders, setAvailableProviders] = useState(INITIAL_AVAILABLE_PROVIDERS);
 
   if (session) {
     return <Navigate to={from} replace />;
+  }
+
+  async function handleOAuth(provider) {
+    setError(null);
+    const { data, error: oauthError, providerDisabled } =
+      await signInWithOAuthRedirect(provider, from);
+    if (providerDisabled) {
+      setAvailableProviders((prev) => prev.filter((value) => value !== provider));
+      setError(`Sign-in with ${provider} is not available right now. Try another option.`);
+      return;
+    }
+    if (oauthError) {
+      setError(oauthError.message);
+      return;
+    }
+    if (data?.url) {
+      window.location.assign(data.url);
+    }
   }
 
   async function handleSubmit(e) {
@@ -37,7 +68,31 @@ export default function LoginScreen() {
   return (
     <main className="container login-screen">
       <h1>GymTrack</h1>
-      <p className="subtitle">Sign in to log a workout</p>
+      <p className="subtitle">Sign in to continue</p>
+
+      <div className="oauth-row" data-testid="login-oauth-row">
+        {availableProviders.includes('google') ? (
+          <button
+            type="button"
+            className="btn-primary oauth-google"
+            onClick={() => handleOAuth('google')}
+            data-testid="login-google"
+          >
+            Continue with Google
+          </button>
+        ) : null}
+
+        {availableProviders.includes('apple') ? (
+          <button
+            type="button"
+            className="btn-primary oauth-apple"
+            onClick={() => handleOAuth('apple')}
+            data-testid="login-apple"
+          >
+            Continue with Apple
+          </button>
+        ) : null}
+      </div>
 
       <form onSubmit={handleSubmit} className="login-form" data-testid="login-form">
         <label className="form-row">
@@ -82,7 +137,7 @@ export default function LoginScreen() {
       </form>
 
       <p className="auth-alt" data-testid="login-create-account">
-        New to GymTrack? <Link to="/signup">Create an account</Link>
+        New to GymTrack? <Link to="/signup" state={{ from: fromState }}>Create an account</Link>
       </p>
     </main>
   );

--- a/apps/gymtrack/src/components/SignUpPage.jsx
+++ b/apps/gymtrack/src/components/SignUpPage.jsx
@@ -38,7 +38,10 @@ export default function SignUpPage() {
   const { session, signUp } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const from = location.state?.from?.pathname ?? '/workout';
+  const fromState = location.state?.from;
+  const from = fromState
+    ? `${fromState.pathname ?? '/workout'}${fromState.search ?? ''}`
+    : '/workout';
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -56,7 +59,7 @@ export default function SignUpPage() {
   async function handleOAuth(provider) {
     setError(null);
     const { data, error: oauthError, providerDisabled } =
-      await signInWithOAuthRedirect(provider);
+      await signInWithOAuthRedirect(provider, from);
     if (providerDisabled) {
       // Mark this provider as disabled in the UI by removing it from the
       // available list so the button disappears on re-render.
@@ -176,7 +179,7 @@ export default function SignUpPage() {
       )}
 
       <p className="auth-alt" data-testid="signup-signin-link">
-        Already have an account? <Link to="/login">Sign in</Link>
+        Already have an account? <Link to="/login" state={{ from: fromState }}>Sign in</Link>
       </p>
     </main>
   );

--- a/apps/gymtrack/src/components/WorkoutsTab.jsx
+++ b/apps/gymtrack/src/components/WorkoutsTab.jsx
@@ -60,6 +60,9 @@ export default function WorkoutsTab() {
           <Link to="/workouts" className="tab active" data-testid="tab-workouts">
             Workouts
           </Link>
+          <Link to="/settings/agents" className="tab" data-testid="tab-agents">
+            Agents
+          </Link>
           <button
             type="button"
             className="btn-ghost"
@@ -83,8 +86,8 @@ export default function WorkoutsTab() {
 
       {!loading && !error && workouts && workouts.length === 0 ? (
         <p className="empty-hint" data-testid="workouts-empty">
-          No upcoming workouts. Connect an agent (coming soon) to have your training
-          planned here.
+          No upcoming workouts yet. Connect Claude or ChatGPT from their MCP client,
+          then manage access in the Agents tab.
         </p>
       ) : null}
 

--- a/apps/gymtrack/src/lib/authFlow.js
+++ b/apps/gymtrack/src/lib/authFlow.js
@@ -57,7 +57,7 @@ export function isProviderDisabledError(err) {
  * Callers should branch on `providerDisabled` first, then `error`, then
  * proceed with `data.url` (window.location.assign or similar).
  */
-export async function signInWithOAuthRedirect(provider) {
+export async function signInWithOAuthRedirect(provider, redirectPath = '/workout') {
   if (!SUPPORTED_OAUTH_PROVIDERS.includes(provider)) {
     return {
       data: null,
@@ -69,7 +69,7 @@ export async function signInWithOAuthRedirect(provider) {
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider,
     options: {
-      redirectTo: `${window.location.origin}/workout`
+      redirectTo: new URL(redirectPath, window.location.origin).toString()
     }
   });
 

--- a/apps/gymtrack/src/lib/connectedAgents.js
+++ b/apps/gymtrack/src/lib/connectedAgents.js
@@ -1,0 +1,74 @@
+import { supabase } from './supabase.js';
+import { mcpUrl } from './mcpConfig.js';
+
+export async function listConnectedAgents() {
+  const { data, error } = await supabase
+    .from('gymtrack_oauth_consents')
+    .select(`
+      id,
+      client_id,
+      scope,
+      granted_at,
+      last_used_at,
+      revoked_at,
+      gymtrack_oauth_clients(client_name)
+    `)
+    .is('revoked_at', null)
+    .order('granted_at', { ascending: false });
+
+  if (error) return { data: null, error };
+
+  return {
+    data: (data ?? []).map((row) => ({
+      id: row.id,
+      clientId: row.client_id,
+      clientName: row.gymtrack_oauth_clients?.client_name ?? row.client_id,
+      scope: row.scope,
+      grantedAt: row.granted_at,
+      lastUsedAt: row.last_used_at,
+      revokedAt: row.revoked_at
+    })),
+    error: null
+  };
+}
+
+export async function revokeConnectedAgent(consentId) {
+  const { error } = await supabase
+    .from('gymtrack_oauth_consents')
+    .update({ revoked_at: new Date().toISOString() })
+    .eq('id', consentId)
+    .is('revoked_at', null);
+
+  return { error: error ?? null };
+}
+
+export async function fetchOAuthClient(clientId) {
+  const { data, error } = await supabase
+    .from('gymtrack_oauth_clients')
+    .select('client_id, client_name, redirect_uris')
+    .eq('client_id', clientId)
+    .maybeSingle();
+
+  return { data: data ?? null, error: error ?? null };
+}
+
+export async function submitAgentConsentDecision({ accessToken, approve, ...payload }) {
+  const response = await fetch(mcpUrl('/oauth/authorize/decision'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`
+    },
+    body: JSON.stringify({ approve, ...payload })
+  });
+
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    return {
+      data: null,
+      error: new Error(data.error_description ?? data.error ?? 'OAuth decision failed.')
+    };
+  }
+
+  return { data, error: null };
+}

--- a/apps/gymtrack/src/lib/connectedAgents.js
+++ b/apps/gymtrack/src/lib/connectedAgents.js
@@ -33,13 +33,31 @@ export async function listConnectedAgents() {
 }
 
 export async function revokeConnectedAgent(consentId) {
-  const { error } = await supabase
-    .from('gymtrack_oauth_consents')
-    .update({ revoked_at: new Date().toISOString() })
-    .eq('id', consentId)
-    .is('revoked_at', null);
+  const {
+    data: { session }
+  } = await supabase.auth.getSession();
 
-  return { error: error ?? null };
+  if (!session?.access_token) {
+    return { error: new Error('You are no longer signed in. Please refresh and try again.') };
+  }
+
+  const response = await fetch('/api/connected-agents/revoke', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${session.access_token}`
+    },
+    body: JSON.stringify({ consentId })
+  });
+
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    return {
+      error: new Error(data.message ?? data.error ?? 'Failed to revoke connected agent.')
+    };
+  }
+
+  return { error: null };
 }
 
 export async function fetchOAuthClient(clientId) {

--- a/apps/gymtrack/src/lib/connectedAgentsHandler.test.js
+++ b/apps/gymtrack/src/lib/connectedAgentsHandler.test.js
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockAdminClient = {
+  auth: { getUser: vi.fn() },
+  from: vi.fn()
+};
+
+vi.mock('../../server/agentAuth.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    adminClient: () => mockAdminClient
+  };
+});
+
+import handler from '../../api/connected-agents/revoke.js';
+
+function buildChain(terminal) {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'then') return (resolve) => resolve(terminal);
+        if (prop === 'single') return () => Promise.resolve(terminal);
+        if (prop === 'maybeSingle') return () => Promise.resolve(terminal);
+        return () => proxy;
+      }
+    }
+  );
+  return proxy;
+}
+
+function makeRes() {
+  const headers = {};
+  return {
+    headers,
+    statusCode: 200,
+    body: null,
+    setHeader(name, value) {
+      headers[name] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/connected-agents/revoke', () => {
+  it('returns 405 for non-POST methods', async () => {
+    const res = makeRes();
+    await handler({ method: 'GET', headers: {}, body: {} }, res);
+    expect(res.statusCode).toBe(405);
+    expect(res.headers.Allow).toBe('POST');
+    expect(res.body).toEqual({ error: 'method_not_allowed' });
+  });
+
+  it('returns 401 when the user session is missing', async () => {
+    const res = makeRes();
+    await handler({ method: 'POST', headers: {}, body: { consentId: 'consent-1' } }, res);
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error).toBe('invalid_session');
+  });
+
+  it('revokes the consent family for the signed-in user', async () => {
+    mockAdminClient.auth.getUser.mockResolvedValueOnce({
+      data: { user: { id: 'user-1' } },
+      error: null
+    });
+    mockAdminClient.from
+      .mockReturnValueOnce(buildChain({ data: { id: 'consent-1', user_id: 'user-1' }, error: null }))
+      .mockReturnValueOnce(buildChain({ error: null }))
+      .mockReturnValueOnce(buildChain({ error: null }))
+      .mockReturnValueOnce(buildChain({ error: null }));
+
+    const res = makeRes();
+    await handler(
+      {
+        method: 'POST',
+        headers: { authorization: 'Bearer supabase-user-token' },
+        body: { consentId: 'consent-1' }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(mockAdminClient.from.mock.calls.map(([table]) => table)).toEqual([
+      'gymtrack_oauth_consents',
+      'gymtrack_oauth_consents',
+      'gymtrack_oauth_tokens',
+      'gymtrack_oauth_authorization_codes'
+    ]);
+  });
+});

--- a/apps/gymtrack/src/lib/mcpConfig.js
+++ b/apps/gymtrack/src/lib/mcpConfig.js
@@ -1,0 +1,7 @@
+export function mcpBaseUrl() {
+  return import.meta.env.VITE_GYMTRACK_MCP_BASE_URL ?? window.location.origin;
+}
+
+export function mcpUrl(path) {
+  return new URL(path, mcpBaseUrl()).toString();
+}

--- a/apps/gymtrack/supabase/migrations/20260804070000_mcp_oauth.sql
+++ b/apps/gymtrack/supabase/migrations/20260804070000_mcp_oauth.sql
@@ -97,22 +97,207 @@ create policy gymtrack_oauth_clients_authenticated_read on public.gymtrack_oauth
   using (auth.role() = 'authenticated');
 
 drop policy if exists gymtrack_oauth_consents_user_isolation on public.gymtrack_oauth_consents;
-create policy gymtrack_oauth_consents_user_isolation on public.gymtrack_oauth_consents
-  for all
-  using (auth.uid() = user_id)
-  with check (auth.uid() = user_id);
+drop policy if exists gymtrack_oauth_consents_user_read on public.gymtrack_oauth_consents;
+create policy gymtrack_oauth_consents_user_read on public.gymtrack_oauth_consents
+  for select
+  using (auth.uid() = user_id);
 
 drop policy if exists gymtrack_oauth_authorization_codes_user_isolation on public.gymtrack_oauth_authorization_codes;
-create policy gymtrack_oauth_authorization_codes_user_isolation on public.gymtrack_oauth_authorization_codes
-  for all
-  using (auth.uid() = user_id)
-  with check (auth.uid() = user_id);
 
 drop policy if exists gymtrack_oauth_tokens_user_isolation on public.gymtrack_oauth_tokens;
-create policy gymtrack_oauth_tokens_user_isolation on public.gymtrack_oauth_tokens
-  for all
-  using (auth.uid() = user_id)
-  with check (auth.uid() = user_id);
+
+create or replace function public.gymtrack_consume_oauth_authorization_code(
+  p_code_hash text,
+  p_client_id text,
+  p_redirect_uri text,
+  p_consumed_at timestamptz
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_code public.gymtrack_oauth_authorization_codes%rowtype;
+begin
+  update public.gymtrack_oauth_authorization_codes
+     set consumed_at = p_consumed_at
+   where code_hash = p_code_hash
+     and client_id = p_client_id
+     and redirect_uri = p_redirect_uri
+     and consumed_at is null
+     and revoked_at is null
+     and expires_at > p_consumed_at
+   returning * into v_code;
+
+  if not found then
+    return null;
+  end if;
+
+  return to_jsonb(v_code);
+end;
+$$;
+
+revoke all on function public.gymtrack_consume_oauth_authorization_code(text, text, text, timestamptz) from public, anon, authenticated;
+grant execute on function public.gymtrack_consume_oauth_authorization_code(text, text, text, timestamptz) to service_role;
+
+create or replace function public.gymtrack_rotate_oauth_refresh_token(
+  p_refresh_token_hash text,
+  p_client_id text,
+  p_rotated_at timestamptz,
+  p_next_access_token_hash text,
+  p_next_refresh_token_hash text,
+  p_next_access_token_expires_at timestamptz,
+  p_next_refresh_token_expires_at timestamptz
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_source public.gymtrack_oauth_tokens%rowtype;
+  v_consent public.gymtrack_oauth_consents%rowtype;
+  v_next public.gymtrack_oauth_tokens%rowtype;
+begin
+  select *
+    into v_source
+    from public.gymtrack_oauth_tokens
+   where refresh_token_hash = p_refresh_token_hash
+     and client_id = p_client_id
+   limit 1
+   for update;
+
+  if not found then
+    return jsonb_build_object('status', 'invalid');
+  end if;
+
+  select *
+    into v_consent
+    from public.gymtrack_oauth_consents
+   where id = v_source.consent_id
+   limit 1
+   for update;
+
+  if not found or v_consent.revoked_at is not null then
+    update public.gymtrack_oauth_tokens
+       set revoked_at = coalesce(revoked_at, p_rotated_at),
+           revocation_reason = coalesce(revocation_reason, 'consent_revoked')
+     where consent_id = v_source.consent_id
+       and revoked_at is null;
+
+    update public.gymtrack_oauth_authorization_codes
+       set revoked_at = coalesce(revoked_at, p_rotated_at)
+     where consent_id = v_source.consent_id
+       and revoked_at is null;
+
+    return jsonb_build_object(
+      'status',
+      'consent_revoked',
+      'source_token',
+      to_jsonb(v_source),
+      'consent',
+      coalesce(to_jsonb(v_consent), 'null'::jsonb)
+    );
+  end if;
+
+  if v_source.revoked_at is not null or v_source.rotated_at is not null then
+    update public.gymtrack_oauth_consents
+       set revoked_at = coalesce(revoked_at, p_rotated_at)
+     where id = v_source.consent_id
+       and revoked_at is null;
+
+    update public.gymtrack_oauth_tokens
+       set revoked_at = coalesce(revoked_at, p_rotated_at),
+           revocation_reason = coalesce(revocation_reason, 'refresh_replay_detected')
+     where family_id = v_source.family_id
+       and revoked_at is null;
+
+    update public.gymtrack_oauth_authorization_codes
+       set revoked_at = coalesce(revoked_at, p_rotated_at)
+     where consent_id = v_source.consent_id
+       and revoked_at is null;
+
+    select *
+      into v_consent
+      from public.gymtrack_oauth_consents
+     where id = v_source.consent_id
+     limit 1;
+
+    return jsonb_build_object(
+      'status',
+      'replayed',
+      'source_token',
+      to_jsonb(v_source),
+      'consent',
+      to_jsonb(v_consent)
+    );
+  end if;
+
+  if v_source.refresh_token_expires_at <= p_rotated_at then
+    return jsonb_build_object(
+      'status',
+      'expired',
+      'source_token',
+      to_jsonb(v_source),
+      'consent',
+      to_jsonb(v_consent)
+    );
+  end if;
+
+  insert into public.gymtrack_oauth_tokens (
+    consent_id,
+    user_id,
+    client_id,
+    scope,
+    family_id,
+    parent_token_id,
+    access_token_hash,
+    refresh_token_hash,
+    access_token_expires_at,
+    refresh_token_expires_at
+  )
+  values (
+    v_source.consent_id,
+    v_source.user_id,
+    v_source.client_id,
+    v_source.scope,
+    v_source.family_id,
+    v_source.id,
+    p_next_access_token_hash,
+    p_next_refresh_token_hash,
+    p_next_access_token_expires_at,
+    p_next_refresh_token_expires_at
+  )
+  returning * into v_next;
+
+  update public.gymtrack_oauth_tokens
+     set rotated_at = p_rotated_at,
+         revoked_at = p_rotated_at,
+         revocation_reason = 'refresh_rotated',
+         replaced_by_token_id = v_next.id,
+         last_used_at = p_rotated_at
+   where id = v_source.id
+   returning * into v_source;
+
+  update public.gymtrack_oauth_consents
+     set last_used_at = p_rotated_at
+   where id = v_source.consent_id
+   returning * into v_consent;
+
+  return jsonb_build_object(
+    'status',
+    'rotated',
+    'source_token',
+    to_jsonb(v_source),
+    'next_token',
+    to_jsonb(v_next),
+    'consent',
+    to_jsonb(v_consent)
+  );
+end;
+$$;
+
+revoke all on function public.gymtrack_rotate_oauth_refresh_token(text, text, timestamptz, text, text, timestamptz, timestamptz) from public, anon, authenticated;
+grant execute on function public.gymtrack_rotate_oauth_refresh_token(text, text, timestamptz, text, text, timestamptz, timestamptz) to service_role;
 
 insert into public.gymtrack_oauth_clients (client_id, client_name, redirect_uris)
 values

--- a/apps/gymtrack/supabase/migrations/20260804070000_mcp_oauth.sql
+++ b/apps/gymtrack/supabase/migrations/20260804070000_mcp_oauth.sql
@@ -1,0 +1,124 @@
+-- GymTrack MCP OAuth server (task 1474d515).
+--
+-- Adds static OAuth clients, authorization-code storage, hashed access/refresh
+-- tokens, and user-visible consent rows so external MCP clients can connect via
+-- OAuth Code + PKCE without exposing plaintext secrets in the database.
+
+create table if not exists public.gymtrack_oauth_clients (
+  client_id      text primary key,
+  client_name    text not null,
+  redirect_uris  text[] not null,
+  created_at     timestamptz not null default now(),
+  check (array_length(redirect_uris, 1) >= 1)
+);
+
+create table if not exists public.gymtrack_oauth_consents (
+  id            uuid primary key default gen_random_uuid(),
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  client_id     text not null references public.gymtrack_oauth_clients(client_id) on delete cascade,
+  scope         text not null,
+  granted_at    timestamptz not null default now(),
+  last_used_at  timestamptz,
+  revoked_at    timestamptz,
+  created_at    timestamptz not null default now()
+);
+
+create unique index if not exists gymtrack_oauth_consents_active_user_client_idx
+  on public.gymtrack_oauth_consents (user_id, client_id)
+  where revoked_at is null;
+
+create index if not exists gymtrack_oauth_consents_user_idx
+  on public.gymtrack_oauth_consents (user_id, granted_at desc);
+
+create table if not exists public.gymtrack_oauth_authorization_codes (
+  id                     uuid primary key default gen_random_uuid(),
+  consent_id             uuid not null references public.gymtrack_oauth_consents(id) on delete cascade,
+  user_id                uuid not null references auth.users(id) on delete cascade,
+  client_id              text not null references public.gymtrack_oauth_clients(client_id) on delete cascade,
+  code_hash              text not null unique,
+  redirect_uri           text not null,
+  scope                  text not null,
+  code_challenge         text not null,
+  code_challenge_method  text not null default 'S256' check (code_challenge_method in ('S256')),
+  expires_at             timestamptz not null,
+  consumed_at            timestamptz,
+  revoked_at             timestamptz,
+  created_at             timestamptz not null default now()
+);
+
+create index if not exists gymtrack_oauth_auth_codes_consent_idx
+  on public.gymtrack_oauth_authorization_codes (consent_id, created_at desc);
+
+create index if not exists gymtrack_oauth_auth_codes_client_idx
+  on public.gymtrack_oauth_authorization_codes (client_id, created_at desc);
+
+create table if not exists public.gymtrack_oauth_tokens (
+  id                       uuid primary key default gen_random_uuid(),
+  consent_id               uuid not null references public.gymtrack_oauth_consents(id) on delete cascade,
+  user_id                  uuid not null references auth.users(id) on delete cascade,
+  client_id                text not null references public.gymtrack_oauth_clients(client_id) on delete cascade,
+  scope                    text not null,
+  family_id                text not null,
+  parent_token_id          uuid references public.gymtrack_oauth_tokens(id) on delete set null,
+  access_token_hash        text not null unique,
+  refresh_token_hash       text not null unique,
+  access_token_expires_at  timestamptz not null,
+  refresh_token_expires_at timestamptz not null,
+  last_used_at             timestamptz,
+  rotated_at               timestamptz,
+  replaced_by_token_id     uuid references public.gymtrack_oauth_tokens(id) on delete set null,
+  revoked_at               timestamptz,
+  revocation_reason        text,
+  created_at               timestamptz not null default now()
+);
+
+create index if not exists gymtrack_oauth_tokens_consent_idx
+  on public.gymtrack_oauth_tokens (consent_id, created_at desc);
+
+create index if not exists gymtrack_oauth_tokens_user_idx
+  on public.gymtrack_oauth_tokens (user_id, created_at desc);
+
+create index if not exists gymtrack_oauth_tokens_access_active_idx
+  on public.gymtrack_oauth_tokens (access_token_hash)
+  where revoked_at is null;
+
+create index if not exists gymtrack_oauth_tokens_refresh_active_idx
+  on public.gymtrack_oauth_tokens (refresh_token_hash)
+  where revoked_at is null;
+
+alter table public.gymtrack_oauth_clients enable row level security;
+alter table public.gymtrack_oauth_consents enable row level security;
+alter table public.gymtrack_oauth_authorization_codes enable row level security;
+alter table public.gymtrack_oauth_tokens enable row level security;
+
+drop policy if exists gymtrack_oauth_clients_authenticated_read on public.gymtrack_oauth_clients;
+create policy gymtrack_oauth_clients_authenticated_read on public.gymtrack_oauth_clients
+  for select
+  using (auth.role() = 'authenticated');
+
+drop policy if exists gymtrack_oauth_consents_user_isolation on public.gymtrack_oauth_consents;
+create policy gymtrack_oauth_consents_user_isolation on public.gymtrack_oauth_consents
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+drop policy if exists gymtrack_oauth_authorization_codes_user_isolation on public.gymtrack_oauth_authorization_codes;
+create policy gymtrack_oauth_authorization_codes_user_isolation on public.gymtrack_oauth_authorization_codes
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+drop policy if exists gymtrack_oauth_tokens_user_isolation on public.gymtrack_oauth_tokens;
+create policy gymtrack_oauth_tokens_user_isolation on public.gymtrack_oauth_tokens
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+insert into public.gymtrack_oauth_clients (client_id, client_name, redirect_uris)
+values
+  ('claude-desktop', 'Claude Desktop', array['https://claude.ai/api/mcp/auth_callback', 'http://localhost/callback', 'http://127.0.0.1/callback']),
+  ('chatgpt', 'ChatGPT', array['https://chatgpt.com/connector_platform_oauth_redirect']),
+  ('local-dev', 'Local development MCP client', array['http://localhost:8788/callback'])
+on conflict (client_id) do update
+set client_name = excluded.client_name,
+    redirect_uris = excluded.redirect_uris;

--- a/docs/specs/gymtrack-mcp-server-oauth-auth-tech-design.md
+++ b/docs/specs/gymtrack-mcp-server-oauth-auth-tech-design.md
@@ -1,0 +1,116 @@
+---
+status: approved
+task_id: 1474d515-041b-4df0-bfd4-6ac727b6840a
+product_spec: brain/tasks/specs/in-progress/gymtrack-mcp-server-oauth-2026-07-27.md
+shipped_pr: null
+shipped_date: null
+---
+
+# GymTrack MCP Server with OAuth Auth
+
+## Links
+
+- Product spec: `brain/tasks/specs/in-progress/gymtrack-mcp-server-oauth-2026-07-27.md`
+- Tech design: `docs/specs/gymtrack-mcp-server-oauth-auth-tech-design.md`
+- Task: `1474d515-041b-4df0-bfd4-6ac727b6840a`
+- Tasks API record: `http://localhost:4001/api/v1/tasks/1474d515-041b-4df0-bfd4-6ac727b6840a`
+
+## Repositories
+
+- Primary repo: `Stoffer-Industries/sindustries`
+- Branch: `task-1474d515-gymtrack-mcp-server-oauth-redo`
+- Worktree: `/Users/quinnstoffer/.openclaw/workspace/worktrees/task-1474d515-gymtrack-mcp-server-oauth-redo`
+- Expected `.openclaw` follow-up: Quinn must ensure Google OAuth is enabled in the GymTrack Supabase project and that the real Claude / ChatGPT redirect URIs are registered in `public.gymtrack_oauth_clients` before production rollout.
+
+## Scope
+
+GymTrack has no MCP server and no self-service key issuance — every agent credential in use has been hand-issued via direct Supabase service-role insert. This task ships:
+
+1. A real MCP server that an external agent (Claude, ChatGPT, any MCP-compatible client) can connect to.
+2. A self-service OAuth authorization flow so any user can grant an agent access without a manual provisioning step.
+3. Per-user data isolation enforced server-side so an agent authorized for one user cannot read or write another user's data.
+4. A migration path for the existing REST endpoints (`/api/agent/planned-workouts`, `/api/agent/history`, `/api/agent/exercises/:name/progression`) so the agent-powered-workouts feature shipped in task `f520c396` does not silently break.
+
+## Ownership boundary
+
+- GymTrack keeps ownership of workout data, planned-workout data, and OAuth consent/token tables in its Supabase project.
+- The MCP server is a separate runtime under `services/gymtrack-mcp/` because it has a different transport/auth surface than the browser SPA, but it still belongs to the GymTrack product boundary.
+- OAuth provider config remains a Supabase / deployment concern outside this repo.
+
+## Implementation plan
+
+### `services/gymtrack-mcp/`
+
+- `src/app.js` — Express app exposing:
+  - `GET /.well-known/oauth-authorization-server`
+  - `GET /.well-known/oauth-protected-resource`
+  - `GET /oauth/authorize`
+  - `POST /oauth/token`
+  - `POST /oauth/revoke`
+  - `POST /mcp`
+- `src/repo.js` — Supabase-backed repo for client rows, consent rows, auth codes, tokens, rotation, and revocation.
+- `src/mcpTools.js` — three tools (`plan_workout`, `read_history`, `read_exercise_progression`) with per-scope enforcement.
+- `test/app.test.js` — integration coverage for OAuth authorize/token/refresh/revoke plus MCP tool discovery/isolation.
+
+### `apps/gymtrack/`
+
+- `src/components/LoginScreen.jsx` — protected-route sign-in now also offers Google OAuth so the `/agent-consent` flow can start from social login, not only email/password.
+- `src/components/AgentConsentPage.jsx` — review-and-approve screen for external MCP clients.
+- `src/components/ConnectedAgentsPage.jsx` — account settings surface listing active MCP consents with revoke actions.
+- `src/lib/connectedAgents.js` — browser-side Supabase queries for client metadata + consent listing/revocation, plus POST helper for approval decisions.
+- `src/lib/authFlow.js` — accepts caller-provided post-OAuth redirect target so protected flows return to `/agent-consent`.
+- `src/App.jsx`, `src/components/WorkoutsTab.jsx` — new routes and navigation entry to the Agents screen.
+- `server/agentData.js` — shared planned-workout/history/progression query logic used by both the legacy REST surface and the MCP service.
+- `api/agent/*.js` — thin wrappers updated to call the shared server module so legacy behaviour and MCP behaviour share one implementation.
+
+### Supabase schema
+
+- `apps/gymtrack/supabase/migrations/20260804070000_mcp_oauth.sql`
+  - `gymtrack_oauth_clients`
+  - `gymtrack_oauth_consents`
+  - `gymtrack_oauth_authorization_codes`
+  - `gymtrack_oauth_tokens`
+  - RLS policies for all new user-scoped tables
+  - Seed rows for `claude-desktop`, `chatgpt`, and `local-dev`
+
+## Data model / API contract
+
+### OAuth
+
+- Authorization Code + PKCE (`S256`) only.
+- Public clients only (`token_endpoint_auth_methods_supported = ["none"]`).
+- Access tokens are short-lived; refresh tokens rotate on every use.
+- Only SHA-256 hashes of authorization codes, access tokens, and refresh tokens are stored.
+- Consent revocation is the root kill-switch: every MCP call and refresh exchange checks `consent.revoked_at`.
+
+### MCP
+
+- Transport: JSON-RPC over `POST /mcp`.
+- Supported methods:
+  - `initialize`
+  - `tools/list`
+  - `tools/call`
+- Supported tools:
+  - `plan_workout`
+  - `read_history`
+  - `read_exercise_progression`
+
+### Legacy REST compatibility
+
+The existing `/api/agent/*` endpoints remain unchanged for already-issued static keys. They continue to authenticate through `gymtrack_agent_api_keys` and return the same request/response shapes. The MCP server is additive rather than a replacement.
+
+## Test plan (AC verification matrix)
+
+| AC | Verification |
+|---|---|
+| AC1 | `services/gymtrack-mcp/test/app.test.js` proves `tools/list` returns the three GymTrack tools and `tools/call` dispatches through the MCP server. |
+| AC2 | The same service test covers `/oauth/authorize`, `/oauth/token`, refresh rotation, and consent-family revocation; `src/components/ConnectedAgentsPage.test.jsx` covers the browser revoke UI. |
+| AC3 | Existing Google social-login coverage (`apps/gymtrack/test/e2e/signup-google.spec.ts`) plus the login-screen redirect wiring ensure the protected-route auth flow can start with Google. |
+| AC4 | `services/gymtrack-mcp/test/app.test.js` asserts the acting `userId` comes from the bearer token identity, not from tool arguments. RLS remains in place on the underlying tables. |
+| AC5 | Existing legacy REST handler tests continue to run; the handlers now delegate to `server/agentData.js` but keep the same static-key auth contract. |
+
+## Risks and notes
+
+- ChatGPT callback URLs may still need real-environment registration before production; the seeded row is a starting point, not a guarantee that the provider-side callback config is complete.
+- Apple social login remains intentionally disabled until Supabase provider wiring exists.
+- Dynamic client registration is explicitly out of scope for this slice.

--- a/docs/systems/gymtrack.md
+++ b/docs/systems/gymtrack.md
@@ -1,0 +1,173 @@
+# GymTrack
+
+**Status:** Live (SPA + legacy REST agent API) / Draft rollout on branch `task-1474d515-gymtrack-mcp-server-oauth-redo` (MCP OAuth server)
+**Last updated:** 2026-08-04
+**Owner:** Rowan (engineering) · Tom (product)
+**Repos:** `Stoffer-Industries/sindustries`
+**Related tasks:** `18256740`, `f520c396`, `72d7cc3b`, `1474d515`
+**Related tech designs:**
+- [GymTrack MVP](../specs/gymtrack-mvp-tech-design.md)
+- [Agent-powered workouts](../specs/gymtrack-agent-powered-workouts-tech-design.md)
+- [Public signup + social login](../specs/gymtrack-public-signup-social-login-tech-design.md)
+- [MCP server + OAuth auth](../specs/gymtrack-mcp-server-oauth-auth-tech-design.md)
+
+---
+
+## What this is
+
+GymTrack is a Supabase-backed workout tracker SPA (`apps/gymtrack`) plus two server-side agent integration surfaces:
+
+1. **Legacy REST endpoints** under `apps/gymtrack/api/agent/*` that authenticate a static bearer key from `public.gymtrack_agent_api_keys`.
+2. **A dedicated MCP OAuth server** under `services/gymtrack-mcp` that exposes tool discovery and invocation through JSON-RPC, with OAuth 2.1 Authorization Code + PKCE, hashed tokens, refresh-token rotation, and user revocation.
+
+The browser app remains the user-facing product. The MCP service is a separate machine-facing boundary that uses the same Supabase project and the same per-user data model.
+
+---
+
+## Architecture and ownership
+
+### Code
+
+- `apps/gymtrack/` — Vite + React SPA, Supabase browser client, public sign-up/sign-in, workout logging/history/planned-workout UI, and the new `AgentConsentPage` + `ConnectedAgentsPage`.
+- `apps/gymtrack/api/agent/*` — legacy REST handlers kept stable for task `f520c396` compatibility.
+- `apps/gymtrack/server/agentAuth.js` — static-key auth lookup for the legacy REST surface.
+- `apps/gymtrack/server/agentData.js` — shared data access/validation used by both the legacy REST handlers and the new MCP service so behaviour cannot drift silently.
+- `services/gymtrack-mcp/src/app.js` — Express app exposing OAuth metadata, `/oauth/*`, and `/mcp`.
+- `services/gymtrack-mcp/src/mcpTools.js` — MCP tool registry and per-tool scope enforcement.
+- `services/gymtrack-mcp/src/repo.js` — Supabase-backed repository for OAuth clients, consents, codes, and tokens.
+- `apps/gymtrack/supabase/migrations/20260804070000_mcp_oauth.sql` — static clients + consent/code/token schema + RLS.
+
+### Service boundary
+
+GymTrack owns its own domain in `apps/gymtrack` and its Supabase project. The MCP server is a separate runtime because it has a different transport and auth lifecycle from the browser SPA, but it still belongs to the GymTrack product boundary rather than to `services/tasks-api` or another shared backend.
+
+The MCP service owns:
+
+- OAuth authorization, token exchange, refresh rotation, and revocation for GymTrack agent access
+- MCP tool discovery and invocation
+- Verification that OAuth bearer tokens map to a single GymTrack user
+
+The SPA owns:
+
+- Human sign-in/sign-up UX
+- Consent review UX (`/agent-consent`)
+- Connected-agent visibility and revocation UX (`/settings/agents`)
+- Workout logging, history, and planned-workout browsing
+
+---
+
+## Runtime behaviour and operational flow
+
+### Browser auth and consent
+
+1. The user signs in to GymTrack via Supabase Auth (email/password or Google).
+2. An external MCP client starts OAuth against `services/gymtrack-mcp`.
+3. `/oauth/authorize` validates the client + redirect URI + PKCE parameters, then redirects the browser into `apps/gymtrack` at `/agent-consent`.
+4. The app checks the Supabase session via `<AuthGate>`; if needed, it redirects through `/login` and preserves the full destination.
+5. `AgentConsentPage` loads the client metadata from `public.gymtrack_oauth_clients`, then POSTs the user's approve/deny decision back to the MCP service with the current Supabase access token.
+6. The MCP service verifies that Supabase token server-side, creates or updates `gymtrack_oauth_consents`, stores a hashed authorization code, and returns the client redirect URL.
+
+### OAuth token lifecycle
+
+1. The external client exchanges the authorization code at `POST /oauth/token` with `code_verifier`.
+2. GymTrack validates PKCE, checks consent status, and issues:
+   - a short-lived access token;
+   - a long-lived refresh token.
+3. Only SHA-256 hashes are stored in `public.gymtrack_oauth_tokens`; plaintext tokens are never written to the database.
+4. `grant_type=refresh_token` rotates the refresh token. Re-using an already-rotated refresh token revokes the whole consent family.
+5. `POST /oauth/revoke` revokes the full consent family for the presented token.
+6. Browser-side revocation from `/settings/agents` sets `consent.revoked_at`; every MCP access-token validation and refresh exchange checks that field, so revoked connections stop working immediately.
+
+### MCP tool flow
+
+1. The external client calls `POST /mcp` with `Authorization: Bearer <oauth access token>`.
+2. The MCP service hashes the token, loads the token row and consent row, verifies expiry and revocation, and derives the acting `user_id` from the token record.
+3. `tools/list` advertises:
+   - `plan_workout`
+   - `read_history`
+   - `read_exercise_progression`
+4. `tools/call` dispatches into `apps/gymtrack/server/agentData.js`, which reuses the same validation and Supabase query logic the legacy REST handlers use.
+5. The acting user is always the token's `user_id`; tool arguments never supply the owner id, which is how the service enforces per-user isolation.
+
+### Legacy REST compatibility
+
+The existing `/api/agent/planned-workouts`, `/api/agent/history`, and `/api/agent/exercises/:name/progression` routes still authenticate only against `public.gymtrack_agent_api_keys`. Their request/response contracts are unchanged, which preserves existing integrations from task `f520c396`.
+
+---
+
+## Data contracts
+
+### Supabase tables
+
+| Table | Purpose | Notes |
+|---|---|---|
+| `workouts` | Logged workout sessions | `user_id`-scoped via RLS |
+| `workout_sets` | Logged sets | Scoped through parent workout |
+| `planned_workouts` | Planned workout shells | Shared by legacy REST and MCP |
+| `planned_workout_sets` | Planned target sets | Shared by legacy REST and MCP |
+| `gymtrack_agent_api_keys` | Legacy static REST credentials | Hashed token only |
+| `gymtrack_oauth_clients` | MCP client allowlist | Static redirect-URI registration |
+| `gymtrack_oauth_consents` | User-visible MCP connections | One active consent per user/client |
+| `gymtrack_oauth_authorization_codes` | PKCE-bound authorization codes | Hashed code only |
+| `gymtrack_oauth_tokens` | Access + refresh tokens | Hashed tokens only; family metadata for rotation/replay detection |
+
+### MCP tools
+
+| Tool | Required scope | Behaviour |
+|---|---|---|
+| `plan_workout` | `workouts:write` | Creates a `planned_workouts` row and child `planned_workout_sets` rows for the token's user |
+| `read_history` | `history:read` | Reads recent workouts and set history for the token's user |
+| `read_exercise_progression` | `progression:read` | Reads per-exercise progression for the token's user |
+
+### OAuth metadata
+
+- `GET /.well-known/oauth-authorization-server`
+- `GET /.well-known/oauth-protected-resource`
+- Public-client OAuth only (`token_endpoint_auth_methods_supported: ["none"]`)
+- Authorization Code + PKCE (`code_challenge_method=S256`)
+- Supported scopes: `workouts:write`, `history:read`, `progression:read`
+
+---
+
+## Runbook notes and failure modes
+
+### Required env/config
+
+SPA (`apps/gymtrack`):
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+- `VITE_GYMTRACK_MCP_BASE_URL` when the MCP service is on a different origin
+
+MCP service (`services/gymtrack-mcp`):
+- `VITE_SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `GYMTRACK_MCP_ISSUER`
+- `GYMTRACK_APP_URL`
+- `GYMTRACK_WEB_ORIGIN`
+
+### Common failure modes
+
+- **Supabase Google provider not configured** — Google buttons exist in the UI, but the backend provider wiring still lives outside this repo. The button-level `providerDisabled` heuristic degrades gracefully if the provider is missing.
+- **MCP client redirect URI mismatch** — `/oauth/authorize` returns `invalid_client` / `redirect_uri is not registered`. Fix the row in `gymtrack_oauth_clients` (or add the right client metadata before rollout).
+- **Consent appears revoked but a client still holds a token** — expected: the client may still possess the old plaintext token, but MCP requests fail because the service checks `consent.revoked_at` at request time.
+- **Refresh-token replay** — the family is revoked. The user must reconnect the client through the browser flow.
+- **Missing service-role key** — both legacy REST and MCP OAuth server fail closed; they do not fall back to browser anon auth for server-side routes.
+
+### Manual checks after deploy
+
+1. Hit `GET /.well-known/oauth-authorization-server` and confirm issuer + endpoints are correct.
+2. Start an OAuth flow from a registered client and confirm `/agent-consent` loads with the expected scopes.
+3. Approve, exchange the code, call `tools/list`, then revoke from `/settings/agents` and verify the same token stops working.
+4. Re-run the three legacy REST curl examples from `apps/gymtrack/README.md` with an existing static key.
+
+---
+
+## Related specs, tasks, and PRs
+
+- Tasks: `18256740`, `f520c396`, `72d7cc3b`, `1474d515`
+- Tech designs:
+  - `docs/specs/gymtrack-mvp-tech-design.md`
+  - `docs/specs/gymtrack-agent-powered-workouts-tech-design.md`
+  - `docs/specs/gymtrack-public-signup-social-login-tech-design.md`
+  - `docs/specs/gymtrack-mcp-server-oauth-auth-tech-design.md`
+- Current implementation branch: `task-1474d515-gymtrack-mcp-server-oauth-redo`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7779,6 +7779,10 @@
       "resolved": "packages/design-tokens",
       "link": true
     },
+    "node_modules/@sindustries/gymtrack-mcp": {
+      "resolved": "services/gymtrack-mcp",
+      "link": true
+    },
     "node_modules/@sindustries/mission-control": {
       "resolved": "apps/mission-control",
       "link": true
@@ -21764,6 +21768,18 @@
         "supertest": "^7.0.0",
         "tsx": "^4.19.1",
         "typescript": "^5.8.2",
+        "vitest": "^4.1.8"
+      }
+    },
+    "services/gymtrack-mcp": {
+      "name": "@sindustries/gymtrack-mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.45.0",
+        "express": "^4.21.0"
+      },
+      "devDependencies": {
+        "supertest": "^7.0.0",
         "vitest": "^4.1.8"
       }
     },

--- a/services/gymtrack-mcp/README.md
+++ b/services/gymtrack-mcp/README.md
@@ -1,0 +1,55 @@
+# GymTrack MCP Server
+
+Machine-facing OAuth + MCP surface for GymTrack.
+
+## Endpoints
+
+- `GET /.well-known/oauth-authorization-server`
+- `GET /.well-known/oauth-protected-resource`
+- `GET /oauth/authorize`
+- `POST /oauth/token`
+- `POST /oauth/revoke`
+- `POST /mcp`
+- `GET /health`
+
+## Tools
+
+- `plan_workout`
+- `read_history`
+- `read_exercise_progression`
+
+## Env
+
+Required:
+
+- `VITE_SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `GYMTRACK_MCP_ISSUER`
+- `GYMTRACK_APP_URL`
+- `GYMTRACK_WEB_ORIGIN`
+
+Optional:
+
+- `GYMTRACK_MCP_PORT` (default `8787`)
+- `GYMTRACK_MCP_ACCESS_TOKEN_TTL_SECONDS` (default `3600`)
+- `GYMTRACK_MCP_REFRESH_TOKEN_TTL_SECONDS` (default `7776000`)
+- `GYMTRACK_MCP_AUTH_CODE_TTL_SECONDS` (default `600`)
+
+## Local run
+
+```bash
+npm --workspace @sindustries/gymtrack-mcp start
+```
+
+## Test
+
+```bash
+npm --workspace @sindustries/gymtrack-mcp test
+```
+
+## Notes
+
+- Uses OAuth Authorization Code + PKCE (`S256`) for public clients.
+- Stores only SHA-256 hashes of authorization codes, access tokens, and refresh tokens.
+- Refresh-token replay revokes the whole token family.
+- Uses the same shared GymTrack query/validation helpers as the legacy `/api/agent/*` routes so tool behaviour stays aligned with the REST contract.

--- a/services/gymtrack-mcp/package.json
+++ b/services/gymtrack-mcp/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@sindustries/gymtrack-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch src/server.js",
+    "start": "node src/server.js",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.0",
+    "express": "^4.21.0"
+  },
+  "devDependencies": {
+    "supertest": "^7.0.0",
+    "vitest": "^4.1.8"
+  }
+}

--- a/services/gymtrack-mcp/src/app.js
+++ b/services/gymtrack-mcp/src/app.js
@@ -55,6 +55,9 @@ function validateAuthorizeRequest(query) {
   if (query.response_type !== 'code') {
     return 'response_type must be code.';
   }
+  if (!String(query.state ?? '').trim()) {
+    return 'state is required.';
+  }
   if (!query.code_challenge) {
     return 'code_challenge is required.';
   }
@@ -274,12 +277,6 @@ export function createApp({
         });
 
         if (!codeRow) return oauthJsonError(res, 400, 'invalid_grant', 'Authorization code is not valid.');
-        if (codeRow.revoked_at || codeRow.consumed_at) {
-          return oauthJsonError(res, 400, 'invalid_grant', 'Authorization code has already been used.');
-        }
-        if (new Date(codeRow.expires_at).getTime() <= now().getTime()) {
-          return oauthJsonError(res, 400, 'invalid_grant', 'Authorization code has expired.');
-        }
         if (codeRow.code_challenge_method !== 'S256') {
           return oauthJsonError(res, 400, 'invalid_grant', 'Unsupported PKCE challenge method.');
         }
@@ -321,53 +318,44 @@ export function createApp({
           return oauthJsonError(res, 400, 'invalid_request', 'refresh_token is required.');
         }
 
-        const tokenRow = await repo.findTokenByRefreshHash(sha256Hex(refreshToken));
-        if (!tokenRow || tokenRow.client_id !== clientId) {
+        const accessToken = randomToken(32);
+        const nextRefreshToken = randomToken(32);
+        const rotation = await repo.rotateRefreshToken({
+          refreshTokenHash: sha256Hex(refreshToken),
+          clientId,
+          rotatedAt: now(),
+          nextAccessTokenHash: sha256Hex(accessToken),
+          nextRefreshTokenHash: sha256Hex(nextRefreshToken),
+          nextAccessTokenExpiresAt: new Date(now().getTime() + config.accessTokenTtlSeconds * 1000),
+          nextRefreshTokenExpiresAt: new Date(now().getTime() + config.refreshTokenTtlSeconds * 1000)
+        });
+
+        if (rotation.status === 'invalid') {
           return oauthJsonError(res, 400, 'invalid_grant', 'Refresh token is not valid.');
         }
 
-        const consent = await repo.getConsent(tokenRow.consent_id);
-        if (!consent || consent.revoked_at) {
+        if (rotation.status === 'consent_revoked') {
           return oauthJsonError(res, 400, 'invalid_grant', 'Consent has been revoked.');
         }
-        if (tokenRow.revoked_at || tokenRow.rotated_at) {
-          await repo.revokeConsentFamily({
-            consentId: tokenRow.consent_id,
-            revokedAt: now(),
-            reason: 'refresh_replay_detected'
-          });
+
+        if (rotation.status === 'replayed') {
           return oauthJsonError(res, 400, 'invalid_grant', 'Refresh token has already been used.');
         }
-        if (new Date(tokenRow.refresh_token_expires_at).getTime() <= now().getTime()) {
+
+        if (rotation.status === 'expired') {
           return oauthJsonError(res, 400, 'invalid_grant', 'Refresh token has expired.');
         }
 
-        const accessToken = randomToken(32);
-        const nextRefreshToken = randomToken(32);
-        const nextRow = await repo.createToken({
-          consentId: consent.id,
-          userId: consent.user_id,
-          clientId: consent.client_id,
-          scope: consent.scope,
-          familyId: tokenRow.family_id,
-          parentTokenId: tokenRow.id,
-          accessTokenHash: sha256Hex(accessToken),
-          refreshTokenHash: sha256Hex(nextRefreshToken),
-          accessTokenExpiresAt: new Date(now().getTime() + config.accessTokenTtlSeconds * 1000),
-          refreshTokenExpiresAt: new Date(now().getTime() + config.refreshTokenTtlSeconds * 1000)
-        });
-        await repo.markTokenRotated({
-          tokenId: tokenRow.id,
-          replacedByTokenId: nextRow.id,
-          rotatedAt: now()
-        });
+        if (rotation.status !== 'rotated') {
+          return oauthJsonError(res, 500, 'server_error', `Unexpected refresh rotation status: ${rotation.status}`);
+        }
 
         return res.status(200).json({
           token_type: 'Bearer',
           access_token: accessToken,
           expires_in: config.accessTokenTtlSeconds,
           refresh_token: nextRefreshToken,
-          scope: consent.scope
+          scope: rotation.consent.scope
         });
       }
 

--- a/services/gymtrack-mcp/src/app.js
+++ b/services/gymtrack-mcp/src/app.js
@@ -1,0 +1,449 @@
+import express from 'express';
+import { randomUUID } from 'node:crypto';
+import { loadConfig } from './config.js';
+import { createSupabaseRepo } from './repo.js';
+import { DEFAULT_SCOPE, normalizeScope, SUPPORTED_SCOPES } from './scopes.js';
+import { MCP_TOOLS, callMcpTool } from './mcpTools.js';
+import { pkceChallengeForVerifier, randomToken, sha256Hex } from './crypto.js';
+import { supabaseAdminClient } from './supabase.js';
+
+function appendOAuthParams(baseUrl, params) {
+  const url = new URL(baseUrl);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value != null && value !== '') url.searchParams.set(key, value);
+  });
+  return url.toString();
+}
+
+function parseBearerToken(req) {
+  const header = req.headers.authorization ?? req.headers.Authorization;
+  if (!header || typeof header !== 'string') return null;
+  const match = header.match(/^Bearer\s+(\S+)$/i);
+  return match ? match[1] : null;
+}
+
+function oauthJsonError(res, status, error, description) {
+  return res.status(status).json({ error, error_description: description });
+}
+
+function jsonRpcSuccess(id, result) {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function jsonRpcError(id, code, message) {
+  return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+async function validateClientRedirect(repo, clientId, redirectUri) {
+  if (!clientId) return { error: 'client_id is required.' };
+  if (!redirectUri) return { error: 'redirect_uri is required.' };
+
+  const oauthClient = await repo.getOAuthClient(clientId);
+  if (!oauthClient) return { error: 'Unknown client_id.' };
+
+  const allowed = Array.isArray(oauthClient.redirect_uris)
+    ? oauthClient.redirect_uris
+    : [];
+  if (!allowed.includes(redirectUri)) {
+    return { error: 'redirect_uri is not registered for this client.' };
+  }
+
+  return { oauthClient };
+}
+
+function validateAuthorizeRequest(query) {
+  if (query.response_type !== 'code') {
+    return 'response_type must be code.';
+  }
+  if (!query.code_challenge) {
+    return 'code_challenge is required.';
+  }
+  if (query.code_challenge_method !== 'S256') {
+    return 'code_challenge_method must be S256.';
+  }
+  const normalized = normalizeScope(query.scope ?? DEFAULT_SCOPE);
+  if (normalized.error) return normalized.error;
+  return null;
+}
+
+async function resolveOAuthIdentity(repo, token, now = new Date()) {
+  if (!token) return null;
+  const row = await repo.findTokenByAccessHash(sha256Hex(token));
+  if (!row) return null;
+  const consent = await repo.getConsent(row.consent_id);
+  if (!consent) return null;
+  if (row.revoked_at || consent.revoked_at) return null;
+  if (new Date(row.access_token_expires_at).getTime() <= now.getTime()) return null;
+
+  repo.touchTokenUsage({ tokenId: row.id, consentId: consent.id, usedAt: now }).catch(() => {});
+
+  return {
+    tokenId: row.id,
+    consentId: consent.id,
+    userId: row.user_id,
+    clientId: row.client_id,
+    scope: row.scope
+  };
+}
+
+export function createApp({
+  config = loadConfig(),
+  repo = createSupabaseRepo(),
+  gymtrackClient = supabaseAdminClient(),
+  now = () => new Date()
+} = {}) {
+  const app = express();
+
+  app.use((req, res, next) => {
+    const origin = req.headers.origin;
+    if (origin && origin === config.webOrigin) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Vary', 'Origin');
+    }
+    res.setHeader('Access-Control-Allow-Methods', 'GET,POST,DELETE,OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    if (req.method === 'OPTIONS') return res.sendStatus(204);
+    next();
+  });
+
+  app.use(express.json({ limit: '100kb' }));
+  app.use(express.urlencoded({ extended: false }));
+
+  app.get('/', (_req, res) => {
+    res.status(200).json({
+      service: 'gymtrack-mcp',
+      mcpEndpoint: `${config.issuer}/mcp`,
+      authorizationServer: `${config.issuer}/.well-known/oauth-authorization-server`
+    });
+  });
+
+  app.get('/health', (_req, res) => {
+    res.status(200).json({ status: 'ok', service: 'gymtrack-mcp' });
+  });
+
+  app.get('/.well-known/oauth-authorization-server', (_req, res) => {
+    res.status(200).json({
+      issuer: config.issuer,
+      authorization_endpoint: `${config.issuer}/oauth/authorize`,
+      token_endpoint: `${config.issuer}/oauth/token`,
+      revocation_endpoint: `${config.issuer}/oauth/revoke`,
+      response_types_supported: ['code'],
+      code_challenge_methods_supported: ['S256'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      token_endpoint_auth_methods_supported: ['none'],
+      scopes_supported: SUPPORTED_SCOPES
+    });
+  });
+
+  app.get('/.well-known/oauth-protected-resource', (_req, res) => {
+    res.status(200).json({
+      resource: `${config.issuer}/mcp`,
+      authorization_servers: [config.issuer],
+      bearer_methods_supported: ['header'],
+      scopes_supported: SUPPORTED_SCOPES
+    });
+  });
+
+  app.get('/oauth/authorize', async (req, res) => {
+    try {
+      const requestError = validateAuthorizeRequest(req.query);
+      if (requestError) return oauthJsonError(res, 400, 'invalid_request', requestError);
+
+      const clientResult = await validateClientRedirect(
+        repo,
+        req.query.client_id,
+        req.query.redirect_uri
+      );
+      if (clientResult.error) {
+        return oauthJsonError(res, 400, 'invalid_client', clientResult.error);
+      }
+
+      const consentUrl = new URL('/agent-consent', config.appUrl);
+      [
+        'client_id',
+        'redirect_uri',
+        'response_type',
+        'scope',
+        'state',
+        'code_challenge',
+        'code_challenge_method'
+      ].forEach((key) => {
+        const value = req.query[key];
+        if (value != null) consentUrl.searchParams.set(key, value);
+      });
+
+      return res.redirect(302, consentUrl.toString());
+    } catch (error) {
+      return oauthJsonError(res, 500, 'server_error', error.message);
+    }
+  });
+
+  app.post('/oauth/authorize/decision', async (req, res) => {
+    try {
+      const bearer = parseBearerToken(req);
+      if (!bearer) return oauthJsonError(res, 401, 'invalid_request', 'Missing user access token.');
+
+      const user = await repo.verifySupabaseUserAccessToken(bearer);
+      if (!user) return oauthJsonError(res, 401, 'access_denied', 'User session is not valid.');
+
+      const requestError = validateAuthorizeRequest({
+        ...req.body,
+        response_type: 'code'
+      });
+      if (requestError) return oauthJsonError(res, 400, 'invalid_request', requestError);
+
+      const clientResult = await validateClientRedirect(repo, req.body.client_id, req.body.redirect_uri);
+      if (clientResult.error) return oauthJsonError(res, 400, 'invalid_client', clientResult.error);
+
+      if (req.body.approve === false) {
+        return res.status(200).json({
+          redirectTo: appendOAuthParams(req.body.redirect_uri, {
+            error: 'access_denied',
+            state: req.body.state ?? ''
+          })
+        });
+      }
+
+      const normalizedScope = normalizeScope(req.body.scope ?? DEFAULT_SCOPE);
+      if (normalizedScope.error) {
+        return oauthJsonError(res, 400, 'invalid_scope', normalizedScope.error);
+      }
+
+      const consent = await repo.upsertConsent({
+        userId: user.id,
+        clientId: req.body.client_id,
+        scope: normalizedScope.scope,
+        grantedAt: now()
+      });
+
+      const code = randomToken(24);
+      await repo.createAuthorizationCode({
+        consentId: consent.id,
+        userId: user.id,
+        clientId: req.body.client_id,
+        codeHash: sha256Hex(code),
+        redirectUri: req.body.redirect_uri,
+        scope: normalizedScope.scope,
+        codeChallenge: req.body.code_challenge,
+        codeChallengeMethod: req.body.code_challenge_method,
+        expiresAt: new Date(now().getTime() + config.authorizationCodeTtlSeconds * 1000)
+      });
+
+      return res.status(200).json({
+        redirectTo: appendOAuthParams(req.body.redirect_uri, {
+          code,
+          state: req.body.state ?? ''
+        })
+      });
+    } catch (error) {
+      return oauthJsonError(res, 500, 'server_error', error.message);
+    }
+  });
+
+  app.post('/oauth/token', async (req, res) => {
+    try {
+      const grantType = req.body.grant_type;
+      const clientId = req.body.client_id;
+      if (!grantType) return oauthJsonError(res, 400, 'invalid_request', 'grant_type is required.');
+      if (!clientId) return oauthJsonError(res, 400, 'invalid_request', 'client_id is required.');
+
+      const oauthClient = await repo.getOAuthClient(clientId);
+      if (!oauthClient) return oauthJsonError(res, 400, 'invalid_client', 'Unknown client_id.');
+
+      if (grantType === 'authorization_code') {
+        const code = req.body.code;
+        const redirectUri = req.body.redirect_uri;
+        const verifier = req.body.code_verifier;
+        if (!code || !redirectUri || !verifier) {
+          return oauthJsonError(
+            res,
+            400,
+            'invalid_request',
+            'code, redirect_uri, and code_verifier are required.'
+          );
+        }
+
+        const clientResult = await validateClientRedirect(repo, clientId, redirectUri);
+        if (clientResult.error) return oauthJsonError(res, 400, 'invalid_client', clientResult.error);
+
+        const codeRow = await repo.consumeAuthorizationCode({
+          codeHash: sha256Hex(code),
+          clientId,
+          redirectUri,
+          consumedAt: now()
+        });
+
+        if (!codeRow) return oauthJsonError(res, 400, 'invalid_grant', 'Authorization code is not valid.');
+        if (codeRow.revoked_at || codeRow.consumed_at) {
+          return oauthJsonError(res, 400, 'invalid_grant', 'Authorization code has already been used.');
+        }
+        if (new Date(codeRow.expires_at).getTime() <= now().getTime()) {
+          return oauthJsonError(res, 400, 'invalid_grant', 'Authorization code has expired.');
+        }
+        if (codeRow.code_challenge_method !== 'S256') {
+          return oauthJsonError(res, 400, 'invalid_grant', 'Unsupported PKCE challenge method.');
+        }
+        if (pkceChallengeForVerifier(verifier) !== codeRow.code_challenge) {
+          return oauthJsonError(res, 400, 'invalid_grant', 'PKCE verification failed.');
+        }
+
+        const consent = await repo.getConsent(codeRow.consent_id);
+        if (!consent || consent.revoked_at) {
+          return oauthJsonError(res, 400, 'invalid_grant', 'Consent has been revoked.');
+        }
+
+        const accessToken = randomToken(32);
+        const refreshToken = randomToken(32);
+        await repo.createToken({
+          consentId: consent.id,
+          userId: consent.user_id,
+          clientId: consent.client_id,
+          scope: consent.scope,
+          familyId: randomUUID(),
+          accessTokenHash: sha256Hex(accessToken),
+          refreshTokenHash: sha256Hex(refreshToken),
+          accessTokenExpiresAt: new Date(now().getTime() + config.accessTokenTtlSeconds * 1000),
+          refreshTokenExpiresAt: new Date(now().getTime() + config.refreshTokenTtlSeconds * 1000)
+        });
+
+        return res.status(200).json({
+          token_type: 'Bearer',
+          access_token: accessToken,
+          expires_in: config.accessTokenTtlSeconds,
+          refresh_token: refreshToken,
+          scope: consent.scope
+        });
+      }
+
+      if (grantType === 'refresh_token') {
+        const refreshToken = req.body.refresh_token;
+        if (!refreshToken) {
+          return oauthJsonError(res, 400, 'invalid_request', 'refresh_token is required.');
+        }
+
+        const tokenRow = await repo.findTokenByRefreshHash(sha256Hex(refreshToken));
+        if (!tokenRow || tokenRow.client_id !== clientId) {
+          return oauthJsonError(res, 400, 'invalid_grant', 'Refresh token is not valid.');
+        }
+
+        const consent = await repo.getConsent(tokenRow.consent_id);
+        if (!consent || consent.revoked_at) {
+          return oauthJsonError(res, 400, 'invalid_grant', 'Consent has been revoked.');
+        }
+        if (tokenRow.revoked_at || tokenRow.rotated_at) {
+          await repo.revokeConsentFamily({
+            consentId: tokenRow.consent_id,
+            revokedAt: now(),
+            reason: 'refresh_replay_detected'
+          });
+          return oauthJsonError(res, 400, 'invalid_grant', 'Refresh token has already been used.');
+        }
+        if (new Date(tokenRow.refresh_token_expires_at).getTime() <= now().getTime()) {
+          return oauthJsonError(res, 400, 'invalid_grant', 'Refresh token has expired.');
+        }
+
+        const accessToken = randomToken(32);
+        const nextRefreshToken = randomToken(32);
+        const nextRow = await repo.createToken({
+          consentId: consent.id,
+          userId: consent.user_id,
+          clientId: consent.client_id,
+          scope: consent.scope,
+          familyId: tokenRow.family_id,
+          parentTokenId: tokenRow.id,
+          accessTokenHash: sha256Hex(accessToken),
+          refreshTokenHash: sha256Hex(nextRefreshToken),
+          accessTokenExpiresAt: new Date(now().getTime() + config.accessTokenTtlSeconds * 1000),
+          refreshTokenExpiresAt: new Date(now().getTime() + config.refreshTokenTtlSeconds * 1000)
+        });
+        await repo.markTokenRotated({
+          tokenId: tokenRow.id,
+          replacedByTokenId: nextRow.id,
+          rotatedAt: now()
+        });
+
+        return res.status(200).json({
+          token_type: 'Bearer',
+          access_token: accessToken,
+          expires_in: config.accessTokenTtlSeconds,
+          refresh_token: nextRefreshToken,
+          scope: consent.scope
+        });
+      }
+
+      return oauthJsonError(res, 400, 'unsupported_grant_type', `Unsupported grant_type: ${grantType}`);
+    } catch (error) {
+      return oauthJsonError(res, 500, 'server_error', error.message);
+    }
+  });
+
+  app.post('/oauth/revoke', async (req, res) => {
+    try {
+      const token = req.body.token;
+      if (!token) return res.status(200).end();
+
+      const tokenHash = sha256Hex(token);
+      const row =
+        (await repo.findTokenByAccessHash(tokenHash)) ??
+        (await repo.findTokenByRefreshHash(tokenHash));
+
+      if (row) {
+        await repo.revokeConsentFamily({
+          consentId: row.consent_id,
+          revokedAt: now(),
+          reason: 'oauth_revocation'
+        });
+      }
+
+      return res.status(200).end();
+    } catch (error) {
+      return oauthJsonError(res, 500, 'server_error', error.message);
+    }
+  });
+
+  app.post('/mcp', async (req, res) => {
+    const rpc = req.body;
+    if (!rpc || typeof rpc !== 'object') {
+      return res.status(400).json(jsonRpcError(null, -32700, 'Invalid JSON-RPC payload.'));
+    }
+
+    try {
+      const identity = await resolveOAuthIdentity(repo, parseBearerToken(req), now());
+      if (!identity) {
+        return res.status(401).json(jsonRpcError(rpc.id ?? null, -32001, 'Unauthorized.'));
+      }
+
+      if (rpc.method === 'initialize') {
+        return res.status(200).json(
+          jsonRpcSuccess(rpc.id ?? null, {
+            protocolVersion: '2025-03-26',
+            capabilities: { tools: {} },
+            serverInfo: { name: 'gymtrack-mcp', version: '0.1.0' }
+          })
+        );
+      }
+
+      if (rpc.method === 'tools/list') {
+        return res.status(200).json(jsonRpcSuccess(rpc.id ?? null, { tools: MCP_TOOLS }));
+      }
+
+      if (rpc.method === 'tools/call') {
+        const result = await callMcpTool({
+          client: gymtrackClient,
+          identity,
+          name: rpc.params?.name,
+          args: rpc.params?.arguments ?? {}
+        });
+        return res.status(200).json(jsonRpcSuccess(rpc.id ?? null, result));
+      }
+
+      return res.status(404).json(jsonRpcError(rpc.id ?? null, -32601, `Method not found: ${rpc.method}`));
+    } catch (error) {
+      const status = error?.status ?? 500;
+      const code = status === 400 ? -32602 : status === 403 ? -32003 : -32000;
+      return res.status(status).json(jsonRpcError(rpc.id ?? null, code, error.message));
+    }
+  });
+
+  return app;
+}

--- a/services/gymtrack-mcp/src/config.js
+++ b/services/gymtrack-mcp/src/config.js
@@ -1,0 +1,15 @@
+export function loadConfig(env = process.env) {
+  const issuer = env.GYMTRACK_MCP_ISSUER ?? `http://localhost:${env.GYMTRACK_MCP_PORT ?? '8787'}`;
+  const appUrl = env.GYMTRACK_APP_URL ?? 'http://localhost:5173';
+  const webOrigin = env.GYMTRACK_WEB_ORIGIN ?? new URL(appUrl).origin;
+
+  return {
+    port: Number(env.GYMTRACK_MCP_PORT ?? 8787),
+    issuer,
+    appUrl,
+    webOrigin,
+    accessTokenTtlSeconds: Number(env.GYMTRACK_MCP_ACCESS_TOKEN_TTL_SECONDS ?? 3600),
+    refreshTokenTtlSeconds: Number(env.GYMTRACK_MCP_REFRESH_TOKEN_TTL_SECONDS ?? 60 * 60 * 24 * 90),
+    authorizationCodeTtlSeconds: Number(env.GYMTRACK_MCP_AUTH_CODE_TTL_SECONDS ?? 600)
+  };
+}

--- a/services/gymtrack-mcp/src/crypto.js
+++ b/services/gymtrack-mcp/src/crypto.js
@@ -1,0 +1,13 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+export function sha256Hex(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function randomToken(size = 32) {
+  return randomBytes(size).toString('base64url');
+}
+
+export function pkceChallengeForVerifier(verifier) {
+  return createHash('sha256').update(verifier).digest('base64url');
+}

--- a/services/gymtrack-mcp/src/mcpTools.js
+++ b/services/gymtrack-mcp/src/mcpTools.js
@@ -1,0 +1,143 @@
+import {
+  createPlannedWorkout,
+  exerciseNameErrorMessage,
+  fetchExerciseProgression,
+  fetchWorkoutHistory,
+  normalizeExerciseName,
+  parseHistoryLimit,
+  parseProgressionLimit,
+  validatePlannedWorkoutBody
+} from '../../../apps/gymtrack/server/agentData.js';
+import { scopeAllows } from './scopes.js';
+
+export const MCP_TOOLS = [
+  {
+    name: 'plan_workout',
+    description: 'Create a planned workout for the authenticated GymTrack user.',
+    inputSchema: {
+      type: 'object',
+      required: ['scheduledFor', 'title', 'exercises'],
+      properties: {
+        scheduledFor: { type: 'string', description: 'Workout date in YYYY-MM-DD format.' },
+        title: { type: 'string' },
+        notes: { type: 'string' },
+        exercises: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['name', 'sets'],
+            properties: {
+              name: { type: 'string' },
+              sets: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['reps', 'weight'],
+                  properties: {
+                    reps: { type: 'integer' },
+                    weight: { type: 'number' },
+                    unit: { type: 'string', enum: ['kg', 'lb'] },
+                    notes: { type: 'string' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    name: 'read_history',
+    description: 'Read the authenticated user\'s recent GymTrack workout history.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'integer', minimum: 1, maximum: 50 }
+      }
+    }
+  },
+  {
+    name: 'read_exercise_progression',
+    description: 'Read progression history for one exercise for the authenticated GymTrack user.',
+    inputSchema: {
+      type: 'object',
+      required: ['exerciseName'],
+      properties: {
+        exerciseName: { type: 'string' },
+        limit: { type: 'integer', minimum: 1, maximum: 200 }
+      }
+    }
+  }
+];
+
+function mcpJson(payload) {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(payload)
+      }
+    ],
+    structuredContent: payload
+  };
+}
+
+export async function callMcpTool({ client, identity, name, args }) {
+  if (name === 'plan_workout') {
+    if (!scopeAllows(identity.scope, 'workouts:write')) {
+      throw Object.assign(new Error('Missing required scope workouts:write.'), { status: 403 });
+    }
+    const validationError = validatePlannedWorkoutBody(args);
+    if (validationError) {
+      throw Object.assign(new Error(validationError), { status: 400 });
+    }
+    const result = await createPlannedWorkout(client, {
+      userId: identity.userId,
+      legacyAgentKeyId: null,
+      body: args
+    });
+    return mcpJson(result);
+  }
+
+  if (name === 'read_history') {
+    if (!scopeAllows(identity.scope, 'history:read')) {
+      throw Object.assign(new Error('Missing required scope history:read.'), { status: 403 });
+    }
+    const limit = parseHistoryLimit(args?.limit);
+    if (typeof limit === 'string') {
+      throw Object.assign(new Error(limit), { status: 400 });
+    }
+    return mcpJson(
+      await fetchWorkoutHistory(client, {
+        userId: identity.userId,
+        limit
+      })
+    );
+  }
+
+  if (name === 'read_exercise_progression') {
+    if (!scopeAllows(identity.scope, 'progression:read')) {
+      throw Object.assign(new Error('Missing required scope progression:read.'), { status: 403 });
+    }
+    const exerciseName = normalizeExerciseName(args?.exerciseName);
+    if (exerciseName == null) {
+      throw Object.assign(new Error(exerciseNameErrorMessage(args?.exerciseName) ?? 'exerciseName is required.'), {
+        status: 400
+      });
+    }
+    const limit = parseProgressionLimit(args?.limit);
+    if (typeof limit === 'string') {
+      throw Object.assign(new Error(limit), { status: 400 });
+    }
+    return mcpJson(
+      await fetchExerciseProgression(client, {
+        userId: identity.userId,
+        exerciseName,
+        limit
+      })
+    );
+  }
+
+  throw Object.assign(new Error(`Unknown tool: ${name}`), { status: 404 });
+}

--- a/services/gymtrack-mcp/src/repo.js
+++ b/services/gymtrack-mcp/src/repo.js
@@ -1,0 +1,210 @@
+import { supabaseAdminClient } from './supabase.js';
+
+function iso(value) {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+export function createSupabaseRepo({ client = supabaseAdminClient() } = {}) {
+  return {
+    async getOAuthClient(clientId) {
+      const { data, error } = await client
+        .from('gymtrack_oauth_clients')
+        .select('*')
+        .eq('client_id', clientId)
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+
+    async getConsent(consentId) {
+      const { data, error } = await client
+        .from('gymtrack_oauth_consents')
+        .select('*')
+        .eq('id', consentId)
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+
+    async upsertConsent({ userId, clientId, scope, grantedAt }) {
+      const { data: existing, error: existingError } = await client
+        .from('gymtrack_oauth_consents')
+        .select('*')
+        .eq('user_id', userId)
+        .eq('client_id', clientId)
+        .is('revoked_at', null)
+        .maybeSingle();
+      if (existingError) throw existingError;
+
+      if (existing) {
+        const { data, error } = await client
+          .from('gymtrack_oauth_consents')
+          .update({
+            scope,
+            granted_at: iso(grantedAt)
+          })
+          .eq('id', existing.id)
+          .select()
+          .single();
+        if (error) throw error;
+        return data;
+      }
+
+      const { data, error } = await client
+        .from('gymtrack_oauth_consents')
+        .insert({
+          user_id: userId,
+          client_id: clientId,
+          scope,
+          granted_at: iso(grantedAt)
+        })
+        .select()
+        .single();
+      if (error) throw error;
+      return data;
+    },
+
+    async createAuthorizationCode(record) {
+      const { data, error } = await client
+        .from('gymtrack_oauth_authorization_codes')
+        .insert({
+          consent_id: record.consentId,
+          user_id: record.userId,
+          client_id: record.clientId,
+          code_hash: record.codeHash,
+          redirect_uri: record.redirectUri,
+          scope: record.scope,
+          code_challenge: record.codeChallenge,
+          code_challenge_method: record.codeChallengeMethod,
+          expires_at: iso(record.expiresAt)
+        })
+        .select()
+        .single();
+      if (error) throw error;
+      return data;
+    },
+
+    async consumeAuthorizationCode({ codeHash, clientId, redirectUri, consumedAt }) {
+      const { data, error } = await client
+        .from('gymtrack_oauth_authorization_codes')
+        .select('*')
+        .eq('code_hash', codeHash)
+        .eq('client_id', clientId)
+        .eq('redirect_uri', redirectUri)
+        .maybeSingle();
+      if (error) throw error;
+      if (!data) return null;
+
+      const { error: updateError } = await client
+        .from('gymtrack_oauth_authorization_codes')
+        .update({ consumed_at: iso(consumedAt) })
+        .eq('id', data.id)
+        .is('consumed_at', null);
+      if (updateError) throw updateError;
+      return data;
+    },
+
+    async createToken(record) {
+      const { data, error } = await client
+        .from('gymtrack_oauth_tokens')
+        .insert({
+          consent_id: record.consentId,
+          user_id: record.userId,
+          client_id: record.clientId,
+          scope: record.scope,
+          family_id: record.familyId,
+          parent_token_id: record.parentTokenId ?? null,
+          access_token_hash: record.accessTokenHash,
+          refresh_token_hash: record.refreshTokenHash,
+          access_token_expires_at: iso(record.accessTokenExpiresAt),
+          refresh_token_expires_at: iso(record.refreshTokenExpiresAt)
+        })
+        .select()
+        .single();
+      if (error) throw error;
+      return data;
+    },
+
+    async markTokenRotated({ tokenId, replacedByTokenId, rotatedAt }) {
+      const { error } = await client
+        .from('gymtrack_oauth_tokens')
+        .update({
+          rotated_at: iso(rotatedAt),
+          revoked_at: iso(rotatedAt),
+          revocation_reason: 'refresh_rotated',
+          replaced_by_token_id: replacedByTokenId
+        })
+        .eq('id', tokenId);
+      if (error) throw error;
+    },
+
+    async findTokenByAccessHash(accessTokenHash) {
+      const { data, error } = await client
+        .from('gymtrack_oauth_tokens')
+        .select('*')
+        .eq('access_token_hash', accessTokenHash)
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+
+    async findTokenByRefreshHash(refreshTokenHash) {
+      const { data, error } = await client
+        .from('gymtrack_oauth_tokens')
+        .select('*')
+        .eq('refresh_token_hash', refreshTokenHash)
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+
+    async touchTokenUsage({ tokenId, consentId, usedAt }) {
+      const timestamp = iso(usedAt);
+      const [tokenResult, consentResult] = await Promise.all([
+        client.from('gymtrack_oauth_tokens').update({ last_used_at: timestamp }).eq('id', tokenId),
+        client.from('gymtrack_oauth_consents').update({ last_used_at: timestamp }).eq('id', consentId)
+      ]);
+      if (tokenResult.error) throw tokenResult.error;
+      if (consentResult.error) throw consentResult.error;
+    },
+
+    async revokeConsentFamily({ consentId, revokedAt, reason }) {
+      const timestamp = iso(revokedAt);
+      const [consentResult, tokenResult, codeResult] = await Promise.all([
+        client
+          .from('gymtrack_oauth_consents')
+          .update({ revoked_at: timestamp })
+          .eq('id', consentId)
+          .is('revoked_at', null),
+        client
+          .from('gymtrack_oauth_tokens')
+          .update({ revoked_at: timestamp, revocation_reason: reason ?? 'revoked' })
+          .eq('consent_id', consentId)
+          .is('revoked_at', null),
+        client
+          .from('gymtrack_oauth_authorization_codes')
+          .update({ revoked_at: timestamp })
+          .eq('consent_id', consentId)
+          .is('revoked_at', null)
+      ]);
+      if (consentResult.error) throw consentResult.error;
+      if (tokenResult.error) throw tokenResult.error;
+      if (codeResult.error) throw codeResult.error;
+    },
+
+    async revokeAccessOrRefreshToken({ tokenId, revokedAt, reason }) {
+      const { error } = await client
+        .from('gymtrack_oauth_tokens')
+        .update({ revoked_at: iso(revokedAt), revocation_reason: reason ?? 'revoked' })
+        .eq('id', tokenId)
+        .is('revoked_at', null);
+      if (error) throw error;
+    },
+
+    async verifySupabaseUserAccessToken(accessToken) {
+      const { data, error } = await client.auth.getUser(accessToken);
+      if (error) return null;
+      return data.user ?? null;
+    }
+  };
+}

--- a/services/gymtrack-mcp/src/repo.js
+++ b/services/gymtrack-mcp/src/repo.js
@@ -85,23 +85,14 @@ export function createSupabaseRepo({ client = supabaseAdminClient() } = {}) {
     },
 
     async consumeAuthorizationCode({ codeHash, clientId, redirectUri, consumedAt }) {
-      const { data, error } = await client
-        .from('gymtrack_oauth_authorization_codes')
-        .select('*')
-        .eq('code_hash', codeHash)
-        .eq('client_id', clientId)
-        .eq('redirect_uri', redirectUri)
-        .maybeSingle();
+      const { data, error } = await client.rpc('gymtrack_consume_oauth_authorization_code', {
+        p_code_hash: codeHash,
+        p_client_id: clientId,
+        p_redirect_uri: redirectUri,
+        p_consumed_at: iso(consumedAt)
+      });
       if (error) throw error;
-      if (!data) return null;
-
-      const { error: updateError } = await client
-        .from('gymtrack_oauth_authorization_codes')
-        .update({ consumed_at: iso(consumedAt) })
-        .eq('id', data.id)
-        .is('consumed_at', null);
-      if (updateError) throw updateError;
-      return data;
+      return data ?? null;
     },
 
     async createToken(record) {
@@ -136,6 +127,28 @@ export function createSupabaseRepo({ client = supabaseAdminClient() } = {}) {
         })
         .eq('id', tokenId);
       if (error) throw error;
+    },
+
+    async rotateRefreshToken({
+      refreshTokenHash,
+      clientId,
+      rotatedAt,
+      nextAccessTokenHash,
+      nextRefreshTokenHash,
+      nextAccessTokenExpiresAt,
+      nextRefreshTokenExpiresAt
+    }) {
+      const { data, error } = await client.rpc('gymtrack_rotate_oauth_refresh_token', {
+        p_refresh_token_hash: refreshTokenHash,
+        p_client_id: clientId,
+        p_rotated_at: iso(rotatedAt),
+        p_next_access_token_hash: nextAccessTokenHash,
+        p_next_refresh_token_hash: nextRefreshTokenHash,
+        p_next_access_token_expires_at: iso(nextAccessTokenExpiresAt),
+        p_next_refresh_token_expires_at: iso(nextRefreshTokenExpiresAt)
+      });
+      if (error) throw error;
+      return data ?? { status: 'invalid' };
     },
 
     async findTokenByAccessHash(accessTokenHash) {

--- a/services/gymtrack-mcp/src/scopes.js
+++ b/services/gymtrack-mcp/src/scopes.js
@@ -1,0 +1,29 @@
+export const SUPPORTED_SCOPES = [
+  'workouts:write',
+  'history:read',
+  'progression:read'
+];
+
+export const DEFAULT_SCOPE = SUPPORTED_SCOPES.join(' ');
+
+export function normalizeScope(scope = DEFAULT_SCOPE) {
+  const parts = String(scope)
+    .split(/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  const unique = [...new Set(parts)];
+  if (unique.length === 0) return { scope: DEFAULT_SCOPE, scopes: [...SUPPORTED_SCOPES] };
+
+  const invalid = unique.filter((value) => !SUPPORTED_SCOPES.includes(value));
+  if (invalid.length > 0) {
+    return { error: `Unsupported scope: ${invalid.join(', ')}` };
+  }
+
+  return { scope: unique.join(' '), scopes: unique };
+}
+
+export function scopeAllows(scope, required) {
+  const granted = new Set(String(scope).split(/\s+/).filter(Boolean));
+  return granted.has(required);
+}

--- a/services/gymtrack-mcp/src/server.js
+++ b/services/gymtrack-mcp/src/server.js
@@ -1,0 +1,9 @@
+import { createApp } from './app.js';
+import { loadConfig } from './config.js';
+
+const config = loadConfig();
+const app = createApp({ config });
+
+app.listen(config.port, () => {
+  console.log(`gymtrack-mcp listening on ${config.port}`);
+});

--- a/services/gymtrack-mcp/src/supabase.js
+++ b/services/gymtrack-mcp/src/supabase.js
@@ -1,0 +1,24 @@
+import { createClient } from '@supabase/supabase-js';
+
+let cached = null;
+
+export function createSupabaseAdminClient(env = process.env) {
+  const url = env.VITE_SUPABASE_URL;
+  const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    throw new Error('GymTrack MCP: VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set.');
+  }
+
+  return createClient(url, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false }
+  });
+}
+
+export function supabaseAdminClient(env = process.env) {
+  if (!cached) cached = createSupabaseAdminClient(env);
+  return cached;
+}
+
+export function resetSupabaseAdminClientForTests() {
+  cached = null;
+}

--- a/services/gymtrack-mcp/test/app.test.js
+++ b/services/gymtrack-mcp/test/app.test.js
@@ -88,9 +88,15 @@ class FakeRepo {
       (item) => item.code_hash === codeHash && item.client_id === clientId && item.redirect_uri === redirectUri
     );
     if (!row) return null;
-    const before = structuredClone(row);
-    if (row.consumed_at == null) row.consumed_at = consumedAt.toISOString();
-    return before;
+    if (
+      row.consumed_at != null ||
+      row.revoked_at != null ||
+      new Date(row.expires_at).getTime() <= consumedAt.getTime()
+    ) {
+      return null;
+    }
+    row.consumed_at = consumedAt.toISOString();
+    return structuredClone(row);
   }
 
   async createToken(record) {
@@ -122,6 +128,83 @@ class FakeRepo {
     row.revoked_at = rotatedAt.toISOString();
     row.revocation_reason = 'refresh_rotated';
     row.replaced_by_token_id = replacedByTokenId;
+  }
+
+  async rotateRefreshToken({
+    refreshTokenHash,
+    clientId,
+    rotatedAt,
+    nextAccessTokenHash,
+    nextRefreshTokenHash,
+    nextAccessTokenExpiresAt,
+    nextRefreshTokenExpiresAt
+  }) {
+    const source = this.tokens.find(
+      (item) => item.refresh_token_hash === refreshTokenHash && item.client_id === clientId
+    );
+    if (!source) return { status: 'invalid' };
+
+    const consent = this.consents.find((item) => item.id === source.consent_id) ?? null;
+    if (!consent || consent.revoked_at) {
+      await this.revokeConsentFamily({
+        consentId: source.consent_id,
+        revokedAt: rotatedAt,
+        reason: 'consent_revoked'
+      });
+      return {
+        status: 'consent_revoked',
+        source_token: structuredClone(source),
+        consent: consent ? structuredClone(consent) : null
+      };
+    }
+
+    if (source.revoked_at || source.rotated_at) {
+      await this.revokeConsentFamily({
+        consentId: source.consent_id,
+        revokedAt: rotatedAt,
+        reason: 'refresh_replay_detected'
+      });
+      return {
+        status: 'replayed',
+        source_token: structuredClone(source),
+        consent: structuredClone(consent)
+      };
+    }
+
+    if (new Date(source.refresh_token_expires_at).getTime() <= rotatedAt.getTime()) {
+      return {
+        status: 'expired',
+        source_token: structuredClone(source),
+        consent: structuredClone(consent)
+      };
+    }
+
+    const nextRow = await this.createToken({
+      consentId: consent.id,
+      userId: consent.user_id,
+      clientId: consent.client_id,
+      scope: consent.scope,
+      familyId: source.family_id,
+      parentTokenId: source.id,
+      accessTokenHash: nextAccessTokenHash,
+      refreshTokenHash: nextRefreshTokenHash,
+      accessTokenExpiresAt: nextAccessTokenExpiresAt,
+      refreshTokenExpiresAt: nextRefreshTokenExpiresAt
+    });
+
+    source.rotated_at = rotatedAt.toISOString();
+    source.revoked_at = rotatedAt.toISOString();
+    source.revocation_reason = 'refresh_rotated';
+    source.replaced_by_token_id = nextRow.id;
+    source.last_used_at = rotatedAt.toISOString();
+    consent.last_used_at = rotatedAt.toISOString();
+
+    return {
+      status: 'rotated',
+      source_token: structuredClone(source),
+      next_token: structuredClone(nextRow),
+      consent: structuredClone(consent)
+    };
   }
 
   async findTokenByAccessHash(hash) {
@@ -211,6 +294,26 @@ describe('GymTrack MCP OAuth server', () => {
     expect(response.headers.location).toContain('state=opaque-state');
   });
 
+  it('rejects authorize requests without a non-empty state value', async () => {
+    const { app } = makeApp();
+
+    const response = await request(app)
+      .get('/oauth/authorize')
+      .query({
+        response_type: 'code',
+        client_id: 'claude-desktop',
+        redirect_uri: 'https://claude.example/callback',
+        scope: 'history:read progression:read workouts:write',
+        state: '   ',
+        code_challenge: 'pkce-challenge',
+        code_challenge_method: 'S256'
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_request');
+    expect(response.body.error_description).toMatch(/state is required/i);
+  });
+
   it('issues hashed access+refresh tokens and rotates refresh tokens', async () => {
     const fixedNow = new Date('2026-08-03T00:00:00.000Z');
     const { app, repo } = makeApp({ now: () => fixedNow });
@@ -257,6 +360,20 @@ describe('GymTrack MCP OAuth server', () => {
     expect(repo.tokens[0].access_token_hash).not.toBe(exchange.body.access_token);
     expect(repo.tokens[0].refresh_token_hash).not.toBe(exchange.body.refresh_token);
 
+    const reusedCode = await request(app)
+      .post('/oauth/token')
+      .type('form')
+      .send({
+        grant_type: 'authorization_code',
+        client_id: 'claude-desktop',
+        redirect_uri: 'https://claude.example/callback',
+        code,
+        code_verifier: verifier
+      });
+
+    expect(reusedCode.status).toBe(400);
+    expect(reusedCode.body.error).toBe('invalid_grant');
+
     const refresh = await request(app)
       .post('/oauth/token')
       .type('form')
@@ -283,6 +400,64 @@ describe('GymTrack MCP OAuth server', () => {
     expect(replay.status).toBe(400);
     expect(replay.body.error).toBe('invalid_grant');
     expect(repo.consents[0].revoked_at).toBe(fixedNow.toISOString());
+  });
+
+  it('revocation disables both MCP access and refresh-token exchange', async () => {
+    const { app, repo } = makeApp();
+
+    const decision = await request(app)
+      .post('/oauth/authorize/decision')
+      .set('Authorization', 'Bearer supabase-user-token')
+      .send({
+        approve: true,
+        client_id: 'claude-desktop',
+        redirect_uri: 'https://claude.example/callback',
+        scope: 'history:read progression:read workouts:write',
+        state: 'opaque-state',
+        code_challenge: 'dmVyLWNoYWxsZW5nZQ',
+        code_challenge_method: 'S256'
+      });
+
+    const verifier = 'verifier-123';
+    repo.codes[0].code_challenge = pkceChallengeForVerifier(verifier);
+    const code = new URL(decision.body.redirectTo).searchParams.get('code');
+
+    const exchange = await request(app)
+      .post('/oauth/token')
+      .type('form')
+      .send({
+        grant_type: 'authorization_code',
+        client_id: 'claude-desktop',
+        redirect_uri: 'https://claude.example/callback',
+        code,
+        code_verifier: verifier
+      });
+
+    const revoke = await request(app)
+      .post('/oauth/revoke')
+      .type('form')
+      .send({ token: exchange.body.refresh_token });
+
+    expect(revoke.status).toBe(200);
+
+    const refresh = await request(app)
+      .post('/oauth/token')
+      .type('form')
+      .send({
+        grant_type: 'refresh_token',
+        client_id: 'claude-desktop',
+        refresh_token: exchange.body.refresh_token
+      });
+
+    expect(refresh.status).toBe(400);
+    expect(refresh.body.error).toBe('invalid_grant');
+
+    const mcp = await request(app)
+      .post('/mcp')
+      .set('Authorization', `Bearer ${exchange.body.access_token}`)
+      .send({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+
+    expect(mcp.status).toBe(401);
   });
 
   it('lists tools and enforces user isolation from the token identity', async () => {

--- a/services/gymtrack-mcp/test/app.test.js
+++ b/services/gymtrack-mcp/test/app.test.js
@@ -1,0 +1,348 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import { pkceChallengeForVerifier, sha256Hex } from '../src/crypto.js';
+
+const createPlannedWorkout = vi.fn();
+const fetchWorkoutHistory = vi.fn();
+const fetchExerciseProgression = vi.fn();
+
+vi.mock('../../../apps/gymtrack/server/agentData.js', () => ({
+  createPlannedWorkout: (...args) => createPlannedWorkout(...args),
+  fetchWorkoutHistory: (...args) => fetchWorkoutHistory(...args),
+  fetchExerciseProgression: (...args) => fetchExerciseProgression(...args),
+  validatePlannedWorkoutBody: () => null,
+  parseHistoryLimit: (value) => (value == null ? 10 : Number(value)),
+  parseProgressionLimit: (value) => (value == null ? 20 : Number(value)),
+  normalizeExerciseName: (value) => (typeof value === 'string' ? value.trim() : null),
+  exerciseNameErrorMessage: () => 'exerciseName is required.'
+}));
+
+const { createApp } = await import('../src/app.js');
+
+class FakeRepo {
+  constructor() {
+    this.clients = [
+      {
+        client_id: 'claude-desktop',
+        client_name: 'Claude Desktop',
+        redirect_uris: ['https://claude.example/callback']
+      }
+    ];
+    this.users = new Map([['supabase-user-token', { id: 'user-1', email: 'rowan@example.com' }]]);
+    this.consents = [];
+    this.codes = [];
+    this.tokens = [];
+  }
+
+  async getOAuthClient(clientId) {
+    return this.clients.find((client) => client.client_id === clientId) ?? null;
+  }
+
+  async getConsent(consentId) {
+    return this.consents.find((consent) => consent.id === consentId) ?? null;
+  }
+
+  async upsertConsent({ userId, clientId, scope, grantedAt }) {
+    let consent = this.consents.find(
+      (row) => row.user_id === userId && row.client_id === clientId && row.revoked_at == null
+    );
+    if (!consent) {
+      consent = {
+        id: `consent-${this.consents.length + 1}`,
+        user_id: userId,
+        client_id: clientId,
+        scope,
+        granted_at: grantedAt.toISOString(),
+        revoked_at: null,
+        last_used_at: null
+      };
+      this.consents.push(consent);
+    } else {
+      consent.scope = scope;
+      consent.granted_at = grantedAt.toISOString();
+    }
+    return structuredClone(consent);
+  }
+
+  async createAuthorizationCode(record) {
+    const row = {
+      id: `code-${this.codes.length + 1}`,
+      consent_id: record.consentId,
+      user_id: record.userId,
+      client_id: record.clientId,
+      code_hash: record.codeHash,
+      redirect_uri: record.redirectUri,
+      scope: record.scope,
+      code_challenge: record.codeChallenge,
+      code_challenge_method: record.codeChallengeMethod,
+      expires_at: record.expiresAt.toISOString(),
+      consumed_at: null,
+      revoked_at: null
+    };
+    this.codes.push(row);
+    return structuredClone(row);
+  }
+
+  async consumeAuthorizationCode({ codeHash, clientId, redirectUri, consumedAt }) {
+    const row = this.codes.find(
+      (item) => item.code_hash === codeHash && item.client_id === clientId && item.redirect_uri === redirectUri
+    );
+    if (!row) return null;
+    const before = structuredClone(row);
+    if (row.consumed_at == null) row.consumed_at = consumedAt.toISOString();
+    return before;
+  }
+
+  async createToken(record) {
+    const row = {
+      id: `token-${this.tokens.length + 1}`,
+      consent_id: record.consentId,
+      user_id: record.userId,
+      client_id: record.clientId,
+      scope: record.scope,
+      family_id: record.familyId,
+      parent_token_id: record.parentTokenId ?? null,
+      access_token_hash: record.accessTokenHash,
+      refresh_token_hash: record.refreshTokenHash,
+      access_token_expires_at: record.accessTokenExpiresAt.toISOString(),
+      refresh_token_expires_at: record.refreshTokenExpiresAt.toISOString(),
+      revoked_at: null,
+      revocation_reason: null,
+      rotated_at: null,
+      replaced_by_token_id: null,
+      last_used_at: null
+    };
+    this.tokens.push(row);
+    return structuredClone(row);
+  }
+
+  async markTokenRotated({ tokenId, replacedByTokenId, rotatedAt }) {
+    const row = this.tokens.find((item) => item.id === tokenId);
+    row.rotated_at = rotatedAt.toISOString();
+    row.revoked_at = rotatedAt.toISOString();
+    row.revocation_reason = 'refresh_rotated';
+    row.replaced_by_token_id = replacedByTokenId;
+  }
+
+  async findTokenByAccessHash(hash) {
+    const row = this.tokens.find((item) => item.access_token_hash === hash);
+    return row ? structuredClone(row) : null;
+  }
+
+  async findTokenByRefreshHash(hash) {
+    const row = this.tokens.find((item) => item.refresh_token_hash === hash);
+    return row ? structuredClone(row) : null;
+  }
+
+  async touchTokenUsage({ tokenId, consentId, usedAt }) {
+    const timestamp = usedAt.toISOString();
+    const token = this.tokens.find((item) => item.id === tokenId);
+    const consent = this.consents.find((item) => item.id === consentId);
+    token.last_used_at = timestamp;
+    consent.last_used_at = timestamp;
+  }
+
+  async revokeConsentFamily({ consentId, revokedAt, reason }) {
+    const timestamp = revokedAt.toISOString();
+    const consent = this.consents.find((item) => item.id === consentId);
+    if (consent && consent.revoked_at == null) consent.revoked_at = timestamp;
+    this.tokens.forEach((token) => {
+      if (token.consent_id === consentId && token.revoked_at == null) {
+        token.revoked_at = timestamp;
+        token.revocation_reason = reason ?? 'revoked';
+      }
+    });
+    this.codes.forEach((code) => {
+      if (code.consent_id === consentId && code.revoked_at == null) {
+        code.revoked_at = timestamp;
+      }
+    });
+  }
+
+  async verifySupabaseUserAccessToken(accessToken) {
+    return this.users.get(accessToken) ?? null;
+  }
+}
+
+function makeApp(overrides = {}) {
+  const repo = overrides.repo ?? new FakeRepo();
+  const gymtrackClient = overrides.gymtrackClient ?? {};
+  const now = overrides.now ?? (() => new Date('2026-08-03T00:00:00.000Z'));
+  const app = createApp({
+    repo,
+    gymtrackClient,
+    now,
+    config: {
+      issuer: 'https://mcp.example',
+      appUrl: 'https://gymtrack.example',
+      webOrigin: 'https://gymtrack.example',
+      port: 8787,
+      accessTokenTtlSeconds: 3600,
+      refreshTokenTtlSeconds: 60 * 60 * 24 * 90,
+      authorizationCodeTtlSeconds: 600
+    }
+  });
+  return { app, repo };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GymTrack MCP OAuth server', () => {
+  it('redirects authorize requests into the GymTrack consent page', async () => {
+    const { app } = makeApp();
+
+    const response = await request(app)
+      .get('/oauth/authorize')
+      .query({
+        response_type: 'code',
+        client_id: 'claude-desktop',
+        redirect_uri: 'https://claude.example/callback',
+        scope: 'history:read progression:read workouts:write',
+        state: 'opaque-state',
+        code_challenge: 'pkce-challenge',
+        code_challenge_method: 'S256'
+      });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toContain('https://gymtrack.example/agent-consent');
+    expect(response.headers.location).toContain('client_id=claude-desktop');
+    expect(response.headers.location).toContain('state=opaque-state');
+  });
+
+  it('issues hashed access+refresh tokens and rotates refresh tokens', async () => {
+    const fixedNow = new Date('2026-08-03T00:00:00.000Z');
+    const { app, repo } = makeApp({ now: () => fixedNow });
+
+    const decision = await request(app)
+      .post('/oauth/authorize/decision')
+      .set('Authorization', 'Bearer supabase-user-token')
+      .send({
+        approve: true,
+        client_id: 'claude-desktop',
+        redirect_uri: 'https://claude.example/callback',
+        scope: 'history:read progression:read workouts:write',
+        state: 'opaque-state',
+        code_challenge: 'dmVyLWNoYWxsZW5nZQ',
+        code_challenge_method: 'S256'
+      });
+
+    expect(decision.status).toBe(200);
+    const redirectUrl = new URL(decision.body.redirectTo);
+    const code = redirectUrl.searchParams.get('code');
+    expect(code).toBeTruthy();
+
+    const verifier = 'verifier-123';
+    // Override the stored PKCE challenge so the test can exchange the code with a known verifier.
+    repo.codes[0].code_challenge = pkceChallengeForVerifier(verifier);
+
+    const exchange = await request(app)
+      .post('/oauth/token')
+      .type('form')
+      .send({
+        grant_type: 'authorization_code',
+        client_id: 'claude-desktop',
+        redirect_uri: 'https://claude.example/callback',
+        code,
+        code_verifier: verifier
+      });
+
+    expect(exchange.status).toBe(200);
+    expect(exchange.body.token_type).toBe('Bearer');
+    expect(exchange.body.scope).toBe('history:read progression:read workouts:write');
+    expect(repo.tokens).toHaveLength(1);
+    expect(repo.tokens[0].access_token_hash).toBe(sha256Hex(exchange.body.access_token));
+    expect(repo.tokens[0].refresh_token_hash).toBe(sha256Hex(exchange.body.refresh_token));
+    expect(repo.tokens[0].access_token_hash).not.toBe(exchange.body.access_token);
+    expect(repo.tokens[0].refresh_token_hash).not.toBe(exchange.body.refresh_token);
+
+    const refresh = await request(app)
+      .post('/oauth/token')
+      .type('form')
+      .send({
+        grant_type: 'refresh_token',
+        client_id: 'claude-desktop',
+        refresh_token: exchange.body.refresh_token
+      });
+
+    expect(refresh.status).toBe(200);
+    expect(repo.tokens).toHaveLength(2);
+    expect(repo.tokens[0].rotated_at).toBe(fixedNow.toISOString());
+    expect(repo.tokens[1].parent_token_id).toBe(repo.tokens[0].id);
+
+    const replay = await request(app)
+      .post('/oauth/token')
+      .type('form')
+      .send({
+        grant_type: 'refresh_token',
+        client_id: 'claude-desktop',
+        refresh_token: exchange.body.refresh_token
+      });
+
+    expect(replay.status).toBe(400);
+    expect(replay.body.error).toBe('invalid_grant');
+    expect(repo.consents[0].revoked_at).toBe(fixedNow.toISOString());
+  });
+
+  it('lists tools and enforces user isolation from the token identity', async () => {
+    const { app, repo } = makeApp();
+    const consent = await repo.upsertConsent({
+      userId: 'user-1',
+      clientId: 'claude-desktop',
+      scope: 'history:read progression:read workouts:write',
+      grantedAt: new Date('2026-08-03T00:00:00.000Z')
+    });
+    await repo.createToken({
+      consentId: consent.id,
+      userId: 'user-1',
+      clientId: 'claude-desktop',
+      scope: consent.scope,
+      familyId: 'family-1',
+      accessTokenHash: sha256Hex('oauth-access-token'),
+      refreshTokenHash: sha256Hex('oauth-refresh-token'),
+      accessTokenExpiresAt: new Date('2026-08-03T01:00:00.000Z'),
+      refreshTokenExpiresAt: new Date('2026-11-01T00:00:00.000Z')
+    });
+
+    createPlannedWorkout.mockResolvedValueOnce({ plannedWorkoutId: 'plan-1', setCount: 1 });
+    fetchWorkoutHistory.mockResolvedValueOnce({ workouts: [{ id: 'workout-1' }] });
+    fetchExerciseProgression.mockResolvedValueOnce({ exerciseName: 'Bench Press', sets: [] });
+
+    const list = await request(app)
+      .post('/mcp')
+      .set('Authorization', 'Bearer oauth-access-token')
+      .send({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+
+    expect(list.status).toBe(200);
+    expect(list.body.result.tools.map((tool) => tool.name)).toEqual([
+      'plan_workout',
+      'read_history',
+      'read_exercise_progression'
+    ]);
+
+    const call = await request(app)
+      .post('/mcp')
+      .set('Authorization', 'Bearer oauth-access-token')
+      .send({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'plan_workout',
+          arguments: {
+            scheduledFor: '2026-08-03',
+            title: 'Push Day',
+            userId: 'malicious-user',
+            exercises: [{ name: 'Bench Press', sets: [{ reps: 5, weight: 80, unit: 'kg' }] }]
+          }
+        }
+      });
+
+    expect(call.status).toBe(200);
+    expect(createPlannedWorkout).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ userId: 'user-1', legacyAgentKeyId: null })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a standalone GymTrack MCP service with OAuth 2.1 Authorization Code + PKCE, discovery metadata, scoped/revocable credentials, and the three required workout tools.
- Add per-user connected-agent consent/revocation UI and Google social-login continuation for the authorization flow.
- Enforce tenant isolation, hashed token storage, atomic authorization-code consumption and refresh rotation, refresh replay family revocation, and trusted server-side revocation.
- Preserve the existing REST agent endpoints and legacy credentials without changing their public contracts.

Task: `1474d515-041b-4df0-bfd4-6ac727b6840a`
Replaces closed invalid PR #347; this branch was rebuilt from current `main` and contains only task-related changes.

## Acceptance Criteria

- [x] AC1: GymTrack exposes an MCP server that an external agent (e.g. Claude, ChatGPT, or any MCP-compatible client) can connect to and discover the available tools (plan a workout, read history, read exercise progression) without needing access to GymTrack's source code. (🧪 testID: services/gymtrack-mcp/test/app.test.js)
- [x] AC2: A user can authorize an agent to act on their behalf via an OAuth flow (not a hand-copied API key) — the agent receives a scoped, revocable credential tied to that user's account, and the user can see and revoke connected agents from their account settings. (🧪 testID: services/gymtrack-mcp/test/app.test.js; apps/gymtrack/src/lib/connectedAgentsHandler.test.js)
- [x] AC3: Signing in to start the authorization flow supports social login (e.g. Google or Apple) as an option, so a user does not need to create or remember a separate GymTrack password to connect an agent. (🧪 testID: apps/gymtrack/src/App.test.jsx)
- [x] AC4: The MCP server enforces per-user data isolation — an agent authorized for one user cannot read or write another user's workouts, plans, or history under any request shape. (🧪 testID: services/gymtrack-mcp/test/app.test.js)
- [x] AC5: The existing REST endpoints (`/api/agent/planned-workouts`, `/api/agent/history`, `/api/agent/exercises/:name/progression`) continue to work for any already-issued credentials, or are cleanly migrated/deprecated with a documented transition path — no silent breakage of the agent-powered-workouts feature shipped in task `f520c396`. (🧪 testID: apps/gymtrack/src/lib/agentAuth.test.js; apps/gymtrack/src/lib/plannedWorkoutsHandler.test.js; apps/gymtrack/src/lib/historyHandler.test.js; apps/gymtrack/src/lib/progressionHandler.test.js)

## System Spec

- `docs/systems/gymtrack.md`
- `apps/gymtrack/SPEC.md`

## Test plan

- [x] `npm test` in `services/gymtrack-mcp` — 5 tests passed.
- [x] `npm test` in `apps/gymtrack` — 132 tests passed.
- [x] `npm run build` in `apps/gymtrack` — production build passed.
- [x] `git diff --check origin/main...HEAD` passed.
- [x] Deep security review completed; findings fixed before opening this PR.

## Deployment follow-up

Supabase Google OAuth and the MCP service runtime secrets/URLs must be configured outside this repository before production use. The exact request is posted on the task as `[openclaw-needed]`.

## Out of scope

- Public connector-directory submission.
- Dynamic OAuth client registration.
- Per-agent billing, metering, or rate limiting.
