### PR TITLE
docs(agents): collapse Rust gate detail into feature-task WORKFLOW

### DIFF
--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -187,21 +187,10 @@ Use the pr-process skill for the full PR lifecycle (reviewer duties, merging): `
 
 ### Rust quality gates (feature-task workflow only)
 
-When a PR touches Rust code under `agents/workflows/feature-task/**`, the following commands must pass locally **before** the PR is opened (or converted from draft → ready-for-review):
-
-```bash
-cargo test  --manifest-path agents/workflows/feature-task/Cargo.toml
-cargo clippy --manifest-path agents/workflows/feature-task/Cargo.toml --all-targets -- -D warnings
-```
-
-These mirror the CI jobs:
-
-- `feature-task-workflow-tests` (in `.github/workflows/ci.yml`) — runs `cargo test`.
-- `feature-task clippy (-D warnings)` (in `.github/workflows/feature-task-clippy.yml`) — runs the clippy command above.
-
-Clippy failures must be fixed before review unless the PR description explicitly documents an accepted temporary exception (and a follow-up issue to track the fix). Do not open a PR with unresolved clippy warnings and rely on the reviewer to approve the exception — exceptions are rare and must be called out.
-
-These gates apply **only** to Rust changes in `agents/workflows/feature-task/**`. Content-only, doc-only, and other non-Rust PRs are explicitly exempt — do not run or report on clippy for those. The matching PR-body checklist in `agents/skills/dev/pr-open/SKILL.md` is conditional for the same reason.
+PRs that touch `agents/workflows/feature-task/**` must satisfy that crate's
+quality gates (local + CI) before ready-for-review. Commands, exception policy,
+and scope live in `agents/workflows/feature-task/WORKFLOW.md` — do not
+duplicate them here. Content/doc/non-Rust PRs are exempt.
 
 When Rowan opens a PR:
 - open as **draft** with **no assignee** — this signals the PR is not yet ready for Tom's attention

--- a/agents/skills/dev/pr-open/SKILL.md
+++ b/agents/skills/dev/pr-open/SKILL.md
@@ -15,23 +15,11 @@ Use this skill whenever you need to open a pull request in the Sindustries repos
 
 ### Validation — Rust workflow PRs
 
-If the PR touches Rust code under `agents/workflows/feature-task/**`, both of these commands must exit zero locally **before** the PR is opened (or moved from draft → ready-for-review):
-
-```bash
-cargo test  --manifest-path agents/workflows/feature-task/Cargo.toml
-cargo clippy --manifest-path agents/workflows/feature-task/Cargo.toml --all-targets -- -D warnings
-```
-
-For these PRs, include the matching conditional checklist in the PR body (under `## Test plan` or as a separate `## Validation` section) so reviewers see the gate evidence at a glance:
-
-```markdown
-- [ ] `cargo test --manifest-path agents/workflows/feature-task/Cargo.toml` (Rust changes only)
-- [ ] `cargo clippy --manifest-path agents/workflows/feature-task/Cargo.toml --all-targets -- -D warnings` (Rust changes only)
-```
-
-Clippy failures must be fixed before review; the only acceptable unfixed-clippy state is a PR description that explicitly documents an accepted temporary exception plus a follow-up issue.
-
-This block applies **only** to PRs that touch `agents/workflows/feature-task/**`. Content-only, doc-only, and other non-Rust PRs are explicitly exempt — omit the checklist entirely. Full rationale lives in `agents/definitions/rowan/WORKFLOW.md`.
+If the PR touches `agents/workflows/feature-task/**`, follow the quality gates
+in `agents/workflows/feature-task/WORKFLOW.md` before opening or marking
+ready-for-review (CI enforces the same gates). Note in the PR test plan that
+tests/clippy are green — do not paste the full `cargo` command lines into
+every PR body. Content/doc/non-Rust PRs skip this entirely.
 
 ## The gh pr create Command
 


### PR DESCRIPTION
## Summary

Follow-up to [#368](https://github.com/Stoffer-Industries/sindustries/pull/368): the Rust quality-gate *detail* (full `cargo test` / `cargo clippy` commands, exception policy, PR-body checklist) was duplicated in Rowan's personal `WORKFLOW.md` and the generic `pr-open` skill. That is the wrong layer.

- **Keep:** CI gates + canonical local commands in `agents/workflows/feature-task/WORKFLOW.md`
- **Collapse:** Rowan `WORKFLOW.md` and `pr-open/SKILL.md` to one-paragraph pointers
- **Drop:** forced PR-body checklist of full cargo command lines

## System Spec

No system spec change — docs/process only.

## Test plan
- [x] `rg "cargo clippy --manifest-path" agents/definitions/rowan/WORKFLOW.md agents/skills/dev/pr-open/SKILL.md` → no matches
- [x] Same command still documented in `agents/workflows/feature-task/WORKFLOW.md`
- [x] Both files still mention feature-task gates and point at the crate WORKFLOW
