### PR TITLE
docs(agents): mark codebases/sindustries out of bounds; use worktrees

### DIFF
--- a/agents/crons/prompts/repo-audit-weekly.md
+++ b/agents/crons/prompts/repo-audit-weekly.md
@@ -4,25 +4,28 @@ Read and execute the skill at:
 ## Working directory rule (HARD CONSTRAINT)
 
 This cron runs in an isolated session whose `cwd` is **NOT** the sindustries
-repo. Every shell command (Phase 1 exploration, Phase 4 git ops, anything
-that touches the repo) MUST either:
+repo.
 
-1. Use absolute paths (`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/...`), OR
-2. Be prefixed with `cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries && ...`
+**Never mutate the canonical Edge-managed checkout**
+(`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`) — it must stay
+on a clean `main`. Read-only absolute paths into that checkout are fine for
+discovery. For **any write / branch / commit / push**, create a worktree first
+(see the skill runbook step 0) and operate only under
+`/Users/quinnstoffer/.openclaw/workspace/worktrees/repo-audit-<YYYY-Www>/`.
 
-Do NOT rely on relative paths like `services/...`, `docs/...`, `apps/...`. They
-will resolve against the wrong cwd and fail with `exit 1` — this is the bug
-that broke the W31 audit (and probably W28–W30 silently).
+Do NOT `cd` into `codebases/sindustries` for git ops. Do NOT rely on relative
+paths like `services/...`, `docs/...`, `apps/...` without the worktree prefix —
+they resolve against the wrong cwd and fail with `exit 1` (the W31 audit bug).
 
 ## Completion gate (HARD CONSTRAINT)
 
 A successful session MUST end with all four of these, in order, before the
 session ends:
 
-1. `docs/repo-audits/<YYYY-Www>.md` written to disk (not just planned in
-   the assistant text — actually written via `write` tool).
-2. `git add docs/repo-audits/<YYYY-Www>.md && git commit -m "..."` (or
-   the matching commit style).
+1. `docs/repo-audits/<YYYY-Www>.md` written to disk **inside the audit worktree**
+   (not just planned in the assistant text — actually written via `write` tool).
+2. `git add docs/repo-audits/<YYYY-Www>.md && git commit -m "..."` **from that
+   worktree** (or the matching commit style).
 3. `git push -u origin <branch>` — the branch must land on the remote.
 4. PR opened via the pr-open skill (`cod—audit: ...` title, Executive Summary
    body, `code-audit` label, `Stoff81` assignee, `Stoff81` reviewer).

--- a/agents/definitions/README.md
+++ b/agents/definitions/README.md
@@ -10,7 +10,7 @@ Each agent under `agents/definitions/<name>/` uses a consistent set of markdown 
 | `SOUL.md` | Voice, values, character. Who this agent *is*. | Character or voice shifts. Never for procedural rules. |
 | `IDENTITY.md` | Name, avatar, immutable identity facts. | Rarely — identity is stable. |
 | `USER.md` | Facts about the humans this agent serves. | New context about the user. |
