### PR TITLE
fix(workflow): surface open tech-design tasks to Rowan

### DIFF
--- a/agents/definitions/rowan/HEARTBEAT.md
+++ b/agents/definitions/rowan/HEARTBEAT.md
@@ -34,7 +34,7 @@ For each returned task, follow `WORKFLOW.md` for the execution steps in that sta
 
 **Heartbeat cadence rule — the only per-pass opinion layered on top of `WORKFLOW.md`:**
 
-If any assigned task is in `ready` and lacks a posted `[tech-design]` comment, prioritise writing and posting that tech design before continuing implementation on any `doing`/`acceptance` task. After posting `[tech-design]`, return to the active implementation work — do not start implementing the `ready` task.
+If any assigned implementation task is in `open` and lacks a posted `[tech-design]` comment or `[tech-design-not-required]` waiver, prioritise writing and posting that tech design before continuing implementation on any `doing`/`acceptance` task. After posting `[tech-design]`, return to the active implementation work — do not start implementing the `open` task until Quinn approves the design.
 
 ---
 
@@ -45,7 +45,7 @@ Read and follow:
 
 **Limit:** Open at most 1 code-garden PR at a time. Check for open PRs first — if one exists, skip this step.
 
-**Skip code gardening entirely** if any assigned feature task in `ready` is waiting for a tech design, or any `doing`/`acceptance` task can be materially progressed this pass (implementation, review feedback, merge/post-merge work, required comments/specs, or validation). Code garden is only on the table when all active feature tasks are waiting on someone else's action and any needed nudge has already been sent.
+**Skip code gardening entirely** if any assigned implementation task in `open` is waiting for its tech design, or any `doing`/`acceptance` task can be materially progressed this pass (implementation, review feedback, merge/post-merge work, required comments/specs, or validation). Code garden is only on the table when all active implementation tasks are waiting on someone else's action and any needed nudge has already been sent.
 
 **Only those three bullets are valid reasons to skip code garden.** `DEPENDENCY_BLOCKED` and `WAITING_EXTERNAL` classifications from the queue are explicitly NOT skip reasons on their own — they mean Step 2 has nothing to progress, which is exactly the signal to move to Step 3. Do not invent additional judgment calls this file doesn't list (e.g. "don't compete for review attention," "hold until the dependency chain clears," "avoid opening a PR while other tasks are mid-flight") as reasons to skip. If the three bullets don't apply, open code gardening — that is the required action, not a fallback to consider.
 

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -130,7 +130,7 @@ Before writing any code on a feature task, write the tech design:
 ### Implementation
 - Work on the same branch as the tech design; all changes come via PRs — no direct pushes to main
 - Open a **DRAFT PR** after the tech design is approved and implementation begins; this keeps the branch reviewable but signals work is in progress
-- Capacity: 1 unblocked feature task per implementation state at a time. `ready` tech design work is the exception: if an assigned `ready` task lacks a posted/approved tech design, write and post that tech design ASAP even when another task is already in `doing`; then return to the active implementation task.
+- Capacity: 1 unblocked implementation task per implementation state at a time. `open` tech-design work is the exception: if an assigned `open` feature or code task lacks a posted/approved tech design (or an explicit `[tech-design-not-required]` waiver), write and post that tech design ASAP even when another task is already in `doing`; then return to the active implementation task. Do not implement the `open` task until Quinn approves the design and Lobster promotes it to `ready`/`doing`.
 - When `.openclaw` changes are needed: post `[openclaw-needed]` task comment with exact file paths, proposed diff, validation command, and rollback note; do not touch `~/.openclaw/` yourself
 - **Do not post `[implementer-prs]`** until all task ACs are implemented and the PR is converted from draft to ready-for-review
 - When the PR is ready: convert draft → ready-for-review, then post `[implementer-prs] <url>` as a task comment

--- a/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
@@ -225,6 +225,22 @@ def classify_task(
     texts = _comment_texts(task)
     latest_progress = _latest_progress_comment(texts)
 
+    if status == "open" and task_type in IMPLEMENTATION_TYPES:
+        # Since task 3ba96b5e split the bundled ready gate, a task can only
+        # reach `ready` once its tech design (or an explicit waiver) is
+        # already approved. That means "tech design missing" is an `open`
+        # task condition, not a `ready` one — see the mirrored check below,
+        # which is now unreachable in practice but left in place as a
+        # harmless no-op in case pipeline behavior changes again.
+        has_design = _has_prefix(texts, (TECH_DESIGN_TAG,))
+        has_approval = _tech_design_approved(task)
+        has_waiver = _has_prefix(texts, (TECH_DESIGN_WAIVER_TAG,))
+        if not has_design and not has_waiver:
+            return "ACTIONABLE", "tech design or explicit waiver is missing"
+        if has_approval or has_waiver:
+            return "WAITING_EXTERNAL", "tech design is ready for Lobster promotion to ready"
+        return "WAITING_EXTERNAL", "tech design is waiting for approval"
+
     if status == "ready" and task_type in IMPLEMENTATION_TYPES:
         has_design = _has_prefix(texts, (TECH_DESIGN_TAG,))
         has_approval = _tech_design_approved(task)
@@ -311,7 +327,7 @@ def fetch_agent_tasks(assignee: str, base_url: str | None = None) -> list[dict[s
     base = base_url or tasks_api_client.get_base_url()
     summaries = tasks_api_client.list_tasks(
         limit=50,
-        status=["ready", "doing", "acceptance"],
+        status=["open", "ready", "doing", "acceptance"],
         assignee=assignee,
         base_url=base,
     )

--- a/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
@@ -134,7 +134,12 @@ class AgentTaskQueueTest(unittest.TestCase):
         self.assertEqual(classification, "WAITING_EXTERNAL")
         self.assertIn("waiting on review", reason)
 
-    def test_ready_without_tech_design_is_actionable(self):
+    def test_open_without_tech_design_is_actionable(self):
+        classification, reason = agent_task_queue.classify_task(task(status="open"))
+        self.assertEqual(classification, "ACTIONABLE")
+        self.assertIn("tech design", reason)
+
+    def test_ready_without_tech_design_remains_defensive(self):
         classification, reason = agent_task_queue.classify_task(task(status="ready"))
         self.assertEqual(classification, "ACTIONABLE")
         self.assertIn("tech design", reason)
@@ -222,9 +227,9 @@ class AgentTaskQueueTest(unittest.TestCase):
 
         self.assertEqual(
             list_tasks.call_args.kwargs["status"],
-            ["ready", "doing", "acceptance"],
+            ["open", "ready", "doing", "acceptance"],
         )
-        self.assertNotIn("open", list_tasks.call_args.kwargs["status"])
+        self.assertIn("open", list_tasks.call_args.kwargs["status"])
 
     def test_work_queue_exposes_all_read_only_queue_keys(self):
         queue = agent_task_queue.build_work_queue(


### PR DESCRIPTION
## Summary
- Include open feature/code tasks in Rowan's queue so missing tech-design work is surfaced as actionable.
- Classify open implementation tasks without a design or explicit waiver as requiring tech-design work.
- Correct Rowan's heartbeat/workflow guidance to pick up tech designs from `open`, matching the current `open → ready → doing` pipeline.

## System Spec
No system spec change — workflow/agent operating guidance and read-only queue classification only.

## Test plan
- [x] `python3 -m unittest agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py` (27 tests)
- [x] Live queue verification surfaces `6492813a` as `ACTIONABLE: tech design or explicit waiver is missing`.
- [x] `git diff --check`