### PR TITLE
feat(tasks-api): TaskApproval collection + endpoints (WS1, AC1-AC2)

### DIFF
--- a/apps/tasks/SPEC.md
+++ b/apps/tasks/SPEC.md
@@ -1,6 +1,6 @@
 # Tasks App — Behavioural Spec
 
-**Last updated:** 2026-07-22
+**Last updated:** 2026-08-08
 **Original design:** `docs/designs/tasks/SPEC.md` (Mowgli/Pulse v12)
 **System doc:** n/a (tasks app is a standalone surface, no cross-cutting system doc)
 
@@ -29,6 +29,13 @@ A focused task management surface for Tom and the agent team. Supports capturing
 4. Rendered markdown description content wraps within the task card instead of overflowing horizontally
 5. User can navigate to a full-screen detail view via explicit action
 6. Changes persist on save
+7. An **Approvals** sub-section renders one row per required approval type for the task's type (`spec`, `tech_design`, `qa`):
+   - Each row is a read-only checkbox + avatar pair (the Tasks UI never writes approvals — the lobster and agents do via `POST /tasks/:id/approvals`).
+   - Checkbox checked = `approved`; unchecked = `pending` or `revoked` (state is distinguished by avatar opacity / strike-through rather than inline text).
+   - Owner display name and timestamp move to the `aria-label` / hover tooltip so the visual stays uncluttered.
+   - The required-approvals list is fetched from `GET /task-types/:type/required-approvals` when a `taskType` is set; if none are required the section shows a friendly empty state.
+   - When the task has no `taskType` set yet, the section shows a placeholder asking the user to select one.
+   - Fetch errors render an inline error message and do not crash the editor.
 
 ### 3. Move a task through the board
 1. User drags a task card between Kanban columns (desktop)
@@ -75,6 +82,7 @@ A focused task management surface for Tom and the agent team. Supports capturing
 | Task dependencies UI | `test/e2e/dependency-ui.spec.js` |
 | Markdown checkbox toggle + description wrapping | `apps/tasks/src/components/TaskEditor.test.jsx`, `apps/tasks/src/utils/markdown.test.js` |
 | Filter by priority | `test/e2e/priority-filter.spec.js` |
+| Approvals sub-section (read-only checkbox + avatar, empty + missing-type placeholders, fetch error) | `apps/tasks/src/components/ApprovalsSection.test.jsx` |
 
 ---
 
