### PR TITLE
fix(gymtrack): use Vercel remote build in deploy workflow

### DIFF
--- a/.github/workflows/gymtrack-deploy.yml
+++ b/.github/workflows/gymtrack-deploy.yml
@@ -68,15 +68,11 @@ jobs:
         working-directory: apps/gymtrack
         run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
 
-      - name: Build Vercel output
-        working-directory: apps/gymtrack
-        run: vercel build --prod --token="$VERCEL_TOKEN"
-
       - name: Deploy to Vercel
         id: deploy
         working-directory: apps/gymtrack
         run: |
-          DEPLOY_URL=$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")
+          DEPLOY_URL=$(vercel deploy --prod --yes --token="$VERCEL_TOKEN")
           echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
           {
             echo "### GymTrack deployment"


### PR DESCRIPTION
## Summary
- Remove the failing local `vercel build` step from the GymTrack production workflow.
- Deploy directly with Vercel's production build path so the runner no longer hits `spawn npm ENOENT`.

## System Spec
No system spec change — CI/deployment plumbing only; no product behaviour changed.

## Test plan
- [x] Workflow YAML parses locally.
- [x] `npm test --workspace apps/gymtrack` — 132 tests passed.
- [ ] Merge and verify the GymTrack Deploy workflow completes through Vercel production deployment.

## Acceptance Criteria
- [x] The existing GymTrack deployment workflow reaches the Vercel production deployment step without failing on the local `spawn npm ENOENT` error. (⚠️ not tested: requires GitHub Actions after merge)