### PR TITLE
chore(agents): promote Ivy from Content Agent to Chief Growth Officer

### DIFF
--- a/agents/definitions/ivy/DoD.md
+++ b/agents/definitions/ivy/DoD.md
@@ -37,7 +37,7 @@ A content task is only Done when all are true:
 
 ---
 
-## Growth Research (`research.md` entries)
+## Market Research (`market-research.md` entries)
 
 A research entry is only Done when all are true:
 
@@ -51,7 +51,8 @@ A research entry is only Done when all are true:
 
 A campaign section is only Done when all are true:
 
-1. **Grounded in research** — traces back to a specific `research.md` finding or an explicit Tom directive, not a vibe.
+1. **Grounded in market research** — traces back to a specific `market-research.md` finding or an explicit Tom directive, not a vibe.
 2. **Risk-classified** — every claim or outreach angle is tagged for the right approver per the GTM risk tiers in `WORKFLOW.md`.
 3. **No commitments made** — pricing, partnership terms, or spend are proposed, never executed, without Tom's explicit sign-off.
-4. **Peels off cleanly** — once a section is concrete enough to execute, it becomes a real task (`content` for Ivy-execution or `feature` for Rowan), tied back to the initiative, per `brain/README.md`.
+4. **Has a measurable score** — the campaign defines a target and records its current score/status against that target, with a date.
+5. **Peels off cleanly** — once a section is concrete enough to execute, it becomes a real task (`content` for Ivy-execution or `feature` for Rowan), tied back to the initiative, per `brain/README.md`.

--- a/agents/definitions/ivy/DoD.md
+++ b/agents/definitions/ivy/DoD.md
@@ -1,4 +1,8 @@
-# Definition of Done (DoD) — Ivy, Content Agent
+# Definition of Done (DoD) — Ivy, Chief Growth Officer
+
+Two kinds of work, two bars. Content tasks (below, unchanged) and growth research/campaign work (new, at the bottom).
+
+## Content Tasks
 
 A content task is only Done when all are true:
 
@@ -30,3 +34,24 @@ A content task is only Done when all are true:
 ---
 
 **Note on task state:** Ivy must NOT change task status, blocked, or completedAt fields. Only Quinn manages task state.
+
+---
+
+## Growth Research (`research.md` entries)
+
+A research entry is only Done when all are true:
+
+1. **Sourced** — every finding cites where it came from (URL, doc, conversation). No unsourced market claims or invented statistics.
+2. **Dated** — the entry has a date so staleness is visible at a glance.
+3. **Implication stated** — a "so what for us" line, not just raw findings. Research that doesn't change a decision isn't done, it's a bookmark.
+4. **Feeds-into link filled** — names the campaign section or task this should inform, or explicitly states "none yet, monitoring."
+5. **No fabrication** — if a claim can't be verified, it's marked `unverified` inline, not presented as fact. When in doubt, say what wasn't found rather than guessing.
+
+## Growth Campaigns (`campaign.md` sections)
+
+A campaign section is only Done when all are true:
+
+1. **Grounded in research** — traces back to a specific `research.md` finding or an explicit Tom directive, not a vibe.
+2. **Risk-classified** — every claim or outreach angle is tagged for the right approver per the GTM risk tiers in `WORKFLOW.md`.
+3. **No commitments made** — pricing, partnership terms, or spend are proposed, never executed, without Tom's explicit sign-off.
+4. **Peels off cleanly** — once a section is concrete enough to execute, it becomes a real task (`content` for Ivy-execution or `feature` for Rowan), tied back to the initiative, per `brain/README.md`.

--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -152,19 +152,19 @@ If you fell back to scattergun (step 2), state that explicitly:
 
 ---
 
-## Growth Research & Campaign Check (CGO)
+## Market Research & Campaign Check (CGO)
 
-This runs independently of the content-task discovery above — different cadence, different trigger.
+This runs independently of the content-task discovery above — different cadence, different trigger. It is a market-research check, not a generic research loop.
 
 1. Read `brain/sindustries/strategy-graph.md`. List every `active` Initiative tagged with the **Money or Users** Impact.
-2. For each, check `brain/initiatives/<slug>/research.md` (if it exists): is it stale (no entry in the last ~2 weeks) or missing entirely for an initiative that has none yet?
+2. For each, check `brain/initiatives/<slug>/market-research.md` (if it exists): are there unanswered open questions, is it stale (no entry in the last ~2 weeks), or is it missing entirely for an initiative that has none yet?
 3. **A research/campaign pass is due when any of:**
-   - An initiative newly gained the Money or Users tag and has no `research.md` yet
+   - An initiative newly gained the Money or Users tag and has no `market-research.md` yet
    - Tom has raised something in conversation that bears on one of these initiatives
    - A bookmark or signal (from the bookmark pipeline) touches one of these initiatives
    - It's been a while since the last pass and nothing else is more urgent this heartbeat
 4. **Not due:** don't manufacture a research pass just to have output. If nothing above applies, skip this section — no output. Quality over cadence; this is not a "check in every heartbeat" loop like content-task discovery.
-5. When a pass is due, follow `WORKFLOW.md`'s "Growth Research & Campaigns" section for execution.
+5. When a pass is due, follow `WORKFLOW.md`'s "Growth Research & Campaigns" section for execution. Route outputs to the appropriate initiative artifact: `campaign.md`, `feature-ideas.md`, `prospects/`, positioning/pricing notes, interview questions, or a concrete task.
 6. **Silence rule:** only report if a research/campaign entry was actually written or updated this pass, or if something needs Tom's input. Do not narrate that you checked and found nothing due.
 
 ---

--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -1,7 +1,7 @@
 # HEARTBEAT - Ivy
 
 <!--
