### PR TITLE
fix(content-workflow): require queued tweet traceability

### DIFF
--- a/agents/workflows/content-tasks/scripts/common.py
+++ b/agents/workflows/content-tasks/scripts/common.py
@@ -27,6 +27,7 @@ from tasks_api_client import api_request, get_base_url, get_task, list_tasks  # 
 STATE_TAG = "[lobster-state]"
 IVY_PRS_TAG = "[ivy-prs]"
 IVY_TWEETS_QUEUED_TAG = "[ivy-tweets-queued]"
+IVY_TWEETS_QUEUED_RE = re.compile(r"^\[ivy-tweets-queued\]\s+theme:\s+\S")
 WEEKLY_CONTENT_TITLE_RE = re.compile(r"weekly\s+(review|content\s+updates?)", re.I)
 AUTHOR = "Lobster"
 STATUS_ORDER = {"open": 0, "ready": 1, "doing": 2, "acceptance": 3, "done": 4}
@@ -337,11 +338,11 @@ def task_is_weekly_content(task: dict[str, Any]) -> bool:
 
 
 def has_ivy_tweets_queued(task: dict[str, Any]) -> bool:
-    """True if a `[ivy-tweets-queued]` comment has been posted on this task."""
-    for comment in task_comments(task):
-        if IVY_TWEETS_QUEUED_TAG in comment_text(comment):
-            return True
-    return False
+    """True if a valid `[ivy-tweets-queued] theme: ...` traceability comment exists."""
+    return any(
+        IVY_TWEETS_QUEUED_RE.match(comment_text(comment))
+        for comment in task_comments(task)
+    )
 
 
 def parse_pr_url(url: str) -> tuple[str, str, str] | None:

--- a/tests/test_content_task_workflow.py
+++ b/tests/test_content_task_workflow.py
@@ -63,6 +63,30 @@ class ContentTaskHeadingTests(unittest.TestCase):
             self.assertIsNotNone(match)
             self.assertFalse(match.group(0).startswith("\n"))
 
+    def test_tweets_queued_accepts_traceability_comment(self):
+        task = {
+            "comments": [
+                {
+                    "text": "[ivy-tweets-queued] theme: Agents as first-class users\n"
+                    "- tweet-id — launch context"
+                }
+            ]
+        }
+
+        self.assertTrue(content_common.has_ivy_tweets_queued(task))
+
+    def test_tweets_queued_rejects_blocker_text_that_mentions_tag(self):
+        task = {
+            "comments": [
+                {
+                    "text": "Tweet campaign is blocked; "
+                    "`[ivy-tweets-queued]` remains pending."
+                }
+            ]
+        }
+
+        self.assertFalse(content_common.has_ivy_tweets_queued(task))
+
     @patch.object(content_common, "gh_api")
     def test_pr_routing_uses_rest_user_endpoints(self, gh_api):
         gh_api.side_effect = [


### PR DESCRIPTION
## Summary
- Require the weekly-content tweets gate to match a genuine `[ivy-tweets-queued] theme: ...` traceability comment at the start of the comment.
- Prevent blocker prose that merely mentions the tag as pending from admitting `doing` → `acceptance`.
- Add regression coverage for both the valid traceability format and the task 70970701 blocker-text case.

## System Spec
No system spec change — this is a narrow parser correction that restores the documented content-workflow gate.

## Test plan
- [x] `python3 -m pytest tests/test_content_task_workflow.py` (7 passed)
- [x] Valid `[ivy-tweets-queued] theme: ...` traceability comments satisfy the gate
- [x] Blocker prose mentioning `` `[ivy-tweets-queued]` remains pending `` does not satisfy the gate

🤖 Generated with Claude Code