### PR TITLE
fix(crons): remove 'no bookmarks' soft-fail keyword false-positive

### DIFF
--- a/agents/crons/prompts/bookmark-ingestion.md
+++ b/agents/crons/prompts/bookmark-ingestion.md
@@ -5,5 +5,6 @@ Do not reimplement the ingest flow. Do not add extra logic. Just run the script 
 
 # notify-soft-fails
 Read /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/notify-soft-fail/SKILL.md and follow it.
-- If the script exits with a non-zero return code, OR if the output contains 'error', 'failed', 'exception', 'traceback', or 'no bookmarks': send failure notification as described in the skill with text: 'Bookmark Ingestion cron failure: <brief summary of what went wrong from the output>'
+- If the script exits with a non-zero return code, OR if the output contains 'error', 'failed', 'exception', or 'traceback': send failure notification as described in the skill with text: 'Bookmark Ingestion cron failure: <brief summary of what went wrong from the output>'
+- NOTE: do NOT treat the success-path stdout 'No pending bookmarks.' (from process.cjs:459 when pending.length === 0) as a soft failure. The 'No pending bookmarks.' message is a healthy no-op (fetch succeeded, 0 new bookmarks since last run, pending queue is empty). The `failed` keyword already covers the actual fetch-failure path ('Failed to fetch bookmarks:' from fetch.cjs:205). See infra/runbooks/notify-soft-fail-keyword-false-positive.md for the false-positive class context (regression observed 2026-08-10).
 - If the script succeeds with no issues, do nothing further.

--- a/agents/skills/bookmarks/x-ingest/SKILL.md
+++ b/agents/skills/bookmarks/x-ingest/SKILL.md
@@ -22,7 +22,9 @@ When a bookmarked tweet quotes a tweet that contains a Twitter article, the
 article body is also captured via the X API.
 
 Report success or failure from the command result. On a non-zero exit, or output
-containing `error`, `failed`, `exception`, `traceback`, or `no bookmarks`, follow
+containing `error`, `failed`, `exception`, or `traceback`, follow
 `../../ops/notify-soft-fail/SKILL.md` and send:
 
 `Bookmark Ingestion cron failure: <brief summary of what went wrong from the output>`
+
+**Do NOT treat the success-path stdout `No pending bookmarks.` (from `process.cjs:459` when `pending.length === 0`) as a soft failure.** That message is the healthy no-op — the fetch succeeded, no new bookmarks have been queued since the last run, and the pending queue is empty. The `failed` keyword already covers the real fetch-failure path (`Failed to fetch bookmarks: ...` from `fetch.cjs:205`). See `infra/runbooks/notify-soft-fail-keyword-false-positive.md` for the regression context (false-positive class observed 2026-08-10 when 'no bookmarks' was in the trigger keyword list — substring-matched the success-path stdout).

--- a/agents/skills/ops/notify-soft-fail/SKILL.md
+++ b/agents/skills/ops/notify-soft-fail/SKILL.md
@@ -47,7 +47,10 @@ Standard set to check for (extend per job as needed):
 - `failed`
 - `exception`
 - `traceback`
-- `no bookmarks` / `no items` / `nothing to process` (job-specific)
+
+**Avoid "no X" / "nothing to process" / "empty queue" style job-specific keywords** unless you can confirm they ONLY appear on a failure path and never on a healthy no-op stdout. Substring matching fires before any LLM-level disambiguation, so any keyword that overlaps with the steady-state "nothing to do" message will escalate every healthy idle run. The 2026-08-10 regression (cron `92efaff7`, bookmark ingestion) was caused by the keyword `no bookmarks` matching the success-path stdout `No pending bookmarks.` from `process.cjs:459` — the substring trigger fires regardless of context, and the keyword was redundant anyway (the real fetch-failure path emits `Failed to fetch bookmarks:` which is caught by `failed`). See `infra/runbooks/notify-soft-fail-keyword-false-positive.md` for the diagnosis + fix pattern.
+
+If you need a job-specific keyword for a *failure* mode that the standard set doesn't cover, prefer a distinctive phrase tied to the failure (e.g. `insufficient balance`, `401 unauthorized`, `permission denied`, `migration failed`) over a generic "no X" phrase that overlaps with idle stdout.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Removes the `no bookmarks` trigger keyword from the bookmark-ingestion cron's soft-fail detection (`agents/crons/prompts/bookmark-ingestion.md`, `agents/skills/bookmarks/x-ingest/SKILL.md`) — it substring-matches the healthy no-op stdout `No pending bookmarks.` (`process.cjs:459`), causing 1-3 false-positive escalations/week to Lox. The `failed` keyword already covers the real fetch-failure path (`Failed to fetch bookmarks:`, `fetch.cjs:205`), so the removed keyword was both redundant and misleading.
- Updates `agents/skills/ops/notify-soft-fail/SKILL.md` with a warning against "no X" / "nothing to process" style keywords for future cron authors, since substring matching fires before any LLM-level disambiguation.
- Drafted by Lox after investigating a soft-fail escalation (2026-08-10 04:13 NZST, runId `8fabe6b6-cf47-47a4-82da-ade75ce864cd`); reviewed by Quinn, who verified the cited source lines (`process.cjs:459`, `fetch.cjs:205`) match the claims. Runbook: `infra/runbooks/notify-soft-fail-keyword-false-positive.md`.

## System Spec
No system spec change — ops/cron-prompt tuning only, no user-facing behaviour.

## Test plan
- [ ] Confirm `agents/crons/prompts/bookmark-ingestion.md` and `agents/skills/bookmarks/x-ingest/SKILL.md` no longer list `no bookmarks` as a trigger keyword, and both explain the `No pending bookmarks.` no-op path
- [ ] Confirm `agents/skills/ops/notify-soft-fail/SKILL.md` still lists `error`/`failed`/`exception`/`traceback` as trigger keywords (real failure detection unchanged)
- [ ] Next scheduled bookmark-ingestion cron run with 0 pending bookmarks does not escalate to Lox

🤖 Generated with Claude Code