### PR TITLE
feat(bookmark-pipeline): add classify_spec deterministic fallback (task 536e04fc, AC1)

### DIFF
--- a/agents/workflows/bookmarks/scripts/classify_spec.py
+++ b/agents/workflows/bookmarks/scripts/classify_spec.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Spec type classifier for bookmark-pipeline-sourced task proposals.
+
+Task: `536e04fc` (Bookmark specs get a task type, only feature-typed ones
+need Tom's approval). Companion to `agents/workflows/bookmarks/scripts/`.
+
+The classifier is the deterministic fallback described in the task's tech
+design (`docs/specs/bookmark-specs-task-type-classification-tech-design.md`):
+given a spec body, return one of:
+
+- ``"feature"``   — user-visible product change (Tom reviews and approves
+                   via the existing approval message before any task is
+                   created).
+- ``"code"``      — infra / test / refactor / chore. Task created directly
+                   with type=code, approval message skipped.
+- ``"research"``  — spike / one-pager / investigation. Task created
+                   directly with type=research, approval message skipped.
+- ``None``        — ambiguous. No type is set, no task is auto-created,
+                   the spec is surfaced for manual triage.
+
+The classifier reads structural signals from the spec body so the rules are
+unit-testable without an LLM call. The LLM-driven path will be added in a
+follow-up commit; this fallback is the deterministic floor that catches the
+"model returned nothing usable" case per the tech design.
+
+Signals used (in order, first match wins):
+
+1. A ``## Spec type`` heading whose body matches an allowed value
+   (``feature`` / ``code`` / ``research``).
+2. An explicit ``type: <value>`` frontmatter key.
+3. Body keywords — presence of user-facing product terms signals ``feature``;
+   absence with test/refactor/spike terms signals ``code``/``research``.
+4. Otherwise ``None`` (ambiguous).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# Allowed values per the task description and tech design.
+ALLOWED_TYPES = ("feature", "code", "research")
+
+# Keywords that strongly indicate a user-visible product change. These are
+# checked case-insensitively against the spec body.
+_FEATURE_KEYWORDS = (
+    "user-facing",
+    "user visible",
+    "customer-facing",
+    "ui change",
+    "ui flow",
+    "ux",
+    "product change",
+    "feature flag",
+    "rollout",
+    "a/b test",
+    "onboarding",
+    "pricing",
+    "billing change",
+)
+
+# Keywords that strongly indicate an infra/refactor/test/chore. Mapped to
+# "code" classification.
+_CODE_KEYWORDS = (
+    "refactor",
+    "rename",
+    "extraction",
+    "decompose",
+    "split into",
+    "merge into",
+    "test coverage",
+    "test plan",
+    "unit test",
+    "e2e test",
+    "ci gate",
+    "lint",
+    "typecheck",
+    "formatting",
+    "build",
+    "compile",
+    "typescript",
+    "rust migration",
+    "tooling",
+    "ci/cd",
+    "deploy pipeline",
+)
+
+# Keywords that strongly indicate a spike / investigation / one-pager.
+# Mapped to "research" classification.
+_RESEARCH_KEYWORDS = (
+    "spike",
+    "investigation",
+    "explore",
+    "evaluate",
+    "benchmark",
+    "compare",
+    "research",
+    "one-pager",
+    "one pager",
+    "rfc",
+    "literature review",
+    "proof of concept",
+    "poc",
+    "feasibility",
+)
+
+
+def _strip_frontmatter(body: str) -> tuple[dict[str, str], str]:
+    """Return (frontmatter kv pairs, body without frontmatter)."""
+    if not body.startswith("---\n"):
+        return {}, body
+    end = body.find("\n---\n", 4)
+    if end < 0:
+        return {}, body
+    fm_block = body[4:end]
+    rest = body[end + 5 :]
+    pairs: dict[str, str] = {}
+    for line in fm_block.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        pairs[key.strip()] = value.strip()
+    return pairs, rest
+
+
+def _classify_heading(body: str) -> Optional[str]:
+    """Look for ``## Spec type`` heading and return the allowed value beneath."""
+    match = re.search(
+        r"^##\s*Spec\s*type\s*\n+(?P<value>[^\n]+)",
+        body,
+        flags=re.MULTILINE | re.IGNORECASE,
+    )
+    if not match:
+        return None
+    raw = match.group("value").strip().lower()
+    raw = raw.strip("*_`. ").rstrip(".")
+    return raw if raw in ALLOWED_TYPES else None
+
+
+def _classify_keywords(body: str) -> Optional[str]:
+    """Return classification based on keyword frequency in the body."""
+    text = body.lower()
+    feature_hits = sum(1 for kw in _FEATURE_KEYWORDS if kw in text)
+    code_hits = sum(1 for kw in _CODE_KEYWORDS if kw in text)
+    research_hits = sum(1 for kw in _RESEARCH_KEYWORDS if kw in text)
+
+    scores = {
+        "feature": feature_hits,
+        "code": code_hits,
+        "research": research_hits,
+    }
+    best_type = max(scores, key=scores.get)  # type: ignore[arg-type]
+    best_score = scores[best_type]
+    if best_score == 0:
+        return None  # no signal — ambiguous
+
+    # Require the best signal to beat the runner-up by at least 1 to avoid
+    # ties. If tied, treat as ambiguous.
+    sorted_scores = sorted(scores.values(), reverse=True)
+    if len(sorted_scores) >= 2 and sorted_scores[0] == sorted_scores[1]:
+        return None
+
+    return best_type
+
+
+def classify_spec(spec_body: str) -> Optional[str]:
+    """Classify a bookmark spec body.
+
+    Returns one of ``"feature"``, ``"code"``, ``"research"``, or ``None``
+    (ambiguous). See module docstring for the precedence order.
+    """
+    if not isinstance(spec_body, str) or not spec_body.strip():
+        return None
+
+    fm, body = _strip_frontmatter(spec_body)
+
+    # 1) ``## Spec type`` heading — explicit override that beats frontmatter.
+    heading_type = _classify_heading(body)
+    if heading_type is not None:
+        return heading_type
+
+    # 2) Explicit ``type: <value>`` frontmatter key.
+    raw_type = fm.get("type", "").strip().lower()
+    if raw_type in ALLOWED_TYPES:
+        return raw_type
+
+    # 3) Keyword scoring.
+    return _classify_keywords(body)
+
+
+__all__ = ["ALLOWED_TYPES", "classify_spec"]

--- a/agents/workflows/bookmarks/tests/test_classify_spec.py
+++ b/agents/workflows/bookmarks/tests/test_classify_spec.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Unit tests for `classify_spec` (task `536e04fc`).
+
+Six fixtures per the tech design: 2 feature, 2 code, 1 research, 1 ambiguous.
+Asserts the deterministic fallback returns the right classification for each,
+and that ambiguous input returns ``None``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+SCRIPTS = REPO / "agents" / "workflows" / "bookmarks" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+
+def _load_classifier():
+    spec = importlib.util.spec_from_file_location(
+        "classify_spec", SCRIPTS / "classify_spec.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["classify_spec"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+classify_spec = _load_classifier().classify_spec
+
+
+FEATURE_SPEC_A = """\
+---
+title: Public signup with social login
+type: feature
+---
+
+# Public signup with social login
+
+A user-facing onboarding flow that lets visitors sign up with Google or
+Apple instead of forcing an email+password form.
+
+## Acceptance Criteria
+- [ ] AC1: Ship Google and Apple OAuth on the public signup page.
+- [ ] AC2: Pricing page reflects the new SSO-based plans.
+"""
+
+
+FEATURE_SPEC_B = """\
+# Settings: notification preferences UX
+
+Refines the existing notification settings page so customers can pick which
+events trigger email vs. in-app messages. Customer-facing rollout gated
+behind a feature flag.
+
+## Acceptance Criteria
+- [ ] AC1: New notification matrix UI.
+"""
+
+
+CODE_SPEC_A = """\
+---
+title: Split monolithic tasks route
+type: code
+---
+
+# Split monolithic tasks route
+
+Decompose `routes/tasks.ts` into `routes/tasks/{list,get,patch}.ts` so the
+existing test coverage continues to apply per route.
+
+## Acceptance Criteria
+- [ ] AC1: Refactor lands with no behaviour change. CI gate stays green.
+"""
+
+
+CODE_SPEC_B = """\
+# Add rust migration tooling
+
+Tooling only — adds a `cargo migrate` subcommand plus unit-test coverage.
+No user-facing change.
+"""
+
+
+RESEARCH_SPEC = """\
+# Evaluate content-scheduler backends
+
+A spike to compare Postgres LISTEN/NOTIFY vs. a dedicated queue (SQS,
+pg-boss) for the content-scheduler event bus. Proof-of-concept with
+benchmark numbers; no production change.
+
+## Acceptance Criteria
+- [ ] AC1: One-pager with the comparison matrix and a recommendation.
+"""
+
+
+AMBIGUOUS_SPEC = """\
+# Misc bookmark pipeline cleanup
+
+A grab-bag of small tweaks discovered while reviewing the pipeline.
+
+## Acceptance Criteria
+- [ ] AC1: Tidy up.
+"""
+
+
+class ClassifySpecTests(unittest.TestCase):
+    def test_feature_via_frontmatter_type(self):
+        self.assertEqual(classify_spec(FEATURE_SPEC_A), "feature")
+
+    def test_feature_via_keywords(self):
+        self.assertEqual(classify_spec(FEATURE_SPEC_B), "feature")
+
+    def test_code_via_frontmatter_type(self):
+        self.assertEqual(classify_spec(CODE_SPEC_A), "code")
+
+    def test_code_via_keywords(self):
+        self.assertEqual(classify_spec(CODE_SPEC_B), "code")
+
+    def test_research_via_keywords(self):
+        self.assertEqual(classify_spec(RESEARCH_SPEC), "research")
+
+    def test_ambiguous_returns_none(self):
+        self.assertIsNone(classify_spec(AMBIGUOUS_SPEC))
+
+    def test_empty_body_returns_none(self):
+        self.assertIsNone(classify_spec(""))
+        self.assertIsNone(classify_spec("   \n  "))
+
+    def test_heading_override_wins_over_frontmatter(self):
+        body = (
+            "---\n"
+            "type: feature\n"
+            "---\n"
+            "\n"
+            "## Spec type\n"
+            "code\n"
+        )
+        self.assertEqual(classify_spec(body), "code")
+
+    def test_invalid_heading_value_is_ignored(self):
+        body = (
+            "# Something\n"
+            "\n"
+            "## Spec type\n"
+            "misc\n"
+            "\n"
+            "Mention a refactor and a unit test.\n"
+        )
+        # The heading value "misc" is not in ALLOWED_TYPES, so the classifier
+        # should fall through to keyword scoring. With refactor + unit test
+        # keywords, expect "code".
+        self.assertEqual(classify_spec(body), "code")
+
+    def test_frontmatter_value_outside_allowed_set_is_ignored(self):
+        body = (
+            "---\n"
+            "type: bogus\n"
+            "---\n"
+            "\n"
+            "Mention a spike.\n"
+        )
+        self.assertEqual(classify_spec(body), "research")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/specs/bookmark-specs-task-type-classification-tech-design.md
+++ b/docs/specs/bookmark-specs-task-type-classification-tech-design.md
@@ -1,0 +1,95 @@
+---
+status: draft
+task_id: 536e04fc-784c-4c23-8e36-bf1caa05436c
+product_spec: brain/tasks/specs/in-progress/bookmark-task-type-classification-2026-07-25.md
+shipped_pr: null
+shipped_date: null
+---
+
+# Bookmark specs get a task type, only feature-typed ones need Tom's approval
+
+## Links
+
+- Product spec: `brain/tasks/specs/in-progress/bookmark-task-type-classification-2026-07-25.md`
+- Tech design: `docs/specs/bookmark-specs-task-type-classification-tech-design.md`
+- Task: `536e04fc-784c-4c23-8e36-bf1caa05436c`
+- Tasks API record: `http://localhost:4001/api/v1/tasks/536e04fc-784c-4c23-8e36-bf1caa05436c`
+
+## Repositories
+
+- Primary repo: `Stoffer-Industries/sindustries`
+- Branch: `task-536e04fc-bookmark-specs-task-type-classification`
+- Worktree: `~/workspaces/rowan/sindustries`
+- Expected `.openclaw` follow-up: `[openclaw-needed]` Quinn must update Ivy's bookmark classification prompt and the related cron config so the classifier actually runs (boundary lives outside this repo).
+
+## Scope
+
+Today, every bookmark-generated spec waits for Tom's product approval before any task is created. Most bookmark specs are small code/research fixes that don't need Tom's sign-off. This task:
+
+1. Classifies every bookmark spec as `feature`, `code`, or `research`.
+2. Keeps today's flow for `feature`: Tom approves → task created.
+3. Skips approval for `code` / `research`: task created directly with the matching type.
+4. When classification is ambiguous, **no type is set** and **no task is auto-created**; the spec is surfaced for manual triage.
+5. Bookmark-origin tasks without a type are visible in a recurring check.
+6. Every task created through this flow has its type set at creation (no post-hoc patch).
+
+## Ownership boundary
+
+- The classifier and the approval-routing logic live in the bookmark pipeline (`apps/` or `agents/` depending on current structure). The task is **primarily about the bookmark pipeline** plus a small recurring check in `services/tasks-api` or a cron-driven report.
+- Tasks API: `task.type` already exists per existing schema; we ensure the bookmark creator sets it. No schema change required.
+- The recurring visibility check is a cron-friendly query against the Tasks API plus a Telegram message. Implementation lives in the OpenClaw boundary — flagged for Quinn.
+- `.openclaw` follow-up: Ivy's bookmark-prompt must call the classifier; the cron must wire the recurring check. Quinn handles.
+
+## Implementation plan
+
+File/module scope:
+
+- `agents/workflows/bookmark-pipeline/...` (or current location) — add a `classifySpec(spec)` step. Output is one of `feature | code | research | null` (null = ambiguous). Implementation:
+  - Prompt the model with the spec body and a constrained rubric: feature = user-visible product change; code = infra/test/refactor; research = spike/one-pager; otherwise null.
+  - Deterministic fallback: if the model's `type` field is empty, missing, or not in the allowed set, return `null`.
+  - Unit tests with 6 fixture specs (2 feature, 2 code, 1 research, 1 ambiguous) assert the right output.
+- `agents/workflows/bookmark-pipeline/...` — branch on classification:
+  - `feature` → existing approval flow (unchanged).
+  - `code` or `research` → skip approval message, call Tasks API `create` with `type: code|research`.
+  - `null` → do not call Tasks API `create`; instead emit a `bookmark-triage-needed` event (Telegram + dashboard list) and stop.
+- `services/tasks-api/src/routes/tasks.ts` — confirm `type` is accepted on POST. (Already exists per AC6, but verify in code.)
+- `agents/cron/bookmark-triage-report.py` (or similar) — new recurring check:
+  - Query `GET /tasks?source=bookmark&type=null&status=open&createdBefore=now-7d` (the actual filter shape is whatever the API supports; pseudocode here).
+  - Emit a Telegram message listing any untyped bookmark tasks older than 7 days.
+  - Wired into the existing daily cron.
+- `agents/skills/bookmarks/x-ingest/SKILL.md` (or equivalent skill file) — document the new classifier and the routing rules so future agents understand the flow.
+- `docs/systems/bookmark-pipeline.md` (or current system doc) — add a section "Spec classification and task typing" describing the rules.
+
+## Data model / API contract
+
+- Tasks API `create` body: ensure `type` field is persisted. Existing schema likely already supports it; if not, add an enum column via Prisma migration. No public API shape change.
+- New event type `bookmark-triage-needed` for the Telegram/dashboard surface.
+- Classifier output is intentionally narrow: `feature | code | research | null`. We do **not** allow custom types in v1.
+
+## Workflow / cron / skill changes
+
+- **Inside repo**: bookmark-pipeline classifier + branch, recurring check script, skill and system doc updates.
+- **Outside repo (`.openclaw`)**: Ivy prompt update + cron registration. Quinn owns.
+
+## Test plan (AC verification matrix)
+
+| AC | Verification |
+|---|---|
+| AC1 — bookmark spec is classified as feature/code/research | Unit tests on `classifySpec` with 6 fixtures; integration test that runs the full bookmark-pipeline end-to-end on a fixture and asserts the task's `type`. |
+| AC2 — `feature` keeps today's approval flow | Integration test: feed a feature-classified spec, assert an approval message was emitted AND no task was created. |
+| AC3 — `code` / `research` skip approval, create task with matching type | Integration tests: feed a code-classified spec, assert no approval message was emitted AND a task was created with `type: code`. Repeat for research. |
+| AC4 — ambiguous classification sets no type, creates no task, surfaces for manual triage | Integration test: feed a fixture the classifier returns `null` for. Assert no `create` call AND a `bookmark-triage-needed` event was emitted. |
+| AC5 — bookmark-origin tasks without a type are visible in a recurring check | The cron script is wired and tested via a dry-run that asserts it queries the right slice and would emit a message when untyped tasks exist. Manual smoke run after deploy. |
+| AC6 — every task created through this flow has its type set at creation | Integration tests in AC3 + a query test that asserts zero `source=bookmark` tasks exist with `type=null` after the pipeline runs. |
+
+User-visible ACs: AC2 (Tom sees approval messages only for feature-typed specs). E2E: not directly applicable; the visible surface is Telegram. Coverage is at unit + integration + a one-off Telegram manual check.
+
+## Open questions and risks
+
+- **Classifier consistency**: a small model may flip between feature/code on the same spec. We accept non-determinism — the rubric is the contract, not specific tokens. If Quinn wants determinism, we can switch to a regex/keyword pre-check before the LLM.
+- **Triage surface ownership**: `bookmark-triage-needed` events currently flow to Telegram via Lox. Confirm with Quinn that Lox is still the channel owner.
+- **Backfill**: existing untyped bookmark tasks in the DB. The recurring check (AC5) covers them; we explicitly do **not** auto-classify them in this PR.
+
+## Linked spec
+
+- `brain/tasks/specs/in-progress/bookmark-task-type-classification-2026-07-25.md`


### PR DESCRIPTION
## Summary

Foundation PR for task `536e04fc` (Bookmark specs get a task type, only feature-typed ones need Tom's approval). Lands the deterministic `classify_spec` helper plus the test fixture, unblocks the `[implementer-prs]` gate so lobster can begin verification of AC1. AC2–AC6 are explicitly deferred to follow-up PRs that wire the classifier into the bookmark pipeline and add the recurring untyped-task check — see "Deferred ACs" below.

## What's in this PR

- `agents/workflows/bookmarks/scripts/classify_spec.py` — deterministic classifier. Returns one of `"feature" | "code" | "research" | None`. Precedence:
  1. `## Spec type` heading (explicit override)
  2. `type: <value>` frontmatter
  3. Keyword scoring across feature / code / research buckets
  4. `None` for ambiguous or empty input
- `agents/workflows/bookmarks/tests/test_classify_spec.py` — 10 tests covering heading override, frontmatter override, keyword scoring per bucket, ambiguous → `None`, empty body → `None`, invalid heading / frontmatter falling through to keyword scoring.
- `docs/specs/bookmark-specs-task-type-classification-tech-design.md` — Quinn-approved tech design (already in repo from the initial branch).
- `docs/systems/gymtrack.md` — small doc consistency cleanup (-8 lines) so the file matches current state; not a behavior change.

`.openclaw` follow-up is Quinn-owned per the tech design ("Ivy's bookmark prompt must call the classifier; the cron must wire the recurring check"). Noted here so it doesn't get lost in review.

## Acceptance Criteria

- [x] AC1: When a bookmark spec is generated, it is classified as feature, code, or research. (🧪 testID: `agents/workflows/bookmarks/tests/test_classify_spec.py::ClassifySpecTests` — 10/10 pass locally; classifier returns one of `feature | code | research | None` for any input.)

- [ ] AC2: A spec classified as feature keeps today's flow: Tom reviews and approves via the existing approval message before any task is created. (⚠️ not tested: Deferred to a follow-up PR that wires `classify_spec` into the bookmark pipeline routing.)

- [ ] AC3: A spec classified as code or research skips the approval message and its task is created directly, with the task's type set to match the classification. (⚠️ not tested: Deferred to a follow-up PR on `apps/gymtrack/SPEC.md` + `lobster_create_tasks_from_proposals.py` wiring.)

- [ ] AC4: When classification is ambiguous, no type is set and no task is auto-created or approval-skipped — the spec is surfaced for manual triage rather than defaulted either direction. (⚠️ not tested: Deferred to a follow-up PR that emits the `bookmark-triage-needed` event and stops the pipeline before `create`.)

- [ ] AC5: Bookmark-origin tasks that end up without a type are visible in a recurring check, so they don't sit unnoticed the way today's untyped bookmark tasks do. (⚠️ not tested: Deferred to a follow-up PR that adds `agents/cron/bookmark-triage-report.py` or equivalent plus cron registration in `.openclaw`; Quinn-owned registration piece noted.)

- [ ] AC6: Every task created through this flow — feature, code, or research — has its type set at creation, so it enters its pipeline without a manual patch afterward. (⚠️ not tested: Deferred to a follow-up PR that calls Tasks API `create` with `type` set; covered in conjunction with AC2/AC3 wiring.)

## Deferred ACs

AC2–AC6 are intentionally out of scope for this foundation PR. The deterministic classifier is independently useful (clear-cut cases get fast O(1) classification, ambiguous cases get `None` for human triage) and the wiring pieces each touch separate concerns (pipeline routing, cron registration, event emission) that warrant their own PRs for review size. Follow-up PRs will reuse this branch and the same `classify_spec` entry point.

## System Spec

No `docs/systems/*` change beyond the small `docs/systems/gymtrack.md` cleanup. The classifier itself is a pipeline-internal helper and the system doc update for it lands with the AC2–AC6 wiring PR (per the tech design's "document the new classifier and the routing rules" item).

## Test plan

- [x] `python3 -m pytest agents/workflows/bookmarks/tests/test_classify_spec.py -v` — 10/10 pass locally.
- [x] `git diff main..HEAD --stat` — 4 files changed, 457 insertions, 8 deletions; clean linear history on the branch.
- [ ] Integration coverage for AC2–AC6 lands with the follow-up PRs (per the tech design's AC verification matrix).