### PR TITLE
fix(workflows): restore task lobster cron plumbing

### DIFF
--- a/agents/workflows/content-tasks/scripts/common.py
+++ b/agents/workflows/content-tasks/scripts/common.py
@@ -12,8 +12,13 @@ import sys
 from pathlib import Path
 from typing import Any
 
-WORKSPACE = Path(os.environ.get("OPENCLAW_WORKSPACE_ROOT") or Path(__file__).resolve().parents[5])
-TASKS_CLIENT_DIR = WORKSPACE / "agents" / "skills" / "ops" / "tasks-api"
+# Compute the tasks-api client directory relative to this file. The client lives inside the
+# sindustries repo at <sindustries>/agents/skills/ops/tasks-api/. Resolving from __file__
+# avoids the OPENCLAW_WORKSPACE_ROOT convention entirely and survives cron contexts where the
+# env var is unset (which previously broke — see task-lobster-runner-flag-and-path-drift runbook).
+_SCRIPT_DIR = Path(__file__).resolve().parent  # .../content-tasks/scripts
+_SINDUSTRIES_ROOT = _SCRIPT_DIR.parents[3]  # .../sindustries (parents[3] from scripts/)
+TASKS_CLIENT_DIR = _SINDUSTRIES_ROOT / "agents" / "skills" / "ops" / "tasks-api"
 if str(TASKS_CLIENT_DIR) not in sys.path:
     sys.path.insert(0, str(TASKS_CLIENT_DIR))
 

--- a/agents/workflows/feature-task/code-task.lobster.yaml
+++ b/agents/workflows/feature-task/code-task.lobster.yaml
@@ -37,6 +37,8 @@ args:
     default: ${WORKSPACE_ROOT}
   dryRun:
     default: false
+  approvalSource:
+    default: legacy
 
 steps:
   - id: load_task
@@ -47,33 +49,33 @@ steps:
   - id: code_task_tech_design_check
     command: >-
       cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
-      code-task-tech-design-check --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+      code-task-tech-design-check --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot} --approval-source ${approvalSource}
     stdin: $load_task.stdout
 
   - id: code_task_ready_checks
     command: >-
       cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
-      code-task-ready-checks --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+      code-task-ready-checks --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot} --approval-source ${approvalSource}
     stdin: $code_task_tech_design_check.stdout
     condition: $code_task_tech_design_check.json.criteriaMet
 
   - id: code_task_verify_delivery
     command: >-
       cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
-      verify-delivery --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+      verify-delivery --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot} --approval-source ${approvalSource}
     stdin: $code_task_ready_checks.stdout
     condition: $code_task_ready_checks.json.criteriaMet
 
   - id: feedback_aggregate
     command: >-
       cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
-      feedback-aggregate --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+      feedback-aggregate --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot} --approval-source ${approvalSource}
     stdin: $code_task_verify_delivery.stdout
     condition: $code_task_verify_delivery.json.criteriaMet
 
   - id: post_merge
     command: >-
       cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
-      post-merge --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+      post-merge --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot} --approval-source ${approvalSource}
     stdin: $feedback_aggregate.stdout
     condition: $feedback_aggregate.json.criteriaMet

--- a/agents/workflows/feature-task/feature-task.lobster.yaml
+++ b/agents/workflows/feature-task/feature-task.lobster.yaml
@@ -11,6 +11,8 @@ args:
     default: ${WORKSPACE_ROOT}
   dryRun:
     default: false
+  approvalSource:
+    default: legacy
 
 steps:
   - id: load_task
@@ -21,33 +23,33 @@ steps:
   - id: spec_check
     command: >-
       cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
-      spec-check --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+      spec-check --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot} --approval-source ${approvalSource}
     stdin: $load_task.stdout
 
   - id: ready_checks
     command: >-
       cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
-      ready-checks --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+      ready-checks --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot} --approval-source ${approvalSource}
     stdin: $spec_check.stdout
     condition: $spec_check.json.criteriaMet
 
   - id: verify_delivery
     command: >-
       cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
-      verify-delivery --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+      verify-delivery --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot} --approval-source ${approvalSource}
     stdin: $ready_checks.stdout
     condition: $ready_checks.json.criteriaMet
 
   - id: feedback_aggregate
     command: >-
       cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