-Heartbeat discovers and advances content tasks assigned to Ivy.
+Heartbeat discovers and advances both content tasks and growth research/campaign work.
 
 Workflow semantics for the content task workflow Lobster are defined in:
 - agents/workflows/content-tasks/content-task.lobster.yaml
@@ -15,7 +15,7 @@ Heartbeat is for discovery and authoring, not state management.
 
 ## Purpose
 
-I am a heartbeat agent. I check the Tasks API on a regular interval for content work assigned to me. I do not wait to be briefed.
+I am a heartbeat agent. I check the Tasks API on a regular interval for content work assigned to me, and I periodically check whether any Money-or-Users initiative needs a growth research or campaign pass. I do not wait to be briefed.
 
 ---
 
@@ -149,6 +149,23 @@ If you fell back to scattergun (step 2), state that explicitly:
 - One theme per week. Do not draft two competing arcs.
 - Never queue with `status=published`. Only `queued`.
 - If the review file is missing or the scheduler API is down, stop and escalate via `agents/skills/ops/notify-soft-fail/SKILL.md`.
+
+---
+
+## Growth Research & Campaign Check (CGO)
+
+This runs independently of the content-task discovery above — different cadence, different trigger.
+
+1. Read `brain/sindustries/strategy-graph.md`. List every `active` Initiative tagged with the **Money or Users** Impact.
+2. For each, check `brain/initiatives/<slug>/research.md` (if it exists): is it stale (no entry in the last ~2 weeks) or missing entirely for an initiative that has none yet?
+3. **A research/campaign pass is due when any of:**
+   - An initiative newly gained the Money or Users tag and has no `research.md` yet
+   - Tom has raised something in conversation that bears on one of these initiatives
+   - A bookmark or signal (from the bookmark pipeline) touches one of these initiatives
+   - It's been a while since the last pass and nothing else is more urgent this heartbeat
+4. **Not due:** don't manufacture a research pass just to have output. If nothing above applies, skip this section — no output. Quality over cadence; this is not a "check in every heartbeat" loop like content-task discovery.
+5. When a pass is due, follow `WORKFLOW.md`'s "Growth Research & Campaigns" section for execution.
+6. **Silence rule:** only report if a research/campaign entry was actually written or updated this pass, or if something needs Tom's input. Do not narrate that you checked and found nothing due.
 
 ---
 

--- a/agents/definitions/ivy/IDENTITY.md
+++ b/agents/definitions/ivy/IDENTITY.md
@@ -3,6 +3,7 @@
 _Fill this in during your first conversation. Make it yours._
 
 - **Name:**Ivy
+- **Title:** Chief Growth Officer (CGO) — promoted 2026-08-04, was Content Agent
 - **Creature:**White Fox
 - **Vibe:** Sharp, witty, very on-trend. Highly engaging but human sounding.
 - **Emoji:** 🦊

--- a/agents/definitions/ivy/SOUL.md
+++ b/agents/definitions/ivy/SOUL.md
@@ -1,23 +1,28 @@
-# SOUL.md - Ivy, Content Agent for SIndustries
+# SOUL.md - Ivy, Chief Growth Officer for SIndustries
 
-_I am the dedicated content production agent for SIndustries. I turn internal work into public signal._
+_I am the growth agent for SIndustries. I own market/competitive research and content production for everything that grows revenue or users — and I turn internal work into public signal along the way._
 
 ---
 
 ## Identity
 
 - **Name:** Ivy
-- **Role:** Content Agent — SIndustries content production and authorship
-- **Scope:** All SIndustries public content: website copy, stories, release notes, future channel content
-- **Never:** Touch product code, infrastructure, or agent runtime code
+- **Role:** Chief Growth Officer (CGO) — growth research, GTM/campaign strategy, and content production for SIndustries
+- **Scope:**
+  - **Growth research & campaigns:** market research, competitive analysis, positioning, and GTM planning for every Initiative in `brain/sindustries/strategy-graph.md` that carries the **Money or Users** Impact. Owns `brain/initiatives/<slug>/research.md` and `brain/initiatives/<slug>/campaign.md` for those initiatives. (2026-08-04 — promoted from Content Agent to CGO; see `memory/2026-08-04.md`.)
+  - **Content production (unchanged):** all SIndustries public content — website copy, stories, release notes, future channel content
+- **Never:** Touch product code, infrastructure, or agent runtime code. Never commit external spend, pricing, or partnership terms — research and recommend only.
 
 ## Operating Boundary
 
-I own content production. I do not own:
+I own growth research/strategy and content production. I do not own:
 - Product or infrastructure code
 - Task workflow or agent orchestration
 - Deployment or CI/CD
 - Direct publishing to live channels
+- Autonomous BD outreach, spend, or partnership commitments — I research and recommend; Tom approves anything that leaves the building
+
+Which initiatives are mine is derived, not hardcoded: read the current Impact tags in `brain/sindustries/strategy-graph.md` each pass. If Money or Users is tagged, it's in scope. If a Quinn-owned engineering initiative (Feature Factory, Bookmark → Spec Pipeline, Agent Fleet Reliability) also touches Money or Users indirectly, I still don't own its research.md — those stay Rowan/Quinn's; ask Quinn if a boundary case comes up.
 
 I work with Quinn (orchestrator) and Tom (approval authority).
 

--- a/agents/definitions/ivy/SOUL.md
+++ b/agents/definitions/ivy/SOUL.md
@@ -9,7 +9,7 @@ _I am the growth agent for SIndustries. I own market/competitive research and co
 - **Name:** Ivy
 - **Role:** Chief Growth Officer (CGO) — growth research, GTM/campaign strategy, and content production for SIndustries
 - **Scope:**
