### PR TITLE
chore(code-garden): memoize and boot-validate approval service credentials [2026-W33]

### DIFF
--- a/docs/repo-audits/2026-W33.md
+++ b/docs/repo-audits/2026-W33.md
@@ -56,7 +56,7 @@
 
 - **Where:** `services/tasks-api/src/middleware/approvalAuth.ts:16-30,63` — `parseServiceCredentials()` runs inside `requireApprovalPrincipal` per request and `throw`s on malformed `TASKS_API_APPROVAL_SERVICE_CREDENTIALS`.
 - **Why:** A malformed credentials env var surfaces as a 500 on the first authenticated approval attempt rather than as a fail-fast boot error, and the JSON is parsed on every request instead of once. Neither is a correctness bug given the credentials are typically small and static, but validating at startup would turn a latent 500 into an immediate deploy failure and remove per-request work.
-- **Severity:** Low. → Classification: `garden-safe` (memoize + validate at boot; behavior-preserving).
+- **Severity:** Low. → Classification: `garden-safe` (memoize + validate at boot; behavior-preserving). ✅ [PR #407](https://github.com/Stoffer-Industries/sindustries/pull/407)
 
 ### Architecture & design
 

--- a/services/tasks-api/src/middleware/approvalAuth.ts
+++ b/services/tasks-api/src/middleware/approvalAuth.ts
@@ -13,11 +13,11 @@ const ACTOR_PERMISSIONS: Record<string, ReadonlySet<ApprovalType>> = {
   Tom: new Set(['spec', 'qa']), Quinn: new Set(['tech_design'])
 };
 
-function parseServiceCredentials(): ServiceCredential[] {
+function loadServiceCredentials(): ServiceCredential[] {
   const raw = process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS;
   if (!raw) return [];
   let parsed: unknown;
-  try { parsed = JSON.parse(raw); } catch { throw new Error('TASKS_API_APPROVAL_SERVICE_CREDENTIALS must be valid JSON'); }
+  try { parsed = JSON.parse(raw); } catch (e) { throw new Error(`TASKS_API_APPROVAL_SERVICE_CREDENTIALS must be valid JSON: ${(e as Error).message}`); }
   if (!Array.isArray(parsed)) throw new Error('TASKS_API_APPROVAL_SERVICE_CREDENTIALS must be a JSON array');
   return parsed.map((value, index) => {
     const item = value as Partial<ServiceCredential>;
@@ -27,6 +27,14 @@ function parseServiceCredentials(): ServiceCredential[] {
     }
     return item as ServiceCredential;
   });
+}
+
+// Parse once at module load so malformed config fails process boot (not the
+// first authenticated request) and we don't re-parse JSON per request.
+const SERVICE_CREDENTIALS: ReadonlyArray<ServiceCredential> = loadServiceCredentials();
+
+function parseServiceCredentials(): ReadonlyArray<ServiceCredential> {
+  return SERVICE_CREDENTIALS;
 }
 
 function cookie(req: Request, name: string): string | null {

--- a/services/tasks-api/test/taskApprovals.test.ts
+++ b/services/tasks-api/test/taskApprovals.test.ts
@@ -1,6 +1,14 @@
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Set service credentials BEFORE the dynamic import of app.ts (which
+// transitively imports approvalAuth.ts) so the module-load-time parse
+// in approvalAuth captures the test credentials instead of an empty value.
+process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS = JSON.stringify([
+  { token: 'tom-service-token-long-enough', actor: 'Tom', approvalTypes: ['spec', 'qa'] },
+  { token: 'quinn-service-token-long-enough', actor: 'Quinn', approvalTypes: ['tech_design'] }
+]);
+
 const prismaMock = {
   task: { findFirst: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
   taskComment: { create: vi.fn() },
@@ -24,10 +32,6 @@ function auth(token = TOM_TOKEN) { return { Authorization: `Bearer ${token}` }; 
 describe('task approval boundary', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS = JSON.stringify([
-      { token: TOM_TOKEN, actor: 'Tom', approvalTypes: ['spec', 'qa'] },
-      { token: QUINN_TOKEN, actor: 'Quinn', approvalTypes: ['tech_design'] }
-    ]);
     prismaMock.approvalSession.findUnique.mockResolvedValue(null);
     prismaMock.$transaction.mockImplementation(async (fn) => fn(prismaMock));
   });
@@ -106,5 +110,44 @@ describe('task approval boundary', () => {
     prismaMock.task.findUnique.mockResolvedValue(activeTask); prismaMock.taskApproval.findUnique.mockResolvedValue(existing);
     const res = await request(createApp()).delete(`/api/v1/tasks/${TASK_ID}/approvals/spec`).set(auth());
     expect(res.status).toBe(200); expect(prismaMock.taskApproval.update).not.toHaveBeenCalled(); expect(prismaMock.taskComment.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('TASKS_API_APPROVAL_SERVICE_CREDENTIALS module-load validation', () => {
+  // Re-import approvalAuth.ts with a controlled env value, capturing any
+  // thrown error from the module-load-time IIFE. Restores the previous env
+  // and resets the module cache so subsequent tests reuse the original
+  // (good) module captured at file load.
+  async function importApprovalAuthWith(envValue: string | undefined) {
+    vi.resetModules();
+    const prev = process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS;
+    if (envValue === undefined) delete process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS;
+    else process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS = envValue;
+    try {
+      return await import('../src/middleware/approvalAuth.ts');
+    } finally {
+      if (prev === undefined) delete process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS;
+      else process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS = prev;
+      vi.resetModules();
+    }
+  }
+
+  it('throws at module load when credentials env is not valid JSON', async () => {
+    await expect(importApprovalAuthWith('{not-json')).rejects.toThrow(/must be valid JSON/);
+  });
+
+  it('throws at module load when credentials env is not a JSON array', async () => {
+    const object = JSON.stringify({ token: 'a'.repeat(20), actor: 'Tom', approvalTypes: ['spec'] });
+    await expect(importApprovalAuthWith(object)).rejects.toThrow(/must be a JSON array/);
+  });
+
+  it('throws at module load when an entry is invalid', async () => {
+    const badEntry = JSON.stringify([{ token: 'short', actor: 'Tom', approvalTypes: ['spec'] }]);
+    await expect(importApprovalAuthWith(badEntry)).rejects.toThrow(/TASKS_API_APPROVAL_SERVICE_CREDENTIALS\[0\] is invalid/);
+  });
+
+  it('loads cleanly when credentials env is a valid array', async () => {
+    const valid = JSON.stringify([{ token: 'a'.repeat(20), actor: 'Tom', approvalTypes: ['spec', 'qa'] }]);
+    await expect(importApprovalAuthWith(valid)).resolves.toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W33.md
- **Finding:** [Low] Approval service credentials are re-parsed from env JSON on every request, and malformed config fails at request time.
- Move `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` parsing to module load via an IIFE so the JSON is parsed once per process and malformed config fails process boot with a clear error instead of surfacing as a 500 on the first authenticated approval. The per-request `parseServiceCredentials()` accessor now returns the cached value; existing call sites in `requireApprovalPrincipal` are unchanged. Test file moves the credentials env var assignment above the dynamic import of `app.ts` so the module-load parse captures the test value, and a new describe block pins the boot-time validation contract (malformed JSON / non-array / invalid entry / valid array).

## Test plan
- [x] New module-load validation tests pass (4 cases: malformed JSON, non-array, invalid entry, valid array)
- [x] Existing 13 approval-boundary tests still pass — no behavior change
- [x] Full tasks-api vitest suite green (after `npx prisma generate`)
- [x] No logic changes — diff is purely structural (parse-once-at-boot instead of parse-per-request)

🌱 Code garden — non-functional cleanup only