### PR TITLE
chore(code-garden): replace hard-coded workspace path in incident_state [2026-W29]

### DIFF
--- a/agents/lib/incident_state.py
+++ b/agents/lib/incident_state.py
@@ -64,7 +64,9 @@ SCHEMA_PATH_DEFAULT = (
 QUINN_STATE_RELATIVE = Path("brain/state/quinn-ops-state.json")
 LOX_STATE_RELATIVE = Path("brain/state/lox-incident-state.json")
 
-WORKSPACE_DEFAULT = Path(os.environ.get("OPENCLAW_WORKSPACE", "/Users/quinnstoffer/.openclaw/workspace"))
+WORKSPACE_DEFAULT = Path(
+    os.environ.get("OPENCLAW_WORKSPACE") or (Path.home() / ".openclaw" / "workspace")
+)
 
 VALID_OWNERS = {"lox", "quinn"}
 VALID_STATUSES = {"watching", "escalated", "resolved", "false_positive"}

--- a/agents/lib/test_incident_state.py
+++ b/agents/lib/test_incident_state.py
@@ -12,6 +12,7 @@ dedicated test that gracefully skips if jsonschema is not installed.
 from __future__ import annotations
 
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -220,6 +221,30 @@ class LoadAllIncidentsTests(unittest.TestCase):
         out = ist.load_all_incidents(workspace=self.tmpdir)
         self.assertEqual(len(out), 2)
         self.assertTrue(all(e["owner"] == "quinn" for e in out))
+
+
+class WorkspaceDefaultTests(unittest.TestCase):
+    """W29 audit [Low]: WORKSPACE_DEFAULT must not hard-code a laptop path."""
+
+    def test_openclaw_workspace_env_override_is_used(self):
+        sentinel = "/tmp/incident_state_env_override_test"
+        with mock.patch.dict(os.environ, {"OPENCLAW_WORKSPACE": sentinel}, clear=False):
+            # Reload the module so the module-level constant re-evaluates with
+            # the patched env var. Patching os.environ alone does not refresh
+            # already-bound names.
+            import importlib
+            reloaded = importlib.reload(ist)
+            self.assertEqual(
+                Path(reloaded.WORKSPACE_DEFAULT), Path(sentinel)
+            )
+
+    def test_home_fallback_when_env_unset(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("OPENCLAW_WORKSPACE", None)
+            import importlib
+            reloaded = importlib.reload(ist)
+            expected = Path.home() / ".openclaw" / "workspace"
+            self.assertEqual(Path(reloaded.WORKSPACE_DEFAULT), expected)
 
 
 class NeedsTomTests(unittest.TestCase):

--- a/docs/repo-audits/2026-W29.md
+++ b/docs/repo-audits/2026-W29.md
@@ -99,7 +99,7 @@ AI agents
 - *Why it matters:* `sindustriesRepo: /Users/quinnstoffer/workspaces/rowan/sindustries` is Rowan's local path. Any other developer or CI environment must supply the flag explicitly on every `lobster` invocation or the workflow breaks silently.
 - *Severity:* Medium
 
-**[Low] `agents/lib/incident_state.py` reads from a hardcoded default workspace path.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**[Low] `agents/lib/incident_state.py` reads from a hardcoded default workspace path.** ✅ [PR #389](https://github.com/Stoffer-Industries/sindustries/pull/389)
 - *Where:* `agents/lib/incident_state.py` (OPENCLAW workspace root used as default for state file paths)
 - *Why it matters:* Tests must pass a `workspace` argument explicitly to avoid coupling to Quinn's filesystem. The pattern is correct (workspace is a param), but the default is still a path assumption — CI on another machine will skip the filesystem fallback silently.
 - *Severity:* Low

--- a/docs/repo-audits/2026-W29.md
+++ b/docs/repo-audits/2026-W29.md
@@ -99,7 +99,7 @@ AI agents
 - *Why it matters:* `sindustriesRepo: /Users/quinnstoffer/workspaces/rowan/sindustries` is Rowan's local path. Any other developer or CI environment must supply the flag explicitly on every `lobster` invocation or the workflow breaks silently.
 - *Severity:* Medium
 
-**[Low] `agents/lib/incident_state.py` reads from a hardcoded default workspace path.**
+**[Low] `agents/lib/incident_state.py` reads from a hardcoded default workspace path.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 - *Where:* `agents/lib/incident_state.py` (OPENCLAW workspace root used as default for state file paths)
 - *Why it matters:* Tests must pass a `workspace` argument explicitly to avoid coupling to Quinn's filesystem. The pattern is correct (workspace is a param), but the default is still a path assumption — CI on another machine will skip the filesystem fallback silently.
 - *Severity:* Low

--- a/scripts/check-no-absolute-paths.mjs
+++ b/scripts/check-no-absolute-paths.mjs
@@ -19,7 +19,7 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { extname, join, relative, resolve } from 'node:path';
 
-const DEFAULT_ROOTS = ['apps', 'services', 'packages', 'agents/workflows'];
+const DEFAULT_ROOTS = ['apps', 'services', 'packages', 'agents/workflows', 'agents/lib'];
 
 // Directories we never descend into. These are build outputs, vendored
 // deps, or generated artefacts where absolute paths are expected and


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W29.md
- **Finding:** [Low] `agents/lib/incident_state.py` reads from a hardcoded default workspace path.
- Replace the `/Users/<name>/.openclaw/workspace` fallback in `WORKSPACE_DEFAULT` with a portable `Path.home() / '.openclaw' / 'workspace'`. Functionally equivalent on this host (same path), removes the laptop-specific default for any other operator. Extend the no-absolute-paths lint to scan `agents/lib/` so future regressions in shared agent helpers are caught by the same guardrail that already guards `agents/workflows/`.

## Test plan
- [x] Relevant tests pass — `python3 -m unittest agents.lib.test_incident_state` → 22/22 (including 2 new `WorkspaceDefaultTests` covering the env-var override and the `Path.home()` fallback)
- [x] No logic changes — diff is structural: env-default swap + lint root extension + matching tests
- [x] Lint clean — `node scripts/check-no-absolute-paths.mjs` scans 466 files, no offenders
- [x] Lint tests pass — `node scripts/test/check-no-absolute-paths.test.mjs` → 11/11

🌱 Code garden — non-functional cleanup only