-      feedback-aggregate --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+      feedback-aggregate --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot} --approval-source ${approvalSource}
     stdin: $verify_delivery.stdout
     condition: $verify_delivery.json.criteriaMet
 
   - id: post_merge
     command: >-
       cargo run --manifest-path ${sindustriesRepo}/agents/workflows/feature-task/Cargo.toml --
-      post-merge --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot}
+      post-merge --base-url ${tasksApiBaseUrl} --dry-run ${dryRun} --repo ${sindustriesRepo} --workspace-root ${workspaceRoot} --approval-source ${approvalSource}
     stdin: $feedback_aggregate.stdout
     condition: $feedback_aggregate.json.criteriaMet

--- a/agents/workflows/feature-task/run.py
+++ b/agents/workflows/feature-task/run.py
@@ -117,7 +117,7 @@ def stream_reader(pipe, prefix: str, sink: list[str]) -> None:
         pipe.close()
 
 
-def run_workflow(task_id: str, base_url: str, dry_run: bool, pipeline: Path) -> dict[str, Any]:
+def run_workflow(task_id: str, base_url: str, dry_run: bool, approval_source: str, pipeline: Path) -> dict[str, Any]:
     args_json = json.dumps(
         {
             "taskId": task_id,
@@ -125,8 +125,14 @@ def run_workflow(task_id: str, base_url: str, dry_run: bool, pipeline: Path) -> 
             "sindustriesRepo": str(REPO),
             "workspaceRoot": str(WORKSPACE_ROOT),
             "dryRun": dry_run,
+            "approvalSource": approval_source,
         }
     )
+    # NOTE: --approval-source is NOT passed as a top-level flag to the lobster CLI
+    # (the Node.js lobster CLI does not accept that flag; see the PR #371 / #372
+    # history and the abandoned ff14d56 plumbing). It travels through the
+    # --args-json payload → YAML `approvalSource` arg → ${approvalSource}
+    # expansion in each cargo run subcommand.
     cmd = ["lobster", "run", "--mode", "tool", str(pipeline), "--args-json", args_json]
     proc = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=workflow_env())
     stdout_lines: list[str] = []
@@ -158,11 +164,23 @@ def main() -> int:
     parser.add_argument("--base-url", default=os.environ.get("TASKS_API_BASE_URL", DEFAULT_BASE_URL))
     parser.add_argument("--limit", type=int, default=100)
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--approval-source",
+        default=os.environ.get("LOBSTER_APPROVAL_SOURCE", "legacy"),
+        choices=["legacy", "api", "auto"],
+        help="Approval source mode for lobster gates. Mirrors the lobster CLI flag added in PR #371 (commit 062985d). Default 'legacy' preserves the pre-#372 cron behaviour; the Task Lobsters cron promotes to 'auto'.",
+    )
     args = parser.parse_args()
 
     tasks = discover_tasks(args.base_url, args.limit)
     results = [
-        run_workflow(str(task["id"]), args.base_url, args.dry_run, Path(task["_pipeline"]))
+        run_workflow(
+            str(task["id"]),
+            args.base_url,
+            args.dry_run,
+            args.approval_source,
+            Path(task["_pipeline"]),
+        )
         for task in tasks
     ]
     errors = [result for result in results if result.get("returncode") != 0 or result.get("error")]


### PR DESCRIPTION
## Summary
- Restore `--approval-source` plumbing from the Task Lobsters Python runner through both Lobster YAML pipelines into the Rust workflow commands.
- Resolve the content-task Tasks API client relative to `common.py`, so cron runs no longer depend on an unset workspace environment variable.

## System Spec
No system spec change — this restores existing workflow invocation and import behavior after runner/config path drift.

## Test plan
- [x] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml` (199 passed)
- [x] `cargo clippy --manifest-path agents/workflows/feature-task/Cargo.toml --all-targets -- -D warnings`
- [x] Dry-run `feature-task.lobster.yaml` with `approvalSource:auto` and verify the expanded Rust command includes `--approval-source auto`
- [x] Dry-run `code-task.lobster.yaml` with `approvalSource:auto` and verify the expanded Rust command includes `--approval-source auto`
- [x] Import `common` and its Tasks API client symbols with `OPENCLAW_WORKSPACE_ROOT` unset
