### PR TITLE
content: agents as first-class users (Tom-approval)

### DIFF
--- a/apps/website/src/content/experiments.json
+++ b/apps/website/src/content/experiments.json
@@ -124,7 +124,7 @@
     "status": "active",
     "summary": "A mobile-capable workout logging app experiment for testing whether lightweight fitness tracking can become a useful consumer product wedge.",
     "why": "GymTrack is a small consumer-app experiment under the Stoffer umbrella: narrow enough to ship quickly, but real enough to test account creation, repeated use, and mobile-first product quality.\n\nThe first bet is intentionally practical. Workout logging is familiar, recurring, and easy to validate without a large marketplace or complex integrations. A useful MVP only needs to make workouts and sets quick to capture, easy to review, and reliable on the phone someone already brings to the gym.\n\nThe experiment is less about building a full fitness platform and more about testing whether SIndustries can repeatedly take a focused consumer workflow from idea to mobile-capable MVP, then learn from actual usage constraints before overbuilding.",
-    "successCriteria": "The MVP supports authenticated users, workout creation, set logging, and repeated use from iOS Safari without breaking the flow.\n\nThe next evidence gate is live deployment after Supabase provisioning: can the app be used outside the development environment, and does the logging loop feel fast enough to use during a real workout?\n\nSuccess means the product exposes a clear next decision: continue into habit-building features, narrow the use case further, or stop because the workflow is too generic to earn attention.",
+    "successCriteria": "The live product supports authenticated users, workout creation, set logging, and repeated use from iOS Safari without breaking the flow. Public sign-up now lets new users create isolated accounts without manual provisioning.\n\nThe next evidence gate is repeated use beyond the original account: do multiple people return to log workouts, and do connected agents complete the OAuth onboarding path and create useful planned workouts?\n\nSuccess means the usage evidence supports a clear next decision: invest in habit-building and agent-assisted workflows, narrow the use case, or stop because the product does not earn repeated attention.",
     "currentLearning": [
       "The first MVP is built with Vite, React, Supabase auth, and row-level-secured workout and set records.",
       "Mobile web is the first distribution path: the app is designed for iOS Safari before any native wrapper work.",
@@ -133,7 +133,7 @@
       "The first agent-facing feature moved from specification to main in 48 hours with 76 tests passing, providing an end-to-end test of the delivery workflow on a consumer product."
     ],
     "startedAt": "2026-07-13",
-    "updatedAt": "2026-07-31",
+    "updatedAt": "2026-08-06",
     "links": [],
     "image": "/brand/studio/gymtrack-hero.jpg",
     "visibility": "published"

--- a/apps/website/src/content/stories/agents-as-first-class-users.json
+++ b/apps/website/src/content/stories/agents-as-first-class-users.json
@@ -1,0 +1,18 @@
+{
+  "title": "Onboarding agents as first-class users",
+  "slug": "agents-as-first-class-users",
+  "dek": "GymTrack now gives AI agents a real OAuth onboarding path, from an in-product connect action to a live MCP server.",
+  "body": "GymTrack started as a workout logger for people. It now has a second kind of user: an AI agent.\n\nThe latest release puts a Connect to your agent action inside the Workouts tab. It opens a real OAuth flow against GymTrack's live MCP server, so an agent can connect through the product instead of relying on copied tokens or manual setup.\n\n## Why the onboarding path matters\n\nAn API can technically support agents without treating them as users. The difference is onboarding. Human users expect a sign-up screen, clear permissions, and a route into the product. Agents need the same product thinking, expressed through OAuth discovery, scoped access, and an interface that tells the person what they are connecting.\n\nGymTrack now connects those pieces end to end. Public sign-up creates isolated human accounts with Google or Apple. The in-product action starts the agent connection. The MCP server handles OAuth on a live endpoint. Once connected, an agent can work with the secured planned-workout capability that shipped earlier.\n\n## What shipped\n\nThe server is deployed on Fly with live health and OAuth discovery checks. The product action is wired to that server rather than a placeholder. The release passed 138 tests and a live smoke test against the deployed service.\n\nThose details matter because agent integrations often stop at a local demo. A local tool call proves the interface can work. A discoverable OAuth server and an in-product onboarding route prove that another account can reach it through the product.\n\n## The next evidence gate\n\nThe plumbing is live, but shipping it does not prove people want it. The next question is whether real users connect agents repeatedly and whether those agents create planned workouts worth returning to. That usage will decide whether GymTrack invests further in agent-assisted workflows or keeps the integration narrow.\n\nFor now, GymTrack has a complete path for two user types: a person can create an isolated account, and that person can connect an agent through a real OAuth flow.",
+  "source": "internal",
+  "topics": [
+    "SIndustries",
+    "GymTrack",
+    "agents",
+    "MCP",
+    "OAuth"
+  ],
+  "draftedAt": "2026-08-09",
+  "publishedAt": null,
+  "displayOrder": 0,
+  "visibility": "draft"
+}


### PR DESCRIPTION
## Needs Tom approval

## Acceptance criteria

- [x] EDIT experiment/gymtrack — consider updating `successCriteria`: the app is now live-deployed and multi-tenant, so the "live deployment after Supabase provisioning" gate is met. The next evidence gate should move to real repeated multi-user usage / agent-connect adoption. (Rewrites success-gate framing — Tom's call.)
- [x] POSSIBLE STORY — "Agents as first-class users": the GymTrack MCP server + agent-connect CTA is a genuinely novel narrative (a consumer app onboarding AI agents, not just humans, via real OAuth). Strong build-in-public material if Tom wants to greenlight a long-form story. First-person / strategic voice — needs Tom.

## Verification

- `pnpm --dir apps/website run check:content-links`
- `PATH="$PWD/node_modules/.bin:$PATH" pnpm --dir apps/website run build`

Task: 70970701-16aa-4ebc-a5c8-bf4979b4c3e4
