### PR TITLE
test(tasks-api): cover dependencyBlocked preservation across attention-owner PATCH (task 66054ab4 WS4)

### DIFF
--- a/docs/systems/tasks.md
+++ b/docs/systems/tasks.md
@@ -222,6 +222,13 @@ The two filters combine via AND: a UI can show "Quinn's outstanding gates AND th
 - Resolving one attention owner (PATCH replacement) does not affect other attention owners, workflow-gate ownership, dependencies, or `task.blocked`.
 - Changing `taskType` does not retroactively create or remove attention-owner rows; attention is decoupled from task-type policy.
 
+**Cross-row validation contract for `PATCH /tasks/:id` with `attentionOwners`** (AC7, AC8 of task `66054ab4`):
+
+- The PATCH handler never writes to the `TaskDependency` table. `prisma.taskDependency.deleteMany` and `prisma.taskDependency.createMany` are not invoked as a side effect of an attention-owner PATCH — either full-replacement or `[]` clear.
+- `dependencyBlocked` (computed from `dependsOn.some(d => d.status !== 'done')`) survives unchanged across attention-owner PATCHes because the dependency rows themselves are untouched. A task blocked only via a dependency stays blocked when attention owners are added or cleared.
+- `task.update` accepts only the attention-owner write path for this PATCH; passing `dependencies` as part of its `data` argument would be a regression and is asserted not to happen.
+- Covered by `services/tasks-api/test/workflowGatesRouteLayer.test.ts` — `"does not touch task.blocked or dependencies when clearing attention owners (AC7, AC8)"` and `"preserves dependencyBlocked across attention-owner PATCHes (AC7 cross-row)"`.
+
 **CLI:** `tasks_api_client.py` exposes `--workflow-gate-owner <name>` and `--attention-owner <name>` for `list`, plus `--attention-owners <name...>` and `--clear-attention-owners` for `patch`.
 
 ---

--- a/services/tasks-api/test/workflowGatesRouteLayer.test.ts
+++ b/services/tasks-api/test/workflowGatesRouteLayer.test.ts
@@ -598,6 +598,58 @@ describe('PATCH /api/v1/tasks/:id — attentionOwners', () => {
     expect(prismaMock.taskDependency.deleteMany).not.toHaveBeenCalled();
     expect(prismaMock.taskDependency.createMany).not.toHaveBeenCalled();
   });
+
+  it('preserves dependencyBlocked across attention-owner PATCHes (AC7 cross-row)', async () => {
+    // The task is blocked *via a non-done dependency* (`dependencyBlocked` is
+    // derived from `dependsOn.some(d => d.status !== 'done')`), not via
+    // `task.blocked`. Clearing or replacing attention owners must not clear
+    // or re-derive that signal; the existing `Blocked` indicator stays
+    // backward-compatible.
+    const existing = { id: TASK_ID, taskType: 'feature', archivedAt: null };
+    const blockedDep = {
+      id: 'dep-other',
+      taskId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      dependsOnId: TASK_ID,
+      dependsOn: {
+        id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        title: 'Prereq task',
+        status: 'doing',
+        completedAt: null
+      }
+    };
+    prismaMock.task.findFirst
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce({
+        ...baseTaskFixture({
+          blocked: false,
+          dependencies: [blockedDep],
+          attentionOwners: [
+            { id: 'ao-1', taskId: TASK_ID, owner: 'Tom', addedBy: null, note: null, createdAt: new Date() }
+          ]
+        })
+      });
+
+    const app = createApp();
+    const response = await request(app)
+      .patch(`/api/v1/tasks/${TASK_ID}`)
+      .send({ attentionOwners: [] });
+
+    expect(response.status).toBe(200);
+    // The mapper derives dependencyBlocked from the dependency plane; the
+    // PATCH must leave the dependency row untouched so the signal survives.
+    expect(response.body.data.dependencyBlocked).toBe(true);
+    expect(response.body.data.dependsOn).toEqual([
+      expect.objectContaining({ id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', status: 'doing' })
+    ]);
+    expect(response.body.data.attentionOwners).toEqual([]);
+    expect(prismaMock.taskDependency.deleteMany).not.toHaveBeenCalled();
+    expect(prismaMock.taskDependency.createMany).not.toHaveBeenCalled();
+    // task.update was called, but only to write attention-owner rows; the
+    // dependency plane is never its argument.
+    expect(prismaMock.task.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ dependencies: expect.anything() }) })
+    );
+  });
 });
 
 describe('GET /api/v1/tasks — discovery filters', () => {

--- a/services/tasks-api/test/workflowGatesRouteLayer.test.ts
+++ b/services/tasks-api/test/workflowGatesRouteLayer.test.ts
@@ -626,7 +626,8 @@ describe('PATCH /api/v1/tasks/:id — attentionOwners', () => {
           attentionOwners: [
             { id: 'ao-1', taskId: TASK_ID, owner: 'Tom', addedBy: null, note: null, createdAt: new Date() }
           ]
-        })
+        }),
+        attentionOwners: []
       });
 
     const app = createApp();


