### PR TITLE
chore(code-garden): mark 2026-W30 content-scheduler-auto-post doc finding done

### DIFF
--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -219,8 +219,8 @@ No new performance concerns this week. The Content Scheduler auto-post correctly
 
 ### Documentation
 
-**[Low] `docs/systems/content-scheduler-auto-post.md` describes the JobSchedulerAdapter interface but does not document that the in-process adapter loses jobs on restart.**
-- *Where:* `docs/systems/content-scheduler-auto-post.md`
+**[Low] `docs/systems/content-scheduler-auto-post.md` describes the JobSchedulerAdapter interface but does not document that the in-process adapter loses jobs on restart.** ✅ [PR #268](https://github.com/Stoffer-Industries/sindustries/pull/268) (content since consolidated into [`docs/systems/content-scheduler.md` § In-process adapter: durability and isolation limitations](systems/content-scheduler.md))
+- *Where:* `docs/systems/content-scheduler-auto-post.md` (content now in `docs/systems/content-scheduler.md` § "In-process adapter: durability and isolation limitations")
 - *Why it matters:* Operators need to know the failure mode. The tech-design does discuss "cloud swap = single-class change" but the currently-shipping v1 has an operational limitation that's not captured in the current system doc.
 - *Severity:* Low (new)
 


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W30.md
- **Finding:** [Low] `docs/systems/content-scheduler-auto-post.md` describes the JobSchedulerAdapter interface but does not document that the in-process adapter loses jobs on restart
- The underlying doc work landed in PR #268 (merged 2026-07-20, Tom). The audit's Milestone 3-A entry already cites #268, but the finding line in the Audit Report body had no `✅ [PR #...]` marker. Also updates the finding's `Where:` line to point at the consolidated home of the content (`docs/systems/content-scheduler.md` § "In-process adapter: durability and isolation limitations") since the originally referenced `docs/systems/content-scheduler-auto-post.md` no longer exists.

## Test plan
- [x] No logic changes — diff is purely an audit markdown update (1 file, 2 insertions, 2 deletions)
- [x] `docs/repo-audits/2026-W30.md` now reads with `✅ [PR #268]` on the finding line and a corrected `Where:` pointer
- [x] No code files touched; no tests affected

🌱 Code garden — non-functional cleanup only