### PR TITLE
chore(code-garden): extract usePulseCelebration hook from App.jsx [2026-W30]

### DIFF
--- a/apps/tasks/src/App.jsx
+++ b/apps/tasks/src/App.jsx
@@ -17,13 +17,14 @@ import { useTasks } from './useTasks.js';
 import { useTaskDrafts } from './useTaskDrafts.js';
 import { fetchTask } from './tasksApi';
 import { useDebounce } from './hooks/useDebounce.js';
+import { usePulseCelebration } from './hooks/usePulseCelebration.js';
 import { useToast } from './hooks/useToast.js';
 import { ConfettiLayer } from './components/ConfettiLayer.jsx';
 import { TaskCardSummary } from './components/TaskCardSummary.jsx';
 import { TaskEditor } from './components/TaskEditor.jsx';
 import { ToastStack } from './components/ToastStack.jsx';
 import { STATUSES, STATUS_LABELS, PRIORITIES, PRIORITY_SCORE, ASSIGNEE_OPTIONS, TASK_TYPES, TASK_TYPE_LABELS } from './utils/constants.js';
-import { createConfettiPieces, normalizeTaskForEditor, taskCardTilt } from './utils/helpers.js';
+import { normalizeTaskForEditor, taskCardTilt } from './utils/helpers.js';
 import { getStoredView, setStoredView } from './utils/storage.js';
 
 function isReadyTask(task) {
@@ -109,11 +110,9 @@ export function App() {
   const { toasts, showToast } = useToast();
 
   const [newTask, setNewTask] = useState({ title: '', expanded: false, description: '', priority: 'medium', assignee: '', dueAt: '', tagsText: '', blocked: false, taskType: '' });
-  const [confettiBursts, setConfettiBursts] = useState([]);
   const [submittingCommentForTaskId, setSubmittingCommentForTaskId] = useState(null);
-  const confettiTimeoutsRef = useRef(new Map());
-  const audioContextRef = useRef(null);
   const taskCardRefs = useRef({});
+  const { confettiBursts, triggerCelebration, hoverProps: pulseHoverProps } = usePulseCelebration();
 
   // Scroll to task card after save/close if needed
   // AC9: When closing a task that has a long card (top above window), scroll should reset accounting for header
@@ -175,18 +174,6 @@ export function App() {
     });
     return Array.from(tagSet).sort();
   }, [tasks]);
