### PR TITLE
chore(crons): promote Task Lobsters to --approval-source=auto (task ffa30da7 follow-up)

### DIFF
--- a/agents/crons/prompts/task-lobsters.md
+++ b/agents/crons/prompts/task-lobsters.md
@@ -3,10 +3,12 @@ Run the Feature Factory and Content Task workflow lobsters once each.
 ## 1. Feature Task Lobster
 
 ```
-TASKS_API_BASE_URL=${TASKS_API_BASE_URL:-http://localhost:4001/api/v1} python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/feature-task/run.py
+TASKS_API_BASE_URL=${TASKS_API_BASE_URL:-http://localhost:4001/api/v1} python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/feature-task/run.py --approval-source=auto
 ```
 
 The runner discovers active tasks in `open`, `ready`, `doing`, and `acceptance` where `taskType == "feature"` (or `feature-factory` tag), then invokes Lobster for each task.
+
+`--approval-source=auto` was promoted from `legacy` after Quinn's PR #371 smoke tests confirmed gate verdicts match between `--approval-source=legacy` and `--approval-source=auto` paths (PR #371 review, 2026-08-08T07:53:20Z). `auto` reads structured `TaskApproval` rows from the API when present and falls back to legacy text-matching otherwise — no behavior change for tasks without API rows, structured path active for tasks approved via the new endpoints.
 
 **If the lobster reports `ready_checks_blocked` due to missing `[tech-design]`:**
 - Check if Rowan is free (no tasks in `doing` assigned to Rowan):


### PR DESCRIPTION
## Summary

- Promote the Task Lobsters cron to pass `--approval-source=auto` to the feature-task runner, completing the operational follow-up Quinn called out in the PR #371 review.
- `auto` reads structured `TaskApproval` rows from the Tasks API when present and falls back to legacy text-matching otherwise. Quinn's PR #371 review confirmed smoke tests on both `legacy` and `auto` paths matched gate verdicts, so the promotion is safe.
- No behavior change for in-flight tasks with legacy approval encodings (they keep working); structured path is active for tasks approved via the new `/approvals` endpoints (PR #370).

## Context

- PR #371 (WS3 lobster rewire, task ffa30da7 AC4) shipped `--approval-source=legacy|api|auto` with default `legacy` so existing cron behavior was bit-preserved until smoke tests confirmed `auto` was safe.
- Quinn's PR #371 review (2026-08-08T07:53:20Z) ran ready-checks on task `66054ab4` (ready feature) and post-merge on `ffa30da7` with both `--approval-source=legacy` and `--approval-source=auto`; gate verdicts matched. Review explicitly delegated this cron promotion: "After merge, cron can be promoted to `--approval-source=auto` per the PR body."
- This PR is purely operational — one CLI flag on the existing cron command plus a one-paragraph context note for future readers.

## Acceptance Criteria

- [x] AC1: A task exposes a structured `approvals` collection — each entry has a type, an owner, an approved state, and a timestamp — readable via the existing task GET and list endpoints (🔗 pr: #370)
- [x] AC2: An agent or caller can set an approval to approved (or revoke it) via a dedicated PATCH or POST endpoint, without modifying the task description or posting a comment (🔗 pr: #370)
- [x] AC3: Which approval types are required for a task is determined by its `taskType` — the mapping is configurable without a code deploy (e.g. `feature` requires `spec`, `tech-design`, `qa`; `content` requires `spec`, `qa`) (🔗 pr: #370)
- [x] AC4: The lobster's `spec_check`, `ready_checks`, and `post_merge` gates read approval state from the API fields rather than parsing description text or comment bodies (🔗 pr: #371)
- [x] AC5: Existing tasks with approval state encoded in descriptions or comments are migrated or remain functional — a task that previously passed a lobster gate continues to pass it after the migration (🔗 pr: #370)
- [x] AC6: The Tasks UI surfaces the approval state for each required approval on a task's detail view, including who approved and when (🔗 pr: #370)

## Test plan

- [ ] `python3 agents/workflows/feature-task/run.py --help` confirms `--approval-source` accepts `legacy | api | auto` (per PR #371 binary, already in main).
- [ ] Next Task Lobsters cron sweep (every 2h) picks up the new flag automatically.
- [ ] Watch ffa30da7 transition `doing → acceptance` on the next post_merge sweep with `--approval-source=auto`.

Refs task ffa30da7 (post-merge follow-up), PR #370, PR #371.