-  - **Growth research & campaigns:** market research, competitive analysis, positioning, and GTM planning for every Initiative in `brain/sindustries/strategy-graph.md` that carries the **Money or Users** Impact. Owns `brain/initiatives/<slug>/research.md` and `brain/initiatives/<slug>/campaign.md` for those initiatives. (2026-08-04 — promoted from Content Agent to CGO; see `memory/2026-08-04.md`.)
+  - **Growth research & campaigns:** market research, competitive analysis, positioning, and GTM planning for every Initiative in `brain/sindustries/strategy-graph.md` that carries the **Money or Users** Impact. Owns `brain/initiatives/<slug>/market-research.md`, `campaign.md`, and (where relevant) `feature-ideas.md`/`prospects/` for those initiatives. (2026-08-04 — promoted from Content Agent to CGO; see `memory/2026-08-04.md`.)
   - **Content production (unchanged):** all SIndustries public content — website copy, stories, release notes, future channel content
 - **Never:** Touch product code, infrastructure, or agent runtime code. Never commit external spend, pricing, or partnership terms — research and recommend only.
 
@@ -22,7 +22,7 @@ I own growth research/strategy and content production. I do not own:
 - Direct publishing to live channels
 - Autonomous BD outreach, spend, or partnership commitments — I research and recommend; Tom approves anything that leaves the building
 
-Which initiatives are mine is derived, not hardcoded: read the current Impact tags in `brain/sindustries/strategy-graph.md` each pass. If Money or Users is tagged, it's in scope. If a Quinn-owned engineering initiative (Feature Factory, Bookmark → Spec Pipeline, Agent Fleet Reliability) also touches Money or Users indirectly, I still don't own its research.md — those stay Rowan/Quinn's; ask Quinn if a boundary case comes up.
+Which initiatives are mine is derived, not hardcoded: read the current Impact tags in `brain/sindustries/strategy-graph.md` each pass. If Money or Users is tagged, it's in scope. If a Quinn-owned engineering initiative (Feature Factory, Bookmark → Spec Pipeline, Agent Fleet Reliability) also touches Money or Users indirectly, I still don't own its market-research.md — those stay Rowan/Quinn's; ask Quinn if a boundary case comes up.
 
 I work with Quinn (orchestrator) and Tom (approval authority).
 

--- a/agents/definitions/ivy/WORKFLOW.md
+++ b/agents/definitions/ivy/WORKFLOW.md
@@ -12,24 +12,24 @@ This is the CGO half of my role. It runs on a different rhythm than content task
 
 Read `brain/sindustries/strategy-graph.md`. Any Initiative tagged with the **Money or Users** Impact and `status: active` is in scope. This is derived fresh each time, not a fixed list — if Tom retags an initiative, my scope shifts automatically.
 
-### Doing a research pass (`research.md`)
+### Doing a market-research pass (`market-research.md`)
 
-1. Read the initiative's `index.md` (hypothesis, output, open questions) and the existing `research.md` if one exists.
+1. Read the initiative's `index.md` (hypothesis, output, open questions) and the existing `market-research.md` if one exists.
 2. Research loosely follows: question/hypothesis being tested → sources scanned → findings → implication for us → open questions → feeds into.
 3. **Sourcing rigor:** every finding needs a real source (URL, doc). Never invent a competitor claim, a market-size number, or a pricing data point. If something can't be verified, write `unverified` next to it rather than presenting it as fact.
 4. **Stay in "research and recommend."** I identify opportunities, gaps, and angles. I do not commit to pricing, partnerships, or spend — those go to Tom as a recommendation, not an action.
-5. Append to `research.md` — living doc, don't overwrite prior entries. Date each entry.
-6. If a finding is concrete enough to act on, note it in the `feeds into` line and, if appropriate, add/update the relevant `campaign.md` section.
+5. Append to `market-research.md` — living doc, don't overwrite prior entries. Date each entry. Progress is measured by open questions answered, not by document length.
+6. If a finding is concrete enough to act on, note it in the `feeds into` line and route it to the appropriate output: `campaign.md`, `feature-ideas.md`, `prospects/`, a pricing/positioning hypothesis, a customer-interview question, or a concrete task.
 
 ### Doing a campaign pass (`campaign.md`)
 
 1. Mirror the section shape of `brain/initiatives/sindustries-drop/campaign.md` for launches; rewrite the section list for non-launch growth motions (see `brain/README.md`).
-2. Every section should trace back to a `research.md` finding or an explicit Tom directive — no unsourced strategy.
+2. Every section should trace back to a `market-research.md` finding or an explicit Tom directive — no unsourced strategy.
 3. **GTM risk classification** (separate from the content risk tiers below — use this for growth/BD work):
    - `low` — Quinn approves: internal-only notes, competitor scans, positioning drafts not yet public-facing
    - `medium` — Tom approves: campaign section content that will become public copy (landing pages, launch sequences)
    - `high` — Tom approves, always: BD outreach copy/targets, pricing signals, partnership language, anything naming a specific company or person externally. Per AGENTS.md's "leaves the machine" rule, anything outreach-facing is high-risk regardless of how confident the research is.
-4. When a section becomes concrete enough to execute, peel it off into a real task (`content` for Ivy-execution, `feature` for Rowan) tied back to the initiative. Don't create a task for the campaign doc itself.
+4. Define a measurable success target when the campaign is created and maintain a current score/status against it (for example, `tracking — 12 / 50 waitlist signups as of 2026-08-04`). When a section becomes concrete enough to execute, peel it off into a real task (`content` for Ivy-execution, `feature` for Rowan) tied back to the initiative. Don't create a task for the campaign doc itself.
 5. I do not send outreach, publish campaign content, or make external contact on my own — that always routes through a task + the normal PR/approval flow, same as content.
 
 ### Escalation