-
-  useEffect(() => {
-    return () => {
-      for (const timeoutId of confettiTimeoutsRef.current.values()) {
-        window.clearTimeout(timeoutId);
-      }
-      confettiTimeoutsRef.current.clear();
-      if (audioContextRef.current) {
-        audioContextRef.current.close().catch(() => {});
-      }
-    };
-  }, []);
 
   useEffect(() => {
     if (!hasUnsavedDrafts) return undefined;
@@ -287,56 +274,6 @@ export function App() {
     }
   }
 
-  async function playSalesBell() {
-    try {
-      const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
-      if (!AudioContextCtor) return;
-
-      if (!audioContextRef.current) {
-        audioContextRef.current = new AudioContextCtor();
-      }
-
-      const context = audioContextRef.current;
-      if (context.state === 'suspended') {
-        await context.resume();
-      }
-
-      const now = context.currentTime + 0.02;
-      const notes = [523.25, 659.25, 783.99, 1046.5];
-
-      notes.forEach((frequency, index) => {
-        const start = now + index * 0.09;
-        const duration = 0.24;
-
-        const lead = context.createOscillator();
-        const leadGain = context.createGain();
-        lead.type = 'square';
-        lead.frequency.setValueAtTime(frequency, start);
-        leadGain.gain.setValueAtTime(0.001, start);
-        leadGain.gain.exponentialRampToValueAtTime(0.17, start + 0.02);
-        leadGain.gain.exponentialRampToValueAtTime(0.001, start + duration);
-        lead.connect(leadGain);
-        leadGain.connect(context.destination);
-        lead.start(start);
-        lead.stop(start + duration + 0.03);
-
-        const shimmer = context.createOscillator();
-        const shimmerGain = context.createGain();
-        shimmer.type = 'triangle';
-        shimmer.frequency.setValueAtTime(frequency * 2, start);
-        shimmerGain.gain.setValueAtTime(0.001, start);
-        shimmerGain.gain.exponentialRampToValueAtTime(0.06, start + 0.02);
-        shimmerGain.gain.exponentialRampToValueAtTime(0.001, start + duration);
-        shimmer.connect(shimmerGain);
-        shimmerGain.connect(context.destination);
-        shimmer.start(start);
-        shimmer.stop(start + duration + 0.03);
-      });
-    } catch {
-      // No-op on browsers that block or lack Web Audio.
-    }
-  }
-
   function openTask(taskId) {
     setSelectedId(taskId);
     void refreshTask(taskId).catch(() => {});
@@ -350,56 +287,6 @@ export function App() {
     openTask(taskId);
   }
 
-  function launchPulseCelebration() {
-    void playSalesBell();
-
-    const id = window.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
-    const pieces = createConfettiPieces();
-    setConfettiBursts((current) => [...current, { id, pieces }]);
-
-    const timeoutId = window.setTimeout(() => {
-      setConfettiBursts((current) => current.filter((burst) => burst.id !== id));
-      confettiTimeoutsRef.current.delete(id);
-    }, 2800);
-
-    confettiTimeoutsRef.current.set(id, timeoutId);
-  }
-
-  function updatePulseHoverMotion(event) {
-    const element = event.currentTarget;
-    const bounds = element.getBoundingClientRect();
-    if (!bounds.width || !bounds.height) return;
-
-    const x = Math.min(Math.max((event.clientX - bounds.left) / bounds.width, 0), 1);
-    const y = Math.min(Math.max((event.clientY - bounds.top) / bounds.height, 0), 1);
-    const centerX = x - 0.5;
-    const centerY = y - 0.5;
-    const distance = Math.min(Math.hypot(centerX, centerY), 0.75);
-
-    const sway = centerX * 11;
-    const lift = 3 + Math.abs(centerY) * 7;
-    const speed = 460 + Math.round(distance * 360);
-
-    element.style.setProperty('--pulse-tilt', `${(centerX * 5.5).toFixed(2)}deg`);
-    element.style.setProperty('--pulse-sway-a', `${sway.toFixed(2)}px`);
-    element.style.setProperty('--pulse-sway-b', `${(-sway * 0.72).toFixed(2)}px`);
-    element.style.setProperty('--pulse-up-a', `-${lift.toFixed(2)}px`);
-    element.style.setProperty('--pulse-up-b', `-${(lift + 1.8).toFixed(2)}px`);
-    element.style.setProperty('--pulse-down', `${(centerY * 1.6).toFixed(2)}px`);
-    element.style.setProperty('--pulse-speed', `${speed}ms`);
-  }
-
-  function resetPulseHoverMotion(event) {
-    const element = event.currentTarget;
-    element.style.removeProperty('--pulse-tilt');
-    element.style.removeProperty('--pulse-sway-a');
-    element.style.removeProperty('--pulse-sway-b');
-    element.style.removeProperty('--pulse-up-a');
-    element.style.removeProperty('--pulse-up-b');
-    element.style.removeProperty('--pulse-down');
-    element.style.removeProperty('--pulse-speed');
-  }
-
   return (
     <main className="app-shell">
       <header className="hero-header">
@@ -409,11 +296,9 @@ export function App() {
             <button
               type="button"
               className="brand brand-btn si-font-display"
-              onClick={launchPulseCelebration}
-              onPointerEnter={updatePulseHoverMotion}
-              onPointerMove={updatePulseHoverMotion}
-              onPointerLeave={resetPulseHoverMotion}
+              onClick={triggerCelebration}
               aria-label="Ring Pulse sales bell"
+              {...pulseHoverProps}
             >
               Pulse
             </button>

--- a/apps/tasks/src/hooks/usePulseCelebration.js
+++ b/apps/tasks/src/hooks/usePulseCelebration.js
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createConfettiPieces } from '../utils/helpers.js';
+
+const CONFETTI_BURST_DURATION_MS = 2800;
+const SALES_BELL_NOTES = [523.25, 659.25, 783.99, 1046.5];
+const SALES_BELL_NOTE_SPACING_S = 0.09;
+const SALES_BELL_NOTE_DURATION_S = 0.24;
+const SALES_BELL_LEAD_GAIN_PEAK = 0.17;
+const SALES_BELL_SHIMMER_GAIN_PEAK = 0.06;
+const SALES_BELL_GAIN_RAMP_S = 0.02;
+const SALES_BELL_START_OFFSET_S = 0.02;
+
+/**
+ * Owns the Pulse brand-button celebration: the sales bell, the confetti burst,
+ * and the hover-tilt CSS animation. All state/effects are scoped to the
+ * component's mount cycle so the App.jsx render tree stays a UI shell.
+ *
+ * Returns:
+ *   - confettiBursts: array of { id, pieces } to feed <ConfettiLayer bursts={...} />
+ *   - triggerCelebration: click handler for the brand button
+ *   - hoverProps: spread onto the brand button for onPointerEnter/Move/Leave
+ */
+export function usePulseCelebration() {
+  const [confettiBursts, setConfettiBursts] = useState([]);
+  const confettiTimeoutsRef = useRef(new Map());
+  const audioContextRef = useRef(null);
+
+  // Cleanup pending confetti timeouts and the lazily-created AudioContext on unmount.
+  useEffect(() => {
+    return () => {
+      for (const timeoutId of confettiTimeoutsRef.current.values()) {
+        window.clearTimeout(timeoutId);
+      }
+      confettiTimeoutsRef.current.clear();
+      if (audioContextRef.current) {
+        audioContextRef.current.close().catch(() => {});
+      }
+    };
+  }, []);
+
+  const playSalesBell = useCallback(async () => {
+    try {
+      const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+      if (!AudioContextCtor) return;
+
+      if (!audioContextRef.current) {
+        audioContextRef.current = new AudioContextCtor();
+      }
+
+      const context = audioContextRef.current;
+      if (context.state === 'suspended') {
+        await context.resume();
+      }
+
+      const now = context.currentTime + SALES_BELL_START_OFFSET_S;
+
+      SALES_BELL_NOTES.forEach((frequency, index) => {
+        const start = now + index * SALES_BELL_NOTE_SPACING_S;
+        const duration = SALES_BELL_NOTE_DURATION_S;
+
+        const lead = context.createOscillator();
+        const leadGain = context.createGain();
+        lead.type = 'square';
+        lead.frequency.setValueAtTime(frequency, start);
+        leadGain.gain.setValueAtTime(0.001, start);
+        leadGain.gain.exponentialRampToValueAtTime(SALES_BELL_LEAD_GAIN_PEAK, start + SALES_BELL_GAIN_RAMP_S);
+        leadGain.gain.exponentialRampToValueAtTime(0.001, start + duration);
+        lead.connect(leadGain);
+        leadGain.connect(context.destination);
+        lead.start(start);
+        lead.stop(start + duration + 0.03);
+
+        const shimmer = context.createOscillator();
+        const shimmerGain = context.createGain();
+        shimmer.type = 'triangle';
+        shimmer.frequency.setValueAtTime(frequency * 2, start);
+        shimmerGain.gain.setValueAtTime(0.001, start);
+        shimmerGain.gain.exponentialRampToValueAtTime(SALES_BELL_SHIMMER_GAIN_PEAK, start + SALES_BELL_GAIN_RAMP_S);
+        shimmerGain.gain.exponentialRampToValueAtTime(0.001, start + duration);
+        shimmer.connect(shimmerGain);
+        shimmerGain.connect(context.destination);
+        shimmer.start(start);
+        shimmer.stop(start + duration + 0.03);
+      });
+    } catch {
+      // No-op on browsers that block or lack Web Audio.
+    }
+  }, []);
+
+  const triggerCelebration = useCallback(() => {
+    void playSalesBell();
+
+    const id = window.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
+    const pieces = createConfettiPieces();
+    setConfettiBursts((current) => [...current, { id, pieces }]);
+
+    const timeoutId = window.setTimeout(() => {
+      setConfettiBursts((current) => current.filter((burst) => burst.id !== id));
+      confettiTimeoutsRef.current.delete(id);
+    }, CONFETTI_BURST_DURATION_MS);
+
+    confettiTimeoutsRef.current.set(id, timeoutId);
+  }, [playSalesBell]);
+
+  const updateHoverMotion = useCallback((event) => {
+    const element = event.currentTarget;
+    const bounds = element.getBoundingClientRect();
+    if (!bounds.width || !bounds.height) return;
+
+    const x = Math.min(Math.max((event.clientX - bounds.left) / bounds.width, 0), 1);
+    const y = Math.min(Math.max((event.clientY - bounds.top) / bounds.height, 0), 1);
+    const centerX = x - 0.5;
+    const centerY = y - 0.5;
+    const distance = Math.min(Math.hypot(centerX, centerY), 0.75);
+
+    const sway = centerX * 11;
+    const lift = 3 + Math.abs(centerY) * 7;
+    const speed = 460 + Math.round(distance * 360);
+
+    element.style.setProperty('--pulse-tilt', `${(centerX * 5.5).toFixed(2)}deg`);
+    element.style.setProperty('--pulse-sway-a', `${sway.toFixed(2)}px`);
+    element.style.setProperty('--pulse-sway-b', `${(-sway * 0.72).toFixed(2)}px`);
+    element.style.setProperty('--pulse-up-a', `-${lift.toFixed(2)}px`);
+    element.style.setProperty('--pulse-up-b', `-${(lift + 1.8).toFixed(2)}px`);
+    element.style.setProperty('--pulse-down', `${(centerY * 1.6).toFixed(2)}px`);
+    element.style.setProperty('--pulse-speed', `${speed}ms`);
+  }, []);
+
+  const resetHoverMotion = useCallback((event) => {
+    const element = event.currentTarget;
+    element.style.removeProperty('--pulse-tilt');
+    element.style.removeProperty('--pulse-sway-a');
+    element.style.removeProperty('--pulse-sway-b');
+    element.style.removeProperty('--pulse-up-a');
+    element.style.removeProperty('--pulse-up-b');
+    element.style.removeProperty('--pulse-down');
+    element.style.removeProperty('--pulse-speed');
+  }, []);
+
+  const hoverProps = {
+    onPointerEnter: updateHoverMotion,
+    onPointerMove: updateHoverMotion,
+    onPointerLeave: resetHoverMotion
+  };
+
+  return {
+    confettiBursts,
+    triggerCelebration,
+    hoverProps
+  };
+}

--- a/apps/tasks/src/hooks/usePulseCelebration.test.js
+++ b/apps/tasks/src/hooks/usePulseCelebration.test.js
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { usePulseCelebration } from './usePulseCelebration.js';
+
+const CONFETTI_BURST_DURATION_MS = 2800;
+
+describe('usePulseCelebration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts with no bursts', () => {
+    const { result } = renderHook(() => usePulseCelebration());
+    expect(result.current.confettiBursts).toEqual([]);
+  });
+
+  it('triggerCelebration adds a burst to the state', () => {
+    const { result } = renderHook(() => usePulseCelebration());
+
+    act(() => {
+      result.current.triggerCelebration();
+    });
+
+    expect(result.current.confettiBursts).toHaveLength(1);
+    expect(result.current.confettiBursts[0]).toHaveProperty('id');
+    expect(result.current.confettiBursts[0]).toHaveProperty('pieces');
+  });
+
+  it('produces unique burst IDs across successive triggers', () => {
+    const { result } = renderHook(() => usePulseCelebration());
+
+    act(() => {
+      result.current.triggerCelebration();
+      result.current.triggerCelebration();
+      result.current.triggerCelebration();
+    });
+
+    const ids = result.current.confettiBursts.map((burst) => burst.id);
+    expect(result.current.confettiBursts).toHaveLength(3);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it('removes the burst after CONFETTI_BURST_DURATION_MS', () => {
+    const { result } = renderHook(() => usePulseCelebration());
+
+    act(() => {
+      result.current.triggerCelebration();
+    });
+
+    const burstId = result.current.confettiBursts[0].id;
+    expect(result.current.confettiBursts).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(CONFETTI_BURST_DURATION_MS - 1);
+    });
+    expect(result.current.confettiBursts.map((b) => b.id)).toContain(burstId);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.confettiBursts.map((b) => b.id)).not.toContain(burstId);
+  });
+
+  it('removes each burst independently when multiple are scheduled', () => {
+    const { result } = renderHook(() => usePulseCelebration());
+
+    act(() => {
+      result.current.triggerCelebration();
+      result.current.triggerCelebration();
+    });
+    const [firstId, secondId] = result.current.confettiBursts.map((b) => b.id);
+
+    act(() => {
+      vi.advanceTimersByTime(CONFETTI_BURST_DURATION_MS);
+    });
+
+    const remaining = result.current.confettiBursts.map((b) => b.id);
+    expect(remaining).not.toContain(firstId);
+    expect(remaining).not.toContain(secondId);
+    expect(result.current.confettiBursts).toHaveLength(0);
+  });
+
+  it('clears pending timeouts on unmount', () => {
+    const clearSpy = vi.spyOn(window, 'clearTimeout');
+    const { result, unmount } = renderHook(() => usePulseCelebration());
+
+    act(() => {
+      result.current.triggerCelebration();
+      result.current.triggerCelebration();
+    });
+
+    expect(clearSpy).not.toHaveBeenCalled();
+    unmount();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it('exposes hoverProps bound to the hover-motion handlers', () => {
+    const { result } = renderHook(() => usePulseCelebration());
+    expect(result.current.hoverProps).toEqual({
+      onPointerEnter: expect.any(Function),
+      onPointerMove: expect.any(Function),
+      onPointerLeave: expect.any(Function)
+    });
+    expect(result.current.hoverProps.onPointerEnter).toBe(result.current.hoverProps.onPointerMove);
+  });
+
+  it('updateHoverMotion writes --pulse-* CSS variables on the target', () => {
+    const { result } = renderHook(() => usePulseCelebration());
+
+    const fakeElement = {
+      getBoundingClientRect: () => ({ left: 0, top: 0, width: 200, height: 100 }),
+      style: {
+        setProperty: vi.fn(),
+        removeProperty: vi.fn()
+      }
+    };
+    const event = { currentTarget: fakeElement, clientX: 100, clientY: 50 };
+
+    act(() => {
+      result.current.hoverProps.onPointerMove(event);
+    });
+
+    expect(fakeElement.style.setProperty).toHaveBeenCalledWith('--pulse-tilt', expect.stringMatching(/deg$/));
+    expect(fakeElement.style.setProperty).toHaveBeenCalledWith('--pulse-sway-a', expect.stringMatching(/px$/));
+    expect(fakeElement.style.setProperty).toHaveBeenCalledWith('--pulse-sway-b', expect.stringMatching(/px$/));
+    expect(fakeElement.style.setProperty).toHaveBeenCalledWith('--pulse-up-a', expect.stringMatching(/px$/));
+    expect(fakeElement.style.setProperty).toHaveBeenCalledWith('--pulse-up-b', expect.stringMatching(/px$/));
+    expect(fakeElement.style.setProperty).toHaveBeenCalledWith('--pulse-down', expect.stringMatching(/px$/));
+    expect(fakeElement.style.setProperty).toHaveBeenCalledWith('--pulse-speed', expect.stringMatching(/ms$/));
+  });
+
+  it('updateHoverMotion is a no-op when bounds have zero width or height', () => {
+    const { result } = renderHook(() => usePulseCelebration());
+
+    const fakeElement = {
+      getBoundingClientRect: () => ({ left: 0, top: 0, width: 0, height: 0 }),
+      style: {
+        setProperty: vi.fn(),
+        removeProperty: vi.fn()
+      }
+    };
+    const event = { currentTarget: fakeElement, clientX: 100, clientY: 50 };
+
+    act(() => {
+      result.current.hoverProps.onPointerMove(event);
+    });
+
+    expect(fakeElement.style.setProperty).not.toHaveBeenCalled();
+  });
+
+  it('resetHoverMotion removes all --pulse-* CSS variables', () => {
+    const { result } = renderHook(() => usePulseCelebration());
+
+    const removedProps = [];
+    const fakeElement = {
+      style: {
+        removeProperty: vi.fn((name) => removedProps.push(name))
+      }
+    };
+    const event = { currentTarget: fakeElement };
+
+    act(() => {
+      result.current.hoverProps.onPointerLeave(event);
+    });
+
+    expect(removedProps).toEqual([
+      '--pulse-tilt',
+      '--pulse-sway-a',
+      '--pulse-sway-b',
+      '--pulse-up-a',
+      '--pulse-up-b',
+      '--pulse-down',
+      '--pulse-speed'
+    ]);
+  });
+
+  it('handles the lack of Web Audio gracefully (jsdom has no AudioContext)', () => {
+    const { result } = renderHook(() => usePulseCelebration());
+
+    // triggerCelebration should not throw in jsdom where AudioContext is undefined.
+    expect(() => {
+      act(() => {
+        result.current.triggerCelebration();
+      });
+    }).not.toThrow();
+
+    expect(result.current.confettiBursts).toHaveLength(1);
+  });
+});

--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -125,7 +125,7 @@ AI agents
 
 ### Code quality
 
-**[Medium] `apps/tasks/src/App.jsx` still 972 lines.**
+**[Medium] `apps/tasks/src/App.jsx` still 972 lines.** ✅ [PR #369](https://github.com/Stoffer-Industries/sindustries/pull/369)
 - *Where:* `apps/tasks/src/App.jsx`
 - *Why it matters:* Unchanged since W29. Continued growth risk noted then; no code change this week.
 - *Severity:* Medium (carryover)


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W30.md
- **Finding:** [Medium] `apps/tasks/src/App.jsx` still 972 lines (carryover from W29)
- Extract the Pulse brand-button celebration (sales bell + confetti + hover-tilt CSS animation) into `apps/tasks/src/hooks/usePulseCelebration.js`. App.jsx loses ~115 lines and the celebration machinery is now reusable + covered by 11 new unit tests. Functional equivalence is preserved — the same hook-extraction pattern the existing `useTasks` / `useTaskDrafts` / `useDebounce` hooks already use; same shape as the W29/W30 `ContentSchedulerTab.jsx` (#306) and `BookmarksTab.jsx` (#363) splits.

## Test plan
- [x] `npx vitest run` — 172 tests pass across 13 files (11 new hook tests + 17 existing App.test.jsx unchanged + 144 from helpers/components/hooks/utils)
- [x] No logic changes — confetti spawn timing (2800ms), sales-bell note frequencies (523.25, 659.25, 783.99, 1046.5 Hz) and CSS variables (`--pulse-tilt`, `--pulse-sway-*`, `--pulse-up-*`, `--pulse-down`, `--pulse-speed`) are byte-identical; only the wrapping function changed
- [x] App.jsx: 972 → 857 lines (−115); `usePulseCelebration` reusable for any future "celebration" surface

🌱 Code garden — non-functional cleanup only