### PR TITLE
cod—audit: sindustries weekly review 2026-W33

### DIFF
--- a/docs/repo-audits/2026-W33.md
+++ b/docs/repo-audits/2026-W33.md
@@ -1,0 +1,119 @@
+# Sindustries Repository Audit — 2026-W33
+
+## Executive Summary
+
+**Health grade: B.** Sindustries remains a well-structured early-production monorepo with clear app/service/package boundaries, a broad CI matrix, and strong momentum on authorization work. The single biggest improvement since W32 is real: the previously-unauthenticated tasks-api approval write surface now has a genuine authentication boundary (browser sessions + service credentials, timing-safe token checks, an actor→approval-type ACL, and server-derived approval owners) — the recurring High finding is resolved. The principal residual risks are all authorization-consistency issues that emerged as auth was added piecemeal: (1) GymTrack's `/api/agent/*` data endpoints still authenticate against the legacy `gymtrack_agent_api_keys` table, which is completely disjoint from the new OAuth consent/revoke UI, so those grants are unrevocable from the product; (2) the new gymtrack-mcp OAuth server — the most security-sensitive new code, including refresh-token rotation — has a test script but **no CI job**, so its logic never runs in CI; and (3) tasks-api task/comment mutation endpoints remain unauthenticated and trust a caller-supplied `author`, so audit-trail comments can be forged as `Tom`/`Quinn` even though approvals are now locked down. No Critical issue was verified. The top opportunities are unifying GymTrack agent auth onto one revocable system, adding a gymtrack-mcp CI job, and extending the approval-style auth boundary to the rest of the tasks-api write surface.
+
+## Repo Map
+
+**Purpose:** Monorepo for Sindustries product surfaces and agent-operated workflows: Tasks, Mission Control, GymTrack, Budget, Website, shared UI/design tokens, backend APIs, and Rust/Python automation.
+
+**Stack:** Node.js 22; npm workspaces (`package.json`); React/Vite web apps; Expo mobile app; Express + Prisma + PostgreSQL services (`services/tasks-api`, `services/budget-api`); Supabase for GymTrack; a standalone MCP OAuth server (`services/gymtrack-mcp`); Rust feature-task workflow; Python operational workflows; Docker Compose/Tilt; GitHub Actions.
+
+**Architecture:** `apps/*` clients call domain services and Supabase; `packages/*` holds shared UI, tokens, telemetry, and domain code; `services/gymtrack-mcp` is an OAuth-authenticated MCP server that reads GymTrack data from Supabase directly; `infra/*` owns runtime wiring; `agents/*` owns automation.
+
+**Key directories:** `apps/` user-facing products; `services/` backend domains (tasks-api, budget-api, gymtrack-mcp); `packages/` shared libraries; `agents/workflows/feature-task/` Rust Lobster workflow; `agents/workflows/bookmarks/` Python bookmark pipeline; `docs/` architecture, system references, specs, runbooks, and audits; `.github/workflows/` CI/deploy.
+
+**Surprise:** GymTrack now has **two parallel, unrelated agent-authorization systems** — a legacy per-user API-key path (`gymtrack_agent_api_keys`, still serving the live `/api/agent/*` HTTP endpoints) and a new OAuth path (`gymtrack_oauth_*`, served by the MCP server). No current code mints legacy API keys, yet the endpoints that consume them are still deployed, and the "Connected agents" revoke UI only touches the OAuth path.
+
+## Audit Report
+
+### Strengths
+
+- **Approval write auth is now real.** `services/tasks-api/src/middleware/approvalAuth.ts:50-70` authenticates via browser session cookie or `Bearer` service credential, compares tokens with `crypto.timingSafeEqual` (`:40`), enforces an actor→approval-type ACL (`:12-14,45-48`), and rejects client-supplied `owner` (`services/tasks-api/src/routes/taskApprovals.ts:53-55`, `FORGEABLE_APPROVAL_OWNER`). This resolves the W32 High finding.
+- **Content-scheduler publish is gated safely.** `services/tasks-api/src/routes/contentSchedulerPublish.ts:300-315` (`checkActorSecret`) fails fast when `X_ACTOR_SECRET` is configured and compares with `timingSafeEqual` on equal-length buffers; the route enforces it before any real X API call (`contentScheduler.ts:344-359`).
+- **GymTrack OAuth revoke checks ownership.** `apps/gymtrack/api/connected-agents/revoke.js:33-54` verifies `consent.user_id === authData.user.id` before revoking, and revokes consent + tokens + auth codes atomically via `Promise.all`.
+- **Agent API tokens and OAuth tokens are stored hashed**, never in plaintext (`apps/gymtrack/server/agentAuth.js:50-52,82-86`; `services/gymtrack-mcp/src/repo.js` operates on `access_token_hash`/`refresh_token_hash`).
+- **Broad CI matrix** (`.github/workflows/ci.yml`): python workflows, otel-node, mission-control, tasks-api (unit + DB integration), feature-task Rust, budget-api, tasks app (unit + Playwright e2e), website, gymtrack app, design-system sync, and a no-absolute-paths lint.
+
+### Security
+
+**[High] GymTrack `/api/agent/*` endpoints authenticate off a legacy key table disjoint from the OAuth revoke UI.**
+
+- **Where:** `apps/gymtrack/api/agent/history.js:59-68`, `apps/gymtrack/api/agent/planned-workouts.js`, `apps/gymtrack/api/agent/exercises/[exerciseName]/progression.js` all call `resolveAgentIdentity` (`apps/gymtrack/server/agentAuth.js:76-99`), which authenticates a bearer token against `gymtrack_agent_api_keys` (`:82-86`). The "Connected agents" page and revoke flow operate exclusively on `gymtrack_oauth_consents`/`gymtrack_oauth_tokens` (`apps/gymtrack/src/lib/connectedAgents.js:6`, `apps/gymtrack/api/connected-agents/revoke.js:44-53`).
+- **Why:** These are two unrelated authorization systems. Revoking a connected agent in the product UI revokes only the OAuth consent/tokens; it does not touch `gymtrack_agent_api_keys`. Any legacy API key still grants full read access to that user's workout history and planned workouts (endpoints use the service-role `adminClient`, which bypasses RLS — `agentAuth.js:31-43`), and there is no product surface to list or revoke those keys. Compounding this: no current code path *mints* `gymtrack_agent_api_keys` rows (the table is only read in `agentAuth.js` and asserted in tests) — the minting path from the earlier `20260723170000_agent_powered_workouts.sql` feature appears to have been superseded by OAuth without decommissioning the consuming endpoints.
+- **Fact vs judgment:** *Fact* — the two systems are disjoint, the `/api/agent/*` endpoints are live and authenticate only via the legacy table, and revoke covers only OAuth. *Judgment* — real-world severity depends on whether any legacy `gymtrack_agent_api_keys` rows exist in production; if they do, they are effectively non-expiring and unrevocable from the UI.
+- **Severity:** High. → Classification: `tracked-code-task` (auth unification / decommission), plus an Open Question on prod key existence.
+
+**[Medium] tasks-api task and comment mutation is unauthenticated and trusts a caller-supplied author.**
+
+- **Where:** `services/tasks-api/src/routes/tasks.ts:239` (`POST /tasks`), `:306` (`PATCH /tasks/:id`), `:469-484` (`POST /tasks/:id/comments`, `author = req.body?.author`), `:500` (`DELETE /tasks/:id`). None of these register an auth middleware (contrast `taskApprovalsRouter` which uses `requireApprovalPrincipal`). `app.ts:104` mounts the router with only rate limiting on `POST /tasks`.
+- **Why:** After the approval-owner hardening, approvals are server-derived and audited — but a caller can still forge task comments authored as `Tom` or `Quinn` (comment `body` becomes part of the task audit trail the workflow and humans read), and can create, re-scope, transition, or delete tasks with no principal. Task status transitions and comments feed the Lobster feature-task gating, so an unauthenticated writer influences workflow decisions. The approval lockdown closes the front door while this side door stays open.
+- **Fact vs judgment:** *Fact* — no auth on these routes; `author` is caller-controlled free text. *Judgment* — exploitability depends on the service being loopback-only; that assumption is not enforced at the HTTP boundary.
+- **Severity:** Medium. → Classification: `tracked-code-task` (extend the approval-principal boundary, or server-derive comment author).
+
+### Testing
+
+**[Medium] gymtrack-mcp (OAuth server incl. refresh-token rotation) has no CI job.**
+
+- **Where:** `services/gymtrack-mcp/package.json` defines `"test": "vitest run"`, but `.github/workflows/ci.yml` has jobs for every other workspace (tasks-api, budget-api, gymtrack *app*, mission-control, website, otel-node, feature-task) and **none** for `services/gymtrack-mcp`. Only one test file exists in the package.
+- **Why:** The MCP server holds the most security-sensitive new logic — OAuth token issuance, hashing, refresh-token rotation via `gymtrack_rotate_oauth_refresh_token` (`services/gymtrack-mcp/src/repo.js:141-168`). This code never runs in CI, so regressions in token rotation, expiry, or revocation ship undetected. Rotation bugs are classic sources of session-fixation and replay vulnerabilities.
+- **Severity:** Medium (High if rotation logic changes frequently). → Classification: `tracked-code-task` (add CI job) — quick win.
+
+### Code quality
+
+**[Low] Approval service credentials are re-parsed from env JSON on every request, and malformed config fails at request time.**
+
+- **Where:** `services/tasks-api/src/middleware/approvalAuth.ts:16-30,63` — `parseServiceCredentials()` runs inside `requireApprovalPrincipal` per request and `throw`s on malformed `TASKS_API_APPROVAL_SERVICE_CREDENTIALS`.
+- **Why:** A malformed credentials env var surfaces as a 500 on the first authenticated approval attempt rather than as a fail-fast boot error, and the JSON is parsed on every request instead of once. Neither is a correctness bug given the credentials are typically small and static, but validating at startup would turn a latent 500 into an immediate deploy failure and remove per-request work.
+- **Severity:** Low. → Classification: `garden-safe` (memoize + validate at boot; behavior-preserving).
+
+### Architecture & design
+
+**[Medium] Two coexisting GymTrack agent-auth models with no bridge or migration marker.**
+
+- **Where:** legacy `gymtrack_agent_api_keys` (`20260723170000_agent_powered_workouts.sql`) vs OAuth `gymtrack_oauth_*` (`20260804070000_mcp_oauth.sql`); consumers split between `apps/gymtrack/api/agent/*` and `services/gymtrack-mcp`.
+- **Why:** This is the architectural root of the High security finding. There is no documented decision recording that OAuth supersedes the API-key path, no migration to move existing keys onto OAuth, and no removal of the legacy endpoints. The ambiguity means future changes may harden one path and leave the other, exactly as happened with revocation.
+- **Severity:** Medium (documentation/decision debt). → Classification: `needs-human-decision` (see Open Questions).
+
+### Dimensions rated healthy (one line each)
+
+- **Performance:** No new N+1 or unbounded-growth patterns observed in the changed surfaces; approval writes and revoke use single transactions / bounded batches.
+- **Dependencies:** No new heavy or unmaintained additions spotted in the reviewed diffs; lockfiles present for both npm and pnpm.
+- **Documentation:** Route and helper files carry accurate header comments and task/tech-design references (e.g. `contentSchedulerPublish.ts`, `agentAuth.js`); the main gap is the missing OAuth-supersedes-API-key decision record.
+
+## Improvement Strategy
+
+**Themes explaining most findings:**
+
+1. **Authorization was added surface-by-surface, and consistency lagged.** Approvals and content-publish got real auth; task/comment mutation and the two GymTrack agent-auth paths did not converge. *Target state:* one clearly-owned auth boundary per service, and one revocable agent-auth system per product. *Principle:* an authorization control is only as strong as its least-guarded equivalent surface.
+2. **Security-critical new code is under-covered by CI.** The OAuth/MCP server ships without a CI job. *Target state:* every workspace with a `test` script has a CI job; security-sensitive packages have explicit rotation/revocation tests. *Principle:* untested auth code is unshipped safety.
+3. **Superseded mechanisms are left live instead of decommissioned.** Legacy API-key endpoints persist after OAuth arrived. *Target state:* superseding a mechanism includes a migration plan and a removal/kill-switch step. *Principle:* dead code with live credentials is not dead.
+
+**Explicit non-goals (recommend NOT fixing now):**
+
+- Do not rip out the legacy `/api/agent/*` endpoints blind — first confirm no production keys/consumers depend on them (Open Question). A blind delete could break live agent integrations.
+- Do not add a heavyweight auth framework to tasks-api; reuse the existing `approvalAuth` principal pattern.
+
+**"Done" signals:** GymTrack has exactly one agent-auth system that the Connected-agents UI can fully revoke; `services/gymtrack-mcp` runs in CI with rotation/revocation tests; tasks-api mutation endpoints either require a principal or derive `author` server-side.
+
+## Task Plan
+
+**Quick wins (high impact, S effort):**
+
+- **QW1 — Add gymtrack-mcp CI job.** Add a `gymtrack-mcp-tests` job to `ci.yml` mirroring the gymtrack app job but running `npm test --workspace services/gymtrack-mcp`. *Files:* `.github/workflows/ci.yml`. *AC:* CI shows a passing gymtrack-mcp job on PRs touching `services/gymtrack-mcp/**`. *Effort:* S. *Risk:* Low. *Deps:* none.
+
+**Milestone 0 — Safety net**
+
+- **T0.1 — Backfill rotation/revocation tests for gymtrack-mcp.** Cover refresh-token rotation happy path, replay of a rotated token (must fail), and revoked-consent access (must fail). *Files:* `services/gymtrack-mcp/src/repo.js`, new test files. *AC:* tests assert a rotated refresh token cannot be reused and a revoked consent's access token is rejected. *Effort:* M. *Risk:* Low. *Deps:* QW1.
+
+**Milestone 1 — Critical fixes (security/correctness)**
+
+- **T1.1 — Unify GymTrack agent authorization onto one revocable system.** Decide (Open Question) whether `/api/agent/*` moves to OAuth-token validation or the legacy key path is decommissioned; implement so the Connected-agents UI can revoke every live grant. *Files:* `apps/gymtrack/server/agentAuth.js`, `apps/gymtrack/api/agent/*`, migration to drain/expire `gymtrack_agent_api_keys`. *AC:* every agent credential that can read workout data is listed and revocable in the Connected-agents UI; revoking blocks subsequent `/api/agent/*` reads. *Effort:* L. *Risk:* Med (touches live auth). *Deps:* Open Question OQ1; tech design required (`docs/specs/gymtrack-agent-auth-unification-tech-design.md`).
+- **T1.2 — Require a principal (or server-derive author) for tasks-api mutation.** Extend the `approvalAuth`-style principal to `POST/PATCH/DELETE /tasks` and `POST /tasks/:id/comments`, or derive comment `author` from the authenticated principal instead of the request body. *Files:* `services/tasks-api/src/routes/tasks.ts`, `services/tasks-api/src/app.ts`, `middleware/approvalAuth.ts`. *AC:* comment `author` can no longer be forged; unauthenticated task mutation is rejected (or explicitly, tested-as loopback-only). *Effort:* M. *Risk:* Med (many callers write tasks). *Deps:* inventory of task-writing agents first.
+
+**Milestone 3 — Quality & polish**
+
+- **T3.1 — Validate approval service credentials at boot and memoize.** Parse/validate `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` once at startup; fail fast on malformed config. *Files:* `services/tasks-api/src/middleware/approvalAuth.ts`. *AC:* malformed credentials env fails process boot with a clear error; no per-request re-parse. *Effort:* S. *Risk:* Low. *Deps:* none. (`garden-safe`.)
+
+**Top-3 implementation sketches:**
+
+- **QW1:** Copy the `gymtrack-tests` job block in `ci.yml`, rename to `gymtrack-mcp-tests`, set the rollup workspace + `npm test --workspace services/gymtrack-mcp`, gate on `paths: services/gymtrack-mcp/**`.
+- **T1.1:** Add an OAuth-token resolver in `agentAuth.js` that validates `gymtrack_oauth_tokens.access_token_hash` (non-revoked, non-expired) and returns `{ user_id }`; switch `/api/agent/*` to it; write a one-shot migration marking all `gymtrack_agent_api_keys` `revoked_at = now()` after confirming no active consumers.
+- **T1.2:** Introduce `requireTaskActor` mirroring `requireApprovalPrincipal`; in the comment handler, replace `req.body?.author` with `req.taskActor.actor`; keep a loopback bypass behind an explicit env flag if needed for local agents.
+
+## Open Questions
+
+1. **OQ1 (blocks T1.1):** Do any `gymtrack_agent_api_keys` rows exist in production, and are any live agents still calling `/api/agent/*` with legacy keys? If none, T1.1 simplifies to deleting the endpoints + table; if some, we need a migration/communication plan before revoking. *Needs Tom/Quinn.*
+2. **OQ2:** Is tasks-api intended to be strictly loopback-only, or is it (now or soon) reachable beyond localhost (e.g. via the Edge tunnel)? This decides whether T1.2 is "add auth" or "document + enforce loopback." *Needs Tom/Quinn.*
+3. **OQ3:** Should superseding an auth mechanism require a recorded decision (ADR) + decommission step as a checklist item, to prevent the legacy-endpoint pattern recurring? *Process decision.*


