### PR TITLE
feat(gymtrack): connect workouts to Claude and ChatGPT

### DIFF
--- a/apps/gymtrack/README.md
+++ b/apps/gymtrack/README.md
@@ -66,8 +66,11 @@ All user-owned tables are RLS-protected.
 
 - `/login` supports email/password and Google sign-in.
 - `/signup` supports Google sign-up plus a collapsed email/password fallback.
+- `/workouts` shows a **Connect to your agent** CTA when the signed-in user has no active MCP consent. Claude and ChatGPT links open the provider's real connector setup, where that client creates the OAuth state + PKCE request.
 - `/agent-consent` is the protected approval page used by external MCP clients.
 - `/settings/agents` lists active MCP connections and lets the user revoke them.
+
+Production provider setup and exact URLs/client IDs are documented in [`docs/runbooks/gymtrack-agent-connect.md`](../../docs/runbooks/gymtrack-agent-connect.md).
 
 Apple remains hidden until Quinn removes `'apple'` from `src/lib/authFlow.js` after the Supabase provider is wired.
 

--- a/apps/gymtrack/SPEC.md
+++ b/apps/gymtrack/SPEC.md
@@ -1,8 +1,8 @@
 # GymTrack — Behavioural spec
 
-Task: `18256740` (Shape GymTrack MVP from saved prototype), `f520c396` (Agent-Powered Workouts), `72d7cc3b` (Public Sign-Up with Social Login), `1474d515` (GymTrack MCP Server with OAuth Auth).
-Tech design: `docs/specs/gymtrack-mvp-tech-design.md`, `docs/specs/gymtrack-agent-powered-workouts-tech-design.md`, `docs/specs/gymtrack-public-signup-social-login-tech-design.md`, `docs/specs/gymtrack-mcp-server-oauth-auth-tech-design.md`.
-Product spec: `brain/tasks/specs/gymtrack-mvp-2026-07-07.md`, `brain/tasks/specs/in-progress/gymtrack-agent-powered-workouts.md`, `brain/tasks/specs/in-progress/gymtrack-signup-social-login-2026-07-27.md`, `brain/tasks/specs/in-progress/gymtrack-mcp-server-oauth-2026-07-27.md`.
+Task: `18256740` (Shape GymTrack MVP from saved prototype), `f520c396` (Agent-Powered Workouts), `72d7cc3b` (Public Sign-Up with Social Login), `1474d515` (GymTrack MCP Server with OAuth Auth), `2306125e` (Workouts Tab with Connect to Your Agent CTA).
+Tech design: `docs/specs/gymtrack-mvp-tech-design.md`, `docs/specs/gymtrack-agent-powered-workouts-tech-design.md`, `docs/specs/gymtrack-public-signup-social-login-tech-design.md`, `docs/specs/gymtrack-mcp-server-oauth-auth-tech-design.md`, `docs/specs/gymtrack-workouts-tab-connect-agent-cta-tech-design.md`.
+Product spec: `brain/tasks/specs/gymtrack-mvp-2026-07-07.md`, `brain/tasks/specs/in-progress/gymtrack-agent-powered-workouts.md`, `brain/tasks/specs/in-progress/gymtrack-signup-social-login-2026-07-27.md`, `brain/tasks/specs/in-progress/gymtrack-mcp-server-oauth-2026-07-27.md`, `brain/tasks/specs/in-progress/gymtrack-workouts-tab-connect-agent-2026-07-27.md`.
 
 ## Overview
 
@@ -39,15 +39,16 @@ The user-facing app surfaces planned workouts (created via either agent surface)
 3. On success → redirect to `/workout` or back to the protected destination that triggered the redirect.
 4. On error → inline error banner; controls re-enable.
 
-### Authorize an external MCP client
+### Connect and authorize an external MCP client
 