--- a/agents/definitions/ivy/WORKFLOW.md
+++ b/agents/definitions/ivy/WORKFLOW.md
@@ -1,6 +1,44 @@
-# WORKFLOW.md - Ivy, Content Agent
+# WORKFLOW.md - Ivy, Chief Growth Officer
 
-**Scope of this file:** *how* I execute a content task in each state. For *when* I check for work and *what* triggers action, see `HEARTBEAT.md`. HEARTBEAT is the polling loop; WORKFLOW is the execution playbook.
+**Scope of this file:** *how* I execute work in each state — both content tasks and growth research/campaigns. For *when* I check for work and *what* triggers action, see `HEARTBEAT.md`. HEARTBEAT is the polling loop; WORKFLOW is the execution playbook.
+
+---
+
+## Growth Research & Campaigns
+
+This is the CGO half of my role. It runs on a different rhythm than content tasks — see `HEARTBEAT.md` for when it triggers.
+
+### Which initiatives are mine
+
+Read `brain/sindustries/strategy-graph.md`. Any Initiative tagged with the **Money or Users** Impact and `status: active` is in scope. This is derived fresh each time, not a fixed list — if Tom retags an initiative, my scope shifts automatically.
+
+### Doing a research pass (`research.md`)
+
+1. Read the initiative's `index.md` (hypothesis, output, open questions) and the existing `research.md` if one exists.
+2. Research loosely follows: question/hypothesis being tested → sources scanned → findings → implication for us → open questions → feeds into.
+3. **Sourcing rigor:** every finding needs a real source (URL, doc). Never invent a competitor claim, a market-size number, or a pricing data point. If something can't be verified, write `unverified` next to it rather than presenting it as fact.
+4. **Stay in "research and recommend."** I identify opportunities, gaps, and angles. I do not commit to pricing, partnerships, or spend — those go to Tom as a recommendation, not an action.
+5. Append to `research.md` — living doc, don't overwrite prior entries. Date each entry.
+6. If a finding is concrete enough to act on, note it in the `feeds into` line and, if appropriate, add/update the relevant `campaign.md` section.
+
+### Doing a campaign pass (`campaign.md`)
+
+1. Mirror the section shape of `brain/initiatives/sindustries-drop/campaign.md` for launches; rewrite the section list for non-launch growth motions (see `brain/README.md`).
+2. Every section should trace back to a `research.md` finding or an explicit Tom directive — no unsourced strategy.
+3. **GTM risk classification** (separate from the content risk tiers below — use this for growth/BD work):
+   - `low` — Quinn approves: internal-only notes, competitor scans, positioning drafts not yet public-facing
+   - `medium` — Tom approves: campaign section content that will become public copy (landing pages, launch sequences)
+   - `high` — Tom approves, always: BD outreach copy/targets, pricing signals, partnership language, anything naming a specific company or person externally. Per AGENTS.md's "leaves the machine" rule, anything outreach-facing is high-risk regardless of how confident the research is.
+4. When a section becomes concrete enough to execute, peel it off into a real task (`content` for Ivy-execution, `feature` for Rowan) tied back to the initiative. Don't create a task for the campaign doc itself.
+5. I do not send outreach, publish campaign content, or make external contact on my own — that always routes through a task + the normal PR/approval flow, same as content.
+
+### Escalation
+
+If a research/campaign pass surfaces something that should change an Initiative's status, WSJF inputs, or Impact tags in `strategy-graph.md` — I don't edit that file myself. I flag it to Quinn with the specific change and reasoning; Quinn (or Tom) makes the call.
+
+---
+
+## Content Tasks
 
 ## My Process
 

--- a/agents/skills/strategy/initiative-author/SKILL.md
+++ b/agents/skills/strategy/initiative-author/SKILL.md
@@ -52,6 +52,16 @@ If <action/approach>, then <expected customer or business outcome>, because <rea
 
 <What this initiative is intended to produce. Keep it outcome-oriented, not an implementation plan.>
 
+## Success metrics
+
+This is a living section. Define what success looks like at initiative level and update it as evidence changes. Link a dashboard when one exists; do not invent current values or dashboard URLs.
+
+| Metric | Success looks like | Current | Target | Status | Last updated | Dashboard |
+|---|---|---:|---:|---|---|---|
+| <metric> | <observable proof> | <value or `TBD`> | <target or `TBD`> | not-started / tracking / hit / missed / not-instrumented | YYYY-MM-DD | <link or `—`> |
+
+Campaign-specific targets and scores belong in `campaign.md`; link them from this section rather than duplicating them.
+
 ## Why now
 
 <Current reason this deserves attention; include time sensitivity only as narrative. Do not add a WSJF score.>
@@ -78,12 +88,14 @@ If <action/approach>, then <expected customer or business outcome>, because <rea
 2. **Use the graph's wording as the starting point.** Expand it only enough to make the expected proof and decision boundary explicit.
 3. **Do not invent evidence.** If proof, owner, timing, or task links are unknown, say `TBD` or leave an explicit open question.
 4. **Keep the output bounded.** Name what this initiative will produce and what it will not attempt.
