### PR TITLE
fix(tasks-api): migrate-legacy-approvals silently skipped all tech_design/qa approvals

### DIFF
--- a/services/tasks-api/scripts/migrate-legacy-approvals.ts
+++ b/services/tasks-api/scripts/migrate-legacy-approvals.ts
@@ -34,6 +34,7 @@
 
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { argv, env, exit } from 'node:process';
 import type { DetectedApproval } from '../src/lib/legacyApprovals.ts';
 import {
@@ -96,8 +97,8 @@ function printHelp() {
   );
 }
 
-async function fetchAllTasks(): Promise<MigrationTask[]> {
-  const tasks: MigrationTask[] = [];
+export async function fetchTaskListIds(): Promise<string[]> {
+  const ids: string[] = [];
   let cursor: string | null = null;
 
   while (true) {
@@ -111,12 +112,46 @@ async function fetchAllTasks(): Promise<MigrationTask[]> {
     if (!response.ok) {
       throw new Error(`GET /tasks ${response.status}: ${await response.text()}`);
     }
-    const body = (await response.json()) as { data: MigrationTask[]; page: { nextCursor: string | null } };
-    tasks.push(...body.data);
+    const body = (await response.json()) as {
+      data: Array<{ id: string }>;
+      page: { nextCursor: string | null };
+    };
+    ids.push(...body.data.map((task) => task.id));
     if (!body.page.nextCursor) break;
     cursor = body.page.nextCursor;
   }
 
+  return ids;
+}
+
+export async function fetchTaskById(id: string): Promise<MigrationTask> {
+  const response = await fetch(`${BASE_URL}/api/v1/tasks/${id}`, {
+    headers: { Accept: 'application/json' }
+  });
+  if (!response.ok) {
+    throw new Error(`GET /tasks/${id} ${response.status}: ${await response.text()}`);
+  }
+  const body = (await response.json()) as { data: MigrationTask };
+  return body.data;
+}
+
+// GET /api/v1/tasks (list) never populates `comments` on each row — only
+// GET /api/v1/tasks/:id returns the full task including comments. The
+// migration script's legacy-detection logic reads `task.comments` to find
+// `[tech-design-approved] true` / `[qa-ac-verified] true`, so a naive list
+// fetch silently misses every legacy tech_design/qa approval (spec
+// approvals still get detected because `description` IS present on the
+// list response). Fetch the id list first, then hydrate each task
+// individually so detection sees real comment bodies.
+//
+// See docs/systems/... list-endpoint comment gap, also hit previously in
+// the tech-design-approval heartbeat check (sindustries PR #295).
+export async function fetchAllTasks(): Promise<MigrationTask[]> {
+  const ids = await fetchTaskListIds();
+  const tasks: MigrationTask[] = [];
+  for (const id of ids) {
+    tasks.push(await fetchTaskById(id));
+  }
   return tasks;
 }
 
@@ -177,7 +212,16 @@ async function main() {
   console.log(JSON.stringify(summary, null, 2));
 }
 
-main().catch((err) => {
-  console.error('[migrate-legacy-approvals] failed:', err);
-  exit(1);
-});
+// Only auto-run when executed directly (`tsx scripts/migrate-legacy-approvals.ts ...`),
+// not when imported as a module (e.g. from tests importing `fetchAllTasks` /
+// `fetchTaskListIds` / `fetchTaskById` directly). Without this guard, importing
+// the module runs `main()` with the importer's argv, hits the "one of --dry-run,
+// --write, or --rollback is required" error, and calls `exit(1)`, killing the
+// process that imported it (e.g. a test worker).
+const isMain = argv[1] && resolve(argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err) => {
+    console.error('[migrate-legacy-approvals] failed:', err);
+    exit(1);
+  });
+}

