### PR TITLE
chore(code-garden): assert required-approvals fallback warn coverage [2026-W32]

### DIFF
--- a/docs/repo-audits/2026-W32.md
+++ b/docs/repo-audits/2026-W32.md
@@ -80,7 +80,7 @@
 - **Why:** Parsing tests do not prove pagination, per-row failure, snapshot creation, retry, and rollback interact safely.
 - **Severity:** Medium.
 
-**[Low] Configuration fallback is not an operational CI-visible failure.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**[Low] Configuration fallback is not an operational CI-visible failure.** ✅ [PR #380](https://github.com/Stoffer-Industries/sindustries/pull/380)
 
 - **Where:** `requiredApprovals.ts:117-141`.
 - **Why:** A malformed `.openclaw` file can switch policy to defaults; tests should assert the warning/health behavior and resolved source.

--- a/docs/repo-audits/2026-W32.md
+++ b/docs/repo-audits/2026-W32.md
@@ -80,7 +80,7 @@
 - **Why:** Parsing tests do not prove pagination, per-row failure, snapshot creation, retry, and rollback interact safely.
 - **Severity:** Medium.
 
-**[Low] Configuration fallback is not an operational CI-visible failure.**
+**[Low] Configuration fallback is not an operational CI-visible failure.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 
 - **Where:** `requiredApprovals.ts:117-141`.
 - **Why:** A malformed `.openclaw` file can switch policy to defaults; tests should assert the warning/health behavior and resolved source.

--- a/services/tasks-api/test/requiredApprovals.test.ts
+++ b/services/tasks-api/test/requiredApprovals.test.ts
@@ -142,6 +142,53 @@ describe('loadRequiredApprovalsConfig', () => {
     expect(config.hash).toBe(DEFAULT_REQUIRED_APPROVALS.hash);
   });
 
+  it('emits a console.warn naming the file when parse fails', () => {
+    const path = join(tmpDir, 'required-approvals.yaml');
+    writeFileSync(path, 'this is not the right shape', 'utf8');
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const config = loadRequiredApprovalsConfig(path);
+      expect(config.source).toBe('builtin-default');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0] ?? '');
+      expect(message).toMatch(/\[required-approvals\]/);
+      expect(message).toContain(path);
+      expect(message).toMatch(/Falling back to built-in default/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not warn when the config file is missing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const config = loadRequiredApprovalsConfig(join(tmpDir, 'does-not-exist.yaml'));
+      expect(config.source).toBe('builtin-default');
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not warn when the config file parses cleanly', () => {
+    const path = join(tmpDir, 'required-approvals.yaml');
+    writeFileSync(
+      path,
+      ['version: 1', 'mappings:', '  feature: [qa]'].join('\n'),
+      'utf8'
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const config = loadRequiredApprovalsConfig(path);
+      expect(config.source).toBe('config-file');
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('returns a stable hash for the builtin default', () => {
     expect(DEFAULT_REQUIRED_APPROVALS.hash).toMatch(/^[0-9a-f]{64}$/);
     expect(DEFAULT_REQUIRED_APPROVALS.hash).toBe(DEFAULT_REQUIRED_APPROVALS.hash);


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W32.md
- **Finding:** [Low] Configuration fallback is not an operational CI-visible failure
- Adds three focused unit tests asserting the `console.warn` emission policy in `loadRequiredApprovalsConfig` — warn is emitted exactly once with a stable `[required-approvals]` prefix on parse failure, and is silent on missing-file (default path) and clean-parse. Test-only; no source or behavior changes.

## Test plan
- [x] `npx vitest run services/tasks-api/test/requiredApprovals.test.ts` — 17/17 pass
- [x] No logic changes — diff is purely test additions and an audit-marker line

🌱 Code garden — non-functional cleanup only