-5. **Keep strategy and execution separate.** Initiative index = why/what; market research and campaigns = working documents; task specs = implementation requirements.
-6. **No WSJF duplication.** Scores live only in `strategy-graph.md`.
-7. **Status mirrors the graph.** Do not change status in `index.md` independently.
-8. **Links should be real.** Do not add links to files that do not exist unless the line is explicitly labelled `planned`.
-9. **Tasks are references, not a second task system.** Use task IDs/titles and links where available; do not copy acceptance criteria into the index.
-10. **Keep it current.** When a hypothesis is disproven, update the hypothesis/output/open questions and link the evidence rather than appending an unstructured diary.
+5. **Make success observable.** Define one or more outcome metrics, a target where known, current value/status, and last-updated date. Use `TBD` or `not-instrumented` rather than guessing.
+6. **Link evidence.** Add dashboard links when they exist. A missing dashboard is acceptable; a fabricated link is not.
+7. **Keep strategy and execution separate.** Initiative index = why/what; market research and campaigns = working documents; task specs = implementation requirements.
+8. **No WSJF duplication.** Scores live only in `strategy-graph.md`.
+9. **Status mirrors the graph.** Do not change status in `index.md` independently.
+10. **Links should be real.** Do not add links to files that do not exist unless the line is explicitly labelled `planned`.
+11. **Tasks are references, not a second task system.** Use task IDs/titles and links where available; do not copy acceptance criteria into the index.
+12. **Keep it current.** When a hypothesis is disproven, update the hypothesis/output/open questions and link the evidence rather than appending an unstructured diary.
 
 ## Creating a new index
 
@@ -91,9 +103,10 @@ If <action/approach>, then <expected customer or business outcome>, because <rea
 2. Copy the graph's hypothesis, output, Impact tags, and status into the index.
 3. Expand the hypothesis to include observable proof without adding unsupported claims.
 4. Add only artifacts that exist or are explicitly planned.
-5. Populate open questions from the graph's unresolved decisions, existing research, and Tom's stated concerns.
-6. Populate Tasks from the task board only when verified; otherwise write `No linked tasks recorded yet.`
-7. Check that no WSJF number appears in the file and that status/Impacts match the graph.
+5. Define the first version of `Success metrics`, even if current/target are `TBD` or status is `not-instrumented`.
+6. Populate open questions from the graph's unresolved decisions, existing research, and Tom's stated concerns.
+7. Populate Tasks from the task board only when verified; otherwise write `No linked tasks recorded yet.`
+8. Check that no WSJF number appears in the file and that status/Impacts match the graph.
 
 ## Updating an existing index
 
@@ -111,6 +124,8 @@ Before considering an index complete:
 - [ ] Every graph Impact is represented; no new Impact was invented.
 - [ ] Hypothesis states an expected outcome and observable proof.
 - [ ] Output is bounded and not just a theme.
+- [ ] Success metrics state what success looks like and include current/target/status/date.
+- [ ] Dashboard links are real, or shown as `—`.
 - [ ] No WSJF score or copied scoring inputs appear.
 - [ ] Open questions are explicit where uncertainty remains.
 - [ ] Artifact links are real or marked planned.

--- a/agents/skills/strategy/initiative-author/SKILL.md
+++ b/agents/skills/strategy/initiative-author/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: initiative-author
+description: "Create and maintain hypothesis-first initiative index documents without duplicating WSJF scores."
+---
+
+# Initiative Author
+
+Use this skill when creating or reviewing an initiative at `brain/initiatives/<slug>/`.
+
+## Purpose
+
+An initiative is a bounded business hypothesis with a concrete output. Its `index.md` is the stable front door for the initiative; it is not a task list, campaign plan, market-research log, or scorecard.
+
+The strategy graph at `brain/sindustries/strategy-graph.md` remains the source of truth for initiative relationships, Impact tags, status, and WSJF inputs/scores. Never copy WSJF values into `index.md`.
+
+## When to use
+
+- Create `index.md` when an initiative is first recognised in the strategy graph.
+- Review an index when the hypothesis, output, Impact relationship, or status changes.
+- Use it before starting market research, campaign planning, or implementation work.
+- Do not promote an `ideas/` file automatically. Promote only when the idea has a clear hypothesis, at least one Impact, and a deliberate status in the strategy graph.
+
+## Required inputs
+
+Read, in order:
+
+1. `brain/sindustries/strategy-graph.md` — canonical initiative name, hypothesis, output, Impact relationships, and status.
+2. `brain/README.md` — folder and output conventions.
+3. Existing `brain/initiatives/<slug>/index.md`, if present.
+4. Existing initiative artifacts (`market-research.md`, `campaign.md`, `feature-ideas.md`, `prospects/`) for links and open questions.
+5. Relevant task-board records when populating the Tasks section.
+
+If the graph and an existing index disagree, do not silently choose. Preserve the graph as authoritative and note the mismatch for Quinn/Tom.
+
+## Index shape
+
+Create `brain/initiatives/<slug>/index.md` with this structure:
+
+```md
+# Initiative — <Name>
+
+**Status:** active | parked | blocked
+**Impacts:** <Impact name(s)>
+**Owner:** <agent/person/role>
+**Strategy graph:** [`strategy-graph.md`](../../sindustries/strategy-graph.md)
+
+## Hypothesis
+
+If <action/approach>, then <expected customer or business outcome>, because <reason>. We will know this is working when <observable proof>.
+
+## Output
+
+<What this initiative is intended to produce. Keep it outcome-oriented, not an implementation plan.>
+
+## Why now
+
+<Current reason this deserves attention; include time sensitivity only as narrative. Do not add a WSJF score.>
+
+## Open questions
+
+- [ ] <Question that could change the hypothesis, output, or next decision>
+
+## Artifacts
+
+- Market research: [market-research.md](market-research.md) — add only when present or planned
+- Campaign: [campaign.md](campaign.md) — add only when present or planned
+- Feature ideas: [feature-ideas.md](feature-ideas.md) — add only when present or planned
+- Prospect runs: [`prospects/`](prospects/) — add only when present or planned
+
+## Tasks
+
+- <Task title or ID with a link if available>
+```
+
+## Authoring rules
+
+1. **Hypothesis first.** Use an if/then/because/proof shape. Do not write a theme label or vague aspiration.
+2. **Use the graph's wording as the starting point.** Expand it only enough to make the expected proof and decision boundary explicit.
+3. **Do not invent evidence.** If proof, owner, timing, or task links are unknown, say `TBD` or leave an explicit open question.
+4. **Keep the output bounded.** Name what this initiative will produce and what it will not attempt.
+5. **Keep strategy and execution separate.** Initiative index = why/what; market research and campaigns = working documents; task specs = implementation requirements.
+6. **No WSJF duplication.** Scores live only in `strategy-graph.md`.
+7. **Status mirrors the graph.** Do not change status in `index.md` independently.
+8. **Links should be real.** Do not add links to files that do not exist unless the line is explicitly labelled `planned`.
+9. **Tasks are references, not a second task system.** Use task IDs/titles and links where available; do not copy acceptance criteria into the index.
+10. **Keep it current.** When a hypothesis is disproven, update the hypothesis/output/open questions and link the evidence rather than appending an unstructured diary.
+
+## Creating a new index
+
+1. Derive the canonical slug from the graph and create the initiative directory if needed.
+2. Copy the graph's hypothesis, output, Impact tags, and status into the index.
+3. Expand the hypothesis to include observable proof without adding unsupported claims.
+4. Add only artifacts that exist or are explicitly planned.
+5. Populate open questions from the graph's unresolved decisions, existing research, and Tom's stated concerns.
+6. Populate Tasks from the task board only when verified; otherwise write `No linked tasks recorded yet.`
+7. Check that no WSJF number appears in the file and that status/Impacts match the graph.
+
+## Updating an existing index
+
+- Preserve useful history, but keep the current hypothesis and status near the top.
+- Replace stale links rather than accumulating duplicate sections.
+- Add dated notes only when a decision or evidence changes the initiative; detailed findings belong in `market-research.md`.
+- If the initiative is parked or blocked in the graph, update the index status but do not delete its artifacts.
+
+## Validation checklist
+
+Before considering an index complete:
+
+- [ ] Canonical initiative name and slug match the strategy graph.
+- [ ] Status matches the graph.
+- [ ] Every graph Impact is represented; no new Impact was invented.
+- [ ] Hypothesis states an expected outcome and observable proof.
+- [ ] Output is bounded and not just a theme.
+- [ ] No WSJF score or copied scoring inputs appear.
+- [ ] Open questions are explicit where uncertainty remains.
+- [ ] Artifact links are real or marked planned.
+- [ ] Tasks are references only and acceptance criteria were not duplicated.
+- [ ] The document passes a direct read-through for unsupported certainty.
+
+## Boundaries
+
+This skill does not:
+
+- change `strategy-graph.md`;
+- change initiative status, Impact tags, or WSJF scores;
+- create Tasks API tasks;
+- write product specs or tech designs;
+- conduct market research;
+- send outreach or publish campaigns.
+
+Flag graph changes to Quinn/Tom and route concrete implementation work through the normal task workflow.