--- a/services/tasks-api/test/migrateLegacyApprovalsFetch.test.ts
+++ b/services/tasks-api/test/migrateLegacyApprovalsFetch.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The script reads TASKS_API_BASE_URL at module-load time, so set it before
+// the dynamic import below and use a fresh module instance per test.
+const BASE_URL = 'http://tasks-api.test';
+
+describe('migrate-legacy-approvals fetchAllTasks', () => {
+  const originalEnv = process.env.TASKS_API_BASE_URL;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.TASKS_API_BASE_URL = BASE_URL;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env.TASKS_API_BASE_URL = originalEnv;
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('hydrates every task via GET /tasks/:id so comments are present, not just the list response', async () => {
+    // The list endpoint intentionally mirrors real API behaviour here:
+    // `comments` is always `[]` on GET /tasks (list), even when the task
+    // has real comments — only GET /tasks/:id includes them. A regression
+    // to `fetchAllTasks` using list-response comments directly would make
+    // this test fail because `task-2`'s legacy tech_design approval would
+    // never be detected.
+    const listResponse = {
+      data: [
+        { id: 'task-1', title: 'A', description: '- [x] **Approved by Tom**', comments: [], approvals: [] },
+        { id: 'task-2', title: 'B', description: null, comments: [], approvals: [] }
+      ],
+      page: { nextCursor: null }
+    };
+
+    const detailResponses: Record<string, unknown> = {
+      'task-1': {
+        data: {
+          id: 'task-1',
+          title: 'A',
+          description: '- [x] **Approved by Tom**',
+          status: 'doing',
+          taskType: 'feature',
+          approvals: [],
+          comments: []
+        }
+      },
+      'task-2': {
+        data: {
+          id: 'task-2',
+          title: 'B',
+          description: null,
+          status: 'doing',
+          taskType: 'feature',
+          approvals: [],
+          comments: [
+            {
+              id: 'c1',
+              author: 'Quinn',
+              text: '[tech-design-approved] true',
+              createdAt: '2026-08-08T00:00:00.000Z',
+              updatedAt: '2026-08-08T00:00:00.000Z'
+            }
+          ]
+        }
+      }
+    };
+
+    const fetchMock = vi.fn(async (input: string) => {
+      const url = String(input);
+      if (url === `${BASE_URL}/api/v1/tasks?limit=200`) {
+        return new Response(JSON.stringify(listResponse), { status: 200 });
+      }
+      const idMatch = url.match(/\/api\/v1\/tasks\/([^/?]+)$/);
+      if (idMatch && detailResponses[idMatch[1]]) {
+        return new Response(JSON.stringify(detailResponses[idMatch[1]]), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const mod = await import('../scripts/migrate-legacy-approvals.ts');
+    const tasks = await mod.fetchAllTasks();
+
+    expect(tasks).toHaveLength(2);
+    // GET /tasks/:id was called once per task, not zero times.
+    const detailCalls = fetchMock.mock.calls.filter(([u]) => /\/tasks\/task-[12]$/.test(String(u)));
+    expect(detailCalls).toHaveLength(2);
+
+    const task2 = tasks.find((t) => t.id === 'task-2');
+    expect(task2?.comments).toHaveLength(1);
+    expect(task2?.comments[0]?.text).toBe('[tech-design-approved] true');
+  });
+
+  it('walks pagination via cursor when hydrating the id list', async () => {
+    const page1 = {
+      data: [{ id: 'task-1', title: 'A', description: null, comments: [], approvals: [] }],
+      page: { nextCursor: 'cursor-1' }
+    };
+    const page2 = {
+      data: [{ id: 'task-2', title: 'B', description: null, comments: [], approvals: [] }],
+      page: { nextCursor: null }
+    };
+    const detail = (id: string) => ({
+      data: { id, title: id, description: null, status: 'doing', taskType: 'feature', approvals: [], comments: [] }
+    });
+
+    const fetchMock = vi.fn(async (input: string) => {
+      const url = String(input);
+      if (url === `${BASE_URL}/api/v1/tasks?limit=200`) {
+        return new Response(JSON.stringify(page1), { status: 200 });
+      }
+      if (url === `${BASE_URL}/api/v1/tasks?limit=200&cursor=cursor-1`) {
+        return new Response(JSON.stringify(page2), { status: 200 });
+      }
+      const idMatch = url.match(/\/api\/v1\/tasks\/([^/?]+)$/);
+      if (idMatch) {
+        return new Response(JSON.stringify(detail(idMatch[1])), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const mod = await import('../scripts/migrate-legacy-approvals.ts');
+    const ids = await mod.fetchTaskListIds();
+
+    expect(ids).toEqual(['task-1', 'task-2']);
+  });
+});


### PR DESCRIPTION
## Summary

`migrate-legacy-approvals.ts` (task ffa30da7 WS4a, PR #370) was silently
skipping every legacy `tech_design`/`qa` approval when hydrating tasks for
migration.

## Root cause

`fetchAllTasks()` read tasks straight from `GET /api/v1/tasks` (the list
endpoint). That endpoint never populates `comments` on each row — only
`GET /api/v1/tasks/:id` returns the full task including comments (this is
the same list-endpoint gap noted in Quinn's memory from PR #295, hit
independently here). `detectLegacyApprovals()` reads `task.comments` to find
`[tech-design-approved] true` / `[qa-ac-verified] true`, so with an
always-empty `comments` array, those two approval types were never detected.
Only `spec` (description-embedded `**Approved by Tom**`) was ever migrated,
with no error or warning surfaced.

Confirmed empirically against the local dev API (187 tasks):

| | before | after |
|---|---|---|
| spec | 34 | 34 |
| tech_design | **0** | **304** |
| qa | **0** | **215** |

## Fix

`fetchAllTasks()` now fetches the id list from the paginated list endpoint,
then hydrates each task individually via `GET /tasks/:id` so the detection
logic sees real comment bodies. No change to the migration algorithm
(`planMigration` / `runWrite` / `runRollback`), snapshot format, or CLI
flags/modes.

Also fixed an adjacent footgun found while adding test coverage: the script
called `main()` unconditionally at module load, so importing it (e.g. from
a test that imports `fetchAllTasks` directly) hit the arg-parse error and
called `exit(1)`, killing the importing process. Guarded with an
`import.meta.url`-vs-`argv[1]` check so it only auto-runs when executed
directly as a CLI.

## Verification

- 🧪 New test `test/migrateLegacyApprovalsFetch.test.ts` (2 cases): mocks
  `fetch` to prove the list response's empty `comments` would (regression)
  cause a legacy `tech_design` approval to go undetected, and asserts
  `GET /tasks/:id` is actually called once per task. Also covers cursor
  pagination on the id-list fetch.
- 🧪 Full `services/tasks-api` suite: `npx vitest run` → 203/203 pass
  (16 files).
- 🧪 Manual dry-run against local API before/after the fix (numbers above).
- `npx tsc --noEmit`: zero new errors introduced (pre-existing unrelated
  errors in `tasks.ts`/`contentScheduler` tests untouched by this change).

## Status

No task tracking this — Tom asked for the fix directly after I ran a
dry-run for the WS4a migration runbook execution and found the gap. This is
a `code` task-shaped fix (bug in existing tooling, no new capability) so no
spec/task required per `agents/skills/ops/tasks-create/SKILL.md`.

**Migration has NOT been run with `--write` on any environment (dev,
staging, or prodlike)** — this PR only fixes the detection bug ahead of that
run.