-1. An external client starts OAuth against `GET /oauth/authorize` on the GymTrack MCP server.
-2. The MCP server validates `client_id`, `redirect_uri`, requested `scope`, and PKCE (`code_challenge`, `code_challenge_method=S256`), then redirects the browser into GymTrack at `/agent-consent?...`.
-3. If the user is not signed in, `<AuthGate>` redirects them to `/login`, preserving the full consent URL. The user can continue with Google or email/password and lands back on `/agent-consent`.
-4. `/agent-consent` shows the client name, redirect URI, and requested scopes.
-5. Approve → GymTrack POSTs the decision to the MCP server with the signed-in Supabase access token; the MCP server verifies the user session, creates/updates the consent row, stores a hashed authorization code, and returns the client redirect URL with `code` and `state`.
-6. Cancel → the user is redirected back with `error=access_denied`.
-7. The external client exchanges the code at `POST /oauth/token` with a PKCE verifier. GymTrack returns a short-lived bearer access token plus a rotated refresh token. Plaintext tokens are never stored in Supabase.
+1. When `/workouts` finds no active OAuth consent, it shows **Connect to your agent** with explicit Claude and ChatGPT options, the remote MCP URL, and each seeded public client ID.
+2. Selecting a provider opens its real MCP connector configuration. The user adds `https://gymtrack-mcp.fly.dev/mcp`; the external client generates OAuth state + a PKCE challenge and starts OAuth against `GET /oauth/authorize` on the GymTrack MCP server.
+3. The MCP server validates `client_id`, `redirect_uri`, requested `scope`, and PKCE (`code_challenge`, `code_challenge_method=S256`), then redirects the browser into GymTrack at `/agent-consent?...`.
+4. If the user is not signed in, `<AuthGate>` redirects them to `/login`, preserving the full consent URL. The user can continue with Google or email/password and lands back on `/agent-consent`.
+5. `/agent-consent` shows the client name, redirect URI, and requested scopes.
+6. Approve → GymTrack POSTs the decision to the MCP server with the signed-in Supabase access token; the MCP server verifies the user session, creates/updates the consent row, stores a hashed authorization code, and returns the client redirect URL with `code` and `state`.
+7. Cancel → the user is redirected back with `error=access_denied`.
+8. The external client exchanges the code at `POST /oauth/token` with a PKCE verifier. GymTrack returns a short-lived bearer access token plus a rotated refresh token. Plaintext tokens are never stored in Supabase.
 
 ### Manage connected agents
 
@@ -78,9 +79,10 @@ The user-facing app surfaces planned workouts (created via either agent surface)
 1. From `/workout` or `/history`, tap the "Workouts" tab → land on `/workouts`.
 2. The page fetches the signed-in user's pending planned workouts (`planned` or `started`), ordered soonest-first by `scheduled_for` ascending.
 3. Each workout renders as a card with title, scheduled date, exercise/set summary, and Today/Overdue badge when relevant.
-4. Empty state: "No upcoming workouts yet. Connect Claude or ChatGPT from their MCP client, then manage access in the Agents tab."
-5. Tap a workout card → land on `/workout?date=YYYY-MM-DD`; if a plan exists for that date, plan mode is rendered.
-6. Error state: inline error banner with retry by reload.
+4. If there is no active agent consent, the provider-specific connection CTA appears independently of whether pending workouts exist.
+5. Empty state: "No upcoming workouts yet. Once connected, your agent can plan one for you."
+6. Tap a workout card → land on `/workout?date=YYYY-MM-DD`; if a plan exists for that date, plan mode is rendered.
+7. Error state: inline error banner with retry by reload.
 
 ### Log a workout against a plan
 
@@ -105,7 +107,7 @@ The user-facing app surfaces planned workouts (created via either agent surface)
 | `/agent-consent` | `AgentConsentPage` | Protected consent review screen for external MCP clients. |
 | `/workout` | `WorkoutLogger` | Date picker + exercise picker + pending sets; accepts `?date=YYYY-MM-DD`. |
 | `/history` | `HistoryList` | Last-30-days grouped history. |
-| `/workouts` | `WorkoutsTab` | Pending planned workouts, soonest-first, with Today/Overdue badges and Agents tab link. |
+| `/workouts` | `WorkoutsTab` | Pending planned workouts, soonest-first, with Today/Overdue badges; users with no active consent also see real Claude/ChatGPT connector links. |
 | `/settings/agents` | `ConnectedAgentsPage` | Lists and revokes active MCP consents. |
 | `*` | redirect | → `/`. |
 
@@ -174,7 +176,7 @@ The MCP server always derives the acting `user_id` from the validated OAuth acce
 |---|---|
 | Email/password login + sign-up | Existing GymTrack unit/component tests + `test/e2e/signup.spec.ts` |
 | Google social login wiring | `test/e2e/signup-google.spec.ts` |