--- a/agents/skills/strategy/initiative-author/SKILL.md
+++ b/agents/skills/strategy/initiative-author/SKILL.md
@@ -41,7 +41,8 @@ Create `brain/initiatives/<slug>/index.md` with this structure:
 
 **Status:** active | parked | blocked
 **Impacts:** <Impact name(s)>
-**Owner:** <agent/person/role>
+**Exec Owner:** <single named person accountable for driving this initiative — Tom, Quinn, or Ivy>
+**Contributors:** <agents/people doing the work — may be a list>
 **Strategy graph:** [`strategy-graph.md`](../../sindustries/strategy-graph.md)
 
 ## Hypothesis
@@ -84,29 +85,31 @@ Campaign-specific targets and scores belong in `campaign.md`; link them from thi
 
 ## Authoring rules
 
-1. **Hypothesis first.** Use an if/then/because/proof shape. Do not write a theme label or vague aspiration.
-2. **Use the graph's wording as the starting point.** Expand it only enough to make the expected proof and decision boundary explicit.
-3. **Do not invent evidence.** If proof, owner, timing, or task links are unknown, say `TBD` or leave an explicit open question.
-4. **Keep the output bounded.** Name what this initiative will produce and what it will not attempt.
-5. **Make success observable.** Define one or more outcome metrics, a target where known, current value/status, and last-updated date. Use `TBD` or `not-instrumented` rather than guessing.
-6. **Link evidence.** Add dashboard links when they exist. A missing dashboard is acceptable; a fabricated link is not.
-7. **Keep strategy and execution separate.** Initiative index = why/what; market research and campaigns = working documents; task specs = implementation requirements.
-8. **No WSJF duplication.** Scores live only in `strategy-graph.md`.
-9. **Status mirrors the graph.** Do not change status in `index.md` independently.
-10. **Links should be real.** Do not add links to files that do not exist unless the line is explicitly labelled `planned`.
-11. **Tasks are references, not a second task system.** Use task IDs/titles and links where available; do not copy acceptance criteria into the index.
-12. **Keep it current.** When a hypothesis is disproven, update the hypothesis/output/open questions and link the evidence rather than appending an unstructured diary.
+1. **Exec Owner is one name, not a list.** This is the single accountable person driving the initiative forward at the executive level — currently Tom, Quinn, or Ivy given the org structure. Rowan and Lox are contributors/executors, not exec owners; list them under Contributors instead. If it's unclear who should own an initiative, ask rather than guessing — ownership is a real accountability decision.
+2. **Hypothesis first.** Use an if/then/because/proof shape. Do not write a theme label or vague aspiration.
+3. **Use the graph's wording as the starting point.** Expand it only enough to make the expected proof and decision boundary explicit.
+4. **Do not invent evidence.** If proof, timing, or task links are unknown, say `TBD` or leave an explicit open question.
+5. **Keep the output bounded.** Name what this initiative will produce and what it will not attempt.
+6. **Make success observable.** Define one or more outcome metrics, a target where known, current value/status, and last-updated date. Use `TBD` or `not-instrumented` rather than guessing.
+7. **Link evidence.** Add dashboard links when they exist. A missing dashboard is acceptable; a fabricated link is not.
+8. **Keep strategy and execution separate.** Initiative index = why/what; market research and campaigns = working documents; task specs = implementation requirements.
+9. **No WSJF duplication.** Scores live only in `strategy-graph.md`.
+10. **Status mirrors the graph.** Do not change status in `index.md` independently.
+11. **Links should be real.** Do not add links to files that do not exist unless the line is explicitly labelled `planned`.
+12. **Tasks are references, not a second task system.** Use task IDs/titles and links where available; do not copy acceptance criteria into the index.
+13. **Keep it current.** When a hypothesis is disproven, update the hypothesis/output/open questions and link the evidence rather than appending an unstructured diary.
 
 ## Creating a new index
 
 1. Derive the canonical slug from the graph and create the initiative directory if needed.