@@ -96,3 +104,4 @@ The list of reserved assignees and their display metadata (id → display name, 
 | archivedAt | Timestamp | Soft delete |
 | tags | String[] | Ad-hoc, case-insensitive unique |
 | blockedBy | UUID[] | Dependency references |
+| approvals | TaskApproval[] | Native approvals owned by the tasks-api (see `services/tasks-api/SPEC.md` for the authoritative schema). The Tasks UI only reads this collection to render the Approvals sub-section — the UI never writes approvals. |

--- a/apps/tasks/src/components/ApprovalsSection.jsx
+++ b/apps/tasks/src/components/ApprovalsSection.jsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react';
+import { Avatar } from '@sindustries/ui/react';
+import { fetchRequiredApprovals } from '../tasksApi.ts';
+import { assigneeDisplayName, findAssigneeUser } from '../users/assignees.js';
+
+const APPROVAL_LABELS = {
+  spec: 'Spec',
+  tech_design: 'Tech Design',
+  qa: 'QA'
+};
+
+/**
+ * Resolve the approval row for a given required type from the task's
+ * `approvals` array. Returns `null` when no row exists (Pending).
+ */
+function findApprovalForType(approvals, type) {
+  if (!Array.isArray(approvals)) return null;
+  // Prefer the most recent state — `approved` wins over `revoked` if both
+  // happen to exist (the migration script can produce both during a
+  // re-run; the upsert keeps `state` as the latest value).
+  return (
+    approvals.find((approval) => approval.type === type && approval.state === 'approved') ??
+    approvals.find((approval) => approval.type === type) ??
+    null
+  );
+}
+
+/**
+ * Format a timestamp for the aria-label tooltip.
+ */
+function formatApprovalTimestamp(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString();
+}
+
+function approvalTooltip(approval, type) {
+  const label = APPROVAL_LABELS[type];
+  if (!approval) return `${label} pending`;
+  const owner = assigneeDisplayName(approval.owner) || approval.owner;
+  const timestamp = formatApprovalTimestamp(approval.approvedAt);
+  if (approval.state === 'revoked') {
+    return `${label} revoked by ${owner}${timestamp ? ` on ${timestamp}` : ''}`;
+  }
+  return `${label} approved by ${owner}${timestamp ? ` on ${timestamp}` : ''}`;
+}
+
+/**
+ * Read-only Approvals section for the task editor.
+ *
+ * The view is intentionally checkbox + avatar only — no "Pending" or
+ * "Approved by <name>" inline text. State is implied by the checkbox
+ * (checked = approved) and the avatar's opacity / strike-through (a
+ * revoked approval renders muted). Owner name + timestamp move to the
+ * aria-label / hover tooltip so the visual is uncluttered.
+ *
+ * Writes flow through `POST /tasks/:id/approvals` (lobster / agent) or
+ * the comment-based legacy path. The Tasks UI is read-only here.
+ *
+ * See docs/specs/tasks-api-native-approvals-tech-design.md WS4b.
+ */
+export function ApprovalsSection({ task }) {
+  const taskType = task?.taskType ?? null;
+  const [requiredApprovals, setRequiredApprovals] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!taskType) {
+      setRequiredApprovals([]);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    fetchRequiredApprovals(taskType)
+      .then((response) => {
+        if (cancelled) return;
+        setRequiredApprovals(response.requiredApprovals);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Failed to load required approvals');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [taskType]);
+
+  if (!taskType) {
+    return (
+      <div className="approvals-section" aria-label="Approvals">
+        <div className="approvals-header">
+          <h4 className="si-font-display">Approvals</h4>
+        </div>
+        <p className="small approvals-empty">Select a task type to view required approvals.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="approvals-section" aria-label="Approvals">
+      <div className="approvals-header">
+        <h4 className="si-font-display">Approvals</h4>
+        {isLoading ? <span className="small">Loading…</span> : null}
+        {error ? <span className="small approvals-error">{error}</span> : null}
+      </div>
+      {requiredApprovals.length === 0 ? (
+        <p className="small approvals-empty">No approvals required for this task type.</p>
+      ) : (
+        <ul className="approvals-list" aria-label="Required approvals">
+          {requiredApprovals.map((type) => {
+            const approval = findApprovalForType(task.approvals, type);
+            const owner = approval?.owner ?? null;
+            const ownerUser = owner ? findAssigneeUser(owner) : null;
+            const ownerLabel = owner ? assigneeDisplayName(owner) || owner : APPROVAL_LABELS[type];
+            const avatarSrc = ownerUser?.avatarSrc ?? null;
+            const state = approval?.state ?? 'pending';
+            const isApproved = state === 'approved';
+            const isRevoked = state === 'revoked';
+
+            return (
+              <li key={type} className="approvals-row" data-state={state}>
+                <label
+                  className="approvals-row-label"
+                  title={approvalTooltip(approval, type)}
+                  aria-label={approvalTooltip(approval, type)}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isApproved}
+                    disabled
+                    readOnly
+                    aria-label={`${APPROVAL_LABELS[type]} approval state`}
+                  />
+                  <Avatar
+                    size="sm"
+                    src={avatarSrc}
+                    alt={ownerLabel}
+                    aria-label={ownerLabel}
+                    className={`approvals-avatar${isApproved ? ' is-approved' : ''}${isRevoked ? ' is-revoked' : ' is-pending'}`}
+                  />
+                  <span className="approvals-row-type">{APPROVAL_LABELS[type]}</span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/tasks/src/components/ApprovalsSection.test.jsx
+++ b/apps/tasks/src/components/ApprovalsSection.test.jsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const fetchRequiredApprovalsMock = vi.fn();
+
+vi.mock('../tasksApi.ts', async () => {
+  const actual = await vi.importActual('../tasksApi.ts');
+  return {
+    ...actual,
+    fetchRequiredApprovals: (...args) => fetchRequiredApprovalsMock(...args)
+  };
+});
+
+const { ApprovalsSection } = await import('./ApprovalsSection.jsx');
+
+describe('ApprovalsSection', () => {
+  beforeEach(() => {
+    fetchRequiredApprovalsMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders one row per required approval type', async () => {
+    fetchRequiredApprovalsMock.mockResolvedValue({
+      taskType: 'feature',
+      requiredApprovals: ['spec', 'tech_design', 'qa'],
+      version: 1,
+      source: 'builtin-default'
+    });
+
+    render(<ApprovalsSection task={{ taskType: 'feature', approvals: [] }} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Spec')).toBeInTheDocument();
+      expect(screen.getByText('Tech Design')).toBeInTheDocument();
+      expect(screen.getByText('QA')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(3);
+    checkboxes.forEach((checkbox) => {
+      expect(checkbox).not.toBeChecked();
+      expect(checkbox).toBeDisabled();
+    });
+  });
+
+  it('marks a row as approved when an approved row exists for the type', async () => {
+    fetchRequiredApprovalsMock.mockResolvedValue({
+      taskType: 'feature',
+      requiredApprovals: ['spec', 'tech_design', 'qa'],
+      version: 1,
+      source: 'builtin-default'
+    });
+
+    render(
+      <ApprovalsSection
+        task={{
+          taskType: 'feature',
+          approvals: [
+            {
+              id: 'a1',
+              type: 'spec',
+              owner: 'Tom',
+              state: 'approved',
+              approvedAt: '2026-08-08T05:00:00.000Z',
+              revokedAt: null,
+              note: null,
+              createdAt: '2026-08-08T05:00:00.000Z',
+              updatedAt: '2026-08-08T05:00:00.000Z'
+            }
+          ]
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes[0]).toBeChecked();
+      expect(checkboxes[1]).not.toBeChecked();
+      expect(checkboxes[2]).not.toBeChecked();
+    });
+  });
+
+  it('shows a friendly empty state when no approvals are required', async () => {
+    fetchRequiredApprovalsMock.mockResolvedValue({
+      taskType: 'research',
+      requiredApprovals: [],
+      version: 1,
+      source: 'builtin-default'
+    });
+
+    render(<ApprovalsSection task={{ taskType: 'research', approvals: [] }} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No approvals required for this task type.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows a placeholder when task type is missing', async () => {
+    render(<ApprovalsSection task={{ taskType: null, approvals: [] }} />);
+
+    expect(
+      screen.getByText('Select a task type to view required approvals.')
+    ).toBeInTheDocument();
+    expect(fetchRequiredApprovalsMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error message when the required-approvals fetch fails', async () => {
+    fetchRequiredApprovalsMock.mockRejectedValue(new Error('boom'));
+
+    render(<ApprovalsSection task={{ taskType: 'feature', approvals: [] }} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('boom')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/tasks/src/components/TaskEditor.jsx
+++ b/apps/tasks/src/components/TaskEditor.jsx
@@ -5,6 +5,7 @@ import { normalizeComments, formatCommentTimestamp } from '../utils/helpers.js';
 import { MarkdownContent } from './MarkdownContent.jsx';
 import { toggleMarkdownTaskCheckbox } from '../utils/markdown.js';
 import { TaskCardSummary } from './TaskCardSummary.jsx';
+import { ApprovalsSection } from './ApprovalsSection.jsx';
 
 /**
  * TaskEditor - Inline editor for task details
@@ -525,6 +526,8 @@ export function TaskEditor({
         </div>
 
         <Divider variant="dashed" />
+
+        <ApprovalsSection task={task} />
 
         <div className="comments-section">
           <div className="comments-header">

--- a/apps/tasks/src/styles/editor.css
+++ b/apps/tasks/src/styles/editor.css
@@ -522,3 +522,82 @@
 .comment-composer .actions {
   justify-content: flex-start;
 }
+
+/* Approvals section (read-only checkboxes + avatars) */
+.approvals-section {
+  align-self: stretch;
+  min-width: 0;
+  padding-top: 4px;
+  width: 100%;
+}
+
+.approvals-header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.approvals-header h4 {
+  color: var(--si-color-text-muted);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.approvals-empty {
+  color: var(--si-color-text-muted);
+  margin: 0;
+}
+
+.approvals-error {
+  color: var(--si-color-danger);
+}
+
+.approvals-list {
+  display: grid;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.approvals-row {
+  align-items: center;
+  display: flex;
+  list-style: none;
+}
+
+.approvals-row-label {
+  align-items: center;
+  cursor: default;
+  display: inline-flex;
+  gap: 10px;
+  padding: 4px 0;
+}
+
+.approvals-row-label input[type="checkbox"] {
+  accent-color: var(--si-color-accent);
+  cursor: not-allowed;
+}
+
+.approvals-row-type {
+  color: var(--si-color-text);
+  font-size: 0.92rem;
+}
+
+.approvals-avatar.is-approved {
+  opacity: 1;
+}
+
+.approvals-avatar.is-pending {
+  opacity: 0.4;
+}
+
+.approvals-avatar.is-revoked {
+  opacity: 0.5;
+  text-decoration: line-through;
+}

--- a/apps/tasks/src/tasksApi.ts
+++ b/apps/tasks/src/tasksApi.ts
@@ -41,6 +41,7 @@ export interface Task {
   createdAt?: string | null;
   statusChangedAt?: string | null;
   comments?: Comment[];
+  approvals?: TaskApproval[];
   dependsOn?: DependencyReference[];
   dependsOnIds?: Array<string | number>;
   dependencyBlocked?: boolean;
@@ -76,6 +77,28 @@ export interface UpdateTaskPayload {
 export interface CreateCommentPayload {
   author: string;
   text: string;
+}
+
+export type ApprovalType = 'spec' | 'tech_design' | 'qa';
+export type ApprovalState = 'approved' | 'revoked';
+
+export interface TaskApproval {
+  id: string;
+  type: ApprovalType;
+  owner: string;
+  state: ApprovalState;
+  approvedAt: string;
+  revokedAt: string | null;
+  note: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RequiredApprovals {
+  taskType: TaskType;
+  requiredApprovals: ApprovalType[];
+  version: number;
+  source: 'config-file' | 'builtin-default';
 }
 
 // API Response wrapper
@@ -165,4 +188,14 @@ export async function createTaskComment(id: string | number, payload: CreateComm
     method: 'POST',
     body: JSON.stringify(payload)
   });
+}
+
+/**
+ * Fetch the required approvals for a given task type.
+ * Used by the editor's Approvals section to resolve which `<ApprovalType>`
+ * rows to render for a task. The Tasks API reads a configurable YAML file
+ * plus a built-in default; this endpoint exposes the resolved list.
+ */
+export async function fetchRequiredApprovals(taskType: TaskType): Promise<RequiredApprovals> {
+  return api<RequiredApprovals>(`/task-types/${taskType}/required-approvals`);
 }

--- a/docs/specs/tasks-api-native-approvals-tech-design.md
+++ b/docs/specs/tasks-api-native-approvals-tech-design.md
@@ -181,16 +181,23 @@ A `--rollback <snapshot-path>` option restores from the snapshot if a follow-up 
 
 **WS4b — Tasks UI (AC6):**
 
-**`apps/tasks/src/tabs/TaskDetail.jsx`** — extend the task detail view to render an `Approvals` section:
+**`apps/tasks/src/components/TaskEditor.jsx`** — extend the task editor view with an `Approvals` section that renders as a checkbox list, one row per required approval type. Each row's checkbox is a `<input type="checkbox" disabled checked={...}>` whose visual state mirrors the approval:
+
+- **Checked** — `state: approved`
+- **Unchecked** — `state: revoked` OR no row exists for the required type (Pending)
+- **Strike-through row text** when `state: revoked`
+
+Visual mock:
 
 ```
-Approvals
-  Spec          Approved by Tom on 2026-07-15
-  Tech Design   Approved by Quinn on 2026-07-20
-  QA            Pending
+☑ Spec          — Approved by Tom on 2026-07-15
+☐ Tech Design   — Pending
+☑ QA            — Approved by Quinn on 2026-07-20
 ```
 
-Each approval renders: type label, state (Approved / Revoked / Pending), owner, timestamp, optional note. The list is sourced from `task.approvals` (always present on `GET /tasks/:id`) and resolved against `requiredApprovalsFor(task.taskType)` so a Pending state is shown for any required type that has no row.
+The checkbox is the primary visual anchor (replacing the "Approved by ..." text label); per-row metadata (type label, owner, timestamp, optional note) is rendered as small text beside it. The list is sourced from `task.approvals` (always present on `GET /tasks/:id`) and resolved against `requiredApprovalsFor(task.taskType)` so a Pending state is shown for any required type that has no row.
+
+The checkbox is `disabled` — approval writes still flow through the lobster (AC4) and `POST /tasks/:id/approvals` endpoint (AC1), not the UI. The Tasks UI is read-only for approvals in this design; the only way to land an approval is the existing comment-tag path (until/unless Quinn opens a follow-up to enable direct UI submission).
 
 No kanban-card changes. No task-list changes. Just the detail view.
 

--- a/docs/specs/tasks-api-native-approvals-tech-design.md
+++ b/docs/specs/tasks-api-native-approvals-tech-design.md
@@ -181,23 +181,30 @@ A `--rollback <snapshot-path>` option restores from the snapshot if a follow-up 
 
 **WS4b — Tasks UI (AC6):**
 
-**`apps/tasks/src/components/TaskEditor.jsx`** — extend the task editor view with an `Approvals` section that renders as a checkbox list, one row per required approval type. Each row's checkbox is a `<input type="checkbox" disabled checked={...}>` whose visual state mirrors the approval:
+**`apps/tasks/src/components/TaskEditor.jsx`** — extend the task editor view with an `Approvals` section that renders as a checkbox + avatar list, one row per required approval type. Per Tom's preference: **no "Pending" or "Approved by [name]" text labels** — pending is implied by the unchecked checkbox, and the owner's avatar replaces the approver name.
 
-- **Checked** — `state: approved`
-- **Unchecked** — `state: revoked` OR no row exists for the required type (Pending)
-- **Strike-through row text** when `state: revoked`
+Each row has two pieces:
+
+- **Checkbox** — `<input type="checkbox" disabled checked={...}>`, the primary visual anchor.
+- **Avatar** — owner's avatar via `<Avatar>` from `@sindustries/ui/react` (same lookup path as `TaskCardSummary.jsx`). For Pending (no row), the avatar is the *expected* approver from `requiredApprovalsFor(task.taskType)`.
+
+State mapping:
+
+- **Checked + full-color avatar** → `state: approved`
+- **Unchecked + faded / muted avatar** → Pending (no row)
+- **Unchecked + strike-through avatar** → `state: revoked`
 
 Visual mock:
 
 ```
-☑ Spec          — Approved by Tom on 2026-07-15
-☐ Tech Design   — Pending
-☑ QA            — Approved by Quinn on 2026-07-20
+☑ [Tom]    Spec
+☐ [Quinn·] Tech Design     ← faded = Pending
+☑ [Quinn]  QA
 ```
 
-The checkbox is the primary visual anchor (replacing the "Approved by ..." text label); per-row metadata (type label, owner, timestamp, optional note) is rendered as small text beside it. The list is sourced from `task.approvals` (always present on `GET /tasks/:id`) and resolved against `requiredApprovalsFor(task.taskType)` so a Pending state is shown for any required type that has no row.
+Owner name + timestamp move to `aria-label` / hover tooltip only — not inline text. Fallback: if the owner isn't in the user registry, render the avatar with initials (same fallback as `TaskCardSummary.jsx`).
 
-The checkbox is `disabled` — approval writes still flow through the lobster (AC4) and `POST /tasks/:id/approvals` endpoint (AC1), not the UI. The Tasks UI is read-only for approvals in this design; the only way to land an approval is the existing comment-tag path (until/unless Quinn opens a follow-up to enable direct UI submission).
+List sourced from `task.approvals` (always present on `GET /tasks/:id`), resolved against `requiredApprovalsFor(task.taskType)`. Checkbox is `disabled` — approval writes still flow through the lobster (AC4) and `POST /tasks/:id/approvals` (AC1). The Tasks UI is read-only for approvals in this design.
 
 No kanban-card changes. No task-list changes. Just the detail view.
 

--- a/docs/specs/tasks-api-native-approvals-tech-design.md
+++ b/docs/specs/tasks-api-native-approvals-tech-design.md
@@ -1,0 +1,264 @@
+---
+status: draft
+task_id: ffa30da7-d019-4413-aeae-ad211b9ea614
+product_spec: brain/tasks/specs/in-progress/tasks-api-native-approvals-2026-07-17.md
+shipped_pr: null
+shipped_date: null
+---
+
+# Tasks API Native Approvals — Tech Design
+
+**Task:** `ffa30da7-d019-4413-aeae-ad211b9ea614` — 🛠 Tasks API Native Approvals (urgent, `ready`)
+**Spec:** `brain/tasks/specs/in-progress/tasks-api-native-approvals-2026-07-17.md` *(see Open question Q1 — spec file is not present in this worktree)*
+**Branch:** `task-ffa30da7-tasks-api-native-approvals`
+**Worktree:** `~/workspaces/rowan/sindustries-task-ffa30da7-tasks-api-native-approvals`
+**Repo:** `Stoffer-Industries/sindustries`
+**Owner (all workstreams):** Rowan
+
+## Product intent
+
+After this ships, approval gates in the feature-factory workflow are first-class fields on the Tasks API rather than conventions embedded in task description text and comment bodies. An agent or UI can set or read any approval (spec, tech-design, qa) via a dedicated API endpoint without parsing markdown checkboxes or comment tags. The lobster and other workflow consumers switch to reading these fields, eliminating the fragile text-matching that currently causes approvals to go missing when specs are created outside the standard skill.
+
+Quoted from the task description.
+
+## Service boundary and ownership
+
+| Concern | Owner | Notes |
+|---|---|---|
+| `TaskApproval` persistence | `services/tasks-api` | New Prisma model, joined to `Task` by `taskId`. One row per `(taskId, type)` pair. |
+| Approvals API (`GET`/`POST`/`DELETE`) | `services/tasks-api` | New routes under `/api/v1/tasks/:id/approvals`. Distinct from the existing `PATCH /tasks/:id` path. |
+| `taskType → required-approvals` map | `services/tasks-api` reads `.openclaw/tasks-api/required-approvals.yaml` on startup | The map lives outside the repo (in `.openclaw/`) so Quinn or Tom can add a gate without a Rust recompile. See WS2. |
+| Lobster approval reads | `agents/workflows/feature-task` (Rust crate) | Replace text-matching paths with reads from the structured `approvals` collection, fall back to legacy comment tags during the migration window. See WS3. |
+| Tasks UI display | `apps/tasks` | Surface per-approval state on the task detail view. See WS4b. |
+| Migration script | `services/tasks-api/scripts/migrate-legacy-approvals.ts` | One-shot script, dry-run + smoke-tests against a snapshot. See WS4a. |
+
+**Why `services/tasks-api` and not a new service?** The Tasks API already owns task and task-comment state. Adding `TaskApproval` to the same service keeps the task record coherent (a task and its approvals are loaded, written, and versioned together) and avoids cross-service consistency. The Tasks UI already calls this service for everything task-shaped.
+
+**Why `.openclaw/` for the required-approvals map?** Two reasons: (1) the spec acceptance criterion explicitly says "configurable without a code deploy", which means a recompile of the Rust lobster must not be in the loop when a new gate is added; (2) the existing `.openclaw/` boundary (documented in `docs/systems/tasks.md`) already handles out-of-repo configuration edits via the `[openclaw-needed]` / `[openclaw-done]` task-comment protocol, so Quinn owns the change path. A committed config file under `services/tasks-api/config/` would violate (1).
+
+## Implementation plan
+
+### WS1 — Approval collection + endpoint (AC1, AC2)
+
+**`services/tasks-api/prisma/schema.prisma`** — add:
+
+```prisma
+enum ApprovalType {
+  spec
+  tech_design
+  qa
+}
+
+enum ApprovalState {
+  approved
+  revoked
+}
+
+model TaskApproval {
+  id          String        @id @default(uuid()) @db.Uuid
+  taskId      String        @db.Uuid
+  type        ApprovalType
+  /// Free-text owner field: "Tom", "Quinn", "Lox", etc. Mirrors the
+  /// `assignee` convention on `Task`. Not a foreign key — humans and
+  /// agents both post approvals, and the field is informational.
+  owner       String
+  state       ApprovalState @default(approved)
+  approvedAt  DateTime      @default(now())
+  revokedAt   DateTime?
+  /// Optional note from the approver — why this was approved or revoked.
+  note        String?
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  task Task @relation(fields: [taskId], references: [id], onDelete: Cascade)
+
+  @@unique([taskId, type])
+  @@index([taskId, state])
+}
+```
+
+Add the reverse relation `approvals TaskApproval[]` on `Task`.
+
+**`services/tasks-api/src/routes/taskApprovals.ts`** — new routes mounted under `/api/v1`:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/tasks/:id/approvals` | List approvals for the task |
+| `POST` | `/tasks/:id/approvals` | Approve. Body: `{ type, owner, note? }`. Upserts on `(taskId, type)`. |
+| `DELETE` | `/tasks/:id/approvals/:type` | Revoke. Sets `state=revoked, revokedAt=now()`. Does not delete the row. |
+
+The `POST` route is idempotent: a second call for the same `(taskId, type)` updates `owner`, `note`, and re-stamps `approvedAt`. The `DELETE` is idempotent: a second call is a no-op (already revoked).
+
+These routes do not modify `Task.description` and do not create `TaskComment` rows. They are intentionally orthogonal to the existing comment-based tag system during the migration window.
+
+**`services/tasks-api/src/routes/tasks.ts`** — extend `GET /tasks` and `GET /tasks/:id` to include `approvals: TaskApproval[]` in the JSON shape. Optional `?include=approvals` query flag keeps response size predictable for list endpoints; always included on `GET /tasks/:id`.
+
+### WS2 — taskType → required-approvals mapping (AC3)
+
+**`.openclaw/tasks-api/required-approvals.yaml`** — out-of-repo config:
+
+```yaml
+# Editable by Quinn or Tom without a code deploy.
+# `services/tasks-api` reads this on startup and exposes the map at
+# `GET /api/v1/task-types/:taskType/required-approvals`.
+version: 1
+mappings:
+  feature: [spec, tech_design, qa]
+  code: [tech_design, qa]
+  content: [spec, qa]
+  research: []
+```
+
+The Tasks API loads this file at startup; if the file is missing it falls back to a built-in default (the contents of the file as shown above, hard-coded in `services/tasks-api/src/config/requiredApprovals.ts`). The fallback is logged at WARN level so an accidental `.openclaw` edit that breaks the YAML is loud.
+
+**`services/tasks-api/src/config/requiredApprovals.ts`** — small wrapper:
+
+```ts
+export interface RequiredApprovalsConfig {
+  version: number;
+  mappings: Record<string, ApprovalType[]>;
+}
+
+export async function loadRequiredApprovalsConfig(): Promise<RequiredApprovalsConfig> { ... }
+export function requiredApprovalsFor(taskType: string | null): ApprovalType[] { ... }
+```
+
+**`GET /api/v1/task-types/:taskType/required-approvals`** — read-only endpoint that returns the resolved list for a given task type. The lobster reads this once per `load-task` invocation and caches for the run.
+
+**`PATCH /api/v1/tasks/:id`** does NOT accept approval state — approvals go through the dedicated `POST` / `DELETE` endpoints. This keeps the partial-update semantics of `PATCH /tasks/:id` (which today accepts `status`, `priority`, `assignee`, `tags`, `specChecksum`, `description`, `dependsOnIds`) from leaking approval writes into the drift-guarded surface.
+
+### WS3 — Lobster reads from API fields (AC4)
+
+**Branch:** `task-ffa30da7-feature-task-lobster-approval-rewire` (separate branch — the lobster is a separate Rust crate with its own build cycle).
+
+**`agents/workflows/feature-task/src/main.rs`** — add a helper:
+
+```rust
+/// Resolve the approval state for `approval_type` on `task`.
+/// Reads `task.approvals` first; falls back to legacy comment-tag
+/// detection (e.g. `[tech-design-approved] true`, `[qa-ac-verified] true`,
+/// `**Approved by Tom**` in description) only if no structured row
+/// exists. Logs a WARN on fallback so we can see migration progress.
+pub fn approval_state(task: &Task, approval_type: ApprovalType) -> ApprovalState { ... }
+```
+
+The three gate sites that currently read text are:
+
+1. `ready_checks` — reads `[tech-design-approved] true` and `specChecksum`. Replace with `approval_state(task, TechDesign) == Approved && approval_state(task, Spec) == Approved` plus the existing `specChecksum` check (drift detection stays).
+2. `verify_delivery` — reads `[qa-ac-verified] true` (during `acceptance → done`). Replace with `approval_state(task, QA) == Approved`. The AC-text check stays — that's a separate concern.
+3. `spec_check` — reads `**Approved by Tom**` in the description. Replace with `approval_state(task, Spec) == Approved`. Falls back to description parsing if no structured row exists.
+
+**Legacy fallback contract:** the legacy text paths stay intact for at least one release after this lands. A new flag `--approval-source=auto|api|legacy` on the lobster CLI defaults to `auto` (try API first, fall back to legacy). When `auto` falls back, it emits a stderr WARN line. The migration script (WS4a) and a follow-up run of the lobster on the full task set will populate the structured rows; once the structured coverage exceeds ~99%, a later task can flip the default to `api` and remove the legacy paths entirely.
+
+This is the **riskiest** WS: the lobster is binary-only and a regression here blocks the lobster cron. Mitigation: keep the legacy paths in place, gate the WS3 PR behind a green feature-factory dry-run on the full active task set, and require Quinn to manually run `feature-task ready-checks --approval-source=auto` on at least one feature task in `ready` and one in `doing` before merge.
+
+### WS4 — Migration + UI (AC5, AC6)
+
+**WS4a — Migration script (AC5):**
+
+**`services/tasks-api/scripts/migrate-legacy-approvals.ts`** — one-shot Node script. Algorithm:
+
+1. Fetch every non-archived task via `GET /api/v1/tasks?limit=200&cursor=...`.
+2. For each task, inspect:
+   - `**Approved by Tom**` checked in description → `INSERT TaskApproval (type=spec, owner='Tom', state=approved)`.
+   - `[tech-design-approved] true` comment → `INSERT TaskApproval (type=tech_design, owner=comment.author, state=approved)`.
+   - `[qa-ac-verified] true` comment → `INSERT TaskApproval (type=qa, owner=comment.author, state=approved)`.
+   - `- [ ] **Approved by Tom**` in description → no `spec` row (correctly absent).
+3. Skip rows that already exist (idempotent on `(taskId, type)`).
+4. Emit a JSON summary: `{ totalTasks, createdApprovals, skippedExisting, breakdownByType }`.
+
+Two modes:
+- `--dry-run` — runs the algorithm, prints the summary, makes no DB writes.
+- `--write` — runs the algorithm and writes via the new `POST /tasks/:id/approvals` endpoint (so the audit trail goes through the canonical write path).
+
+Required safety steps before the `--write` pass:
+1. Snapshot the `task_approvals` table (and `task_comments` if needed for rollback audit).
+2. Run `--dry-run` first; require the summary to look sane (count ≈ number of tasks with at least one legacy approval signal).
+3. Smoke-test the lobster on a single feature task in `ready` with `--approval-source=auto` to confirm it now reads from the structured row.
+4. Then `--write`.
+
+A `--rollback <snapshot-path>` option restores from the snapshot if a follow-up lobster run shows regression. Rollback is intentionally crude (drop all rows from the snapshot's `(taskId, type)` set) — the legacy comments and description checkboxes are untouched, so the system reverts to the pre-migration behavior immediately.
+
+**WS4b — Tasks UI (AC6):**
+
+**`apps/tasks/src/tabs/TaskDetail.jsx`** — extend the task detail view to render an `Approvals` section:
+
+```
+Approvals
+  Spec          Approved by Tom on 2026-07-15
+  Tech Design   Approved by Quinn on 2026-07-20
+  QA            Pending
+```
+
+Each approval renders: type label, state (Approved / Revoked / Pending), owner, timestamp, optional note. The list is sourced from `task.approvals` (always present on `GET /tasks/:id`) and resolved against `requiredApprovalsFor(task.taskType)` so a Pending state is shown for any required type that has no row.
+
+No kanban-card changes. No task-list changes. Just the detail view.
+
+## Test plan (AC verification matrix)
+
+| AC | Test layer | Test file / fixture | Coverage |
+|---|---|---|---|
+| AC1 | integration | `services/tasks-api/test/integration/taskApprovals.test.ts` | Create approval via `POST`, read via `GET /tasks/:id`, verify JSON shape includes `type`, `owner`, `state`, `approvedAt`. |
+| AC1 | unit | `services/tasks-api/test/unit/_approvalRoutes.test.ts` | Verify `?include=approvals` flag works on `GET /tasks`. |
+| AC2 | integration | `services/tasks-api/test/integration/taskApprovals.test.ts` | Approve, revoke, re-approve (state transitions). Verify description and comments unchanged. |
+| AC2 | integration | `services/tasks-api/test/integration/taskApprovals.test.ts` | Approve via `POST`, then `GET /tasks/:id` — assert no `TaskComment` row was created and `description` bytes equal pre-call. |
+| AC3 | unit | `services/tasks-api/test/unit/requiredApprovals.test.ts` | Load `.openclaw/tasks-api/required-approvals.yaml`, assert `feature → [spec, tech_design, qa]`, `content → [spec, qa]`. Fall back to default if file missing. |
+| AC3 | integration | `services/tasks-api/test/integration/requiredApprovals.test.ts` | `GET /api/v1/task-types/feature/required-approvals` returns the configured list. |
+| AC4 | unit | `agents/workflows/feature-task/src/approval_state.rs` (new file) | `approval_state(task, TechDesign)` reads from `task.approvals` when present, falls back to comment-tag parsing otherwise. |
+| AC4 | integration | `agents/workflows/feature-task/test/integration/ready-checks-approvals.test.rs` | Run `ready-checks` against a fixture task with both a `[tech-design-approved]` comment AND a `TaskApproval` row — assert API field wins. |
+| AC4 | manual | Quinn-run smoke test on one `ready` and one `doing` feature task with `--approval-source=auto` before WS3 PR merges. |
+| AC5 | integration | `services/tasks-api/test/integration/migrate-legacy-approvals.test.ts` | Run the migration script against a fixture set of tasks with the full mix of legacy approval signals; assert correct rows created, idempotent on re-run. |
+| AC5 | e2e | `apps/tasks/test/e2e/approvals-display.cy.js` (Playwright) | Pre-migration: a feature task with `[qa-ac-verified] true` comment passes the lobster's `acceptance → done` gate. Post-migration: same task passes after migration has written the `TaskApproval` row and the legacy comment is deleted. |
+| AC6 | e2e | `apps/tasks/test/e2e/approvals-display.cy.js` (Playwright) | Open a task detail view; verify the Approvals section renders one row per required type with correct state/owner/timestamp. |
+
+User-visible ACs (AC6) get e2e coverage. The lobster binary tests (AC4) are integration tests with the Rust crate — no e2e is possible because the lobster is not a UI. AC5's pre/post-migration behavior is verified end-to-end through the lobster running on fixture data.
+
+## Risks and tradeoffs
+
+1. **Lobster binary regression (WS3).** The lobster is rebuilt on every release and any regression in `approval_state()` blocks the feature-task cron. Mitigation: legacy fallback paths stay in place for at least one release, `--approval-source=auto` defaults to API-with-fallback, and Quinn smoke-tests on at least one feature task in each of `ready` and `doing` before the WS3 PR merges.
+
+2. **Migration script partial failure (WS4a).** If the script fails mid-way, in-flight tasks lose their approval state. Mitigation: `--dry-run` first, snapshot-before-write, `--rollback` from snapshot, smoke-test on a single task, then `--write`. The script is also idempotent on `(taskId, type)`, so a re-run picks up where the failure left off without duplication.
+
+3. **`.openclaw/` config edit path.** Quinn or Tom must edit `tasks-api/required-approvals.yaml` for any new gate. Today `.openclaw/` is Quinn's domain via the `[openclaw-needed]` protocol. No new tooling is needed, but the change is gated on Quinn being available. If the file is missing or malformed, the Tasks API falls back to the hard-coded default — this is logged at WARN level so Quinn notices.
+
+4. **Approval `owner` field is a string, not a foreign key.** This matches the existing `Task.assignee` convention (also a free-text string) and lets humans and agents both post approvals without a separate identity service. Trade-off: no referential integrity on `owner`. Acceptable for v1; if abuse becomes a problem, a follow-up can switch to a username enum.
+
+5. **No approval expiry.** Approvals stay approved until explicitly revoked. Matches current behavior (no expiry on `[tech-design-approved]` either). Out of scope for v1.
+
+6. **Spec file (`brain/tasks/specs/in-progress/tasks-api-native-approvals-2026-07-17.md`) is not present in this worktree.** I cannot quote it verbatim or link to it in the `product_spec:` frontmatter. See Open question Q1.
+
+## Open questions
+
+1. **Q1 — Spec file location.** The task description points at `brain/tasks/specs/in-progress/tasks-api-native-approvals-2026-07-17.md`. This file does not exist anywhere in `brain/tasks/specs/` on this worktree (`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`). The `brain/` tree at workspace level (`lobster/brain/`) contains no `tasks/specs/in-progress/` subdirectory either. The task description itself (with full AC text + workstream breakdown) is the most complete product spec available. **Decision needed:** is the spec file at a path Quinn expects me to read from (outside this worktree), or is the task description canonical for this design? If the spec lives in Quinn's private tree and is expected to remain there, the `product_spec:` frontmatter field is `n/a` and the task description is the canonical product spec.
+
+2. **Q2 — Revocation policy.** If Tom revokes his `[qa-ac-verified] true` after a PR has already moved the task to `done`, does the revocation matter? My read is **no** — `done` is terminal. The lobster's `post_merge` runs once and records the terminal summary. A revocation on a `done` task would write a `TaskApproval` row with `state=revoked` but the task stays `done`. Worth confirming with Tom.
+
+3. **Q3 — Bookmark-spec approval reuse.** Bookmarks have their own approval flow (the `bookmark-workflow` system doc). The bookmark-approval task `55ac9240` is in `acceptance` and currently DEPENDENCY_BLOCKED on the Tasks API Native Approvals task. Do bookmark-spec approvals get a separate `ApprovalType` value (e.g. `bookmark_spec`), or do they reuse `spec`? My read: reuse `spec` and have the bookmark workflow write a `TaskApproval` row with `owner='Tom'` for each approved bookmark spec. This keeps the type vocabulary small. Worth confirming with Quinn.
+
+4. **Q4 — Default `code` task required-approvals.** My proposed mapping has `code → [tech_design, qa]`. But the code-task workflow today doesn't always have a Tom product sign-off — some code tasks skip the tech design (waiver) and go straight to implementation. Should `code → []` (no required approvals) be the default, with the existing waiver mechanism covering the rest? Worth confirming with Quinn — my tech design proposal needs Quinn's call before WS2 ships.
+
+## `.openclaw` boundary
+
+No `.openclaw/` edits are required from this repo. The WS2 config file lives in `.openclaw/tasks-api/required-approvals.yaml` — Quinn owns that edit via the existing `[openclaw-needed]` protocol.
+
+## Branch / PR plan
+
+| Workstream | Branch | PR | Reviewer |
+|---|---|---|---|
+| WS1 (data model + endpoint) | `task-ffa30da7-tasks-api-native-approvals` | PR #TBD | Quinn |
+| WS2 (required-approvals map) | same | same PR | Quinn |
+| WS3 (lobster rewire) | `task-ffa30da7-feature-task-lobster-approval-rewire` | separate PR | Quinn |
+| WS4a (migration script) | `task-ffa30da7-tasks-api-native-approvals` | same PR as WS1+WS2 | Quinn |
+| WS4b (UI) | `task-ffa30da7-tasks-api-native-approvals` | same PR | Quinn |
+
+WS1+WS2+WS4a+WS4b ship together in a single PR (single migration + UI surface + API change is one coherent review unit). WS3 lands separately because the lobster crate has its own build cycle and a lobster regression blocks the cron — separate PR keeps the blast radius small.
+
+Quinn merges after Quinn approval + green CI per the standard merge rule.
+
+## Decisions needed before implementation
+
+1. Resolve Q1 (spec file location). If the task description is canonical, no action; if Quinn expects me to read the spec from a private path, Quinn provides the URL and I link it.
+2. Resolve Q2 (revocation policy on `done` tasks).
+3. Resolve Q3 (bookmark-spec approval reuse).
+4. Resolve Q4 (default `code` task required-approvals).
+5. Quinn approves the tech design at the linked branch blob URL.

--- a/services/tasks-api/prisma/migrations/20260808050000_add_task_approvals/migration.sql
+++ b/services/tasks-api/prisma/migrations/20260808050000_add_task_approvals/migration.sql
@@ -1,0 +1,36 @@
+-- First-class approval state for tasks. Each row represents one approval
+-- type (spec / tech_design / qa) for one task. Revoked approvals keep the
+-- row with `state = 'revoked'` and `revokedAt` set so the audit trail is
+-- preserved. See docs/specs/tasks-api-native-approvals-tech-design.md.
+
+CREATE TYPE "ApprovalType" AS ENUM ('spec', 'tech_design', 'qa');
+CREATE TYPE "ApprovalState" AS ENUM ('approved', 'revoked');
+
+CREATE TABLE "TaskApproval" (
+    "id"         UUID NOT NULL,
+    "taskId"     UUID NOT NULL,
+    "type"       "ApprovalType" NOT NULL,
+    "owner"      TEXT NOT NULL,
+    "state"      "ApprovalState" NOT NULL DEFAULT 'approved',
+    "approvedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "revokedAt"  TIMESTAMP(3),
+    "note"       TEXT,
+    "createdAt"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"  TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TaskApproval_pkey" PRIMARY KEY ("id")
+);
+
+-- One approval row per (taskId, type). Upserts target this index.
+CREATE UNIQUE INDEX "TaskApproval_taskId_type_key"
+    ON "TaskApproval"("taskId", "type");
+
+-- Look up approvals by task + state (e.g. "all currently approved").
+CREATE INDEX "TaskApproval_taskId_state_idx"
+    ON "TaskApproval"("taskId", "state");
+
+-- Cascade on task archive/delete so approvals never outlive the task.
+ALTER TABLE "TaskApproval"
+    ADD CONSTRAINT "TaskApproval_taskId_fkey"
+    FOREIGN KEY ("taskId") REFERENCES "Task"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/services/tasks-api/prisma/schema.prisma
+++ b/services/tasks-api/prisma/schema.prisma
@@ -46,6 +46,7 @@ model Task {
   dependencies    TaskDependency[] @relation("TaskDependsOn")
   dependedOnBy    TaskDependency[] @relation("TaskDependedOnBy")
   analyticsEvents FeatureTaskAnalyticsEvent[]
+  approvals       TaskApproval[]
 
   @@index([archivedAt, priority])
   @@index([status, statusChangedAt])
@@ -138,6 +139,45 @@ model FeatureTaskAnalyticsEvent {
   @@index([taskId, occurredAt])
   @@index([occurredAt])
   @@index([eventType, occurredAt])
+}
+
+enum ApprovalType {
+  spec
+  tech_design
+  qa
+}
+
+enum ApprovalState {
+  approved
+  revoked
+}
+
+/// First-class approval state for a task. Each row represents one approval
+/// type (spec / tech_design / qa) for one task. A revoked approval is
+/// represented by `state=revoked` with `revokedAt` set; the row is kept so
+/// the audit trail of who approved and revoked when is preserved.
+///
+/// `owner` is a free-text field (matches `Task.assignee`) — humans and
+/// agents both post approvals, and the field is informational, not a
+/// foreign key. See the Tasks API Native Approvals tech design for the
+/// rationale.
+model TaskApproval {
+  id          String        @id @default(uuid()) @db.Uuid
+  taskId      String        @db.Uuid
+  type        ApprovalType
+  owner       String
+  state       ApprovalState @default(approved)
+  approvedAt  DateTime      @default(now())
+  revokedAt   DateTime?
+  /// Optional note from the approver — why this was approved or revoked.
+  note        String?
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  task Task @relation(fields: [taskId], references: [id], onDelete: Cascade)
+
+  @@unique([taskId, type])
+  @@index([taskId, state])
 }
 
 enum ContentSchedulerItemStatus {

--- a/services/tasks-api/scripts/README.md
+++ b/services/tasks-api/scripts/README.md
@@ -1,0 +1,48 @@
+# Tasks API scripts
+
+## migrate-legacy-approvals.ts
+
+One-shot migration that reads legacy approval state (from task descriptions
+and comment bodies) and writes equivalent `TaskApproval` rows through the
+canonical `POST /api/v1/tasks/:id/approvals` endpoint.
+
+### Modes
+
+```
+# Inspect what would be migrated; no DB writes.
+tsx scripts/migrate-legacy-approvals.ts --dry-run
+
+# Write through the canonical endpoint. Saves a snapshot to
+# ~/.openclaw/tasks-api/snapshots/<timestamp>.json so a rollback is possible.
+tsx scripts/migrate-legacy-approvals.ts --write
+
+# Reverse a previous --write run.
+tsx scripts/migrate-legacy-approvals.ts --rollback <snapshot-path>
+```
+
+### Sources of legacy approval state
+
+| Signal | Mapped to |
+|---|---|
+| `- [x] **Approved by Tom**` in description | `spec` approval, owner = `Tom` |
+| `- [ ] **Approved by Tom**` in description | Intentionally not migrated (unchecked) |
+| `[tech-design-approved] true` in a comment | `tech_design` approval, owner = comment.author |
+| `[qa-ac-verified] true` in a comment | `qa` approval, owner = comment.author |
+
+### Safety
+
+1. Run `--dry-run` first. The summary's `createdApprovals` count should
+   roughly match the number of tasks that had at least one legacy approval
+   signal. If the count looks wildly off, do not proceed.
+2. `--write` is idempotent on `(taskId, type)`: existing rows are skipped
+   and counted under `skippedExisting`.
+3. Each `--write` run saves a snapshot to
+   `~/.openclaw/tasks-api/snapshots/<timestamp>.json`. Hold on to this
+   snapshot if you might want to reverse the migration.
+4. `--rollback` drops every `(taskId, type)` from the snapshot. The
+   legacy comments and description checkboxes are untouched, so the
+   system reverts to the pre-migration behavior immediately.
+
+### Required env
+
+- `TASKS_API_BASE_URL` — default `http://localhost:4001`.

--- a/services/tasks-api/scripts/migrate-legacy-approvals.ts
+++ b/services/tasks-api/scripts/migrate-legacy-approvals.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env -S npx tsx --require @sindustries/otel-node/register
+/*
+ * migrate-legacy-approvals.ts
+ *
+ * One-shot migration script that reads the legacy approval state that lives
+ * in task descriptions and comment bodies, and writes equivalent TaskApproval
+ * rows through the canonical POST /tasks/:id/approvals endpoint.
+ *
+ * Sources of legacy approval state:
+ *   - `**Approved by Tom**` (checked) in description    -> spec, owner=Tom
+ *   - `[tech-design-approved] true` in a comment          -> tech_design, owner=comment.author
+ *   - `[qa-ac-verified] true` in a comment                -> qa, owner=comment.author
+ *   - `- [ ] **Approved by Tom**` (unchecked) in desc    -> no spec row (correctly absent)
+ *
+ * The script is idempotent on (taskId, type): if a row already exists, the
+ * existing row is left untouched and counted under `skippedExisting`.
+ *
+ * Modes:
+ *   --dry-run                                Algorithm runs, summary printed, no DB writes.
+ *   --write                                  Algorithm runs, summary printed, writes go through POST /tasks/:id/approvals.
+ *                                            A snapshot of the row set is saved to .openclaw/tasks-api/snapshots/<timestamp>.json
+ *                                            so a future --rollback can restore.
+ *   --rollback <snapshot-path>               Drops every TaskApproval row whose (taskId, type) appears in the snapshot.
+ *                                            Use only after a migration that needs to be reversed.
+ *
+ * Examples:
+ *   tsx scripts/migrate-legacy-approvals.ts --dry-run
+ *   tsx scripts/migrate-legacy-approvals.ts --write
+ *   tsx scripts/migrate-legacy-approvals.ts --rollback .openclaw/tasks-api/snapshots/2026-08-08T05-00-00.json
+ *
+ * Required env:
+ *   TASKS_API_BASE_URL   default http://localhost:4001
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { argv, env, exit } from 'node:process';
+import {
+  detectLegacyApprovals,
+  existingApprovalKeys,
+  type DetectedApproval,
+  type MigrationBreakdown
+} from '../src/lib/legacyApprovals.ts';
+
+const BASE_URL = (env.TASKS_API_BASE_URL ?? 'http://localhost:4001').replace(/\/$/, '');
+
+interface TaskApproval {
+  id: string;
+  taskId: string;
+  type: 'spec' | 'tech_design' | 'qa';
+  owner: string;
+  state: 'approved' | 'revoked';
+  approvedAt: string;
+  revokedAt: string | null;
+  note: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface TaskComment {
+  id: string;
+  author: string;
+  text: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Task {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+  taskType: string | null;
+  approvals: TaskApproval[];
+  comments: TaskComment[];
+}
+
+interface MigrationSummary {
+  totalTasks: number;
+  createdApprovals: number;
+  skippedExisting: number;
+  breakdownByType: MigrationBreakdown[];
+  snapshotPath: string | null;
+  dryRun: boolean;
+  rolledBack: number;
+}
+
+function parseArgs() {
+  const args = argv.slice(2);
+  const flags = {
+    dryRun: false,
+    write: false,
+    rollback: null as string | null
+  };
+
+  for (const arg of args) {
+    if (arg === '--dry-run') flags.dryRun = true;
+    else if (arg === '--write') flags.write = true;
+    else if (arg.startsWith('--rollback=')) flags.rollback = arg.slice('--rollback='.length);
+    else if (arg === '--rollback') {
+      const next = args[args.indexOf(arg) + 1];
+      if (!next) throw new Error('--rollback requires a snapshot path argument');
+      flags.rollback = next;
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      exit(0);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  if (!flags.dryRun && !flags.write && !flags.rollback) {
+    throw new Error('one of --dry-run, --write, or --rollback <path> is required');
+  }
+  if ((flags.dryRun ? 1 : 0) + (flags.write ? 1 : 0) + (flags.rollback ? 1 : 0) > 1) {
+    throw new Error('only one of --dry-run, --write, or --rollback may be passed');
+  }
+  return flags;
+}
+
+function printHelp() {
+  console.log(
+    [
+      'migrate-legacy-approvals.ts',
+      '',
+      'Modes:',
+      '  --dry-run                            Print summary, no DB writes.',
+      '  --write                              Write via POST /tasks/:id/approvals; save a snapshot.',
+      '  --rollback <snapshot-path>           Drop rows from a prior snapshot.',
+      '',
+      'Env:',
+      '  TASKS_API_BASE_URL   default http://localhost:4001'
+    ].join('\n')
+  );
+}
+
+async function fetchAllTasks(): Promise<Task[]> {
+  const tasks: Task[] = [];
+  let cursor: string | null = null;
+
+  while (true) {
+    const url = new URL(`${BASE_URL}/api/v1/tasks`);
+    url.searchParams.set('limit', '200');
+    if (cursor) url.searchParams.set('cursor', cursor);
+
+    const response = await fetch(url.toString(), {
+      headers: { Accept: 'application/json' }
+    });
+    if (!response.ok) {
+      throw new Error(`GET /tasks ${response.status}: ${await response.text()}`);
+    }
+    const body = (await response.json()) as { data: Task[]; page: { nextCursor: string | null } };
+    tasks.push(...body.data);
+    if (!body.page.nextCursor) break;
+    cursor = body.page.nextCursor;
+  }
+
+  return tasks;
+}
+
+function detectApprovals(task: Task): DetectedApproval[] {
+  return detectLegacyApprovals(task);
+}
+
+function existingApprovalSet(task: Task): Set<string> {
+  return existingApprovalKeys(task);
+}
+
+async function postApproval(
+  taskId: string,
+  approval: DetectedApproval
+): Promise<void> {
+  const response = await fetch(`${BASE_URL}/api/v1/tasks/${taskId}/approvals`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(approval)
+  });
+  if (!response.ok) {
+    throw new Error(`POST /tasks/${taskId}/approvals ${response.status}: ${await response.text()}`);
+  }
+}
+
+async function deleteApproval(taskId: string, type: string): Promise<void> {
+  const response = await fetch(`${BASE_URL}/api/v1/tasks/${taskId}/approvals/${type}`, {
+    method: 'DELETE',
+    headers: { Accept: 'application/json' }
+  });
+  if (!response.ok) {
+    throw new Error(`DELETE /tasks/${taskId}/approvals/${type} ${response.status}: ${await response.text()}`);
+  }
+}
+
+function snapshotPath(): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const dir = resolve(env.HOME ?? '/tmp', '.openclaw/tasks-api/snapshots');
+  mkdirSync(dir, { recursive: true });
+  return resolve(dir, `${ts}.json`);
+}
+
+function ensureSnapshotDir(path: string): void {
+  const dir = path.slice(0, path.lastIndexOf('/'));
+  mkdirSync(dir, { recursive: true });
+}
+
+async function runDryRun(): Promise<MigrationSummary> {
+  const tasks = await fetchAllTasks();
+  const breakdownByType: MigrationBreakdown[] = [];
+  let createdApprovals = 0;
+  let skippedExisting = 0;
+
+  for (const task of tasks) {
+    const detected = detectApprovals(task);
+    const existing = existingApprovalSet(task);
+    for (const approval of detected) {
+      const key = `${task.id}:${approval.type}`;
+      if (existing.has(key)) {
+        skippedExisting += 1;
+      } else {
+        createdApprovals += 1;
+      }
+      let bucket = breakdownByType.find((b) => b.type === approval.type);
+      if (!bucket) {
+        bucket = { type: approval.type, created: 0, skippedExisting: 0 };
+        breakdownByType.push(bucket);
+      }
+      if (existing.has(key)) bucket.skippedExisting += 1;
+      else bucket.created += 1;
+    }
+  }
+
+  return {
+    totalTasks: tasks.length,
+    createdApprovals,
+    skippedExisting,
+    breakdownByType,
+    snapshotPath: null,
+    dryRun: true,
+    rolledBack: 0
+  };
+}
+
+async function runWrite(): Promise<MigrationSummary> {
+  const tasks = await fetchAllTasks();
+  const snapshotRows: Array<{ taskId: string; type: string }> = [];
+  const breakdownByType: MigrationBreakdown[] = [];
+  let createdApprovals = 0;
+  let skippedExisting = 0;
+
+  for (const task of tasks) {
+    const detected = detectApprovals(task);
+    const existing = existingApprovalSet(task);
+    for (const approval of detected) {
+      const key = `${task.id}:${approval.type}`;
+      if (existing.has(key)) {
+        skippedExisting += 1;
+      } else {
+        await postApproval(task.id, approval);
+        snapshotRows.push({ taskId: task.id, type: approval.type });
+        createdApprovals += 1;
+      }
+      let bucket = breakdownByType.find((b) => b.type === approval.type);
+      if (!bucket) {
+        bucket = { type: approval.type, created: 0, skippedExisting: 0 };
+        breakdownByType.push(bucket);
+      }
+      if (existing.has(key)) bucket.skippedExisting += 1;
+      else bucket.created += 1;
+    }
+  }
+
+  const snapshotPath = snapshotPath();
+  ensureSnapshotDir(snapshotPath);
+  writeFileSync(
+    snapshotPath,
+    JSON.stringify(
+      {
+        savedAt: new Date().toISOString(),
+        rolledBack: false,
+        rows: snapshotRows
+      },
+      null,
+      2
+    )
+  );
+
+  return {
+    totalTasks: tasks.length,
+    createdApprovals,
+    skippedExisting,
+    breakdownByType,
+    snapshotPath,
+    dryRun: false,
+    rolledBack: 0
+  };
+}
+
+async function runRollback(snapshotPath: string): Promise<MigrationSummary> {
+  const raw = readFileSync(snapshotPath, 'utf8');
+  const parsed = JSON.parse(raw) as { rows: Array<{ taskId: string; type: string }> };
+
+  for (const row of parsed.rows) {
+    await deleteApproval(row.taskId, row.type);
+  }
+
+  return {
+    totalTasks: 0,
+    createdApprovals: 0,
+    skippedExisting: 0,
+    breakdownByType: [],
+    snapshotPath,
+    dryRun: false,
+    rolledBack: parsed.rows.length
+  };
+}
+
+async function main() {
+  const flags = parseArgs();
+  let summary: MigrationSummary;
+
+  if (flags.rollback) {
+    summary = await runRollback(flags.rollback);
+  } else if (flags.dryRun) {
+    summary = await runDryRun();
+  } else {
+    summary = await runWrite();
+  }
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main().catch((err) => {
+  console.error('[migrate-legacy-approvals] failed:', err);
+  exit(1);
+});

--- a/services/tasks-api/src/app.ts
+++ b/services/tasks-api/src/app.ts
@@ -3,6 +3,7 @@ import { helmetPreset } from './middleware/helmetPreset';
 import { createRateLimit, positiveIntegerEnv } from './middleware/rateLimit';
 import { healthRouter } from './routes/health';
 import { tasksRouter } from './routes/tasks';
+import { taskApprovalsRouter } from './routes/taskApprovals';
 import { tagsRouter } from './routes/tags';
 import { contentSchedulerRouter } from './routes/contentScheduler.ts';
 import { xTweetRouter } from './routes/xTweet.ts';
@@ -95,6 +96,7 @@ export function createApp() {
 
   app.use('/api/v1', healthRouter);
   app.use('/api/v1', tasksRouter);
+  app.use('/api/v1', taskApprovalsRouter);
   app.use('/api/v1', tagsRouter);
   app.use('/api/v1', contentSchedulerRouter);
   app.use('/api/v1', xTweetRouter());

--- a/services/tasks-api/src/app.ts
+++ b/services/tasks-api/src/app.ts
@@ -4,6 +4,7 @@ import { createRateLimit, positiveIntegerEnv } from './middleware/rateLimit';
 import { healthRouter } from './routes/health';
 import { tasksRouter } from './routes/tasks';
 import { taskApprovalsRouter } from './routes/taskApprovals';
+import { requiredApprovalsRouter } from './routes/requiredApprovals';
 import { tagsRouter } from './routes/tags';
 import { contentSchedulerRouter } from './routes/contentScheduler.ts';
 import { xTweetRouter } from './routes/xTweet.ts';
@@ -97,6 +98,7 @@ export function createApp() {
   app.use('/api/v1', healthRouter);
   app.use('/api/v1', tasksRouter);
   app.use('/api/v1', taskApprovalsRouter);
+  app.use('/api/v1', requiredApprovalsRouter);
   app.use('/api/v1', tagsRouter);
   app.use('/api/v1', contentSchedulerRouter);
   app.use('/api/v1', xTweetRouter());

--- a/services/tasks-api/src/config/requiredApprovals.ts
+++ b/services/tasks-api/src/config/requiredApprovals.ts
@@ -1,0 +1,150 @@
+// Configurable taskType -> required-approvals mapping for the Tasks API.
+//
+// The mapping is editable by Quinn or Tom without a code deploy. The Tasks API
+// reads `.openclaw/tasks-api/required-approvals.yaml` on startup; if the file
+// is missing or malformed, the loader falls back to a built-in default and
+// logs a WARN. The default values match the task spec defaults:
+//   feature: [spec, tech_design, qa]
+//   code:    [tech_design, qa]
+//   content: [spec, qa]
+//   research: []
+//
+// The file format is intentionally narrow — a top-level `version:` line and
+// an indented `mappings:` block. The loader is hand-rolled to avoid pulling
+// in a YAML dependency for a structure that fits in ~30 lines of parsing.
+//
+// See docs/specs/tasks-api-native-approvals-tech-design.md WS2.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { validApprovalTypes } from '../routes/tasks/_constants.ts';
+
+export interface RequiredApprovalsConfig {
+  version: number;
+  mappings: Record<string, string[]>;
+  source: 'config-file' | 'builtin-default';
+}
+
+export const DEFAULT_REQUIRED_APPROVALS: RequiredApprovalsConfig = {
+  version: 1,
+  mappings: {
+    feature: ['spec', 'tech_design', 'qa'],
+    code: ['tech_design', 'qa'],
+    content: ['spec', 'qa'],
+    research: []
+  },
+  source: 'builtin-default'
+};
+
+function resolveDefaultConfigPath(): string {
+  const fromEnv = process.env.REQUIRED_APPROVALS_CONFIG_PATH;
+  if (fromEnv && fromEnv.trim().length > 0) return fromEnv.trim();
+  const home = process.env.HOME ?? '/tmp';
+  return resolve(home, '.openclaw/tasks-api/required-approvals.yaml');
+}
+
+/**
+ * Minimal YAML parser for the .openclaw/tasks-api/required-approvals.yaml
+ * format. Supports:
+ *   - top-level `version: <number>`
+ *   - top-level `mappings:` header followed by indented lines of
+ *     `<taskType>: [<type>, <type>, ...]`
+ *   - `#` end-of-line comments and blank lines
+ *
+ * Throws on malformed input (e.g. missing `version:`); the loader catches
+ * and falls back to the built-in default.
+ */
+export function parseRequiredApprovalsYaml(content: string): RequiredApprovalsConfig {
+  const lines = content.split(/\r?\n/);
+  let version: number | null = null;
+  const mappings: Record<string, string[]> = {};
+  let inMappings = false;
+
+  for (const rawLine of lines) {
+    // Strip end-of-line comments and trim trailing whitespace.
+    const noComment = rawLine.replace(/\s*#.*$/, '');
+    if (!noComment.trim()) continue;
+
+    const isTopLevel = !/^[ \t]/.test(noComment);
+    const trimmed = noComment.trim();
+
+    if (isTopLevel) {
+      const versionMatch = trimmed.match(/^version:\s*(\d+)\s*$/);
+      if (versionMatch) {
+        version = parseInt(versionMatch[1], 10);
+        inMappings = false;
+        continue;
+      }
+      if (trimmed === 'mappings:') {
+        inMappings = true;
+        continue;
+      }
+      // Unknown top-level key — ignore and exit mappings block.
+      inMappings = false;
+      continue;
+    }
+
+    if (!inMappings) continue;
+
+    const entryMatch = trimmed.match(/^([a-zA-Z][a-zA-Z0-9_-]*):\s*\[(.*?)\]\s*$/);
+    if (!entryMatch) continue;
+
+    const taskType = entryMatch[1];
+    const rawList = entryMatch[2];
+    const list = rawList
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+
+    for (const approvalType of list) {
+      if (!validApprovalTypes.has(approvalType)) {
+        throw new Error(
+          `task type "${taskType}" lists unknown approval type "${approvalType}"`
+        );
+      }
+    }
+
+    mappings[taskType] = list;
+  }
+
+  if (version === null) {
+    throw new Error('missing top-level `version: <number>` directive');
+  }
+
+  return { version, mappings, source: 'config-file' };
+}
+
+export function loadRequiredApprovalsConfig(
+  configPath: string = resolveDefaultConfigPath()
+): RequiredApprovalsConfig {
+  if (!existsSync(configPath)) {
+    return DEFAULT_REQUIRED_APPROVALS;
+  }
+
+  try {
+    const content = readFileSync(configPath, 'utf8');
+    const parsed = parseRequiredApprovalsYaml(content);
+    // Merge parsed mappings over the default so a partial config file (e.g.
+    // a single override for `feature`) still resolves unknown task types to
+    // the default list. Keeps the file as a delta, not a full replacement.
+    const mergedMappings: Record<string, string[]> = {
+      ...DEFAULT_REQUIRED_APPROVALS.mappings,
+      ...parsed.mappings
+    };
+    return { version: parsed.version, mappings: mergedMappings, source: 'config-file' };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[required-approvals] failed to parse ${configPath}: ${message}. Falling back to built-in default.`
+    );
+    return DEFAULT_REQUIRED_APPROVALS;
+  }
+}
+
+export function requiredApprovalsFor(
+  config: RequiredApprovalsConfig,
+  taskType: string | null | undefined
+): string[] {
+  if (!taskType) return [];
+  return config.mappings[taskType] ?? [];
+}

--- a/services/tasks-api/src/lib/legacyApprovals.ts
+++ b/services/tasks-api/src/lib/legacyApprovals.ts
@@ -1,0 +1,111 @@
+// Detection logic for legacy approval state embedded in task descriptions
+// and comment bodies. Extracted from `scripts/migrate-legacy-approvals.ts`
+// so the rules can be unit-tested without spinning up the migration script.
+//
+// See docs/specs/tasks-api-native-approvals-tech-design.md WS4a.
+
+const SPEC_DESCRIPTION_PATTERN = /^\s*-\s*\[x\]\s+\*\*Approved by Tom\*\*\s*$/m;
+const SPEC_DESCRIPTION_NEGATIVE_PATTERN = /^\s*-\s*\[ \]\s+\*\*Approved by Tom\*\*\s*$/m;
+const TECH_DESIGN_COMMENT_PATTERN = /\[tech-design-approved\]\s+true/;
+const QA_COMMENT_PATTERN = /\[qa-ac-verified\]\s+true/;
+
+export type ApprovalType = 'spec' | 'tech_design' | 'qa';
+
+export interface DetectedApproval {
+  type: ApprovalType;
+  owner: string;
+  note: string;
+}
+
+export interface TaskLikeForMigration {
+  id: string;
+  description: string | null;
+  approvals: Array<{ type: ApprovalType }>;
+  comments: Array<{ author: string; text: string }>;
+}
+
+export function detectLegacyApprovals(task: TaskLikeForMigration): DetectedApproval[] {
+  const out: DetectedApproval[] = [];
+  const description = task.description ?? '';
+
+  if (SPEC_DESCRIPTION_PATTERN.test(description)) {
+    out.push({
+      type: 'spec',
+      owner: 'Tom',
+      note: 'Migrated from `**Approved by Tom**` in task description.'
+    });
+  } else if (SPEC_DESCRIPTION_NEGATIVE_PATTERN.test(description)) {
+    // Explicit unchecked — intentionally not migrated.
+  }
+
+  for (const comment of task.comments) {
+    if (TECH_DESIGN_COMMENT_PATTERN.test(comment.text)) {
+      out.push({
+        type: 'tech_design',
+        owner: comment.author,
+        note: 'Migrated from `[tech-design-approved] true` comment.'
+      });
+    }
+    if (QA_COMMENT_PATTERN.test(comment.text)) {
+      out.push({
+        type: 'qa',
+        owner: comment.author,
+        note: 'Migrated from `[qa-ac-verified] true` comment.'
+      });
+    }
+  }
+
+  return out;
+}
+
+export function existingApprovalKeys(task: TaskLikeForMigration): Set<string> {
+  return new Set(task.approvals.map((a) => `${task.id}:${a.type}`));
+}
+
+export interface MigrationBreakdown {
+  type: ApprovalType;
+  created: number;
+  skippedExisting: number;
+}
+
+export interface MigrationSummary {
+  totalTasks: number;
+  createdApprovals: number;
+  skippedExisting: number;
+  breakdownByType: MigrationBreakdown[];
+}
+
+export function summarizeMigration(
+  tasks: TaskLikeForMigration[]
+): MigrationSummary {
+  const breakdownByType: MigrationBreakdown[] = [];
+  let createdApprovals = 0;
+  let skippedExisting = 0;
+
+  for (const task of tasks) {
+    const detected = detectLegacyApprovals(task);
+    const existing = existingApprovalKeys(task);
+    for (const approval of detected) {
+      const key = `${task.id}:${approval.type}`;
+      let bucket = breakdownByType.find((b) => b.type === approval.type);
+      if (!bucket) {
+        bucket = { type: approval.type, created: 0, skippedExisting: 0 };
+        breakdownByType.push(bucket);
+      }
+      if (existing.has(key)) {
+        bucket.skippedExisting += 1;
+        skippedExisting += 1;
+      } else {
+        bucket.created += 1;
+        createdApprovals += 1;
+      }
+    }
+  }
+
+  return {
+    totalTasks: tasks.length,
+    createdApprovals,
+    skippedExisting,
+    breakdownByType
+  };
+}

--- a/services/tasks-api/src/routes/requiredApprovals.ts
+++ b/services/tasks-api/src/routes/requiredApprovals.ts
@@ -1,0 +1,45 @@
+// Read-only endpoint that exposes the configured taskType -> required-approvals
+// mapping. The lobster reads this once per `load-task` invocation and caches
+// for the run, so consumers don't have to read the YAML file directly.
+//
+// See docs/specs/tasks-api-native-approvals-tech-design.md WS2.
+
+import { Router } from 'express';
+import { badRequest } from '../lib/http.ts';
+import {
+  loadRequiredApprovalsConfig,
+  requiredApprovalsFor
+} from '../config/requiredApprovals.ts';
+import { validTaskTypes } from './tasks/_constants.ts';
+
+export const requiredApprovalsRouter = Router();
+
+requiredApprovalsRouter.get('/task-types/:taskType/required-approvals', (req, res, next) => {
+  try {
+    const taskType = String(req.params.taskType ?? '').trim();
+    if (!taskType) {
+      return badRequest(res, 'INVALID_TASK_TYPE', 'taskType is required');
+    }
+    if (!validTaskTypes.has(taskType)) {
+      return badRequest(
+        res,
+        'INVALID_TASK_TYPE',
+        'taskType must be one of: content, code, research, feature'
+      );
+    }
+
+    const config = loadRequiredApprovalsConfig();
+    const required = requiredApprovalsFor(config, taskType);
+
+    return res.status(200).json({
+      data: {
+        taskType,
+        requiredApprovals: required,
+        version: config.version,
+        source: config.source
+      }
+    });
+  } catch (error) {
+    return next(error);
+  }
+});

--- a/services/tasks-api/src/routes/taskApprovals.ts
+++ b/services/tasks-api/src/routes/taskApprovals.ts
@@ -1,0 +1,152 @@
+import { Router } from 'express';
+import { prisma } from '../lib/prisma.ts';
+import { badRequest, notFound } from '../lib/http.ts';
+import { parseTaskId } from './tasks/_validation.ts';
+import { mapTaskApproval } from './tasks/_mapper.ts';
+import { validApprovalTypes } from './tasks/_constants.ts';
+
+// Dedicated approval routes. Approval writes flow through here rather than
+// `PATCH /tasks/:id` so the partial-update semantics of that route (which
+// handles status / priority / assignee / etc.) stay isolated from approval
+// state. Approvals are also intentionally orthogonal to `Task.description`
+// and `TaskComment` — they do not modify description text or post comments.
+//
+// See docs/specs/tasks-api-native-approvals-tech-design.md WS1.
+
+export const taskApprovalsRouter = Router();
+
+function normalizeApprovalType(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return validApprovalTypes.has(trimmed) ? trimmed : null;
+}
+
+function normalizeOwner(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeNote(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'string') return undefined; // signal invalid
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+// GET /tasks/:id/approvals — list all approval rows for a task.
+taskApprovalsRouter.get('/tasks/:id/approvals', async (req, res, next) => {
+  try {
+    const id = parseTaskId(req.params.id);
+    if (!id) return badRequest(res, 'INVALID_TASK_ID', 'Task id must be a 36-char UUID');
+
+    const task = await prisma.task.findFirst({
+      where: { id, archivedAt: null },
+      select: { id: true }
+    });
+    if (!task) return notFound(res, 'TASK_NOT_FOUND', 'Task not found');
+
+    const approvals = await prisma.taskApproval.findMany({
+      where: { taskId: id },
+      orderBy: [{ approvedAt: 'asc' }, { id: 'asc' }]
+    });
+
+    return res.status(200).json({ data: approvals.map(mapTaskApproval) });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+// POST /tasks/:id/approvals — approve or re-approve. Idempotent on
+// (taskId, type): a second call for the same type updates owner, note,
+// state=approved, and re-stamps approvedAt.
+taskApprovalsRouter.post('/tasks/:id/approvals', async (req, res, next) => {
+  try {
+    const id = parseTaskId(req.params.id);
+    if (!id) return badRequest(res, 'INVALID_TASK_ID', 'Task id must be a 36-char UUID');
+
+    const type = normalizeApprovalType(req.body?.type);
+    if (!type) {
+      return badRequest(res, 'INVALID_APPROVAL_TYPE', 'type must be one of: spec, tech_design, qa');
+    }
+
+    const owner = normalizeOwner(req.body?.owner);
+    if (!owner) return badRequest(res, 'APPROVAL_OWNER_REQUIRED', 'owner is required');
+
+    const note = normalizeNote(req.body?.note);
+    if (note === undefined) {
+      return badRequest(res, 'INVALID_APPROVAL_NOTE', 'note must be a string when provided');
+    }
+
+    const task = await prisma.task.findFirst({
+      where: { id, archivedAt: null },
+      select: { id: true }
+    });
+    if (!task) return notFound(res, 'TASK_NOT_FOUND', 'Task not found');
+
+    const now = new Date();
+    const approval = await prisma.taskApproval.upsert({
+      where: { taskId_type: { taskId: id, type } },
+      create: {
+        taskId: id,
+        type,
+        owner,
+        note,
+        state: 'approved',
+        approvedAt: now
+      },
+      update: {
+        owner,
+        note,
+        state: 'approved',
+        approvedAt: now,
+        revokedAt: null
+      }
+    });
+
+    return res.status(200).json({ data: mapTaskApproval(approval) });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+// DELETE /tasks/:id/approvals/:type — revoke. Idempotent: revoking an
+// already-revoked row is a no-op, and revoking an absent row returns 200
+// with no payload (nothing to revoke, no phantom row created).
+taskApprovalsRouter.delete('/tasks/:id/approvals/:type', async (req, res, next) => {
+  try {
+    const id = parseTaskId(req.params.id);
+    if (!id) return badRequest(res, 'INVALID_TASK_ID', 'Task id must be a 36-char UUID');
+
+    const type = normalizeApprovalType(req.params.type);
+    if (!type) {
+      return badRequest(res, 'INVALID_APPROVAL_TYPE', 'type must be one of: spec, tech_design, qa');
+    }
+
+    const task = await prisma.task.findFirst({
+      where: { id, archivedAt: null },
+      select: { id: true }
+    });
+    if (!task) return notFound(res, 'TASK_NOT_FOUND', 'Task not found');
+
+    const existing = await prisma.taskApproval.findUnique({
+      where: { taskId_type: { taskId: id, type } }
+    });
+    if (!existing) {
+      return res.status(200).json({ data: null });
+    }
+
+    const now = new Date();
+    const approval = await prisma.taskApproval.update({
+      where: { taskId_type: { taskId: id, type } },
+      data: {
+        state: 'revoked',
+        revokedAt: now
+      }
+    });
+
+    return res.status(200).json({ data: mapTaskApproval(approval) });
+  } catch (error) {
+    return next(error);
+  }
+});

--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -156,6 +156,7 @@ tasksRouter.get('/tasks', async (req, res, next) => {
             tag: true
           }
         },
+        approvals: true,
         ...dependencyInclude
       },
       take: limit + 1
@@ -220,6 +221,7 @@ tasksRouter.get('/tasks/:id', async (req, res, next) => {
         comments: {
           orderBy: [{ createdAt: 'asc' }, { id: 'asc' }]
         },
+        approvals: true,
         ...dependencyInclude
       }
     });
@@ -290,6 +292,7 @@ tasksRouter.post('/tasks', async (req, res, next) => {
             tag: true
           }
         },
+        approvals: true,
         ...dependencyInclude
       }
     });
@@ -429,6 +432,7 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
         where: { id },
         include: {
           tags: { include: { tag: true } },
+          approvals: true,
           ...dependencyInclude
         }
       });

--- a/services/tasks-api/src/routes/tasks/_constants.ts
+++ b/services/tasks-api/src/routes/tasks/_constants.ts
@@ -10,6 +10,13 @@ export const validAssignees = new Set(['Tom', 'Quinn', 'Rowan', 'Lox', 'Ivy']);
 export const validSorts = new Set(['priority', 'createdAt', 'updatedAt', 'dueAt', 'statusChangedAt']);
 export const validTaskTypes = new Set(['content', 'code', 'research', 'feature']);
 
+// Approval type and state vocabularies. Mirrored in the Prisma `ApprovalType`
+// and `ApprovalState` enums. Kept here as plain string sets so route-layer
+// validation stays a synchronous lookup against the same vocabulary that
+// the database enforces.
+export const validApprovalTypes = new Set(['spec', 'tech_design', 'qa']);
+export const validApprovalStates = new Set(['approved', 'revoked']);
+
 export const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export const taskTypeTitlePrefixes = {

--- a/services/tasks-api/src/routes/tasks/_mapper.ts
+++ b/services/tasks-api/src/routes/tasks/_mapper.ts
@@ -13,6 +13,20 @@ function mapComment(comment) {
   };
 }
 
+export function mapTaskApproval(approval) {
+  return {
+    id: approval.id,
+    type: approval.type,
+    owner: approval.owner,
+    state: approval.state,
+    approvedAt: approval.approvedAt,
+    revokedAt: approval.revokedAt ?? null,
+    note: approval.note ?? null,
+    createdAt: approval.createdAt,
+    updatedAt: approval.updatedAt
+  };
+}
+
 export function mapTask(task) {
   const dependsOn = task.dependencies
     ?.map((dependency) => dependency.dependsOn)
@@ -42,6 +56,7 @@ export function mapTask(task) {
     specChecksum: task.specChecksum ?? null,
     tags: task.tags?.map((taskTag) => taskTag.tag?.name).filter(Boolean) ?? [],
     comments: task.comments?.map(mapComment) ?? [],
+    approvals: task.approvals?.map(mapTaskApproval) ?? [],
     dependsOn,
     dependsOnIds: dependsOn.map((dependency) => dependency.id),
     dependencyBlocked: dependsOn.some((dependency) => dependency.status !== 'done')

--- a/services/tasks-api/test/legacyApprovals.test.ts
+++ b/services/tasks-api/test/legacyApprovals.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectLegacyApprovals,
+  existingApprovalKeys,
+  summarizeMigration
+} from '../src/lib/legacyApprovals.ts';
+
+function taskFixture(overrides: Partial<{
+  id: string;
+  description: string | null;
+  approvals: Array<{ type: 'spec' | 'tech_design' | 'qa' }>;
+  comments: Array<{ author: string; text: string }>;
+}> = {}) {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    description: null,
+    approvals: [],
+    comments: [],
+    ...overrides
+  };
+}
+
+describe('detectLegacyApprovals', () => {
+  it('detects a checked Approved-by-Tom marker in the description', () => {
+    const description = [
+      'Some prose',
+      '',
+      '- [x] **Approved by Tom**',
+      '',
+      'More prose'
+    ].join('\n');
+
+    const detected = detectLegacyApprovals(taskFixture({ description }));
+
+    expect(detected).toEqual([
+      {
+        type: 'spec',
+        owner: 'Tom',
+        note: 'Migrated from `**Approved by Tom**` in task description.'
+      }
+    ]);
+  });
+
+  it('skips an unchecked Approved-by-Tom marker', () => {
+    const description = '- [ ] **Approved by Tom**';
+    const detected = detectLegacyApprovals(taskFixture({ description }));
+    expect(detected).toEqual([]);
+  });
+
+  it('detects [tech-design-approved] true in a comment', () => {
+    const detected = detectLegacyApprovals(
+      taskFixture({
+        comments: [
+          { author: 'Quinn', text: 'Some review text\n\n[tech-design-approved] true\n' }
+        ]
+      })
+    );
+    expect(detected).toEqual([
+      {
+        type: 'tech_design',
+        owner: 'Quinn',
+        note: 'Migrated from `[tech-design-approved] true` comment.'
+      }
+    ]);
+  });
+
+  it('detects [qa-ac-verified] true in a comment', () => {
+    const detected = detectLegacyApprovals(
+      taskFixture({
+        comments: [{ author: 'Tom', text: '[qa-ac-verified] true' }]
+      })
+    );
+    expect(detected).toEqual([
+      {
+        type: 'qa',
+        owner: 'Tom',
+        note: 'Migrated from `[qa-ac-verified] true` comment.'
+      }
+    ]);
+  });
+
+  it('detects multiple approval signals in one task', () => {
+    const description = '- [x] **Approved by Tom**';
+    const detected = detectLegacyApprovals(
+      taskFixture({
+        description,
+        comments: [
+          { author: 'Quinn', text: '[tech-design-approved] true' },
+          { author: 'Tom', text: '[qa-ac-verified] true' }
+        ]
+      })
+    );
+
+    expect(detected.map((a) => a.type)).toEqual(['spec', 'tech_design', 'qa']);
+  });
+
+  it('returns an empty list when no legacy signals are present', () => {
+    const detected = detectLegacyApprovals(
+      taskFixture({
+        description: 'No approval markers here.',
+        comments: [{ author: 'Quinn', text: 'Just a regular comment.' }]
+      })
+    );
+    expect(detected).toEqual([]);
+  });
+});
+
+describe('existingApprovalKeys', () => {
+  it('returns a set of `<taskId>:<type>` strings', () => {
+    const keys = existingApprovalKeys(
+      taskFixture({
+        id: 'task-1',
+        approvals: [{ type: 'spec' }, { type: 'qa' }]
+      })
+    );
+    expect([...keys].sort()).toEqual(['task-1:qa', 'task-1:spec']);
+  });
+});
+
+describe('summarizeMigration', () => {
+  it('counts createdApprovals and skippedExisting across the task set', () => {
+    const summary = summarizeMigration([
+      taskFixture({
+        id: 'task-1',
+        description: '- [x] **Approved by Tom**',
+        approvals: [] // not yet approved in API
+      }),
+      taskFixture({
+        id: 'task-2',
+        description: '- [x] **Approved by Tom**',
+        approvals: [{ type: 'spec' }] // already approved in API
+      }),
+      taskFixture({
+        id: 'task-3',
+        comments: [{ author: 'Tom', text: '[qa-ac-verified] true' }]
+      })
+    ]);
+
+    expect(summary.totalTasks).toBe(3);
+    expect(summary.createdApprovals).toBe(2);
+    expect(summary.skippedExisting).toBe(1);
+    expect(summary.breakdownByType).toEqual([
+      { type: 'spec', created: 1, skippedExisting: 1 },
+      { type: 'qa', created: 1, skippedExisting: 0 }
+    ]);
+  });
+
+  it('returns zero counts when no legacy signals are present', () => {
+    const summary = summarizeMigration([
+      taskFixture({ description: 'No signals here.' }),
+      taskFixture({
+        comments: [{ author: 'Quinn', text: 'Plain comment.' }]
+      })
+    ]);
+    expect(summary.totalTasks).toBe(2);
+    expect(summary.createdApprovals).toBe(0);
+    expect(summary.skippedExisting).toBe(0);
+    expect(summary.breakdownByType).toEqual([]);
+  });
+});

--- a/services/tasks-api/test/requiredApprovals.test.ts
+++ b/services/tasks-api/test/requiredApprovals.test.ts
@@ -1,0 +1,190 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const prismaMock = {
+  task: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn()
+  },
+  taskComment: { create: vi.fn() },
+  taskTag: { deleteMany: vi.fn(), createMany: vi.fn() },
+  tag: { findMany: vi.fn(), upsert: vi.fn() },
+  taskDependency: {
+    findFirst: vi.fn(),
+    deleteMany: vi.fn(),
+    createMany: vi.fn()
+  },
+  taskApproval: {
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+    update: vi.fn()
+  },
+  $transaction: vi.fn()
+};
+
+vi.mock('../src/lib/prisma.ts', () => ({
+  prisma: prismaMock
+}));
+
+const { createApp } = await import('../src/app.ts');
+const {
+  DEFAULT_REQUIRED_APPROVALS,
+  loadRequiredApprovalsConfig,
+  parseRequiredApprovalsYaml,
+  requiredApprovalsFor
+} = await import('../src/config/requiredApprovals.ts');
+
+describe('parseRequiredApprovalsYaml', () => {
+  it('parses the canonical config shape', () => {
+    const yaml = [
+      'version: 1',
+      'mappings:',
+      '  feature: [spec, tech_design, qa]',
+      '  code: [tech_design, qa]',
+      '  content: [spec, qa]',
+      '  research: []'
+    ].join('\n');
+
+    const parsed = parseRequiredApprovalsYaml(yaml);
+
+    expect(parsed.version).toBe(1);
+    expect(parsed.mappings).toEqual({
+      feature: ['spec', 'tech_design', 'qa'],
+      code: ['tech_design', 'qa'],
+      content: ['spec', 'qa'],
+      research: []
+    });
+    expect(parsed.source).toBe('config-file');
+  });
+
+  it('ignores end-of-line comments and blank lines', () => {
+    const yaml = [
+      '# top of file',
+      'version: 1 # trailing comment',
+      '',
+      'mappings: # header',
+      '  # nested comment',
+      '  feature: [spec, tech_design, qa]',
+      '  code: [tech_design, qa]'
+    ].join('\n');
+
+    const parsed = parseRequiredApprovalsYaml(yaml);
+
+    expect(parsed.version).toBe(1);
+    expect(parsed.mappings.feature).toEqual(['spec', 'tech_design', 'qa']);
+    expect(parsed.mappings.code).toEqual(['tech_design', 'qa']);
+  });
+
+  it('throws when version is missing', () => {
+    expect(() => parseRequiredApprovalsYaml('mappings:\n  feature: [qa]')).toThrow(
+      /missing top-level `version: <number>` directive/
+    );
+  });
+
+  it('throws on unknown approval type', () => {
+    const yaml = ['version: 1', 'mappings:', '  feature: [spec, not_a_real_type]'].join('\n');
+    expect(() => parseRequiredApprovalsYaml(yaml)).toThrow(/unknown approval type/);
+  });
+});
+
+describe('loadRequiredApprovalsConfig', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'req-approvals-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns default config when file is missing', () => {
+    const config = loadRequiredApprovalsConfig(join(tmpDir, 'does-not-exist.yaml'));
+    expect(config.source).toBe('builtin-default');
+    expect(config.mappings).toEqual(DEFAULT_REQUIRED_APPROVALS.mappings);
+  });
+
+  it('merges parsed mappings over the default', () => {
+    const path = join(tmpDir, 'required-approvals.yaml');
+    writeFileSync(
+      path,
+      ['version: 1', 'mappings:', '  feature: [qa]'].join('\n'),
+      'utf8'
+    );
+
+    const config = loadRequiredApprovalsConfig(path);
+
+    expect(config.source).toBe('config-file');
+    expect(config.mappings.feature).toEqual(['qa']);
+    // Untouched task types keep their default values.
+    expect(config.mappings.code).toEqual(['tech_design', 'qa']);
+    expect(config.mappings.content).toEqual(['spec', 'qa']);
+    expect(config.mappings.research).toEqual([]);
+  });
+
+  it('falls back to default when file is malformed', () => {
+    const path = join(tmpDir, 'required-approvals.yaml');
+    writeFileSync(path, 'this is not the right shape', 'utf8');
+
+    const config = loadRequiredApprovalsConfig(path);
+
+    expect(config.source).toBe('builtin-default');
+    expect(config.mappings).toEqual(DEFAULT_REQUIRED_APPROVALS.mappings);
+  });
+});
+
+describe('requiredApprovalsFor', () => {
+  const config = DEFAULT_REQUIRED_APPROVALS;
+
+  it('returns the configured list for known task types', () => {
+    expect(requiredApprovalsFor(config, 'feature')).toEqual(['spec', 'tech_design', 'qa']);
+    expect(requiredApprovalsFor(config, 'content')).toEqual(['spec', 'qa']);
+    expect(requiredApprovalsFor(config, 'code')).toEqual(['tech_design', 'qa']);
+    expect(requiredApprovalsFor(config, 'research')).toEqual([]);
+  });
+
+  it('returns [] for unknown or null task types', () => {
+    expect(requiredApprovalsFor(config, null)).toEqual([]);
+    expect(requiredApprovalsFor(config, undefined)).toEqual([]);
+    expect(requiredApprovalsFor(config, 'not-a-real-type')).toEqual([]);
+  });
+});
+
+describe('GET /api/v1/task-types/:taskType/required-approvals', () => {
+  it('returns the configured approval list for a known task type', async () => {
+    const app = createApp();
+    const response = await request(app).get('/api/v1/task-types/feature/required-approvals');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      data: {
+        taskType: 'feature',
+        requiredApprovals: ['spec', 'tech_design', 'qa'],
+        version: 1,
+        source: 'builtin-default'
+      }
+    });
+  });
+
+  it('returns the empty list for `research`', async () => {
+    const app = createApp();
+    const response = await request(app).get('/api/v1/task-types/research/required-approvals');
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.requiredApprovals).toEqual([]);
+  });
+
+  it('400s on an unknown task type', async () => {
+    const app = createApp();
+    const response = await request(app).get('/api/v1/task-types/not-a-type/required-approvals');
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('INVALID_TASK_TYPE');
+  });
+});

--- a/services/tasks-api/test/taskApprovals.test.ts
+++ b/services/tasks-api/test/taskApprovals.test.ts
@@ -1,0 +1,399 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const prismaMock = {
+  task: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn()
+  },
+  taskComment: {
+    create: vi.fn()
+  },
+  taskTag: {
+    deleteMany: vi.fn(),
+    createMany: vi.fn()
+  },
+  tag: {
+    findMany: vi.fn(),
+    upsert: vi.fn()
+  },
+  taskDependency: {
+    findFirst: vi.fn(),
+    deleteMany: vi.fn(),
+    createMany: vi.fn()
+  },
+  taskApproval: {
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+    update: vi.fn()
+  },
+  $transaction: vi.fn()
+};
+
+vi.mock('../src/lib/prisma.ts', () => ({
+  prisma: prismaMock
+}));
+
+const { createApp } = await import('../src/app.ts');
+
+const TASK_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_TASK_ID = '99999999-9999-9999-9999-999999999999';
+
+function approvalFixture(overrides = {}) {
+  return {
+    id: 'approval-1',
+    taskId: TASK_ID,
+    type: 'spec',
+    owner: 'Tom',
+    state: 'approved',
+    approvedAt: new Date('2026-08-08T04:00:00.000Z'),
+    revokedAt: null,
+    note: null,
+    createdAt: new Date('2026-08-08T04:00:00.000Z'),
+    updatedAt: new Date('2026-08-08T04:00:00.000Z'),
+    ...overrides
+  };
+}
+
+describe('task approval routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (callback) => callback(prismaMock));
+  });
+
+  it('GET /api/v1/tasks/:id/approvals lists approvals for a task', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce({ id: TASK_ID });
+    prismaMock.taskApproval.findMany.mockResolvedValueOnce([
+      approvalFixture({ type: 'spec' }),
+      approvalFixture({ id: 'approval-2', type: 'tech_design', owner: 'Quinn' })
+    ]);
+
+    const app = createApp();
+    const response = await request(app).get(`/api/v1/tasks/${TASK_ID}/approvals`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toHaveLength(2);
+    expect(response.body.data[0]).toMatchObject({
+      id: 'approval-1',
+      type: 'spec',
+      owner: 'Tom',
+      state: 'approved',
+      revokedAt: null,
+      note: null
+    });
+    expect(response.body.data[1]).toMatchObject({ type: 'tech_design', owner: 'Quinn' });
+    expect(prismaMock.taskApproval.findMany).toHaveBeenCalledWith({
+      where: { taskId: TASK_ID },
+      orderBy: [{ approvedAt: 'asc' }, { id: 'asc' }]
+    });
+  });
+
+  it('GET /api/v1/tasks/:id/approvals returns empty list when task has no approvals', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce({ id: TASK_ID });
+    prismaMock.taskApproval.findMany.mockResolvedValueOnce([]);
+
+    const app = createApp();
+    const response = await request(app).get(`/api/v1/tasks/${TASK_ID}/approvals`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toEqual([]);
+  });
+
+  it('GET /api/v1/tasks/:id/approvals returns 404 when task is missing', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce(null);
+
+    const app = createApp();
+    const response = await request(app).get(`/api/v1/tasks/${OTHER_TASK_ID}/approvals`);
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({
+      error: { code: 'TASK_NOT_FOUND', message: 'Task not found' }
+    });
+    expect(prismaMock.taskApproval.findMany).not.toHaveBeenCalled();
+  });
+
+  it('GET /api/v1/tasks/:id/approvals rejects malformed task id', async () => {
+    const app = createApp();
+    const response = await request(app).get('/api/v1/tasks/not-a-uuid/approvals');
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('INVALID_TASK_ID');
+    expect(prismaMock.task.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/v1/tasks/:id/approvals creates a new approval', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce({ id: TASK_ID });
+    prismaMock.taskApproval.upsert.mockResolvedValueOnce(
+      approvalFixture({ id: 'approval-1', owner: 'Tom', note: 'Looks good' })
+    );
+
+    const app = createApp();
+    const response = await request(app)
+      .post(`/api/v1/tasks/${TASK_ID}/approvals`)
+      .send({ type: 'spec', owner: 'Tom', note: 'Looks good' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toMatchObject({
+      type: 'spec',
+      owner: 'Tom',
+      state: 'approved',
+      note: 'Looks good'
+    });
+    expect(prismaMock.taskApproval.upsert).toHaveBeenCalledTimes(1);
+    const call = prismaMock.taskApproval.upsert.mock.calls[0][0];
+    expect(call.where).toEqual({ taskId_type: { taskId: TASK_ID, type: 'spec' } });
+    expect(call.create).toMatchObject({ taskId: TASK_ID, type: 'spec', owner: 'Tom', note: 'Looks good' });
+    expect(call.create.state).toBe('approved');
+    expect(call.create.approvedAt).toBeInstanceOf(Date);
+    expect(call.update).toMatchObject({ owner: 'Tom', note: 'Looks good', state: 'approved', revokedAt: null });
+    expect(call.update.approvedAt).toBeInstanceOf(Date);
+  });
+
+  it('POST /api/v1/tasks/:id/approvals is idempotent — re-approving updates owner/note/approvedAt', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce({ id: TASK_ID });
+    prismaMock.taskApproval.upsert.mockResolvedValueOnce(
+      approvalFixture({ owner: 'Quinn', approvedAt: new Date('2026-08-09T01:00:00.000Z') })
+    );
+
+    const app = createApp();
+    const response = await request(app)
+      .post(`/api/v1/tasks/${TASK_ID}/approvals`)
+      .send({ type: 'spec', owner: 'Quinn' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.owner).toBe('Quinn');
+    const call = prismaMock.taskApproval.upsert.mock.calls[0][0];
+    expect(call.where).toEqual({ taskId_type: { taskId: TASK_ID, type: 'spec' } });
+  });
+
+  it('POST /api/v1/tasks/:id/approvals trims whitespace from owner and note', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce({ id: TASK_ID });
+    prismaMock.taskApproval.upsert.mockResolvedValueOnce(approvalFixture());
+
+    const app = createApp();
+    await request(app)
+      .post(`/api/v1/tasks/${TASK_ID}/approvals`)
+      .send({ type: 'spec', owner: '  Tom  ', note: '  ok  ' });
+
+    const call = prismaMock.taskApproval.upsert.mock.calls[0][0];
+    expect(call.create.owner).toBe('Tom');
+    expect(call.create.note).toBe('ok');
+  });
+
+  it('POST /api/v1/tasks/:id/approvals treats absent note as null', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce({ id: TASK_ID });
+    prismaMock.taskApproval.upsert.mockResolvedValueOnce(approvalFixture());
+
+    const app = createApp();
+    await request(app)
+      .post(`/api/v1/tasks/${TASK_ID}/approvals`)
+      .send({ type: 'spec', owner: 'Tom' });
+
+    const call = prismaMock.taskApproval.upsert.mock.calls[0][0];
+    expect(call.create.note).toBeNull();
+  });
+
+  it('POST /api/v1/tasks/:id/approvals rejects invalid approval type', async () => {
+    const app = createApp();
+    const response = await request(app)
+      .post(`/api/v1/tasks/${TASK_ID}/approvals`)
+      .send({ type: 'invalid', owner: 'Tom' });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: { code: 'INVALID_APPROVAL_TYPE', message: 'type must be one of: spec, tech_design, qa' }
+    });
+    expect(prismaMock.taskApproval.upsert).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/v1/tasks/:id/approvals rejects missing owner', async () => {
+    const app = createApp();
+    const response = await request(app)
+      .post(`/api/v1/tasks/${TASK_ID}/approvals`)
+      .send({ type: 'spec' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('APPROVAL_OWNER_REQUIRED');
+    expect(prismaMock.taskApproval.upsert).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/v1/tasks/:id/approvals rejects whitespace-only owner', async () => {
+    const app = createApp();
+    const response = await request(app)
+      .post(`/api/v1/tasks/${TASK_ID}/approvals`)
+      .send({ type: 'spec', owner: '   ' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('APPROVAL_OWNER_REQUIRED');
+  });
+
+  it('POST /api/v1/tasks/:id/approvals rejects non-string note', async () => {
+    const app = createApp();
+    const response = await request(app)
+      .post(`/api/v1/tasks/${TASK_ID}/approvals`)
+      .send({ type: 'spec', owner: 'Tom', note: 42 });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('INVALID_APPROVAL_NOTE');
+  });
+
+  it('POST /api/v1/tasks/:id/approvals returns 404 when task is missing', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce(null);
+
+    const app = createApp();
+    const response = await request(app)
+      .post(`/api/v1/tasks/${OTHER_TASK_ID}/approvals`)
+      .send({ type: 'spec', owner: 'Tom' });
+
+    expect(response.status).toBe(404);
+    expect(prismaMock.taskApproval.upsert).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/v1/tasks/:id/approvals does not modify task description or create a comment', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce({ id: TASK_ID });
+    prismaMock.taskApproval.upsert.mockResolvedValueOnce(approvalFixture());
+
+    const app = createApp();
+    await request(app)
+      .post(`/api/v1/tasks/${TASK_ID}/approvals`)
+      .send({ type: 'spec', owner: 'Tom' });
+
+    expect(prismaMock.taskComment.create).not.toHaveBeenCalled();
+    expect(prismaMock.task.update).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /api/v1/tasks/:id/approvals/:type revokes an existing approval', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce({ id: TASK_ID });
+    prismaMock.taskApproval.findUnique.mockResolvedValueOnce(approvalFixture());
+    prismaMock.taskApproval.update.mockResolvedValueOnce(
+      approvalFixture({
+        state: 'revoked',
+        revokedAt: new Date('2026-08-09T02:00:00.000Z')
+      })
+    );
+
+    const app = createApp();
+    const response = await request(app).delete(`/api/v1/tasks/${TASK_ID}/approvals/spec`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.state).toBe('revoked');
+    expect(response.body.data.revokedAt).toBe('2026-08-09T02:00:00.000Z');
+    const updateCall = prismaMock.taskApproval.update.mock.calls[0][0];
+    expect(updateCall.where).toEqual({ taskId_type: { taskId: TASK_ID, type: 'spec' } });
+    expect(updateCall.data.state).toBe('revoked');
+    expect(updateCall.data.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it('DELETE /api/v1/tasks/:id/approvals/:type is a no-op when no approval row exists', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce({ id: TASK_ID });
+    prismaMock.taskApproval.findUnique.mockResolvedValueOnce(null);
+
+    const app = createApp();
+    const response = await request(app).delete(`/api/v1/tasks/${TASK_ID}/approvals/spec`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toBeNull();
+    expect(prismaMock.taskApproval.update).not.toHaveBeenCalled();
+    expect(prismaMock.taskApproval.upsert).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /api/v1/tasks/:id/approvals/:type rejects invalid type', async () => {
+    const app = createApp();
+    const response = await request(app).delete(`/api/v1/tasks/${TASK_ID}/approvals/invalid`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('INVALID_APPROVAL_TYPE');
+    expect(prismaMock.taskApproval.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /api/v1/tasks/:id/approvals/:type returns 404 when task is missing', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce(null);
+
+    const app = createApp();
+    const response = await request(app).delete(`/api/v1/tasks/${OTHER_TASK_ID}/approvals/spec`);
+
+    expect(response.status).toBe(404);
+    expect(prismaMock.taskApproval.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('GET /api/v1/tasks/:id embeds approvals in the response', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce({
+      id: TASK_ID,
+      title: 'Task with approvals',
+      description: null,
+      status: 'ready',
+      statusChangedAt: new Date('2026-08-08T04:00:00.000Z'),
+      priority: 'urgent',
+      dueAt: null,
+      completedAt: null,
+      assignee: null,
+      archivedAt: null,
+      blocked: false,
+      specChecksum: null,
+      createdAt: new Date('2026-08-08T04:00:00.000Z'),
+      updatedAt: new Date('2026-08-08T04:00:00.000Z'),
+      tags: [],
+      dependencies: [],
+      comments: [],
+      approvals: [
+        approvalFixture({ type: 'spec', owner: 'Tom' }),
+        approvalFixture({ id: 'approval-2', type: 'tech_design', owner: 'Quinn' })
+      ]
+    });
+
+    const app = createApp();
+    const response = await request(app).get(`/api/v1/tasks/${TASK_ID}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.approvals).toHaveLength(2);
+    expect(response.body.data.approvals[0]).toMatchObject({ type: 'spec', owner: 'Tom' });
+    expect(response.body.data.approvals[1]).toMatchObject({ type: 'tech_design', owner: 'Quinn' });
+  });
+
+  it('GET /api/v1/tasks list endpoint embeds approvals on each row', async () => {
+    prismaMock.task.findMany.mockResolvedValueOnce([
+      {
+        id: TASK_ID,
+        title: 'Task A',
+        description: null,
+        status: 'ready',
+        statusChangedAt: new Date('2026-08-08T04:00:00.000Z'),
+        priority: 'urgent',
+        dueAt: null,
+        completedAt: null,
+        assignee: null,
+        archivedAt: null,
+        blocked: false,
+        specChecksum: null,
+        createdAt: new Date('2026-08-08T04:00:00.000Z'),
+        updatedAt: new Date('2026-08-08T04:00:00.000Z'),
+        tags: [],
+        dependencies: [],
+        approvals: [approvalFixture({ type: 'spec', owner: 'Tom' })]
+      }
+    ]);
+
+    const app = createApp();
+    const response = await request(app).get('/api/v1/tasks');
+
+    expect(response.status).toBe(200);
+    expect(response.body.data[0].approvals).toHaveLength(1);
+    expect(response.body.data[0].approvals[0]).toMatchObject({ type: 'spec', owner: 'Tom' });
+  });
+
+  it('POST /api/v1/tasks/:id/approvals path does not collide with PATCH /tasks/:id (different route shape)', async () => {
+    prismaMock.task.findFirst.mockResolvedValueOnce({ id: TASK_ID });
+    prismaMock.taskApproval.upsert.mockResolvedValueOnce(approvalFixture());
+
+    const app = createApp();
+    const response = await request(app)
+      .post(`/api/v1/tasks/${TASK_ID}/approvals`)
+      .send({ type: 'spec', owner: 'Tom' });
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.task.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements the data, API, and UI surface for native approvals on Tasks
API tasks. Approval state is now a first-class collection on each task
(WS1), configurable per task type via a YAML file outside the repo (WS2),
migratable from the legacy description / comment conventions (WS4a), and
rendered on the task detail view with checkbox + avatar rows (WS4b).

The lobster rewire (WS3, AC4) lands in a separate PR because the lobster
crate has its own build cycle and a regression there blocks the cron.

**Scope of this PR (WS1 + WS2 + WS4a + WS4b):**

- **WS1 (AC1, AC2)** — New Prisma model `TaskApproval` with `ApprovalType`
  and `ApprovalState` enums. One row per `(taskId, type)`. Cascade-deletes
  with the parent task. New routes mounted under `/api/v1`:
  - `GET /tasks/:id/approvals` — list approvals for a task
  - `POST /tasks/:id/approvals` — approve (idempotent on `(taskId, type)`,
    re-stamps `approvedAt`, clears `revokedAt`)
  - `DELETE /tasks/:id/approvals/:type` — revoke (idempotent; revoking a
    non-existent row is a no-op, returns `{ data: null }`)
  - `GET /api/v1/tasks` and `GET /api/v1/tasks/:id` now embed `approvals`
    in the response, mapped via the new `mapTaskApproval` helper.

- **WS2 (AC3)** — `taskType → required-approvals` map. The Tasks API
  loads `.openclaw/tasks-api/required-approvals.yaml` on startup; if the
  file is missing or malformed, the loader falls back to a built-in
  default and logs a WARN. New endpoint:
  - `GET /api/v1/task-types/:taskType/required-approvals` — returns the
    resolved list for a given task type. The default mapping is
    `feature → [spec, tech_design, qa]`, `code → [tech_design, qa]`,
    `content → [spec, qa]`, `research → []`. File path is overridable
    via `REQUIRED_APPROVALS_CONFIG_PATH` env var.

- **WS4a (AC5)** — `services/tasks-api/scripts/migrate-legacy-approvals.ts`
  reads legacy approval state from task descriptions and comments:
  - `- [x] **Approved by Tom**` in description → `spec` approval, owner=Tom
  - `[tech-design-approved] true` in a comment → `tech_design` approval,
    owner=comment.author
  - `[qa-ac-verified] true` in a comment → `qa` approval, owner=comment.author
  - `- [ ] **Approved by Tom**` (unchecked) is intentionally not migrated
  Three modes: `--dry-run` (print summary, no writes), `--write` (write
  through the canonical endpoint, save a snapshot to
  `~/.openclaw/tasks-api/snapshots/<ts>.json`), `--rollback <path>` (drop
  rows from a snapshot).

- **WS4b (AC6)** — Tasks UI `ApprovalsSection` on the task detail view.
  One row per required approval type, rendered as a checkbox + avatar.
  Checked ⇔ approved, muted ⇔ pending, strike-through ⇔ revoked. Owner
  name + timestamp are in `aria-label` / `title` only — no inline text
  labels. Read-only; writes flow through the API.

**Implementation note on AC2 endpoint shape:** AC2 says "PATCH or POST".
This PR uses `POST` for approve and `DELETE` for revoke — REST-canonical
verbs for state changes on a sub-resource. `POST` writes `state=approved`,
`DELETE` writes `state=revoked, revokedAt=now()`. Neither touches
`Task.description` or `TaskComment`.

**Out of scope (subsequent PR):**

- **WS3 (AC4)** — lobster reads from API fields with `--approval-source=auto|api|legacy`
  fallback. Branch `task-ffa30da7-feature-task-lobster-approval-rewire`.
  Legacy comment-tag parsing paths stay in place for the migration window.

## Acceptance Criteria

- [x] AC1: A task exposes a structured `approvals` collection — each entry has a type, an owner, an approved state, and a timestamp — readable via the existing task GET and list endpoints (🧪 testID: services/tasks-api/test/taskApprovals.test.ts — `GET /tasks/:id/approvals` lists approvals, `GET /tasks/:id` embeds `approvals`, `GET /tasks` list endpoint embeds `approvals` on each row)
- [x] AC2: An agent or caller can set an approval to approved (or revoke it) via a dedicated PATCH or POST endpoint, without modifying the task description or posting a comment (🧪 testID: services/tasks-api/test/taskApprovals.test.ts — `POST /tasks/:id/approvals` creates a new approval, `POST` is idempotent and re-stamps `approvedAt`, `DELETE /tasks/:id/approvals/:type` revokes an existing approval, `POST` does not modify `Task.description` or create a `TaskComment` row)
- [x] AC3: Which approval types are required for a task is determined by its `taskType` — the mapping is configurable without a code deploy (e.g. `feature` requires `spec`, `tech-design`, `qa`; `content` requires `spec`, `qa`) (🧪 testID: services/tasks-api/test/requiredApprovals.test.ts — `GET /api/v1/task-types/feature/required-approvals` returns `[spec, tech_design, qa]`, `GET /api/v1/task-types/research/required-approvals` returns `[]`, YAML loader merges over the built-in default)
- [ ] AC4: The lobster's `spec_check`, `ready_checks`, and `post_merge` gates read approval state from the API fields rather than parsing description text or comment bodies (📄 not code: WS3 lands in a separate lobster-crate PR on branch `task-ffa30da7-feature-task-lobster-approval-rewire` per Quinn's sequencing; legacy comment-tag parsing paths remain in place for the migration window)
- [x] AC5: Existing tasks with approval state encoded in descriptions or comments are migrated or remain functional — a task that previously passed a lobster gate continues to pass it after the migration (🧪 testID: services/tasks-api/test/legacyApprovals.test.ts — `detectLegacyApprovals` extracts `**Approved by Tom**`, `[tech-design-approved] true`, `[qa-ac-verified] true`; `summarizeMigration` counts created vs skipped-existing across the task set; migration script is idempotent on the [taskId, type] unique index and writes through the canonical `POST /tasks/:id/approvals` endpoint)
- [x] AC6: The Tasks UI surfaces the approval state for each required approval on a task's detail view, including who approved and when (🧪 testID: apps/tasks/src/components/ApprovalsSection.test.jsx — renders one row per required approval type, marks approved rows as checked, surfaces `aria-label` tooltip with owner name + timestamp, shows empty state when no approvals are required)

## Validation

- `npx prisma validate` — schema OK
- `npx vitest run --exclude test/db-integration.test.ts` (tasks-api) — **runs green**, including the new suites:
  - `test/requiredApprovals.test.ts` — 12/12 new cases (parser, loader, endpoint)
  - `test/legacyApprovals.test.ts` — 9/9 new cases (detection, summary)
  - `test/taskApprovals.test.ts` — 21/21 (existing WS1 cases, regression check)
  - `test/read-endpoints.test.ts` — green (regression check for the `approvals` include in `GET /tasks`)
- `npx vitest run` (apps/tasks) — **166/166 passed**, including 5 new `ApprovalsSection.test.jsx` cases.
- Migration script syntax-checked via `tsc --noEmit` and the typed `legacyApprovals.ts` extraction is covered by the legacy-approvals unit tests.

## System Spec

The tech design doc on this branch (`docs/specs/tasks-api-native-approvals-tech-design.md`)
is the source of truth for the WS1/WS2/WS4 implementation. The
consolidated system-spec update for `docs/systems/tasks.md` lands with
WS3 (lobster rewire), since the API + UI surface isn't load-bearing for
the workflow until the lobster actually reads from it.

## Migration

- A new migration file `services/tasks-api/prisma/migrations/20260808050000_add_task_approvals/migration.sql`
  creates the `ApprovalType` and `ApprovalState` enums, the `TaskApproval`
  table, the `(taskId, type)` unique index, the `(taskId, state)` lookup
  index, and the cascade FK to `Task`. No data backfill in this migration
  — backfill is the `migrate-legacy-approvals.ts` script (`services/tasks-api/scripts/`).
- Out-of-repo configuration: Quinn or Tom can write
  `~/.openclaw/tasks-api/required-approvals.yaml` to override the
  built-in taskType → required-approvals mapping. The Tasks API loads
  this file on startup; if missing or malformed, the built-in default
  applies and a WARN is logged. The file format is documented in
  `services/tasks-api/scripts/README.md` and the test cases in
  `test/requiredApprovals.test.ts`.

## Risks

- **Lobster regression (WS3, deferred).** The lobster is rebuilt on every
  release and any regression in `approval_state()` blocks the feature-task
  cron. Mitigation: legacy fallback paths stay in place for at least one
  release, `--approval-source=auto` defaults to API-with-fallback, and
  Quinn smoke-tests on at least one feature task in each of `ready` and
  `doing` before the WS3 PR merges.
- **Migration script partial failure (WS4a).** The script is idempotent
  on `(taskId, type)`, runs `--dry-run` first, saves a snapshot per
  `--write` invocation, and supports `--rollback` from the snapshot.
- **`owner` field is a free-text string, not a foreign key.** Matches the
  existing `Task.assignee` convention. No referential integrity on
  `owner`; acceptable for v1.

