### PR TITLE
fix(ops): sync-agent-definitions copies AGENTS.md into each agent workspace

### DIFF
--- a/scripts/ops/sync-agent-definitions.sh
+++ b/scripts/ops/sync-agent-definitions.sh
@@ -7,6 +7,12 @@ BACKUP_ROOT=${OPENCLAW_AGENT_DEFS_BACKUP_ROOT:-"$HOME/.openclaw/backups/agent-de
 LOCK_DIR=${OPENCLAW_AGENT_DEFS_LOCK_DIR:-"${TMPDIR:-/tmp}/openclaw-agent-definitions-sync.lock"}
 SOURCE_ROOT=agents/definitions
 AGENTS=(quinn rowan lox ivy)
+# Non-quinn agents also need the canonical AGENTS.md copied from the
+# workspace root into their own workspace dir. It is not sourced from
+# agents/definitions/<agent>/ (it is shared, not per-agent) and previously
+# relied on a workspace-repo-tracked symlink, which is fragile (see
+# workspace PR #60 — symlinks get reasserted by any git restore/checkout).
+WORKSPACE_AGENTS_MD="$WORKSPACE_ROOT/AGENTS.md"
 
 if ! mkdir "$LOCK_DIR" 2>/dev/null; then
   echo "agent-definitions sync already running; skipping"
@@ -61,6 +67,27 @@ for agent in "${AGENTS[@]}"; do
     echo "synced $source_path -> $destination"
     changed=$((changed + 1))
   done < <(git -C "$REPO_ROOT" ls-tree -r --name-only origin/main -- "$source_dir" | grep -E '\.md$')
+
+  # AGENTS.md: canonical copy lives at the workspace root and is shared
+  # across all agents (not agent-specific, so it is not part of
+  # agents/definitions/<agent>/ on origin/main). Copy it into every
+  # non-quinn agent's workspace dir here so it can never silently go
+  # missing or drift to a stale copy.
+  if [[ "$agent" != quinn && -f "$WORKSPACE_AGENTS_MD" ]]; then
+    agents_destination="$destination_dir/AGENTS.md"
+    if [[ ! -L "$agents_destination" && -f "$agents_destination" ]] && cmp -s "$WORKSPACE_AGENTS_MD" "$agents_destination"; then
+      :
+    else
+      if [[ -e "$agents_destination" || -L "$agents_destination" ]]; then
+        mkdir -p "$backup_dir/$agent"
+        cp -pL "$agents_destination" "$backup_dir/$agent/AGENTS.md"
+        rm -f "$agents_destination"
+      fi
+      install -m 0644 "$WORKSPACE_AGENTS_MD" "$agents_destination"
+      echo "synced $WORKSPACE_AGENTS_MD -> $agents_destination"
+      changed=$((changed + 1))
+    fi
+  fi
 done
 
 echo "agent-definitions sync complete: $changed file(s) changed"


### PR DESCRIPTION
## What

Add an AGENTS.md copy step to `scripts/ops/sync-agent-definitions.sh`. After the per-agent file loop, for every non-quinn agent, copy the canonical `\$WORKSPACE_ROOT/AGENTS.md` into `\$WORKSPACE_ROOT/agents/<agent>/AGENTS.md` if missing or drifted. Same backup-before-overwrite pattern as the rest of the script.

## Why

Workspace PR #60 stopped tracking per-agent AGENTS.md symlinks (they were getting reverted by git to mode 120000 on every restore/checkout). After that PR merged and a plain `git pull --ff-only` ran on the workspace repo, the fallout was:

- agents/lox/AGENTS.md — completely missing (clean symlink-to-untracked, deleted on pull)
- agents/ivy/AGENTS.md — completely missing (same)
- agents/rowan/AGENTS.md — stale hand-copied version from an earlier ad-hoc fix, diverged from canonical

AGENTS.md isn't part of `agents/definitions/<agent>/` on origin/main because it's shared, not per-agent — so the main per-file loop never copied it. This PR makes the propagation durable.

## How to verify

```
bash scripts/ops/tests/sync-agent-definitions.test.sh
# sync-agent-definitions: ok

# Manual end-to-end
rm -f /tmp/test-ws/agents/lox/AGENTS.md
SINDUSTRIES_REPO_ROOT=$PWD OPENCLAW_WORKSPACE_ROOT=/tmp/test-ws \
  bash scripts/ops/sync-agent-definitions.sh
# synced <workspace>/AGENTS.md -> /tmp/test-ws/agents/lox/AGENTS.md
```

## Out of scope

- Active-probes wiring is still on `chore/lox-daily-review-probes-wiring` (WIP). Not landed in this PR. Quinn will reopen the active-probes PR separately (cleaned up from a prior cleanup attempt).

## Risk

LOW. Same pattern as the existing per-file loop. Backs up before overwriting. Skips when content already matches. Quinn copy-pasted the canonical AGENTS.md into lox/ivy/rowan manually before this PR landed.