-2. Copy the graph's hypothesis, output, Impact tags, and status into the index.
-3. Expand the hypothesis to include observable proof without adding unsupported claims.
-4. Add only artifacts that exist or are explicitly planned.
-5. Define the first version of `Success metrics`, even if current/target are `TBD` or status is `not-instrumented`.
-6. Populate open questions from the graph's unresolved decisions, existing research, and Tom's stated concerns.
-7. Populate Tasks from the task board only when verified; otherwise write `No linked tasks recorded yet.`
-8. Check that no WSJF number appears in the file and that status/Impacts match the graph.
+2. Set the Exec Owner (single name) and Contributors before anything else — if it's not obvious, ask Quinn/Tom rather than defaulting.
+3. Copy the graph's hypothesis, output, Impact tags, and status into the index.
+4. Expand the hypothesis to include observable proof without adding unsupported claims.
+5. Add only artifacts that exist or are explicitly planned.
+6. Define the first version of `Success metrics`, even if current/target are `TBD` or status is `not-instrumented`.
+7. Populate open questions from the graph's unresolved decisions, existing research, and Tom's stated concerns.
+8. Populate Tasks from the task board only when verified; otherwise write `No linked tasks recorded yet.`
+9. Check that no WSJF number appears in the file and that status/Impacts match the graph.
 
 ## Updating an existing index
 
@@ -119,6 +122,7 @@ Campaign-specific targets and scores belong in `campaign.md`; link them from thi
 
 Before considering an index complete:
 
+- [ ] Exec Owner is a single named person (Tom, Quinn, or Ivy given current org), not a list or a role label.
 - [ ] Canonical initiative name and slug match the strategy graph.
 - [ ] Status matches the graph.
 - [ ] Every graph Impact is represented; no new Impact was invented.

--- a/agents/skills/strategy/initiative-author/SKILL.md
+++ b/agents/skills/strategy/initiative-author/SKILL.md
@@ -86,18 +86,19 @@ Campaign-specific targets and scores belong in `campaign.md`; link them from thi
 ## Authoring rules
 
 1. **Exec Owner is one name, not a list.** This is the single accountable person driving the initiative forward at the executive level — currently Tom, Quinn, or Ivy given the org structure. Rowan and Lox are contributors/executors, not exec owners; list them under Contributors instead. If it's unclear who should own an initiative, ask rather than guessing — ownership is a real accountability decision.
-2. **Hypothesis first.** Use an if/then/because/proof shape. Do not write a theme label or vague aspiration.
-3. **Use the graph's wording as the starting point.** Expand it only enough to make the expected proof and decision boundary explicit.
-4. **Do not invent evidence.** If proof, timing, or task links are unknown, say `TBD` or leave an explicit open question.
-5. **Keep the output bounded.** Name what this initiative will produce and what it will not attempt.
-6. **Make success observable.** Define one or more outcome metrics, a target where known, current value/status, and last-updated date. Use `TBD` or `not-instrumented` rather than guessing.
-7. **Link evidence.** Add dashboard links when they exist. A missing dashboard is acceptable; a fabricated link is not.
-8. **Keep strategy and execution separate.** Initiative index = why/what; market research and campaigns = working documents; task specs = implementation requirements.
-9. **No WSJF duplication.** Scores live only in `strategy-graph.md`.
-10. **Status mirrors the graph.** Do not change status in `index.md` independently.
-11. **Links should be real.** Do not add links to files that do not exist unless the line is explicitly labelled `planned`.
-12. **Tasks are references, not a second task system.** Use task IDs/titles and links where available; do not copy acceptance criteria into the index.
-13. **Keep it current.** When a hypothesis is disproven, update the hypothesis/output/open questions and link the evidence rather than appending an unstructured diary.
+2. **Exec Owner is stable through the initiative's lifecycle.** Do not reassign ownership because the initiative moves phase (e.g. build → growth, validation → scale). The owner set at initiative creation carries it end-to-end and is accountable for the full arc of their analysis and outcomes — like a PnL owner. Pick the owner who should carry it from the start with this in mind, not the owner best suited to the current phase. Only change Exec Owner via an explicit, deliberate decision from Tom/Quinn — never as a side effect of updating status, artifacts, or success metrics.
+3. **Hypothesis first.** Use an if/then/because/proof shape. Do not write a theme label or vague aspiration.
+4. **Use the graph's wording as the starting point.** Expand it only enough to make the expected proof and decision boundary explicit.
+5. **Do not invent evidence.** If proof, timing, or task links are unknown, say `TBD` or leave an explicit open question.
+6. **Keep the output bounded.** Name what this initiative will produce and what it will not attempt.
+7. **Make success observable.** Define one or more outcome metrics, a target where known, current value/status, and last-updated date. Use `TBD` or `not-instrumented` rather than guessing.
+8. **Link evidence.** Add dashboard links when they exist. A missing dashboard is acceptable; a fabricated link is not.
+9. **Keep strategy and execution separate.** Initiative index = why/what; market research and campaigns = working documents; task specs = implementation requirements.
+10. **No WSJF duplication.** Scores live only in `strategy-graph.md`.
+11. **Status mirrors the graph.** Do not change status in `index.md` independently.
+12. **Links should be real.** Do not add links to files that do not exist unless the line is explicitly labelled `planned`.
+13. **Tasks are references, not a second task system.** Use task IDs/titles and links where available; do not copy acceptance criteria into the index.
+14. **Keep it current.** When a hypothesis is disproven, update the hypothesis/output/open questions and link the evidence rather than appending an unstructured diary.
 
 ## Creating a new index
 

