### PR TITLE
fix(tasks-api): revoke spec approval on AC edits

### DIFF
--- a/apps/tasks/SPEC.md
+++ b/apps/tasks/SPEC.md
@@ -37,6 +37,7 @@ A focused task management surface for Tom and the agent team. Supports capturing
    - Each row updates optimistically and only the mutating row is disabled. A failed mutation rolls that row back and exposes an accessible row-level error; success refreshes the parent task to reconcile approvals and audit comments.
    - Archived and done tasks have immutable approval controls.
    - Checkbox checked = `approved`; unchecked = `pending` or `revoked` (state is distinguished by avatar opacity / strike-through rather than inline text).
+   - Editing acceptance criteria automatically revokes the structured `spec` approval and records the change in task history; the approval must be granted again after the revised scope is reviewed.
    - Owner display name and timestamp remain in the `aria-label` / hover tooltip so the visual stays uncluttered.
    - The required-approvals list is fetched from `GET /task-types/:type/required-approvals` when a `taskType` is set; if none are required the section shows a friendly empty state.
    - When the task has no `taskType` set yet, the section shows a placeholder asking the user to select one.

--- a/docs/systems/tasks.md
+++ b/docs/systems/tasks.md
@@ -567,7 +567,7 @@ The lobster (`agents/workflows/feature-task/src/main.rs`) recognises three state
 
 | Surface | Behaviour |
 |---|---|
-| `PATCH /tasks/:id` with `description` change | Drift guard fires UNLESS the description change is marker-only (the `**Approved by Tom**` line toggling checked → unchecked). The marker-only exception lives in `services/tasks-api/src/routes/tasks/_spec.ts` (`descriptionsDifferOnlyByApprovalMarker`); bundling any AC text change with the marker toggle still returns `409 SPEC_CHECKSUM_MISMATCH`. |
+| `PATCH /tasks/:id` with `description` change | Drift guard fires UNLESS the description change is marker-only (the `**Approved by Tom**` line toggling checked → unchecked). The marker-only exception lives in `services/tasks-api/src/routes/tasks/_spec.ts` (`descriptionsDifferOnlyByApprovalMarker`); bundling any AC text change with the marker toggle still returns `409 SPEC_CHECKSUM_MISMATCH`. An actual AC change also revokes the structured `spec` approval in the same transaction and records an audit comment, so the legacy marker and structured gate cannot diverge. |
 | `POST /tasks/:id/comments` | Drift-tolerant. Comments are meta-discussion, not scope changes; the lobster must be able to post `[feature-task-progress-checklist]`, `[spec-resynced]`, `[qa-ac-verified]` even when ACs have drifted. |
 | Status changes / dependency adds / tag edits / AC-free PATCH writes | No drift re-check; succeed even if ACs have drifted. |
 

--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -21,7 +21,7 @@ import {
 } from './tasks/_validation.ts';
 import { decodeCursor, encodeCursor } from './tasks/_pagination.ts';
 import { formatTaskTitle, mapTask, mapTaskComment } from './tasks/_mapper.ts';
-import { descriptionWithSpecDriftApprovalState } from './tasks/_spec.ts';
+import { descriptionHasSpecDrift, descriptionWithSpecDriftApprovalState } from './tasks/_spec.ts';
 import { connectTags, validateDependsOnIds } from './tasks/_deps.ts';
 
 export const tasksRouter = Router();
@@ -326,9 +326,12 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
       return badRequest(res, 'INVALID_DEPENDS_ON_IDS', 'dependsOnIds must be an array of UUID strings');
     }
 
-    if (description !== undefined) {
-      updates.description = descriptionWithSpecDriftApprovalState(existing, description || null);
-    }
+    const nextDescription = description === undefined
+      ? undefined
+      : descriptionWithSpecDriftApprovalState(existing, description || null);
+    const specApprovalRevocationRequired = description !== undefined
+      && descriptionHasSpecDrift(existing, nextDescription);
+    if (nextDescription !== undefined) updates.description = nextDescription;
     if (assignee !== undefined) {
       if (assignee && !validAssignees.has(assignee)) {
         return badRequest(res, 'INVALID_ASSIGNEE', 'Assignee must be one of: Tom, Quinn, Rowan, Lox, Ivy');
@@ -407,6 +410,25 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
         where: { id },
         data: updates
       });
