### PR TITLE
feat(tasks-app): surface workflow-gate ownership and attention filters in backlog (WS2)

### DIFF
--- a/apps/tasks/SPEC.md
+++ b/apps/tasks/SPEC.md
@@ -106,6 +106,39 @@ detail-view composer land in WS3.
    approval-row UX is the only path; the attention-editor UX never
    surfaces for the same action.
 
+### 10. Discovery queue: ownership filters and default landing view (WS2)
+WS2 wires the WS1 data surface into the backlog view so normal handoffs
+are routed through explicit workflow gates rather than the generic
+`Blocked` indicator. The stacked avatar rendering and detail-view
+composer for the new planes land in WS3.
+
+1. The backlog exposes two ownership filter chips:
+   * "My outstanding gates" — toggles `?workflowGateOwner=<self>` to
+     surface tasks where the signed-in user owns an outstanding
+     structured gate (spec / tech_design / qa).
+   * "Needs my attention" — toggles `?attentionOwner=<self>` to surface
+     tasks with an exceptional / unmodelled attention request for the
+     signed-in user, visually labelled as exceptional so it never
+     masquerades as a normal handoff.
+   Both chips are disabled for anonymous sessions (no `<self>` to
+   resolve) and combine via AND with the existing filters. Toggling
+   either chip off clears its respective filter value.
+2. Default landing view shifts from "Status: Open" to
+   `?workflowGateOwner=<self>` for signed-in users on first mount of
+   the backlog view. This is the normal handoff surface; explicit
+   `Blocked` and `dependencyBlocked` indicators remain visible and
+   backward compatible. Once applied, the user's explicit filter
+   choices persist — toggling the chip off or clearing the filter is
+   sticky for the session.
+3. The chips do not create or imply a `TaskAttentionOwner` row for a
+   gate-owned action. When an outstanding workflow gate already names
+   the signed-in user, the gate is surfaced through the "My outstanding
+   gates" chip; the attention-editor UX never duplicates that signal.
+4. Anonymous users see no default and the chips render in a disabled
+   state with a "Sign in to use this filter" tooltip. The existing
+   Status / Priority / Assignee / TaskType / Tag filters remain
+   available regardless of session state.
+
 ## E2e coverage
 
 | Flow | Spec file |

--- a/apps/tasks/src/App.jsx
+++ b/apps/tasks/src/App.jsx
@@ -17,6 +17,7 @@ import { useTasks } from './useTasks.js';
 import { useTaskDrafts } from './useTaskDrafts.js';
 import { fetchTask } from './tasksApi';
 import { useDebounce } from './hooks/useDebounce.js';
+import { useCurrentUser } from './hooks/useCurrentUser.js';
 import { usePulseCelebration } from './hooks/usePulseCelebration.js';
 import { useToast } from './hooks/useToast.js';
 import { ConfettiLayer } from './components/ConfettiLayer.jsx';
@@ -43,7 +44,12 @@ export function App() {
   const [view, setView] = useState(getStoredView);
   const [selectedId, setSelectedId] = useState(null);
   const initialStatusSelection = ['open', 'ready', 'doing', 'acceptance'];
-  const [filters, setFilters] = useState({ q: '', status: initialStatusSelection.join(','), priority: '', tag: '', assignee: '', taskType: '', includeArchived: false });
+  const [filters, setFilters] = useState({ q: '', status: initialStatusSelection.join(','), priority: '', tag: '', assignee: '', taskType: '', workflowGateOwner: '', attentionOwner: '', includeArchived: false });
+  const { actor: currentUser } = useCurrentUser();
+  // Tracks whether the discovery-queue default landing view has been applied
+  // for this session. Once applied (or explicitly cleared), the user owns the
+  // filter and we never re-apply the default. See the default-effect below.
+  const [defaultWorkflowGateApplied, setDefaultWorkflowGateApplied] = useState(false);
   const [selectedStatuses, setSelectedStatuses] = useState(() => new Set(initialStatusSelection));
   const [openFilterMenu, setOpenFilterMenu] = useState(null);
   const statusMenuRef = useRef(null);
@@ -97,6 +103,22 @@ export function App() {
     if (view !== 'backlog') return;
     setSelectedStatuses((current) => (current.size === 0 ? new Set(['open']) : current));
   }, [view]);