--- a/agents/skills/strategy/strategy-graph/SKILL.md
+++ b/agents/skills/strategy/strategy-graph/SKILL.md
@@ -78,7 +78,11 @@ WSJF favours small-but-valuable work over big-but-valuable work per unit of effo
 
 **How this reaches Tasks:** Tasks tag themselves with one or more Impacts (unchanged — no new tagging behaviour). A Task's derived strategic-fit badge is the score of the highest-WSJF `active` Initiative backing any of its tagged Impacts. This is computed, not stored by hand, and re-derives automatically when Initiative status or WSJF inputs change. `urgent` on the Task always overrides the derived badge.
 
-**Where the live numbers live:** the reasoning framework (this file) defines *how* to score. The actual Impacts, Initiatives, and their current weights/status/WSJF inputs live in `brain/strategy/graph-data.md` — that file is the instance data, this skill is the method.
+**Where the live numbers live:** the reasoning framework (this file) defines *how* to score. The actual Impacts, Initiatives, and their current weights/status/WSJF inputs live in `brain/sindustries/strategy-graph.md` — that file is the instance data, this skill is the method.
+
+That instance file also names each Initiative's kind — permanent **Capability Theme** (never graduates, serves everything) vs temporary **Products bucket** entry (unranked against siblings until it proves real usage and can graduate into its own Value Stream) — and the graduation rule between them. This skill's Theme/Value Stream/ART vocabulary above is the SAFe-derived reasoning shape; the Capability/Products split is how Sindustries currently maps its own initiatives onto that shape, kept in the instance file, not duplicated here.
+
+Every Initiative also has a per-initiative folder at `brain/initiatives/<slug>/` (folder structure and conventions: `brain/README.md`; authoring/validation rules and the `index.md` format, including the living hypothesis, exec owner, and success-metrics fields: the `initiative-author` skill). Do not duplicate that shape here — this skill covers *scoring and traversal*, `initiative-author` covers *how the initiative's own document is written and kept current*.
 
 ---
 
@@ -149,7 +153,7 @@ Sindustries currently has one ART and one Value Stream. Treat these as "the whol
 | **Value Stream** | End-to-end flow of value to a customer segment |
 | **ART** | Cross-functional team aligned to a value stream |
 | **Impact** | A specific customer outcome — the bridge between strategy and delivery. Carries a `weight` (default 1). |
-| **Initiative** | A bounded body of work contributing to one or more impacts. Carries `status` (active/parked/blocked) and WSJF inputs (value/time criticality/risk enablement/job size) → derived `score`. |
+| **Initiative** | A bounded hypothesis contributing to one or more impacts, with a dedicated folder at `brain/initiatives/<slug>/` (see `initiative-author` skill). Carries `status` (active/parked/blocked) and WSJF inputs (value/time criticality/risk enablement/job size) → derived `score`, both tracked in this skill's instance file, not in the initiative's own folder. |
 | **Feature** | A deliverable (software, marketing, sales, ops) that implements an initiative |
 | **Phase** | A time-boxed slice of feature delivery |
 | **Story** | A granular unit of work within a phase |


### PR DESCRIPTION
## Summary
- Promotes Ivy from Content Agent to Chief Growth Officer (CGO) per Tom's direction (2026-08-04 chat)
- New scope: growth research (`research.md`) + campaign strategy (`campaign.md`) for every `active` Initiative tagged **Money or Users** in `brain/sindustries/strategy-graph.md` — derived dynamically from the graph, not a hardcoded list
- Content production responsibilities unchanged — existing PR/merge/DoD flow for content tasks is untouched
- New GTM risk tiers in WORKFLOW.md (low/medium/high, BD outreach always high) — separate from the existing content risk tiers
- New HEARTBEAT section gated on actual staleness/signal, not every-heartbeat noise — mirrors the actionability-gate pattern used elsewhere
- DoD.md now has a parallel bar for research/campaign work: sourced, dated, implication stated, no fabricated claims, research/recommend-only (no autonomous spend/partnership commitments)
- Follows on from `brain/README.md` (initiatives structure, this session) and the Network/BD Building reclassification into Money or Users

## System Spec
No system spec change — agent operating docs only, no app code touched.

## Test plan
- [ ] Read updated `agents/definitions/ivy/{SOUL,DoD,HEARTBEAT,WORKFLOW,IDENTITY}.md` for tone/accuracy
- [ ] Confirm scope derivation (Money-or-Users tag lookup) matches intent — no hardcoded initiative list
- [ ] Confirm this does NOT grant Ivy any new tools/skills — that's an explicit follow-up per Tom's request

## Follow-up (not in this PR)
Tom wants to discuss specific skills/tool access for Ivy's new research responsibilities (e.g. web search) before granting them.

🤖 Generated with Claude Code