### PR TITLE
fix(content-tasks): preserve workspace path export

### DIFF
--- a/agents/workflows/content-tasks/scripts/common.py
+++ b/agents/workflows/content-tasks/scripts/common.py
@@ -12,12 +12,12 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Compute the tasks-api client directory relative to this file. The client lives inside the
-# sindustries repo at <sindustries>/agents/skills/ops/tasks-api/. Resolving from __file__
-# avoids the OPENCLAW_WORKSPACE_ROOT convention entirely and survives cron contexts where the
-# env var is unset (which previously broke — see task-lobster-runner-flag-and-path-drift runbook).
+# Compute repo-owned paths relative to this file so cron runs do not depend on
+# OPENCLAW_WORKSPACE_ROOT being set. Keep WORKSPACE as the OpenClaw workspace root for
+# consumers such as format_transition.py that resolve brain/ source paths against it.
 _SCRIPT_DIR = Path(__file__).resolve().parent  # .../content-tasks/scripts
-_SINDUSTRIES_ROOT = _SCRIPT_DIR.parents[3]  # .../sindustries (parents[3] from scripts/)
+_SINDUSTRIES_ROOT = _SCRIPT_DIR.parents[3]  # .../sindustries
+WORKSPACE = Path(os.environ.get("OPENCLAW_WORKSPACE_ROOT") or _SCRIPT_DIR.parents[5])
 TASKS_CLIENT_DIR = _SINDUSTRIES_ROOT / "agents" / "skills" / "ops" / "tasks-api"
 if str(TASKS_CLIENT_DIR) not in sys.path:
     sys.path.insert(0, str(TASKS_CLIENT_DIR))

--- a/tests/test_content_task_workflow.py
+++ b/tests/test_content_task_workflow.py
@@ -12,6 +12,7 @@ loaded_path = sys.path[:]
 sys.path.insert(0, content_scripts)
 try:
     import common as content_common  # noqa: E402
+    import format_transition as content_format_transition  # noqa: E402
     from common import ANY_HEADING_RE, OWNER_HEADING_RE, PR_HEADING_RE  # noqa: E402
     from pr_transition import owner_heading_index, owner_sections  # noqa: E402
 finally:
@@ -36,6 +37,13 @@ DESCRIPTION = """**Source:** brain/content/sindustries-weekly-content/2026-07-31
 
 
 class ContentTaskHeadingTests(unittest.TestCase):
+    def test_format_transition_imports_workspace_from_common(self):
+        self.assertEqual(content_format_transition.WORKSPACE, content_common.WORKSPACE)
+        self.assertEqual(
+            content_common.TASKS_CLIENT_DIR,
+            content_common._SINDUSTRIES_ROOT / "agents" / "skills" / "ops" / "tasks-api",
+        )
+
     def test_owner_sections_preserve_heading_text_after_a_preceding_newline(self):
         sections = owner_sections(DESCRIPTION)
 


### PR DESCRIPTION
## Summary
- Restore the `WORKSPACE` export consumed by `format_transition.py` while keeping repo-owned Tasks API paths anchored to `_SINDUSTRIES_ROOT`.
- Add regression coverage that imports `format_transition` through the shared content-task module and verifies both path contracts.

## System Spec
No system spec change — this is a workflow import/path regression fix following PR #382.

## Test plan
- [x] `python3 -m unittest tests.test_content_task_workflow` (5 passed)
- [x] Import `common`, `format_transition`, and Tasks API symbols with `OPENCLAW_WORKSPACE_ROOT` unset
- [x] Dry-run the complete content-task Lobster pipeline and verify `format_transition` is present in the execution plan