-| Planned workouts browse flow | `test/e2e/workouts-tab.spec.ts` + `src/components/WorkoutsTab.test.jsx` |
+| Planned workouts browse + connect-agent CTA visibility/provider links | `test/e2e/workouts-tab.spec.ts` + `src/components/WorkoutsTab.test.jsx` |
 | Connected agents list + revoke UI | `src/components/ConnectedAgentsPage.test.jsx` |
 | Legacy REST handlers | `src/lib/agentAuth.test.js`, `src/lib/plannedWorkoutsHandler.test.js`, `src/lib/historyHandler.test.js`, `src/lib/progressionHandler.test.js` |
 | MCP OAuth flow, PKCE exchange, refresh rotation, tool discovery | `services/gymtrack-mcp/test/app.test.js` |

--- a/apps/gymtrack/src/components/ConnectAgentCta.jsx
+++ b/apps/gymtrack/src/components/ConnectAgentCta.jsx
@@ -1,0 +1,68 @@
+import { mcpUrl } from '../lib/mcpConfig.js';
+
+export const AGENT_CONNECT_OPTIONS = [
+  {
+    id: 'claude',
+    name: 'Claude',
+    clientId: 'claude-desktop',
+    href: 'https://claude.ai/settings/connectors',
+    instructions: 'Add a custom connector, then approve GymTrack access.'
+  },
+  {
+    id: 'chatgpt',
+    name: 'ChatGPT',
+    clientId: 'chatgpt',
+    href: 'https://chatgpt.com/admin/ca',
+    instructions: 'Create an MCP app, scan its tools, then approve GymTrack access.'
+  }
+];
+
+/**
+ * Agent clients must create the OAuth state and PKCE challenge themselves.
+ * Linking to their real connector screens lets them do that safely; GymTrack
+ * cannot manufacture a valid provider authorization request in the SPA.
+ */
+export default function ConnectAgentCta() {
+  const endpoint = mcpUrl('/mcp');
+
+  return (
+    <section className="connect-agent-cta" data-testid="connect-agent-cta">
+      <p className="connect-agent-eyebrow">AI workout planning</p>
+      <h2>Connect to your agent</h2>
+      <p className="connect-agent-copy">
+        Add GymTrack as an MCP connector. Your agent will open GymTrack’s secure
+        authorization screen before it can read history or plan workouts.
+      </p>
+
+      <div className="connect-agent-endpoint">
+        <span>MCP server</span>
+        <code data-testid="connect-agent-mcp-url">{endpoint}</code>
+      </div>
+
+      <div className="connect-agent-options">
+        {AGENT_CONNECT_OPTIONS.map((option) => (
+          <article className="connect-agent-option" key={option.id}>
+            <h3>{option.name}</h3>
+            <p>{option.instructions}</p>
+            <p className="connect-agent-client-id">
+              OAuth client ID: <code>{option.clientId}</code>
+            </p>
+            <a
+              className="btn-primary connect-agent-link"
+              href={option.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid={`connect-${option.id}`}
+            >
+              Connect {option.name}
+            </a>
+          </article>
+        ))}
+      </div>
+
+      <p className="connect-agent-footnote">
+        ChatGPT custom MCP apps currently require a supported plan and developer-mode access.
+      </p>
+    </section>
+  );
+}

--- a/apps/gymtrack/src/components/WorkoutsTab.jsx
+++ b/apps/gymtrack/src/components/WorkoutsTab.jsx
@@ -1,16 +1,18 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { listPendingPlannedWorkouts } from '../lib/plans.js';
+import { listConnectedAgents } from '../lib/connectedAgents.js';
 import { useAuth } from '../lib/auth.jsx';
+import ConnectAgentCta from './ConnectAgentCta.jsx';
 import WorkoutCard from './WorkoutCard.jsx';
 
 /**
  * `/workouts` tab — lists the signed-in user's pending planned workouts
  * (status `planned` or `started`), soonest-first, with a Today/Overdue
  * visual distinction. Tapping a card lands on the log screen with the
- * workout's date pre-selected via `?date=`. The "Connect to your agent"
- * CTA (AC3/AC4) ships in a separate WS2 PR — it depends on the OAuth flow
- * from sibling task `1474d515`.
+ * workout's date pre-selected via `?date=`. Users without an active OAuth
+ * consent also get provider-specific links into Claude or ChatGPT's real MCP
+ * connector setup, where the agent initiates the PKCE authorization flow.
  */
 export default function WorkoutsTab() {
   const { signOut } = useAuth();
@@ -19,6 +21,9 @@ export default function WorkoutsTab() {
   const [workouts, setWorkouts] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [connectedAgents, setConnectedAgents] = useState(null);
+  const [agentsLoading, setAgentsLoading] = useState(true);
+  const [agentsError, setAgentsError] = useState(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -36,6 +41,27 @@ export default function WorkoutsTab() {
       setLoading(false);
     }
     load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadAgents() {
+      setAgentsLoading(true);
+      setAgentsError(null);
+      const { data, error: fetchErr } = await listConnectedAgents();
+      if (cancelled) return;
+      if (fetchErr) {
+        setAgentsError(fetchErr.message);
+        setConnectedAgents(null);
+      } else {
+        setConnectedAgents(data ?? []);
+      }
+      setAgentsLoading(false);
+    }
+    loadAgents();
     return () => {
       cancelled = true;
     };
@@ -74,6 +100,16 @@ export default function WorkoutsTab() {
         </nav>
       </header>
 
+      {!agentsLoading && !agentsError && connectedAgents?.length === 0 ? (
+        <ConnectAgentCta />
+      ) : null}
+
+      {agentsError ? (
+        <div className="status show error" role="alert" data-testid="agents-status-error">
+          Could not check agent connections: {agentsError}
+        </div>
+      ) : null}
+
       <h2 className="section-title">Pending workouts</h2>
 
       {loading ? <p data-testid="workouts-loading">Loading planned workouts…</p> : null}
@@ -86,8 +122,7 @@ export default function WorkoutsTab() {
 
       {!loading && !error && workouts && workouts.length === 0 ? (
         <p className="empty-hint" data-testid="workouts-empty">
-          No upcoming workouts yet. Connect Claude or ChatGPT from their MCP client,
-          then manage access in the Agents tab.
+          No upcoming workouts yet. Once connected, your agent can plan one for you.
         </p>
       ) : null}
 

--- a/apps/gymtrack/src/components/WorkoutsTab.test.jsx
+++ b/apps/gymtrack/src/components/WorkoutsTab.test.jsx
@@ -12,6 +12,11 @@ vi.mock('../lib/plans.js', () => ({
   markPlannedWorkoutCompleted: vi.fn()
 }));
 
+const mockListConnectedAgents = vi.fn();
+vi.mock('../lib/connectedAgents.js', () => ({
+  listConnectedAgents: (...args) => mockListConnectedAgents(...args)
+}));
+
 // Mock auth so useAuth() returns a signed-in session.
 const mockSignOut = vi.fn();
 vi.mock('../lib/auth.jsx', () => ({
@@ -76,11 +81,13 @@ function makeWorkout({ id, scheduled_for, title = 'Push day', sets = [] }) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockListConnectedAgents.mockResolvedValue({ data: [], error: null });
 });
 
 describe('WorkoutsTab', () => {
   it('renders a loading state on first render', () => {
     mockListPendingPlannedWorkouts.mockReturnValue(new Promise(() => {})); // never resolves
+    mockListConnectedAgents.mockReturnValue(new Promise(() => {}));
     renderWorkoutsTab();
     expect(screen.getByTestId('workouts-loading')).toBeInTheDocument();
     expect(screen.queryByTestId('workout-cards')).not.toBeInTheDocument();
@@ -91,6 +98,56 @@ describe('WorkoutsTab', () => {
     renderWorkoutsTab();
     expect(await screen.findByTestId('workouts-empty')).toBeInTheDocument();
     expect(screen.queryByTestId('workout-cards')).not.toBeInTheDocument();
+  });
+
+  it('shows real Claude and ChatGPT connector links when no agent is connected', async () => {
+    mockListPendingPlannedWorkouts.mockResolvedValueOnce({ data: [], error: null });
+    mockListConnectedAgents.mockResolvedValueOnce({ data: [], error: null });
+    renderWorkoutsTab();
+
+    expect(await screen.findByText('Connect to your agent')).toBeInTheDocument();
+    expect(screen.getByTestId('connect-agent-cta')).toBeInTheDocument();
+    expect(screen.getByTestId('connect-claude')).toHaveAttribute(
+      'href',
+      'https://claude.ai/settings/connectors'
+    );
+    expect(screen.getByTestId('connect-chatgpt')).toHaveAttribute(
+      'href',
+      'https://chatgpt.com/admin/ca'
+    );
+    expect(screen.getByTestId('connect-claude')).toHaveAttribute('target', '_blank');
+    expect(screen.getByTestId('connect-chatgpt')).toHaveAttribute('target', '_blank');
+    expect(screen.getByTestId('connect-agent-mcp-url')).toHaveTextContent(
+      'http://localhost:8787/mcp'
+    );
+    expect(screen.getByText('claude-desktop')).toBeInTheDocument();
+    expect(screen.getByText('chatgpt')).toBeInTheDocument();
+  });
+
+  it('hides the connect CTA when an active agent consent exists', async () => {
+    mockListPendingPlannedWorkouts.mockResolvedValueOnce({ data: [], error: null });
+    mockListConnectedAgents.mockResolvedValueOnce({
+      data: [{ id: 'consent-1', clientId: 'claude-desktop' }],
+      error: null
+    });
+    renderWorkoutsTab();
+
+    expect(await screen.findByTestId('workouts-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('connect-agent-cta')).not.toBeInTheDocument();
+  });
+
+  it('does not claim the user is disconnected when the consent lookup fails', async () => {
+    mockListPendingPlannedWorkouts.mockResolvedValueOnce({ data: [], error: null });
+    mockListConnectedAgents.mockResolvedValueOnce({
+      data: null,
+      error: new Error('consent lookup failed')
+    });
+    renderWorkoutsTab();
+
+    expect(await screen.findByTestId('agents-status-error')).toHaveTextContent(
+      /consent lookup failed/i
+    );
+    expect(screen.queryByTestId('connect-agent-cta')).not.toBeInTheDocument();
   });
 
   it('renders one card per workout, in the order returned by the fetch', async () => {

--- a/apps/gymtrack/src/lib/mcpConfig.js
+++ b/apps/gymtrack/src/lib/mcpConfig.js
@@ -1,7 +1,22 @@
-export function mcpBaseUrl() {
-  return import.meta.env.VITE_GYMTRACK_MCP_BASE_URL ?? window.location.origin;
+export const PRODUCTION_MCP_BASE_URL = 'https://gymtrack-mcp.fly.dev';
+
+export function mcpBaseUrl({
+  configuredBaseUrl = import.meta.env.VITE_GYMTRACK_MCP_BASE_URL,
+  location = window.location
+} = {}) {
+  if (configuredBaseUrl) return configuredBaseUrl;
+
+  // Keep local development zero-config while failing safe to the deployed MCP
+  // service everywhere else. The production Vercel project should still set
+  // VITE_GYMTRACK_MCP_BASE_URL explicitly; this fallback prevents consent POSTs
+  // and CTA setup instructions from silently pointing at the SPA origin.
+  if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
+    return 'http://localhost:8787';
+  }
+
+  return PRODUCTION_MCP_BASE_URL;
 }
 
-export function mcpUrl(path) {
-  return new URL(path, mcpBaseUrl()).toString();
+export function mcpUrl(path, options) {
+  return new URL(path, mcpBaseUrl(options)).toString();
 }

--- a/apps/gymtrack/src/lib/mcpConfig.test.js
+++ b/apps/gymtrack/src/lib/mcpConfig.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { mcpBaseUrl, mcpUrl, PRODUCTION_MCP_BASE_URL } from './mcpConfig.js';
+
+describe('GymTrack MCP URL configuration', () => {
+  it('uses an explicit deployment setting when provided', () => {
+    expect(
+      mcpBaseUrl({
+        configuredBaseUrl: 'https://mcp.example.test',
+        location: { hostname: 'gymtrack.example.test' }
+      })
+    ).toBe('https://mcp.example.test');
+  });
+
+  it('uses the local MCP service during local development', () => {
+    expect(
+      mcpUrl('/mcp', {
+        configuredBaseUrl: '',
+        location: { hostname: 'localhost' }
+      })
+    ).toBe('http://localhost:8787/mcp');
+  });
+
+  it('falls back to the live Fly service outside local development', () => {
+    expect(
+      mcpUrl('/mcp', {
+        configuredBaseUrl: '',
+        location: { hostname: 'gymtrack-sigma-pied.vercel.app' }
+      })
+    ).toBe(`${PRODUCTION_MCP_BASE_URL}/mcp`);
+  });
+});

--- a/apps/gymtrack/src/styles/index.css
+++ b/apps/gymtrack/src/styles/index.css
@@ -372,6 +372,90 @@ button:disabled {
   font-variant-numeric: tabular-nums;
 }
 
+/* Agent connection CTA */
+.connect-agent-cta {
+  margin: 1.25rem 0 1.75rem;
+  padding: 1rem;
+  border: 1px solid rgba(232, 197, 71, 0.45);
+  border-radius: 14px;
+  background: linear-gradient(145deg, rgba(232, 197, 71, 0.1), var(--card) 55%);
+}
+
+.connect-agent-cta h2 {
+  margin-top: 0.2rem;
+  font-size: 1.25rem;
+}
+
+.connect-agent-eyebrow {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.connect-agent-copy,
+.connect-agent-option p,
+.connect-agent-footnote {
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.connect-agent-endpoint {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin: 1rem 0;
+  padding: 0.75rem;
+  overflow-wrap: anywhere;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: rgba(15, 15, 15, 0.65);
+}
+
+.connect-agent-endpoint span,
+.connect-agent-client-id {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.connect-agent-endpoint code,
+.connect-agent-client-id code {
+  color: var(--text);
+}
+
+.connect-agent-options {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.connect-agent-option {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg);
+}
+
+.connect-agent-option h3 {
+  margin: 0;
+}
+
+.connect-agent-link {
+  display: block;
+  margin-top: auto;
+  text-align: center;
+  text-decoration: none;
+}
+
+.connect-agent-footnote {
+  margin-top: 0.85rem;
+  font-size: 0.75rem;
+}
+
 /* Auth gate placeholder */
 .auth-gate-loading {
   text-align: center;

--- a/docs/runbooks/gymtrack-agent-connect.md
+++ b/docs/runbooks/gymtrack-agent-connect.md
@@ -1,0 +1,96 @@
+# GymTrack agent connection rollout
+
+GymTrack's Workouts CTA hands the user to Claude or ChatGPT's connector setup. This is intentional: the agent client must generate the OAuth `state` and PKCE challenge before requesting `GET /oauth/authorize`; the GymTrack SPA cannot safely manufacture a provider request on its behalf.
+
+## Production values
+
+| Setting | Value |
+| --- | --- |
+| GymTrack SPA | `https://gymtrack-sigma-pied.vercel.app` |
+| MCP base / OAuth issuer | `https://gymtrack-mcp.fly.dev` |
+| Remote MCP endpoint | `https://gymtrack-mcp.fly.dev/mcp` |
+| Authorization metadata | `https://gymtrack-mcp.fly.dev/.well-known/oauth-authorization-server` |
+| Protected-resource metadata | `https://gymtrack-mcp.fly.dev/.well-known/oauth-protected-resource` |
+| GymTrack consent page | `https://gymtrack-sigma-pied.vercel.app/agent-consent` |
+
+The CTA links to `https://claude.ai/settings/connectors` for Claude and `https://chatgpt.com/admin/ca` for ChatGPT. It displays the MCP endpoint and the static public OAuth client ID to enter in the provider UI.
+
+## Operator checklist
+
+No client secret is committed or required by GymTrack; both seeded clients are OAuth public clients using Authorization Code + PKCE.
+
+### Vercel / SPA
+
+- [ ] Set `VITE_GYMTRACK_MCP_BASE_URL=https://gymtrack-mcp.fly.dev` in the production Vercel project and redeploy. The app has a production Fly fallback, but the explicit setting is the operational source of truth.
+- [ ] Keep `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` configured in Vercel.
+- [ ] In Supabase Auth URL Configuration, set the Site URL to `https://gymtrack-sigma-pied.vercel.app` and allow `https://gymtrack-sigma-pied.vercel.app/**` as a redirect URL. This preserves `/agent-consent?...` when an unauthenticated user signs in during authorization.
+- [ ] Keep the Google provider enabled if Google sign-in is offered on `/login`; its provider callback remains the Supabase callback shown in the Supabase dashboard.
+
+### Fly MCP service
+
+Verify these non-secret values and existing secrets in the `gymtrack-mcp` Fly app; do not put the service-role key in Vercel client env or the repo.
+
+- [ ] `GYMTRACK_MCP_ISSUER=https://gymtrack-mcp.fly.dev`
+- [ ] `GYMTRACK_APP_URL=https://gymtrack-sigma-pied.vercel.app`
+- [ ] `GYMTRACK_WEB_ORIGIN=https://gymtrack-sigma-pied.vercel.app`
+- [ ] `VITE_SUPABASE_URL` points to the same Supabase project used by the SPA.
+- [ ] `SUPABASE_SERVICE_ROLE_KEY` is present as a Fly secret.
+
+Smoke checks:
+
+```bash
+curl -fsS https://gymtrack-mcp.fly.dev/health
+curl -fsS https://gymtrack-mcp.fly.dev/.well-known/oauth-authorization-server
+curl -fsS https://gymtrack-mcp.fly.dev/.well-known/oauth-protected-resource
+```
+
+### Supabase OAuth clients
+
+Migration `apps/gymtrack/supabase/migrations/20260804070000_mcp_oauth.sql` seeds these exact allowlist values:
+
+| Provider | Client ID | Allowed redirect URI |
+| --- | --- | --- |
+| Claude | `claude-desktop` | `https://claude.ai/api/mcp/auth_callback` |
+| ChatGPT | `chatgpt` | `https://chatgpt.com/connector_platform_oauth_redirect` |
+
+Confirm the production rows have not drifted:
+
+```sql
+select client_id, client_name, redirect_uris
+from public.gymtrack_oauth_clients
+where client_id in ('claude-desktop', 'chatgpt')
+order by client_id;
+```
+
+If either provider reports a redirect mismatch, capture the exact `redirect_uri` it sent, verify it against that provider's current documentation, and update only that client's allowlist. Do not add wildcard redirect URIs.
+
+### Claude end-to-end
+
+- [ ] Open Claude **Settings → Connectors → Add custom connector**.
+- [ ] Name it `GymTrack` and enter `https://gymtrack-mcp.fly.dev/mcp`.
+- [ ] In Advanced settings, enter OAuth Client ID `claude-desktop` and leave the client secret blank (public PKCE client).
+- [ ] Add/connect the connector. Claude should open GymTrack's `/agent-consent` page.
+- [ ] Approve access, return to Claude, and confirm `plan_workout`, `read_history`, and `read_exercise_progression` are discovered.
+
+### ChatGPT end-to-end
+
+ChatGPT custom MCP apps are plan- and role-gated. The current OpenAI flow requires a supported ChatGPT plan plus developer-mode/admin access.
+
+- [ ] Open ChatGPT workspace **Settings → Apps → Create** (the CTA opens `https://chatgpt.com/admin/ca`).
+- [ ] Enable developer mode if prompted.
+- [ ] Create `GymTrack` with endpoint `https://gymtrack-mcp.fly.dev/mcp` and OAuth authentication.
+- [ ] Configure OAuth Client ID `chatgpt` with no client secret if the provider UI accepts a public PKCE client.
+- [ ] Scan tools and complete the GymTrack consent prompt.
+- [ ] Confirm all three tools are discovered.
+
+If ChatGPT requires Client ID Metadata Documents, Dynamic Client Registration, an `offline_access` scope, or a confidential client secret rather than accepting the seeded public client, stop and capture the provider error. Those server capabilities are not implemented by the merged MCP service and need a follow-up design; do not invent a secret or weaken redirect validation.
+
+## Acceptance smoke test
+
+Use a GymTrack account with no active row in `gymtrack_oauth_consents`:
+
+1. Open `/workouts`; verify the **Connect to your agent** panel shows Claude and ChatGPT.
+2. Select each option; verify it opens the real provider connector configuration, not an in-app placeholder.
+3. Add the displayed MCP URL and public client ID in one provider.
+4. Verify the provider-originated OAuth request reaches GymTrack consent, approval returns to the provider, and an active consent appears under `/settings/agents`.
+5. Reload `/workouts`; verify the CTA is hidden now that an active consent exists.

--- a/docs/systems/gymtrack.md
+++ b/docs/systems/gymtrack.md
@@ -78,6 +78,12 @@ The SPA owns:
 5. `POST /oauth/revoke` revokes the full consent family for the presented token.
 6. Browser-side revocation from `/settings/agents` sets `consent.revoked_at`; every MCP access-token validation and refresh exchange checks that field, so revoked connections stop working immediately.
 
+### Agent connection entry point
+
+When a signed-in user has no active row in `gymtrack_oauth_consents`, `/workouts` renders explicit Claude and ChatGPT connection options. Each option links to that provider's real MCP connector setup and displays GymTrack's remote MCP URL plus the seeded public client ID. The provider—not the SPA—must generate OAuth state and the PKCE challenge before calling `/oauth/authorize`.
+
+Production URLs, redirect allowlists, provider steps, and remaining operator checks are in [`docs/runbooks/gymtrack-agent-connect.md`](../runbooks/gymtrack-agent-connect.md).
+
 ### MCP tool flow
 
 1. The external client calls `POST /mcp` with `Authorization: Bearer <oauth access token>`.
@@ -178,4 +184,4 @@ This is a deliberate one-consumer build, consistent with `docs/ARCHITECTURE.md`'
   - `docs/specs/gymtrack-agent-powered-workouts-tech-design.md`
   - `docs/specs/gymtrack-public-signup-social-login-tech-design.md`
   - `docs/specs/gymtrack-mcp-server-oauth-auth-tech-design.md`
-- Current implementation branch: `task-1474d515-gymtrack-mcp-server-oauth-redo`
+- Agent connection rollout runbook: `docs/runbooks/gymtrack-agent-connect.md`


### PR DESCRIPTION
## Summary
- Adds the real **Connect to your agent** panel to `/workouts` when the signed-in user has no active MCP consent, with explicit Claude and ChatGPT options.
- Links directly to each provider's MCP connector setup, showing the live GymTrack MCP endpoint and static public OAuth client ID so the provider can originate the required state + PKCE authorization request; this deliberately avoids a fake in-app OAuth request.
- Routes production consent POSTs and CTA setup to `https://gymtrack-mcp.fly.dev` when Vercel's `VITE_GYMTRACK_MCP_BASE_URL` is absent, while keeping localhost on port 8787.
- Documents exact Fly, Vercel, Supabase, Claude, and ChatGPT production setup/checks in `docs/runbooks/gymtrack-agent-connect.md`. No secrets are committed.

## System Spec
`docs/systems/gymtrack.md` updated with the provider-originated connection entry point and rollout runbook. `apps/gymtrack/SPEC.md` also documents the user-visible CTA/authorization flow and coverage.

## Test plan
- [x] `npm --workspace gymtrack test` — 14 files / 138 tests pass, including no-consent visibility, active-consent hiding, lookup-failure behavior, provider destinations, and MCP URL selection.
- [x] `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=test-anon-key npm --workspace gymtrack run build` — production bundle includes the Fly, Claude, and ChatGPT destinations.
- [x] Live smoke: `https://gymtrack-mcp.fly.dev/health` and both well-known metadata endpoints return 200; seeded Claude and ChatGPT authorize probes return 302 to `https://gymtrack-sigma-pied.vercel.app/agent-consent` with the provider request preserved.
- [ ] Provider-account smoke: follow `docs/runbooks/gymtrack-agent-connect.md` in Tom's Claude/ChatGPT account after confirming plan/admin access and the listed Vercel/Supabase settings.

## Acceptance Criteria
- [x] AC1: A Workouts tab is reachable from the app's main navigation and lists all of the signed-in user's pending planned workouts (status `planned` or `started`), showing at minimum the scheduled date, title, and exercise/set summary for each. (🔗 pr: #333)
- [x] AC2: Pending workouts are ordered soonest-first, and a workout scheduled for today or in the past is visually distinguished from ones scheduled further out. (🔗 pr: #333)
- [x] AC3: When a user has no agent connected, the Workouts tab shows a "Connect to your agent" call to action with explicit options for Claude and ChatGPT. (🧪 testID: `connect-agent-cta`, `connect-claude`, `connect-chatgpt`)
- [x] AC4: Selecting "Connect to your agent" starts (or links to) the authorization flow that grants an agent access — the CTA is not a dead end or placeholder. (🧪 testID: `connect-claude` links to Claude Connectors and `connect-chatgpt` links to ChatGPT Apps; both show `connect-agent-mcp-url` for the live provider-originated PKCE flow)
- [x] AC5: When a user taps into a specific pending workout from the tab, they land on the existing log screen with that workout's date pre-selected, so they can log actuals against it without manually finding the right date. (🔗 pr: #333)

## Remaining production configuration
- Set `VITE_GYMTRACK_MCP_BASE_URL=https://gymtrack-mcp.fly.dev` in Vercel and redeploy (the code fallback makes the current production hostname functional, but the explicit env is the source of truth).
- Confirm Supabase Site URL `https://gymtrack-sigma-pied.vercel.app`, allowed redirect `https://gymtrack-sigma-pied.vercel.app/**`, and the two exact `gymtrack_oauth_clients` rows listed in the runbook.
- Claude: add `https://gymtrack-mcp.fly.dev/mcp` with public client ID `claude-desktop` and no secret.
- ChatGPT: requires a supported plan/developer-mode role. Try public client ID `chatgpt`; if ChatGPT instead requires CIMD/DCR, `offline_access`, or a confidential secret, capture that provider error for a follow-up rather than weakening redirect validation or inventing a secret.

🤖 Generated with Claude Code
