### PR TITLE
fix(rowan): tighten code-garden skip rules + assignee gotcha guard

### DIFF
--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -9,6 +9,8 @@ Before Step 1, run the shared read-only work queue once:
 
 The queue combines task and PR work and returns one deterministic `topCandidate`. Action that candidate in this pass through the matching workflow or `pr-process` skill with Rowan's own identity. The queue never reviews, comments, changes task state, or merges automatically.
 
+**Always use this script — never a raw `curl .../tasks?assignee=...` call.** The tasks-api `assignee` field is the human display name `Rowan`, not the GitHub login `rowanstoffer`; a raw query with the wrong casing silently returns `[]` and has repeatedly masked the entire 4-doing workload, leading to false "nothing assigned" conclusions that skipped straight past Step 3 into `NO_REPLY`. If a raw sanity-check query is ever needed, use `assignee=Rowan` and treat `assignee=rowanstoffer` returning `[]` as expected, not as evidence of an empty queue.
+
 ---
 
 ## Step 1 — PR work
@@ -44,6 +46,8 @@ Read and follow:
 **Limit:** Open at most 1 code-garden PR at a time. Check for open PRs first — if one exists, skip this step.
 
 **Skip code gardening entirely** if any assigned feature task in `ready` is waiting for a tech design, or any `doing`/`acceptance` task can be materially progressed this pass (implementation, review feedback, merge/post-merge work, required comments/specs, or validation). Code garden is only on the table when all active feature tasks are waiting on someone else's action and any needed nudge has already been sent.
+
+**Only those three bullets are valid reasons to skip code garden.** `DEPENDENCY_BLOCKED` and `WAITING_EXTERNAL` classifications from the queue are explicitly NOT skip reasons on their own — they mean Step 2 has nothing to progress, which is exactly the signal to move to Step 3. Do not invent additional judgment calls this file doesn't list (e.g. "don't compete for review attention," "hold until the dependency chain clears," "avoid opening a PR while other tasks are mid-flight") as reasons to skip. If the three bullets don't apply, open code gardening — that is the required action, not a fallback to consider.
 
 ---
 


### PR DESCRIPTION
## Summary
- Diagnoses two compounding bugs in `agents/definitions/rowan/HEARTBEAT.md` that have suppressed every code-garden pass for the past ~12 days (since PR #308 on 2026-07-26).
- Hardens Step 0 (assignee gotcha) and Step 3 (skip criteria) so Rowan can't keep inventing ad-hoc skip reasons.

## What was actually broken

**Bug 1 — invented skip reasons.** HEARTBEAT.md Step 3 lists three explicit bullets for skipping code-garden. But recent memory notes (2026-08-03 → 2026-08-07) show Rowan skipping with phrases not in the file:
- "actionable task in flight" (when the task was DEPENDENCY_BLOCKED, i.e. zero in-lane action)
- "actionable PR feedback in progress, awaiting external state"
- "Hold-the-line" 
- "don't compete for review attention when real tasks are mid-flight"
- "Hold until the clippy chain clears"

All four doing tasks (`e9c06d01`, `cbe3333a`, `55c98158`, `19241c82`) are dependency- or manually-blocked. None has any actual in-lane action this pass — which is exactly the trigger condition the file lists for code garden.

**Bug 2 — `assignee=rowanstoffer` false negatives.** Step 0 says use the shared `agent_task_queue.py` script. Rowan kept falling back to raw `curl .../tasks?assignee=rowanstoffer`. The tasks-api stores assignee as the human display name (`Rowan`), so the raw query returned `[]` and Rowan declared the queue empty for the whole pass. Two recent notes (`2026-08-06 22:28`, `2026-08-06 23:27`) explicitly burned cycles re-confirming the empty result before retrying with the right casing.

The skip rules now state explicitly:
- Only the three listed bullets are valid skip reasons.
- `DEPENDENCY_BLOCKED` / `WAITING_EXTERNAL` on their own are NOT skip reasons — they mean Step 2 has nothing to progress, which is the trigger for code garden.
- Always use the queue script; never raw `curl ...?assignee=...`. Treat `assignee=rowanstoffer` returning `[]` as expected, not as evidence of an empty queue.

## Test plan
- [ ] Reading the rules: someone unfamiliar can confirm the skip list is closed (no judgment calls outside the three bullets).
- [ ] Heartbeat dry-run: with four DEPENDENCY_BLOCKED doing tasks and no in-lane action, Step 3 lands on "open code gardening" instead of "hold-the-line".

## Files changed
- `agents/definitions/rowan/HEARTBEAT.md` (4 lines added)