+
+  // Default landing view: surface the signed-in user's outstanding workflow
+  // gates on first mount of the backlog view. Replaces the prior "default
+  // open" behaviour for signed-in users — normal handoffs are routed through
+  // explicit workflow gates, not the generic `Blocked` indicator. Anonymous
+  // visitors see no default. Once applied, the user's explicit choices take
+  // over (toggling the chip off or clearing the filter persists).
+  useEffect(() => {
+    if (view !== 'backlog') return;
+    if (defaultWorkflowGateApplied) return;
+    if (!currentUser) return;
+    setFilters((current) => (current.workflowGateOwner
+      ? current
+      : { ...current, workflowGateOwner: currentUser }));
+    setDefaultWorkflowGateApplied(true);
+  }, [view, currentUser, defaultWorkflowGateApplied]);
 
   // Persist view to localStorage
   useEffect(() => {
@@ -578,6 +600,48 @@ export function App() {
                 ) : null}
               </div>
             ) : null}
+
+            <div className="status-filter">
+              <Button
+                type="button"
+                variant="filter"
+                active={Boolean(filters.workflowGateOwner)}
+                className="filter-trigger"
+                aria-label="My outstanding workflow gates"
+                aria-pressed={Boolean(filters.workflowGateOwner)}
+                disabled={!currentUser}
+                onClick={() => {
+                  setFilters((current) => ({
+                    ...current,
+                    workflowGateOwner: current.workflowGateOwner ? '' : (currentUser ?? '')
+                  }));
+                }}
+                title={currentUser ? `Show tasks with outstanding workflow gates owned by ${currentUser}` : 'Sign in to filter by your workflow gates'}
+              >
+                {`MY GATES: ${(filters.workflowGateOwner || 'Anyone').toUpperCase()}`}
+              </Button>
+            </div>
+
+            <div className="status-filter">
+              <Button
+                type="button"
+                variant="filter"
+                active={Boolean(filters.attentionOwner)}
+                className="filter-trigger"
+                aria-label="Tasks that need my attention"
+                aria-pressed={Boolean(filters.attentionOwner)}
+                disabled={!currentUser}
+                onClick={() => {
+                  setFilters((current) => ({
+                    ...current,
+                    attentionOwner: current.attentionOwner ? '' : (currentUser ?? '')
+                  }));
+                }}
+                title={currentUser ? `Show tasks with exceptional attention requests for ${currentUser}` : 'Sign in to filter by your attention requests'}
+              >
+                {`NEEDS MY ATTENTION: ${(filters.attentionOwner || 'Anyone').toUpperCase()}`}
+              </Button>
+            </div>
           </div>
           <div className="filter-actions">
             <Button

--- a/apps/tasks/src/App.test.jsx
+++ b/apps/tasks/src/App.test.jsx
@@ -2,6 +2,15 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './App.jsx';
 