+
+      if (specApprovalRevocationRequired) {
+        const specApproval = await tx.taskApproval.findUnique({
+          where: { taskId_type: { taskId: id, type: 'spec' } }
+        });
+        if (specApproval?.state === 'approved') {
+          await tx.taskApproval.update({
+            where: { taskId_type: { taskId: id, type: 'spec' } },
+            data: { state: 'revoked', revokedAt: new Date() }
+          });
+          await tx.taskComment.create({
+            data: {
+              taskId: id,
+              author: 'Tasks API',
+              body: 'Approval spec revoked by Tasks API after acceptance criteria changed.'
+            }
+          });
+        }
+      }
 
       if (hasTagUpdate) {
         await tx.taskTag.deleteMany({ where: { taskId: id } });

--- a/services/tasks-api/src/routes/tasks/_spec.ts
+++ b/services/tasks-api/src/routes/tasks/_spec.ts
@@ -52,8 +52,7 @@ export function uncheckApprovalMarker(description) {
 export function descriptionWithSpecDriftApprovalState(task, description) {
   const nextDescription = description ?? task.description;
   if (!task.specChecksum) return nextDescription;
-  const current = specChecksumForDescription(nextDescription);
-  if (current === task.specChecksum) return nextDescription;
+  if (!descriptionHasSpecDrift(task, nextDescription)) return nextDescription;
   // Allow Tom to check the approval marker even during spec drift — it's his
   // signal to the lobster that he's reviewed the new ACs and authorises resync.
   // Only auto-uncheck when the edit contains actual AC content changes too.
@@ -63,3 +62,12 @@ export function descriptionWithSpecDriftApprovalState(task, description) {
   return uncheckApprovalMarker(nextDescription);
 }
 
+/**
+ * Return whether a proposed description changes the AC checksum already stored
+ * on the task. Marker-only approval changes are intentionally not drift.
+ */
+export function descriptionHasSpecDrift(task, description) {
+  if (!task.specChecksum) return false;
+  if (descriptionsDifferOnlyByApprovalMarker(task.description ?? '', description ?? '')) return false;
+  return specChecksumForDescription(description) !== task.specChecksum;
+}

--- a/services/tasks-api/test/read-endpoints.test.ts
+++ b/services/tasks-api/test/read-endpoints.test.ts
@@ -17,6 +17,10 @@ const prismaMock = {
   taskComment: {
     create: vi.fn()
   },
+  taskApproval: {
+    findUnique: vi.fn(),
+    update: vi.fn()
+  },
   taskTag: {
     deleteMany: vi.fn(),
     createMany: vi.fn()
@@ -456,6 +460,111 @@ describe('tasks api endpoints', () => {
     expect(response.body.data.description).toBe(expectedDescription);
     expect(prismaMock.task.update).toHaveBeenCalledTimes(1);
     expect(prismaMock.task.update.mock.calls[0][0].data.description).toBe(expectedDescription);
+  });
+
+  it('PATCH /api/v1/tasks/:id revokes structured spec approval when ACs drift', async () => {
+    const approvedDescription = '- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it';
+    const driftedDescription = `${approvedDescription}\n- [ ] AC2: Drift`;
+    const expectedDescription = '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n- [ ] AC2: Drift';
+    const checksum = checksumForAcceptanceCriteria(['AC1: Build it']);
+    prismaMock.task.findFirst
+      .mockResolvedValueOnce(
+        task({
+          id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+          description: approvedDescription,
+          specChecksum: checksum
+        })
+      )
+      .mockResolvedValueOnce(
+        task({
+          id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+          description: expectedDescription,
+          specChecksum: checksum,
+          approvals: [{
+            id: 'approval-1',
+            type: 'spec',
+            owner: 'Tom',
+            state: 'revoked',
+            approvedAt: new Date('2026-07-01T00:00:00.000Z'),
+            revokedAt: new Date('2026-07-02T00:00:00.000Z')
+          }]
+        })
+      );
+    prismaMock.task.update.mockResolvedValue(
+      task({
+        id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+        description: expectedDescription,
+        specChecksum: checksum
+      })
+    );
+    prismaMock.taskApproval.findUnique.mockResolvedValue({
+      id: 'approval-1',
+      taskId: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+      type: 'spec',
+      owner: 'Tom',
+      state: 'approved',
+      approvedAt: new Date('2026-07-01T00:00:00.000Z'),
+      revokedAt: null
+    });
+    prismaMock.taskApproval.update.mockResolvedValue({
+      id: 'approval-1',
+      taskId: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+      type: 'spec',
+      owner: 'Tasks API',
+      state: 'revoked',
+      approvedAt: new Date('2026-07-01T00:00:00.000Z'),
+      revokedAt: new Date('2026-07-02T00:00:00.000Z')
+    });
+
+    const app = createApp();
+    const response = await request(app)
+      .patch('/api/v1/tasks/2527ff9d-4369-444f-995d-4d4bb0ac7b70')
+      .send({ description: driftedDescription });
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.taskApproval.findUnique).toHaveBeenCalledWith({
+      where: {
+        taskId_type: {
+          taskId: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+          type: 'spec'
+        }
+      }
+    });
+    expect(prismaMock.taskApproval.update).toHaveBeenCalledWith({
+      where: {
+        taskId_type: {
+          taskId: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+          type: 'spec'
+        }
+      },
+      data: { state: 'revoked', revokedAt: expect.any(Date) }
+    });
+    expect(prismaMock.taskComment.create).toHaveBeenCalledWith({
+      data: {
+        taskId: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+        author: 'Tasks API',
+        body: 'Approval spec revoked by Tasks API after acceptance criteria changed.'
+      }
+    });
+  });
+
+  it('PATCH /api/v1/tasks/:id does not revoke spec approval for marker-only edits', async () => {
+    const storedDescription = '- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it';
+    const updatedDescription = '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it';
+    const checksum = checksumForAcceptanceCriteria(['AC1: Build it']);
+    prismaMock.task.findFirst
+      .mockResolvedValueOnce(task({ description: storedDescription, specChecksum: checksum }))
+      .mockResolvedValueOnce(task({ description: updatedDescription, specChecksum: checksum }));
+    prismaMock.task.update.mockResolvedValue(task({ description: updatedDescription, specChecksum: checksum }));
+
+    const app = createApp();
+    const response = await request(app)
+      .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
+      .send({ description: updatedDescription });
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.taskApproval.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.taskApproval.update).not.toHaveBeenCalled();
   });
 
   it('POST /api/v1/tasks/:id/comments succeeds even when current ACs drifted after spec approval', async () => {


### PR DESCRIPTION
## Summary
- Revoke the structured `spec` approval in the same transaction when a task description edit changes acceptance criteria.
- Preserve the structured approval for marker-only checkbox changes, and record automatic revocation in task comments.
- Document the lifecycle rule in the Tasks system and app specs.

## System Spec
- `docs/systems/tasks.md`
- `apps/tasks/SPEC.md`

## Test plan
- [x] `services/tasks-api`: full test suite — 17 files, 208 tests passed.
- [x] Regression coverage verifies AC drift revokes the structured approval and writes an audit comment.
- [x] Regression coverage verifies marker-only edits do not revoke approval.
- [ ] `npx tsc --noEmit -p services/tasks-api/tsconfig.json` — currently reports pre-existing unrelated test typing/import errors; no errors were reported in the changed source files.

Directly requested by Tom after observing the description marker and structured spec approval diverge.