### PR TITLE
fix(code-garden): route branch creation through sindustries-worktree.sh

### DIFF
--- a/agents/skills/dev/code-garden/SKILL.md
+++ b/agents/skills/dev/code-garden/SKILL.md
@@ -47,12 +47,16 @@ Skip any finding that requires understanding product/business intent. If unsure,
 
 ### 3. Implement on a chore branch off main
 
+**Never edit the canonical sindustries checkout directly.** Use the worktree helper to get an isolated working copy on a fresh branch:
+
 ```bash
-git fetch origin
-git checkout -b chore/code-garden-<audit-week>-<short-slug> origin/main
+infra/guards/sindustries-worktree.sh code-garden-<audit-week>-<short-slug> origin/main chore/code-garden-<audit-week>-<short-slug>
+cd /Users/quinnstoffer/.openclaw/workspace/worktrees/code-garden-<audit-week>-<short-slug>
 ```
 
-e.g. `chore/code-garden-2026-W26-stale-triage-comment`
+e.g. `infra/guards/sindustries-worktree.sh code-garden-2026-W26-stale-triage-comment origin/main chore/code-garden-2026-W26-stale-triage-comment`
+
+The helper always places worktrees at `/Users/quinnstoffer/.openclaw/workspace/worktrees/<name>` — never inside `codebases/sindustries/` itself. Do not run `git worktree add` or `git checkout -b` by hand; both can land you inside the canonical checkout if `cwd` is wrong when the command runs, which trips the `sindustries-main-guard` alert.
 
 Make the minimal change to address the finding. Do not bundle unrelated changes.
 


### PR DESCRIPTION
## Summary
- code-garden's SKILL.md step 3 told agents to `git checkout -b ... origin/main` directly with no worktree guidance, which let a run today create its worktree inside the canonical `codebases/sindustries` checkout (at `codebases/sindustries/workspace/worktrees/...`) instead of `workspace/worktrees/...`, tripping `sindustries-main-guard` for ~5 min until manually moved.
- Updated step 3 to route through `infra/guards/sindustries-worktree.sh` (the paved-path helper all other agent workflows use), with an explicit warning against hand-rolled `git worktree add`/`git checkout -b`.

## System Spec
No system spec change — agent-skill doc fix, no user-facing or app behaviour change.

## Test plan
- [ ] No logic changes — diff is purely doc/instruction wording in `agents/skills/dev/code-garden/SKILL.md`
- [ ] Next code-garden run creates its worktree under `workspace/worktrees/`, not inside `codebases/sindustries/`

🤖 Generated with Claude Code