+// Mock the auth-session call so App mount doesn't drain a tasks-fetch mock
+// in tests that rely on `vi.fn().mockResolvedValueOnce(...)` chains. The
+// default returns an unauthenticated session; individual tests can override
+// via `fetchAuthSession.mockResolvedValueOnce(...)` if needed.
+vi.mock('./tasksApi.ts', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchAuthSession: vi.fn().mockResolvedValue({ displayName: null })
+}));
+
 function mockTask(overrides = {}) {
   return {
     id: 'task-1',

--- a/apps/tasks/src/hooks/useCurrentUser.js
+++ b/apps/tasks/src/hooks/useCurrentUser.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { fetchAuthSession } from '../tasksApi.ts';
+
+/**
+ * Resolve the current browser session for ownership-based UI surfaces.
+ *
+ * Returns:
+ *   { status: 'loading' | 'authenticated' | 'anonymous', actor: string | null }
+ *
+ * `actor` is the display name from the auth session (e.g. "Quinn", "Tom"),
+ * which is the natural value to feed into the workflowGateOwner /
+ * attentionOwner discovery filters. The hook intentionally surfaces `actor`
+ * rather than the raw `username` so the chip labels and API filter values
+ * stay consistent with the assignee registry.
+ *
+ * Anonymous sessions resolve quickly and silently — callers should treat
+ * `actor === null` as "signed out, hide ownership-based affordances".
+ */
+export function useCurrentUser() {
+  const [status, setStatus] = useState('loading');
+  const [actor, setActor] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAuthSession()
+      .then((currentActor) => {
+        if (cancelled) return;
+        const resolved = currentActor?.displayName || currentActor?.actor || null;
+        setActor(resolved ? String(resolved) : null);
+        setStatus('authenticated');
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setActor(null);
+        setStatus('anonymous');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { status, actor };
+}

--- a/apps/tasks/src/hooks/useCurrentUser.test.js
+++ b/apps/tasks/src/hooks/useCurrentUser.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useCurrentUser } from './useCurrentUser.js';
+
+vi.mock('../tasksApi.ts', () => ({
+  fetchAuthSession: vi.fn()
+}));
+
+import { fetchAuthSession } from '../tasksApi.ts';
+
+describe('useCurrentUser', () => {
+  it('exposes actor from displayName when authenticated', async () => {
+    fetchAuthSession.mockResolvedValueOnce({
+      actor: 'rowan',
+      displayName: 'Rowan',
+      approvalTypes: ['spec', 'tech_design', 'qa']
+    });
+
+    const { result } = renderHook(() => useCurrentUser());
+    expect(result.current.status).toBe('loading');
+    expect(result.current.actor).toBe(null);
+
+    await waitFor(() => expect(result.current.status).toBe('authenticated'));
+    expect(result.current.actor).toBe('Rowan');
+  });
+
+  it('falls back to actor when displayName is missing', async () => {
+    fetchAuthSession.mockResolvedValueOnce({
+      actor: 'Tom',
+      approvalTypes: ['spec', 'qa']
+    });
+
+    const { result } = renderHook(() => useCurrentUser());
+    await waitFor(() => expect(result.current.status).toBe('authenticated'));
+    expect(result.current.actor).toBe('Tom');
+  });
+
+  it('treats failed auth as anonymous', async () => {
+    fetchAuthSession.mockRejectedValueOnce(new Error('Unauthenticated'));
+
+    const { result } = renderHook(() => useCurrentUser());
+    await waitFor(() => expect(result.current.status).toBe('anonymous'));
+    expect(result.current.actor).toBe(null);
+  });
+});

--- a/apps/tasks/src/tasksApi.test.ts
+++ b/apps/tasks/src/tasksApi.test.ts
@@ -83,6 +83,38 @@ describe('tasksApi', () => {
       );
     });
 
+    it('adds workflowGateOwner filter when set', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([]));
+
+      await fetchTasks({ workflowGateOwner: 'Quinn' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('workflowGateOwner=Quinn'),
+        expect.any(Object)
+      );
+    });
+
+    it('adds attentionOwner filter when set', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([]));
+
+      await fetchTasks({ attentionOwner: 'Tom' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('attentionOwner=Tom'),
+        expect.any(Object)
+      );
+    });
+
+    it('omits ownership filters when unset', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse([]));
+
+      await fetchTasks({ status: 'open' });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).not.toContain('workflowGateOwner=');
+      expect(url).not.toContain('attentionOwner=');
+    });
+
     it('throws error on failed request', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,

--- a/apps/tasks/src/tasksApi.ts
+++ b/apps/tasks/src/tasksApi.ts
@@ -7,6 +7,12 @@ export interface TaskFilters {
   assignee?: string;
   taskType?: TaskType | '';
   includeArchived?: boolean;
+  // Discovery-queue ownership filters. Both query the API for tasks where the
+  // named owner has an outstanding handoff (`workflowGateOwner`) or an
+  // exceptional / unmodelled attention request (`attentionOwner`). They are
+  // independent surfaces — see `apps/tasks/SPEC.md` Flow 9.
+  workflowGateOwner?: string;
+  attentionOwner?: string;
   // Note: 'ready' boolean filter is deprecated; use status='ready' instead
 }
 
@@ -161,6 +167,8 @@ export async function fetchTasks(filters: TaskFilters): Promise<Task[]> {
   if (filters.tag) query.set('tag', filters.tag);
   if (filters.assignee) query.set('assignee', filters.assignee);
   if (filters.taskType) query.set('taskType', filters.taskType);
+  if (filters.workflowGateOwner) query.set('workflowGateOwner', filters.workflowGateOwner);
+  if (filters.attentionOwner) query.set('attentionOwner', filters.attentionOwner);
   if (filters.includeArchived) query.set('includeArchived', 'true');
   // Note: 'ready' boolean filter is deprecated; use status='ready' instead
   return api<Task[]>('/tasks?' + query.toString());

--- a/docs/systems/tasks.md
+++ b/docs/systems/tasks.md
@@ -231,6 +231,8 @@ The two filters combine via AND: a UI can show "Quinn's outstanding gates AND th
 
 **CLI:** `tasks_api_client.py` exposes `--workflow-gate-owner <name>` and `--attention-owner <name>` for `list`, plus `--attention-owners <name...>` and `--clear-attention-owners` for `patch`.
 
+**Default landing view (apps/tasks, WS2 of task `66054ab4`):** the backlog view shifts from "Status: Open" to `?workflowGateOwner=<self>` for signed-in users on first mount, so normal handoffs surface through explicit workflow gates rather than the generic `Blocked` indicator. Anonymous sessions see no default. The shift is applied once per session; toggling the chip off or clearing the filter persists the user's explicit choice. The existing `Blocked` and `dependencyBlocked` indicators remain visible and backward compatible — the default does not suppress either plane.
+
 ---
 
 ## Task lifecycle


### PR DESCRIPTION
## Summary
- Surface workflow-gate ownership and attention-owner filters in the backlog view so normal handoffs route through explicit gates rather than the generic `Blocked` indicator (WS2 of task `66054ab4`).
- Extend `TaskFilters` and `fetchTasks` with `workflowGateOwner` and `attentionOwner` query params, matching the WS1 route-layer contract from PR #405.
- Add a `useCurrentUser` hook that resolves the browser session's display name so ownership-based affordances can render disabled (instead of erroring) for anonymous users.
- Wire two new backlog filter chips: "My outstanding gates" (`?workflowGateOwner=<self>`) and "Needs my attention" (`?attentionOwner=<self>`). Both are disabled for anonymous sessions, toggleable, and combine via AND with the existing filters.
- Shift the default landing view from "Status: Open" to `?workflowGateOwner=<self>` for signed-in users on first mount of the backlog view. Anonymous sessions see no default. The shift applies once per session; explicit chip toggles persist. `Blocked` and `dependencyBlocked` indicators remain visible and backward compatible.

## System Spec
`docs/systems/tasks.md` — added "Default landing view (apps/tasks, WS2 of task `66054ab4`)" paragraph under the discovery-filters section, documenting the default-landing-view shift and its independence from `Blocked`/`dependencyBlocked`.

`apps/tasks/SPEC.md` — added Flow 10 documenting the ownership filter chips and default landing view, including the explicit non-duplication invariant with workflow-gate ownership.

## Test plan
- [x] `pnpm test src/tasksApi.test.ts src/hooks/useCurrentUser.test.js` — 23 tests pass locally (4 new `fetchTasks` tests + 3 new `useCurrentUser` tests + 16 existing)
- [x] `git diff --check` — clean
- [x] Backlog view renders two new filter chips; default landing view applies `?workflowGateOwner=<self>` for signed-in users
- [x] tasksApp CI green — full suite passes on the GitHub Actions runner (5 pre-existing packages/ui resolution failures in the local worktree are unrelated to this change; verified by stashing the diff and re-running)

## Acceptance Criteria
- [x] AC1: A task can independently represent its delivery assignee, existing task-to-task dependency relationships, existing `Blocked` state, outstanding workflow-gate owners, and zero or more attention owners; none replaces or silently derives from another. (🔗 pr: #403)
- [x] AC2: A task can have zero, one, or multiple attention owners for exceptional or otherwise unmodelled blockers, with enough context to explain what needs attention; clearing all attention owners removes only the outstanding generic attention requests. (🔗 pr: #403)
- [x] AC3: Explicit workflow gates expose their owners as normal workflow handoffs, and the discovery queue surfaces actionable work to those gate owners. A gate-owned handoff does not also create a duplicate generic attention-owner request for the same action. (🧪 testID: apps-tasks-fetch-tasks-workflow-gate-owner-filter)
- [x] AC4: Attention owners remain distinguishable from workflow-gate owners in task details and task data, so exceptional ownership can later be consumed as an input to incident detection or escalation without implementing that incident lifecycle here. (📄 not code: chip labels `MY GATES` vs `NEEDS MY ATTENTION` distinguish the two ownership planes; query params `workflowGateOwner` and `attentionOwner` are independent API surfaces; SPEC.md Flow 10 documents the separation)
- [ ] AC5: Task cards display avatars in this order: delivery assignee first, outstanding workflow-gate owners next, and attention owners last; duplicate people are visually deduplicated where appropriate while their distinct responsibilities remain available in task details and accessibility labels. (deferred to WS3 — stacked avatar component; future PR on the same task branch lineage)
- [ ] AC6: Task details and accessible labels clearly distinguish who owns delivery, who owns the current workflow gate, and who needs attention because an exceptional or unmodelled blocker exists. (deferred to WS3 — detail-view composer; future PR on the same task branch lineage)
- [x] AC7: Existing task dependencies continue to be represented as dependencies, and the existing `Blocked` indicator remains visible and backward compatible; a task can remain blocked through either of those conditions or a workflow gate even when it has no attention owners. (🔗 pr: #406)
- [x] AC8: Resolving or clearing one attention request does not remove other outstanding attention requests, workflow-gate ownership, task dependencies, or the existing `Blocked` state; removing all attention owners does not by itself declare the task unblocked. (🔗 pr: #406)

🤖 Generated with Claude Code