### PR DESCRIPTION
## Executive Summary

**Health grade: B.** Sindustries remains a well-structured early-production monorepo with clear app/service/package boundaries, a broad CI matrix, and strong momentum on authorization work. The single biggest improvement since W32 is real: the previously-unauthenticated tasks-api approval write surface now has a genuine authentication boundary (browser sessions + service credentials, timing-safe token checks, an actor→approval-type ACL, and server-derived approval owners) — the recurring High finding is resolved. The principal residual risks are all authorization-consistency issues that emerged as auth was added piecemeal: (1) GymTrack's `/api/agent/*` data endpoints still authenticate against the legacy `gymtrack_agent_api_keys` table, which is completely disjoint from the new OAuth consent/revoke UI, so those grants are unrevocable from the product; (2) the new gymtrack-mcp OAuth server — the most security-sensitive new code, including refresh-token rotation — has a test script but **no CI job**, so its logic never runs in CI; and (3) tasks-api task/comment mutation endpoints remain unauthenticated and trust a caller-supplied `author`, so audit-trail comments can be forged as `Tom`/`Quinn` even though approvals are now locked down. No Critical issue was verified. The top opportunities are unifying GymTrack agent auth onto one revocable system, adding a gymtrack-mcp CI job, and extending the approval-style auth boundary to the rest of the tasks-api write surface.

---

Full audit: [`docs/repo-audits/2026-W33.md`](https://github.com/Stoffer-Industries/sindustries/blob/code-garden/sindustries/2026-W33/docs/repo-audits/2026-W33.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