### PR DESCRIPTION
## Summary
- Adds a cross-row validation regression test for AC7/AC8: the task is blocked via a non-done dependency (dependencyBlocked derived from `dependsOn.some(d => d.status !== 'done')`), and a PATCH with `attentionOwners: []` must not touch taskDependency rows, must not affect the dependency plane's data on `task.update`, and must leave `dependencyBlocked: true` in the response.
- Extends `docs/systems/tasks.md` with a "Cross-row validation contract for `PATCH /tasks/:id` with `attentionOwners`" section that names the contract and the tests that enforce it (machine-findable for future regressions).
- WS4 follow-up after WS1a (PR #403) and WS1 (PR #405) merged. AC7/AC8 had a unit test for `task.blocked: true`; this PR pins the dependencyBlocked path so a future change cannot quietly regress the cross-row contract.

## Test plan
- [ ] CI green on `services/tasks-api` unit suite.
- [ ] New test (`preserves dependencyBlocked across attention-owner PATCHes (AC7 cross-row)`) passes locally and in CI; assert response.data.dependencyBlocked === true, taskDependency mocks not called, and `task.update` not called with `data.dependencies`.
- [ ] Existing AC7/AC8 test (`does not touch task.blocked or dependencies when clearing attention owners`) still passes — confirms we did not regress the task.blocked path.
- [ ] Docs note renders correctly in `docs/systems/tasks.md` (Cross-row validation contract section after Non-replacement guarantees).

## System Spec
`docs/systems/tasks.md` — extended the Non-replacement guarantees section with a "Cross-row validation contract for `PATCH /tasks/:id` with `attentionOwners`" subsection naming the four invariants and the two tests that pin them.

## Acceptance Criteria
- [x] AC1: A task can independently represent its delivery assignee, existing task-to-task dependency relationships, existing `Blocked` state, outstanding workflow-gate owners, and zero or more attention owners; none replaces or silently derives from another. (🔗 pr: #403)
- [x] AC2: A task can have zero, one, or multiple attention owners for exceptional or otherwise unmodelled blockers, with enough context to explain what needs attention; clearing all attention owners removes only the outstanding generic attention requests. (🔗 pr: #403)
- [x] AC3: Explicit workflow gates expose their owners as normal workflow handoffs, and the discovery queue surfaces actionable work to those gate owners. A gate-owned handoff does not also create a duplicate generic attention-owner request for the same action. (🔗 pr: #405)
- [x] AC4: Attention owners remain distinguishable from workflow-gate owners in task details and task data, so exceptional ownership can later be consumed as an input to incident detection or escalation without implementing that incident lifecycle here. (🔗 pr: #405)
- [ ] AC5: Task cards display avatars in this order: delivery assignee first, outstanding workflow-gate owners next, and attention owners last; duplicate people are visually deduplicated where appropriate while their distinct responsibilities remain available in task details and accessibility labels. (⚠️ not tested: deferred to WS3 stacked-avatar component on apps/tasks; not in scope for this PR)
- [ ] AC6: Task details and accessible labels clearly distinguish who owns delivery, who owns the current workflow gate, and who needs attention because an exceptional or unmodelled blocker exists. (⚠️ not tested: deferred to WS3 detail-view composer on apps/tasks; not in scope for this PR)
- [x] AC7: Existing task dependencies continue to be represented as dependencies, and the existing `Blocked` indicator remains visible and backward compatible; a task can remain blocked through either of those conditions or a workflow gate even when it has no attention owners. (🧪 testID: vitest:services/tasks-api/test/workflowGatesRouteLayer.test.ts:preserves dependencyBlocked across attention-owner PATCHes (AC7 cross-row))
- [x] AC8: Resolving or clearing one attention request does not remove other outstanding attention requests, workflow-gate ownership, task dependencies, or the existing `Blocked` state; removing all attention owners does not by itself declare the task unblocked. (🧪 testID: vitest:services/tasks-api/test/workflowGatesRouteLayer.test.ts:does not touch task.blocked or dependencies when clearing attention owners (AC7, AC8))

🤖 Generated with [Claude Code](https://claude.com/claude-code)