-| `TOOLS.md` | Local notes about tools, tokens, worktrees, host-specific config. | Environment or credentials change. |
+| `TOOLS.md` | Local notes about tools, tokens, worktrees, host-specific config. | Environment or credentials change. **Sindustries git work always happens in a personal worktree** — never in the Edge-managed `codebases/sindustries` checkout (see each agent's WORKFLOW.md Worktrees section and workspace `AGENTS.md`). |
 | `HEARTBEAT.md` | **When** the agent checks for work each pass, and **what triggers action**. Polling cadence + per-pass priority rules. | Cadence changes, new triggers, new per-pass campaigns. |
 | `WORKFLOW.md` | **How** the agent executes work — task-state rules, PR standards, escalation triggers. The execution playbook. | Execution steps change, new task states, new PR conventions. |
 | `DoD.md` | Definition of Done — quality bar for calling a task complete. | Quality bar changes. |

--- a/agents/definitions/ivy/WORKFLOW.md
+++ b/agents/definitions/ivy/WORKFLOW.md
@@ -92,7 +92,18 @@ When in doubt, escalate to Tom (medium/high), not Quinn (low).
 
 **Always work in my dedicated worktree: `~/workspaces/ivy/sindustries`**
 
-Never touch the main sindustries worktree (`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`). That is for Rowan. All my git work — branching, committing, pushing — happens in my worktree only.
+Never touch the canonical Edge-managed checkout
+(`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`). It must stay
+on a clean `main` for openclaw-edge + agent-definition sync — it is not a
+working tree for anyone (including Rowan). All my git work — branching,
+committing, pushing — happens in my worktree only.
+
+If that dedicated worktree is missing, create a fresh one with the paved path
+(never check out bare `main` elsewhere):
+
+```bash
+/Users/quinnstoffer/.openclaw/workspace/infra/guards/sindustries-worktree.sh ivy-<slug>
+```
 
 Before starting any new task, ensure my worktree is on a clean `main`:
 ```bash

--- a/agents/definitions/lox/WORKFLOW.md
+++ b/agents/definitions/lox/WORKFLOW.md
@@ -7,9 +7,22 @@ Lox handles infra, security, reliability, and hardening work.
 
 ## Worktrees
 
-Lox's worktrees:
-- `~/workspaces/lox/workspace` — workspace repo (agents, docs, configs)
-- `~/workspaces/lox/sindustries/` — sindustries repo
+**Canonical checkout is out of bounds.**
+`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries` is Edge-managed
+and must stay on a clean `main`. Never `git switch`, edit, commit, or push there.
+A pre-commit hook blocks commits; a 5-min guard resets stray branches.
+
+For every Sindustries code change, create (or reuse) your own worktree:
+
+```bash
+/Users/quinnstoffer/.openclaw/workspace/infra/guards/sindustries-worktree.sh <name>
+cd /Users/quinnstoffer/.openclaw/workspace/worktrees/<name>
+```
+
+- Never `git worktree add … main` (bare `main` may only live in the canonical checkout)
+- After merge: `git -C /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries worktree remove /Users/quinnstoffer/.openclaw/workspace/worktrees/<name>`
+
+Reading skills/scripts under the canonical path is fine; mutating that checkout is not.
 
 ---
 

--- a/agents/definitions/rowan/TOOLS.md
+++ b/agents/definitions/rowan/TOOLS.md
@@ -51,12 +51,17 @@ Rowan has different names in different systems — use the right one per system,
 
 ### Git commits and pushes (sindustries repo)
 
+**Work only inside your own worktree** (see `WORKFLOW.md` → Worktrees). Never
+commit in `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries` — that
+checkout is Edge-managed and a pre-commit hook will block you.
+
 The sindustries repo local git config is set to Quinn's identity. Always
 override the author when committing, and push using an explicit URL with your
 PAT so you never touch the stored remote:
 
 ```bash
 source ~/.openclaw/.env
+# From your worktree (e.g. workspace/worktrees/<name>):
 # Commit as Rowan (override local config inline)
 git -c user.name="rowanstoffer" -c user.email="rowanstoffer@gmail.com" commit -m "..."
 # Push as Rowan (explicit URL, does not change stored origin)

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -9,11 +9,22 @@
 
 ## Worktrees
 
-Rowan's worktrees:
-- `~/workspaces/rowan/workspace` — workspace repo (agents, docs, configs)
-- `~/workspaces/rowan/sindustries/` — sindustries repo
-- Create feature branches from `main`
+**Canonical checkout is out of bounds.**
+`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries` is Edge-managed
+and must stay on a clean `main`. Never `git switch`, edit, commit, or push there.
+A pre-commit hook blocks commits; a 5-min guard resets stray branches.
+
+For every Sindustries code change, create (or reuse) your own worktree:
+
+```bash
+/Users/quinnstoffer/.openclaw/workspace/infra/guards/sindustries-worktree.sh <name>
+cd /Users/quinnstoffer/.openclaw/workspace/worktrees/<name>
+```
+
+- Create feature branches from `origin/main` **inside that worktree**
 - Open PRs from your branch
+- Never `git worktree add … main` (bare `main` may only live in the canonical checkout)
+- After merge: `git -C /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries worktree remove /Users/quinnstoffer/.openclaw/workspace/worktrees/<name>`
 
 ---
 

--- a/agents/skills/dev/code-garden/SKILL.md
+++ b/agents/skills/dev/code-garden/SKILL.md
@@ -45,14 +45,21 @@ Pick one finding that:
 
 Skip any finding that requires understanding product/business intent. If unsure, skip.
 
-### 3. Implement on a chore branch off main
+### 3. Implement in a worktree on a chore branch off main
+
+**Never** branch or commit in the canonical Edge-managed checkout
+(`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`). Create a
+worktree first:
 
 ```bash
-git fetch origin
-git checkout -b chore/code-garden-<audit-week>-<short-slug> origin/main
+SLUG="<audit-week>-<short-slug>"   # e.g. 2026-W26-stale-triage-comment
+BRANCH="chore/code-garden-${SLUG}"
+/Users/quinnstoffer/.openclaw/workspace/infra/guards/sindustries-worktree.sh \
+  "code-garden-${SLUG}" origin/main "$BRANCH"
+cd "/Users/quinnstoffer/.openclaw/workspace/worktrees/code-garden-${SLUG}"
 ```
 
-e.g. `chore/code-garden-2026-W26-stale-triage-comment`
+e.g. branch `chore/code-garden-2026-W26-stale-triage-comment`
 
 Make the minimal change to address the finding. Do not bundle unrelated changes.
 

--- a/agents/skills/dev/repo-audit/SKILL.md
+++ b/agents/skills/dev/repo-audit/SKILL.md
@@ -16,13 +16,21 @@ Ground every claim in actual files: cite file paths and line numbers. If you can
 **Phase 1 / Discovery & Mapping** (read before judging)
 
 > **Working-directory rule.** This audit runs in an isolated session whose
-> `cwd` is NOT the target repo. Every `exec` / `read` / `list` / `git` call
-> MUST use either absolute paths (`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/...`)
-> or be prefixed with `cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries && ...`.
-> Relative paths like `services/...`, `docs/...`, `apps/...` will resolve
-> against the wrong cwd and fail silently with `exit 1`. This is the bug
-> that broke the W31 audit (and may have been silently dropping findings
-> in W28–W30).
+> `cwd` is NOT the sindustries repo. **Never mutate the canonical Edge-managed
+> checkout** at `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`
+> (it must stay on clean `main`). For **read-only** discovery you may use
+> absolute paths into that checkout. For **any write / branch / commit / push**,
+> first create a worktree and operate only there:
+>
+> ```bash
+> /Users/quinnstoffer/.openclaw/workspace/infra/guards/sindustries-worktree.sh \
+>   repo-audit-<YYYY-Www> origin/main code-garden/sindustries/<YYYY-Www>
+> WT=/Users/quinnstoffer/.openclaw/workspace/worktrees/repo-audit-<YYYY-Www>
+> ```
+>
+> Then use `$WT/...` paths or `cd "$WT" && ...`. Relative paths like
+> `services/...` without that prefix resolve against the wrong cwd and fail
+> silently (`exit 1`) — that broke the W31 audit.
 
 Explore the repository systematically before forming any opinions:
 
@@ -137,15 +145,24 @@ after planning; do the write, commit, push, and PR.**
 
 ## Runbook
 
-Target repo: `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`
+Canonical checkout (read-only): `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`
 
-**1. Audit** — run the four-phase prompt above against the target repo. Produce the audit document in memory.
+**0. Create a worktree for all writes** (before writing the audit file or any git ops):
 
-**1a. Verify cwd before any execution.** Run `pwd` first; if it does not
-print `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries`, then
-prefix every subsequent command with `cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries && ...`
-or use absolute paths. This is a one-time check at the start of each Phase 1
-exploration to surface the cwd-mismatch bug if it ever recurs.
+```bash
+WEEK=$(python3 -c "import datetime; y,w,_=datetime.date.today().isocalendar(); print(f'{y}-W{w:02d}')")
+/Users/quinnstoffer/.openclaw/workspace/infra/guards/sindustries-worktree.sh \
+  "repo-audit-${WEEK}" origin/main "code-garden/sindustries/${WEEK}"
+WT="/Users/quinnstoffer/.openclaw/workspace/worktrees/repo-audit-${WEEK}"
+```
+
+Never `cd` into the canonical checkout for branch/commit/push — that breaks Edge.
+
+**1. Audit** — run the four-phase prompt above. Read-only discovery may use
+absolute paths under the canonical checkout; write the document into `$WT`.
+
+**1a. Verify write cwd.** `pwd` / write targets must be under `$WT`, not under
+`codebases/sindustries`. Relative paths without `$WT` will hit the wrong cwd.
 
 **2. Determine the current ISO week:**
 
@@ -153,17 +170,15 @@ exploration to surface the cwd-mismatch bug if it ever recurs.
 python3 -c "import datetime; y,w,_=datetime.date.today().isocalendar(); print(f'{y}-W{w:02d}')"
 ```
 
-**3. Write the audit document** to `docs/repo-audits/<YYYY-Www>.md` in the sindustries repo.
+**3. Write the audit document** to `$WT/docs/repo-audits/<YYYY-Www>.md`.
 
-**4. Create a branch, commit, and push:**
+**4. Commit and push from the worktree:**
 
 ```bash
-cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries
-git fetch origin
-git switch -C code-garden/sindustries/<YYYY-Www> origin/main
-git add docs/repo-audits/<YYYY-Www>.md
-git commit -m "docs: add repo audit <YYYY-Www>"
-git push -u origin code-garden/sindustries/<YYYY-Www> --force-with-lease
+cd "$WT"
+git add "docs/repo-audits/${WEEK}.md"
+git commit -m "docs: add repo audit ${WEEK}"
+git push -u origin "code-garden/sindustries/${WEEK}" --force-with-lease
 ```
 
 **5. Open the PR** using the pr-open skill:


### PR DESCRIPTION
## Summary

Documents that `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries` is the **Edge-managed canonical checkout** and must stay on a clean `main`. Agents must make Sindustries changes in personal worktrees (`infra/guards/sindustries-worktree.sh` / `workspace/worktrees/<name>`), never by branching or committing in the canonical path.

Companion to the workspace main-guard / pre-commit work.

### Files
- `agents/definitions/{rowan,lox,ivy}/WORKFLOW.md` (+ Rowan's `TOOLS.md`) — out-of-bounds rule + paved-path worktree helper; Ivy no longer says the canonical checkout is "for Rowan"
- `agents/skills/dev/repo-audit/SKILL.md` + `agents/crons/prompts/repo-audit-weekly.md` — stop `cd`/`git switch` in canonical; create audit worktree for writes
- `agents/skills/dev/code-garden/SKILL.md` — create worktree before chore branch
- `agents/definitions/README.md` — TOOLS.md row notes the invariant

## Test plan
- [x] Edits landed in a worktree (`workspace/worktrees/docs-canonical-checkout-oob`); canonical stayed on `main` and clean
- [ ] After merge: Edge sync picks up agent-definition updates
- [ ] Spot-check: Rowan/Ivy/Lox heartbeat/WORKFLOW readers see the Worktrees section
