### PR TITLE
fix(gymtrack): deploy MCP server on Fly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+node_modules
+agents
+brain
+worktrees
+.git-worktrees
+.env
+*.env

--- a/services/gymtrack-mcp/Dockerfile
+++ b/services/gymtrack-mcp/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine AS base
+WORKDIR /app
+
+COPY services/gymtrack-mcp/package.json ./package.json
+RUN npm install --omit=dev
+
+COPY services/gymtrack-mcp/src ./src
+# The MCP implementation reuses GymTrack's canonical server-side data helpers.
+# This absolute path matches the existing ../../../apps/gymtrack/server import.
+COPY apps/gymtrack/server/agentData.js /apps/gymtrack/server/agentData.js
+
+ENV NODE_ENV=production
+EXPOSE 8787
+
+CMD ["node", "src/server.js"]

--- a/services/gymtrack-mcp/fly.toml
+++ b/services/gymtrack-mcp/fly.toml
@@ -1,0 +1,24 @@
+# fly.toml app configuration file generated for gymtrack-mcp on 2026-08-05T16:03:50+12:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'gymtrack-mcp'
+primary_region = 'syd'
+
+[build]
+  dockerfile = './Dockerfile'
+
+[http_service]
+  internal_port = 8787
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 1024

--- a/services/gymtrack-mcp/src/server.js
+++ b/services/gymtrack-mcp/src/server.js
@@ -4,6 +4,6 @@ import { loadConfig } from './config.js';
 const config = loadConfig();
 const app = createApp({ config });
 
-app.listen(config.port, () => {
-  console.log(`gymtrack-mcp listening on ${config.port}`);
+app.listen(config.port, '0.0.0.0', () => {
+  console.log(`gymtrack-mcp listening on 0.0.0.0:${config.port}`);
 });


### PR DESCRIPTION
Deploys the merged GymTrack MCP service to Fly.io and makes the runtime reproducible.

Changes:
- Add Fly app configuration for gymtrack-mcp in Sydney.
- Add a Dockerfile using Node 22 (Supabase JS requires native WebSocket support on Node 22+).
- Include the canonical GymTrack agent data helper used by the MCP service.
- Bind Express to 0.0.0.0 for Fly proxy reachability.
- Add a focused Docker build context ignore list.

Validation:
- npm test --workspace @sindustries/gymtrack-mcp — 5/5 passing.
- Live https://gymtrack-mcp.fly.dev/health — HTTP 200.
- Live OAuth authorization-server metadata — HTTP 200.

The app is already deployed from this branch; this PR records the production deployment artifacts and runtime fixes.