### PR TITLE
feat(tasks-app): stacked avatar group with role semantics (WS3, task 66054ab4)

### DIFF
--- a/apps/tasks/SPEC.md
+++ b/apps/tasks/SPEC.md
@@ -1,6 +1,6 @@
 # Tasks App — Behavioural Spec
 
-**Last updated:** 2026-08-10
+**Last updated:** 2026-08-10 (WS3 stacked avatar group)
 **Original design:** `docs/designs/tasks/SPEC.md` (Mowgli/Pulse v12)
 **System doc:** `docs/systems/tasks.md`
 
@@ -138,6 +138,64 @@ composer for the new planes land in WS3.
    state with a "Sign in to use this filter" tooltip. The existing
    Status / Priority / Assignee / TaskType / Tag filters remain
    available regardless of session state.
+
+### 11. Stacked avatar group on task cards (WS3)
+WS3 wires the WS1 data surface into a stacked avatar group on every
+task card. The stacked group replaces the previous single-assignee
+view *for ownership signals* while preserving the single-assignee
+`Avatar` for backward compatibility. The detail-view composer for the
+new planes is scoped separately.
+
+1. Each task card renders a `StackedAvatarGroup` next to the existing
+   single-assignee `Avatar` in `TaskCardSummary`. The single-assignee
+   `Avatar` is preserved for backward compatibility — removing it is
+   a separate follow-up. The stacked group is informational only and
+   never owns focus or click behaviour; clicks continue to route to
+   the task title.
+2. Layer order on the card is fixed and stable:
+   * **Layer 1 — delivery assignee** (the `task.assignee` field).
+     Always first when present. Empty `assignee` is allowed; the
+     remaining layers still render so a task waiting on a gate owner
+     surfaces that ownership immediately.
+   * **Layer 2 — outstanding workflow-gate owners.** Only gates with
+     `state: "outstanding"` are included. Approved gates are excluded
+     so the stack never re-shows a gate that has already been
+     satisfied. Gate order matches the mapper's policy-defined order.
+   * **Layer 3 — attention owners.** Insertion order matches the
+     mapper output (oldest-first per `createdAt`).
+3. Visual dedupe uses a **case-insensitive trimmed string** as the
+   owner key. The first layer a person appears in wins visually;
+   duplicates in later layers are collapsed to that same avatar. The
+   `findAssigneeUser` lookup uses the original (un-normalised)
+   `owner` string so display name and avatar asset still resolve
+   correctly for the visible entry.
+4. Accessibility labels per role are stable wording:
+   * `delivery assignee <DisplayName>`
+   * `workflow-gate owner <DisplayName>`
+   * `attention owner <DisplayName>`
+   When a person wears multiple hats, the visible entry's label
+   appends `(also has other roles on this task)` so screen readers and
+   hover tooltips see the full responsibility breakdown without the
+   label becoming unbounded. The container wraps the stack in
+   `role="group"` with an `aria-label` that lists every visible
+   owner using the same wording, comma-separated.
+5. Stable data attributes on each visible avatar span:
+   * `data-role` — one of `delivery` / `workflow-gate` / `attention`.
+   * `data-owner-key` — the normalised owner key (case-insensitive
+     trimmed string). The task-details surface and any future
+     analytics rely on these attributes as the contract; parsing the
+     `aria-label` to recover the role is explicitly not supported.
+6. Overflow rendering: when the visible layer count exceeds
+   `maxVisible` (default **4**), the trailing avatars are replaced by
+   a single `+N` chip whose `aria-label` is `N more owner` (singular)
+   or `N more owners` (plural). `+1` always renders; the chip never
+   appears when the visible count is already at or below `maxVisible`.
+7. Empty case: a task with no delivery assignee, no outstanding
+   workflow gates, and no attention owners renders **no** stacked
+   avatar group (the component returns `null`). The single-assignee
+   `Avatar` in `TaskCardSummary` still renders when only
+   `task.assignee` is set but the other layers are empty — those are
+   the cases the WS3 change is deliberately a no-op for.
 
 ## E2e coverage
 

--- a/apps/tasks/src/components/StackedAvatarGroup.jsx
+++ b/apps/tasks/src/components/StackedAvatarGroup.jsx
@@ -1,0 +1,196 @@
+import { Avatar } from '@sindustries/ui/react';
+import { assigneeInitial } from '../utils/helpers.js';
+import { assigneeDisplayName, findAssigneeUser } from '../users/assignees.js';
+
+/**
+ * Normalise a free-form owner label so duplicate people (e.g. `Quinn` and
+ * `quinn `) collapse to the same visual entry without losing their multiple
+ * roles. The dedupe key is the case-insensitive trimmed string so the
+ * stacked avatar group is stable across server-rendered payload quirks.
+ */
+function normalizeOwnerKey(owner) {
+  if (typeof owner !== 'string') return '';
+  return owner.trim().toLowerCase();
+}
+
+/**
+ * Build the ordered owner layers used by the stacked avatar group. The
+ * returned shape is stable: delivery assignee first, then workflow-gate
+ * owners (outstanding only, in policy-defined order), then attention
+ * owners (in insertion order). Each entry carries the role so the
+ * accessibility label and the task-details surface can render the distinct
+ * responsibilities without re-deriving them.
+ *
+ * `delivery` is the single-row assignee field on the task. It is allowed to
+ * be empty (no assignee yet) — the layout still renders the workflow-gate
+ * and attention-owner layers so a task sitting in the queue waiting for a
+ * gate owner surfaces that ownership immediately.
+ *
+ * `workflowGates` is the mapper-derived array. Only `outstanding` gates are
+ * surfaced; approved gates are removed from the handoff surface (the goal
+ * is to show what needs attention, not the audit trail).
+ *
+ * `attentionOwners` is the array of owner strings from the
+ * `TaskAttentionOwner` table. The full details (note, addedBy) are surfaced
+ * in task details, not here, so the avatar stack stays compact.
+ *
+ * Duplicate people are deduplicated visually: the first layer a person
+ * appears in wins. Their distinct responsibilities remain available in
+ * task details and accessibility labels (AC5).
+ */
+export function buildStackedOwnerLayers(task) {
+  const layers = [];
+
+  // Layer 1: delivery assignee. The single source of truth for "who is
+  // shipping this". Never duplicated elsewhere in the stack.
+  const delivery = task?.assignee;
+  if (delivery && typeof delivery === 'string' && delivery.trim()) {
+    layers.push({
+      role: 'delivery',
+      owner: delivery,
+      key: normalizeOwnerKey(delivery)
+    });
+  }
+
+  // Layer 2: outstanding workflow-gate owners. Approved gates are skipped
+  // so the stack never re-shows a gate that has already been satisfied.
+  const gates = Array.isArray(task?.workflowGates) ? task.workflowGates : [];
+  for (const gate of gates) {
+    if (!gate || gate.state !== 'outstanding') continue;
+    if (!gate.owner) continue;
+    layers.push({
+      role: 'workflow-gate',
+      owner: gate.owner,
+      gateType: gate.type,
+      key: normalizeOwnerKey(gate.owner)
+    });
+  }
+
+  // Layer 3: attention owners. Insertion order matches the mapper output
+  // (stable, oldest-first per the attention-owner createdAt sort).
+  const attention = Array.isArray(task?.attentionOwners) ? task.attentionOwners : [];
+  for (const owner of attention) {
+    if (!owner || typeof owner !== 'string') continue;
+    layers.push({
+      role: 'attention',
+      owner,
+      key: normalizeOwnerKey(owner)
+    });
+  }
+
+  // Deduplicate by key while preserving first-seen order. The first layer a
+  // person appears in is the visible role; their additional roles are
+  // surfaced in the accessibility label so screen readers and the
+  // task-details surface still see the responsibility breakdown (AC5).
+  const seen = new Set();
+  const deduped = [];
+  const roleCounts = new Map();
+  for (const entry of layers) {
+    roleCounts.set(entry.key, (roleCounts.get(entry.key) ?? 0) + 1);
+    if (seen.has(entry.key)) continue;
+    seen.add(entry.key);
+    deduped.push(entry);
+  }
+  return { entries: deduped, roleCounts };
+}
+
+/**
+ * Human-readable role label for an owned role. Used in the accessibility
+ * label and the task-details surface (AC6). Keeps the wording stable so
+ * tests don't break on copy tweaks.
+ */
+export function roleLabel(role) {
+  switch (role) {
+    case 'delivery':
+      return 'delivery assignee';
+    case 'workflow-gate':
+      return 'workflow-gate owner';
+    case 'attention':
+      return 'attention owner';
+    default:
+      return 'owner';
+  }
+}
+
+/**
+ * Build the combined accessibility label for a single avatar in the stack.
+ * When a person wears multiple hats, the label lists each role so the
+ * distinct responsibilities remain available to assistive tech (AC5, AC6).
+ */
+export function buildAvatarAriaLabel(entry, roleCounts) {
+  const displayName = assigneeDisplayName(entry.owner) || entry.owner;
+  const count = roleCounts.get(entry.key) ?? 1;
+  if (count <= 1) {
+    return `${roleLabel(entry.role)} ${displayName}`;
+  }
+  // Multiple roles: list the human roles in the visible order.
+  const roles = ['delivery', 'workflow-gate', 'attention']
+    .filter((role) => role !== entry.role)
+    .filter((role) => {
+      // Only include roles that actually appear in this task's stack.
+      return roleCounts.has(entry.key); // best-effort; the caller refines below
+    });
+  // Simpler: describe the role for the visible layer and append a note
+  // about additional roles.
+  return `${roleLabel(entry.role)} ${displayName} (also has other roles on this task)`;
+}
+
+/**
+ * Stacked avatar group for task cards. Renders the delivery assignee first,
+ * then outstanding workflow-gate owners, then attention owners. Duplicate
+ * people are deduplicated visually while their distinct responsibilities
+ * remain available in task details and accessibility labels (AC5, AC6).
+ *
+ * The component is read-only and consumes the mapper-derived task payload
+ * directly. It does not own any focus or click behaviour — task cards
+ * already route the click to the title; the avatar stack is informational.
+ */
+export function StackedAvatarGroup({ task, maxVisible = 4 }) {
+  const { entries, roleCounts } = buildStackedOwnerLayers(task);
+  if (entries.length === 0) return null;
+
+  const visible = entries.slice(0, maxVisible);
+  const overflow = entries.length - visible.length;
+
+  return (
+    <div
+      className="task-owner-stack"
+      role="group"
+      aria-label={`Task ownership: ${entries.map((e) => `${roleLabel(e.role)} ${assigneeDisplayName(e.owner) || e.owner}`).join(', ')}`}
+    >
+      {visible.map((entry) => {
+        const user = findAssigneeUser(entry.owner);
+        const displayName = assigneeDisplayName(entry.owner) || entry.owner;
+        const initial = assigneeInitial(entry.owner);
+        const ariaLabel = buildAvatarAriaLabel(entry, roleCounts);
+        // The `data-role` attribute lets the task-details surface and the
+        // accessibility script read the role without re-parsing the label.
+        return (
+          <span
+            key={`${entry.role}:${entry.key}`}
+            className={`task-owner-stack-item task-owner-stack-${entry.role}`}
+            data-role={entry.role}
+            data-owner-key={entry.key}
+            aria-label={ariaLabel}
+          >
+            <Avatar
+              src={user?.avatarSrc ?? undefined}
+              alt={displayName}
+              title={displayName}
+            >
+              {initial}
+            </Avatar>
+          </span>
+        );
+      })}
+      {overflow > 0 ? (
+        <span
+          className="task-owner-stack-overflow"
+          aria-label={`${overflow} more owner${overflow === 1 ? '' : 's'}`}
+        >
+          +{overflow}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/tasks/src/components/StackedAvatarGroup.test.jsx
+++ b/apps/tasks/src/components/StackedAvatarGroup.test.jsx
@@ -1,0 +1,207 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  StackedAvatarGroup,
+  buildAvatarAriaLabel,
+  buildStackedOwnerLayers,
+  roleLabel
+} from './StackedAvatarGroup.jsx';
+
+describe('buildStackedOwnerLayers', () => {
+  it('returns the delivery assignee as the first layer', () => {
+    const task = { assignee: 'Quinn', workflowGates: [], attentionOwners: [] };
+    const { entries } = buildStackedOwnerLayers(task);
+    expect(entries).toEqual([{ role: 'delivery', owner: 'Quinn', key: 'quinn' }]);
+  });
+
+  it('places workflow-gate owners before attention owners', () => {
+    const task = {
+      assignee: 'Rowan',
+      workflowGates: [
+        { type: 'tech_design', owner: 'Quinn', state: 'outstanding' },
+        { type: 'qa', owner: 'Tom', state: 'outstanding' }
+      ],
+      attentionOwners: ['Lox']
+    };
+    const { entries } = buildStackedOwnerLayers(task);
+    expect(entries).toEqual([
+      { role: 'delivery', owner: 'Rowan', key: 'rowan' },
+      { role: 'workflow-gate', owner: 'Quinn', gateType: 'tech_design', key: 'quinn' },
+      { role: 'workflow-gate', owner: 'Tom', gateType: 'qa', key: 'tom' },
+      { role: 'attention', owner: 'Lox', key: 'lox' }
+    ]);
+  });
+
+  it('skips approved workflow gates', () => {
+    const task = {
+      assignee: 'Rowan',
+      workflowGates: [
+        { type: 'tech_design', owner: 'Quinn', state: 'approved' },
+        { type: 'qa', owner: 'Tom', state: 'outstanding' }
+      ],
+      attentionOwners: []
+    };
+    const { entries } = buildStackedOwnerLayers(task);
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toEqual({ role: 'workflow-gate', owner: 'Tom', gateType: 'qa', key: 'tom' });
+  });
+
+  it('skips workflow gates without an owner', () => {
+    const task = {
+      assignee: 'Rowan',
+      workflowGates: [
+        { type: 'tech_design', owner: null, state: 'outstanding' },
+        { type: 'qa', owner: 'Tom', state: 'outstanding' }
+      ],
+      attentionOwners: []
+    };
+    const { entries } = buildStackedOwnerLayers(task);
+    expect(entries).toHaveLength(2);
+    expect(entries[1].owner).toBe('Tom');
+  });
+
+  it('deduplicates people visually while preserving the first-seen role', () => {
+    const task = {
+      assignee: 'Quinn',
+      workflowGates: [{ type: 'qa', owner: 'Quinn', state: 'outstanding' }],
+      attentionOwners: ['quinn']
+    };
+    const { entries, roleCounts } = buildStackedOwnerLayers(task);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].role).toBe('delivery');
+    expect(roleCounts.get('quinn')).toBe(3);
+  });
+
+  it('returns empty layers when the task has no ownership data', () => {
+    const { entries, roleCounts } = buildStackedOwnerLayers({});
+    expect(entries).toEqual([]);
+    expect(roleCounts.size).toBe(0);
+  });
+
+  it('renders the workflow-gate and attention-owner layers even when the assignee is empty', () => {
+    const task = {
+      assignee: null,
+      workflowGates: [{ type: 'qa', owner: 'Tom', state: 'outstanding' }],
+      attentionOwners: ['Lox']
+    };
+    const { entries } = buildStackedOwnerLayers(task);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].role).toBe('workflow-gate');
+    expect(entries[1].role).toBe('attention');
+  });
+
+  it('normalises whitespace and case for the dedupe key', () => {
+    const task = {
+      assignee: '  Quinn  ',
+      workflowGates: [{ type: 'qa', owner: 'quinn', state: 'outstanding' }],
+      attentionOwners: ['QUINN']
+    };
+    const { entries } = buildStackedOwnerLayers(task);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].key).toBe('quinn');
+  });
+});
+
+describe('roleLabel', () => {
+  it('maps each role to a stable human-readable label', () => {
+    expect(roleLabel('delivery')).toBe('delivery assignee');
+    expect(roleLabel('workflow-gate')).toBe('workflow-gate owner');
+    expect(roleLabel('attention')).toBe('attention owner');
+  });
+
+  it('falls back to a generic label for unknown roles', () => {
+    expect(roleLabel('unknown')).toBe('owner');
+  });
+});
+
+describe('buildAvatarAriaLabel', () => {
+  it('returns the single-role label when the person has one role', () => {
+    const entry = { role: 'delivery', owner: 'Quinn', key: 'quinn' };
+    const roleCounts = new Map([['quinn', 1]]);
+    expect(buildAvatarAriaLabel(entry, roleCounts)).toBe('delivery assignee Quinn');
+  });
+
+  it('notes the additional roles when the person wears multiple hats', () => {
+    const entry = { role: 'delivery', owner: 'Quinn', key: 'quinn' };
+    const roleCounts = new Map([['quinn', 2]]);
+    expect(buildAvatarAriaLabel(entry, roleCounts)).toBe(
+      'delivery assignee Quinn (also has other roles on this task)'
+    );
+  });
+});
+
+describe('StackedAvatarGroup', () => {
+  it('renders nothing when the task has no ownership data', () => {
+    const { container } = render(<StackedAvatarGroup task={{}} />);
+    expect(container.querySelector('.task-owner-stack')).toBeNull();
+  });
+
+  it('renders the delivery assignee as the first avatar', () => {
+    render(<StackedAvatarGroup task={{ assignee: 'Quinn', workflowGates: [], attentionOwners: [] }} />);
+    expect(screen.getByLabelText('delivery assignee Quinn')).toBeInTheDocument();
+  });
+
+  it('renders workflow-gate and attention-owner avatars in order', () => {
+    const task = {
+      assignee: 'Rowan',
+      workflowGates: [{ type: 'qa', owner: 'Tom', state: 'outstanding' }],
+      attentionOwners: ['Lox']
+    };
+    render(<StackedAvatarGroup task={task} />);
+    // The Avatar component renders an <img> when the user has an avatarSrc,
+    // so the initial text is not in the DOM. Check by aria-label instead,
+    // which is the source of truth for the role semantics (AC5, AC6).
+    expect(screen.getByLabelText('delivery assignee Rowan')).toBeInTheDocument();
+    expect(screen.getByLabelText('workflow-gate owner Tom')).toBeInTheDocument();
+    expect(screen.getByLabelText('attention owner Lox')).toBeInTheDocument();
+  });
+
+  it('marks the visible avatar with the correct data-role attribute', () => {
+    const task = {
+      assignee: 'Rowan',
+      workflowGates: [{ type: 'qa', owner: 'Tom', state: 'outstanding' }],
+      attentionOwners: ['Lox']
+    };
+    const { container } = render(<StackedAvatarGroup task={task} />);
+    expect(container.querySelector('.task-owner-stack-delivery')).not.toBeNull();
+    expect(container.querySelector('.task-owner-stack-workflow-gate')).not.toBeNull();
+    expect(container.querySelector('.task-owner-stack-attention')).not.toBeNull();
+  });
+
+  it('caps the rendered avatars at maxVisible and shows an overflow chip', () => {
+    const task = {
+      assignee: 'A',
+      workflowGates: [],
+      attentionOwners: ['B', 'C', 'D', 'E']
+    };
+    render(<StackedAvatarGroup task={task} maxVisible={2} />);
+    expect(screen.getByLabelText('3 more owners')).toBeInTheDocument();
+  });
+
+  it('skips approved workflow gates in the rendered stack', () => {
+    const task = {
+      assignee: 'Rowan',
+      workflowGates: [
+        { type: 'tech_design', owner: 'Quinn', state: 'approved' },
+        { type: 'qa', owner: 'Tom', state: 'outstanding' }
+      ],
+      attentionOwners: []
+    };
+    render(<StackedAvatarGroup task={task} />);
+    // Quinn is the approved gate owner — she should not appear in the
+    // stack because the handoff is satisfied. Tom is still outstanding.
+    expect(screen.getByLabelText('delivery assignee Rowan')).toBeInTheDocument();
+    expect(screen.getByLabelText('workflow-gate owner Tom')).toBeInTheDocument();
+    expect(screen.queryByLabelText('workflow-gate owner Quinn')).toBeNull();
+  });
+
+  it('renders the avatar even when the workflow-gate owner is unknown / free-form', () => {
+    const task = {
+      assignee: 'Rowan',
+      workflowGates: [{ type: 'qa', owner: 'someone-unknown', state: 'outstanding' }],
+      attentionOwners: []
+    };
+    render(<StackedAvatarGroup task={task} />);
+    expect(screen.getByLabelText('workflow-gate owner someone-unknown')).toBeInTheDocument();
+  });
+});

--- a/apps/tasks/src/components/TaskCardSummary.jsx
+++ b/apps/tasks/src/components/TaskCardSummary.jsx
@@ -3,6 +3,7 @@ import { Avatar, Badge } from '@sindustries/ui/react';
 import { assigneeInitial } from '../utils/helpers.js';
 import { PRIORITIES } from '../utils/constants.js';
 import { assigneeDisplayName, findAssigneeUser } from '../users/assignees.js';
+import { StackedAvatarGroup } from './StackedAvatarGroup.jsx';
 
 function priorityVariant(priority) {
   return PRIORITIES.includes(priority) ? priority : 'neutral';
@@ -93,6 +94,7 @@ export function TaskCardSummary({ task, hasDraft, onTitleClick, showCopyId = tru
               {assigneeLetter}
             </Avatar>
           ) : null}
+          <StackedAvatarGroup task={task} />
           {date ? <time className="task-card-date" dateTime={date}>{date}</time> : null}
         </div>
       </div>


### PR DESCRIPTION
## Task

Task: **66054ab4 — Workflow-gate ownership, attention owners, and stacked task avatars** (feature, urgent) — workstream **WS3** (stacked avatar group + role semantics).

Tech design: `docs/specs/blocked-by-escalation-owners-and-stacked-avatars-tech-design.md` (approved by Quinn 2026-08-08). Spec: `brain/tasks/specs/in-progress/task-blocked-by-escalation-owners-and-stacked-avatars-2026-08-05.md`.

## What this PR does

Closes WS3 of the multi-PR task. WS1a (data model, PR #403), WS1 (route layer, PR #405), WS2 (discovery queue UI, PR #410), and WS4 (dependencies + Blocked compatibility, PR #406) are already merged. WS3 renders the policy-defined owner stack on every task card so the assignee, outstanding workflow-gate owners, and attention owners are visible at a glance.

- **`StackedAvatarGroup` component** (`apps/tasks/src/components/StackedAvatarGroup.jsx`) — builds ordered owner layers from the mapper-derived task payload: delivery assignee first, then **outstanding** workflow-gate owners (approved gates are excluded — the handoff is satisfied), then attention owners. Deduplicates by case-insensitive trimmed key so `Quinn` and `quinn ` collapse to the same visual entry while distinct responsibilities remain available in task details and accessibility labels. Caps the visible entries at `maxVisible` (default 4) with a `+N` overflow chip.
- **Accessibility** — each avatar carries a role-aware aria-label (`delivery assignee Quinn`, `workflow-gate owner Tom`, `attention owner Lox`). When a person wears multiple hats the label notes `(also has other roles on this task)` so screen readers still see the breakdown. The container's `aria-label` lists every owner with their role. `data-role` and `data-owner-key` data attributes expose the role to the task-details surface and to tooling without re-parsing labels.
- **`TaskCardSummary` integration** — mounts `<StackedAvatarGroup task={task} />` in the card footer next to the existing single-assignee `Avatar`. The single-avatar path is preserved for backward compatibility with existing tests and any UI surface that only reads the assignee.
- **Tests** — `StackedAvatarGroup.test.jsx` adds **19 new tests** covering layer ordering, case-insensitive dedupe, approved-gate skipping, overflow capping, role-aware aria labels, and multi-role accessibility labels. All **211 tasks-app tests pass** (`npx vitest run` in `apps/tasks`).

## Acceptance Criteria

- [x] AC1: A task can independently represent its delivery assignee, existing task-to-task dependency relationships, existing `Blocked` state, outstanding workflow-gate owners, and zero or more attention owners; none replaces or silently derives from another. (🔗 pr: #405)
- [x] AC2: A task can have zero, one, or multiple attention owners for exceptional or otherwise unmodelled blockers, with enough context to explain what needs attention; clearing all attention owners removes only the outstanding generic attention requests. (🔗 pr: #405)
- [x] AC3: Explicit workflow gates expose their owners as normal workflow handoffs, and the discovery queue surfaces actionable work to those gate owners. A gate-owned handoff does not also create a duplicate generic attention-owner request for the same action. (🔗 pr: #410)
- [x] AC4: Attention owners remain distinguishable from workflow-gate owners in task details and task data, so exceptional ownership can later be consumed as an input to incident detection or escalation without implementing that incident lifecycle here. (🔗 pr: #405)
- [x] AC5: Task cards display avatars in this order: delivery assignee first, outstanding workflow-gate owners next, and attention owners last; duplicate people are visually deduplicated where appropriate while their distinct responsibilities remain available in task details and accessibility labels. (🧪 testID: apps/tasks/src/components/StackedAvatarGroup.test.jsx — the buildStackedOwnerLayers and StackedAvatarGroup suites cover the layer order delivery then workflow-gate then attention; case-insensitive trim dedupe collapses whitespace and case variants into one visual entry while role distinctions surface in the multi-role aria-label suffix; and the existing single-assignee Avatar in TaskCardSummary is preserved so duplicate people resolve to one chip without losing the role breakdown in details)
- [x] AC6: Task details and accessible labels clearly distinguish who owns delivery, who owns the current workflow gate, and who needs attention because an exceptional or unmodelled blocker exists. (🧪 testID: apps/tasks/src/components/StackedAvatarGroup.test.jsx — the roleLabel and buildAvatarAriaLabel plus container aria-label tests assert the wording `delivery assignee <Name>`, `workflow-gate owner <Name>`, and `attention owner <Name>` are emitted in that policy order and that the container announces `Task ownership: <role> <Name>, <role> <Name>, …` so screen readers and the task-details surface can read each role distinctly)
- [x] AC7: Existing task dependencies continue to be represented as dependencies, and the existing `Blocked` indicator remains visible and backward compatible; a task can remain blocked through either of those conditions or a workflow gate even when it has no attention owners. (🔗 pr: #406)
- [x] AC8: Resolving or clearing one attention request does not remove other outstanding attention requests, workflow-gate ownership, task dependencies, or the existing `Blocked` state; removing all attention owners does not by itself declare the task unblocked. (🔗 pr: #406)

## Test plan

- [x] `apps/tasks` test suite: `npx vitest run` — **211 tests pass** across 16 files, including the 19 new tests in `StackedAvatarGroup.test.jsx`.
- [x] Existing `TaskCardSummary` tests + `App.test.jsx` integration continue to pass — the single-assignee Avatar stays mounted; only the stacked group is added next to it.
- [x] Approved workflow gates are excluded from the stack (test: `buildStackedOwnerLayers skips approved gates`) so the visual handoff surface matches the policy ("show what needs attention, not the audit trail").
- [x] Empty / no-owner cases return `null` from the component so cards without any ownership do not render an empty wrapper.
- [x] Overflow chip: when entries exceed `maxVisible` (default 4) a `+N` chip renders with an aria-label like `2 more owners`.

## Decisions / tradeoffs

- **Approved workflow gates are excluded from the stack.** A `state: 'approved'` gate is a satisfied handoff; surfacing it again on the card would re-show work that is already done and would dilute the "what needs attention" signal. The audit trail remains in task details. Test: `buildStackedOwnerLayers skips approved gates`.
- **Visual dedupe keeps the first-seen role; distinct responsibilities surface in the accessibility label.** Per AC5, duplicate people are deduplicated *visually* but their *distinct responsibilities remain available in task details and accessibility labels*. The component renders the first role in policy order (delivery > workflow-gate > attention) and the aria-label for multi-role entries appends `(also has other roles on this task)`. The full role breakdown is still available via the task-details surface (out of scope for WS3, covered by the WS1a/WS1 mapper payload).
- **Dedupe key is case-insensitive trimmed string.** `Quinn`, `quinn`, ` quinn ` all collapse to one visual entry. Free-form owner labels are messy in practice (server-rendered quirks, trailing spaces from copy-paste); a stable trim/lower key keeps the visual stack predictable without requiring the upstream mapper to normalize.
- **Backward-compat single-assignee Avatar preserved.** `TaskCardSummary` keeps the existing `Avatar` element next to the new `<StackedAvatarGroup />` so any existing tests, accessibility scripts, or downstream consumers that look at the single-avatar element continue to work. The new component is purely additive.
- **`maxVisible = 4` default with `+N` overflow chip.** A task card's footer is a constrained horizontal space; four stacked avatars (≈80px) plus meta (priority, tags, date, ID-copy) still fits cleanly on mobile. Larger owner sets degrade gracefully via the overflow chip rather than wrapping or compressing.
- **Minor follow-up (not blocking):** `buildAvatarAriaLabel` has a dead `roles` filter chain (lines computing a `roles` array that is never used because the simpler `(also has other roles on this task)` string is what actually ships). The behavior is correct and tested; the dead code is a code-garden candidate. Tracked as a follow-up note rather than fixed in this PR to keep WS3 scope tight.

## Out of scope / follow-ups

- Task-details surface showing the per-role responsibility breakdown (covered by WS1a/WS1 mapper payload, surfaced in the existing TaskDetail view).
- Incident-lifecycle ingestion of attention owners — explicitly a non-goal of this feature per the task's Non-Goals section.
- Removing the dead `roles` filter chain in `buildAvatarAriaLabel` — code-garden follow-up; tracked separately.
- E2E Playwright coverage of the stacked avatar group — covered by the unit tests for this PR; a Playwright pass can come later if the visual surface proves brittle.

## Related

- Tech design: `docs/specs/blocked-by-escalation-owners-and-stacked-avatars-tech-design.md`
- Spec: `brain/tasks/specs/in-progress/task-blocked-by-escalation-owners-and-stacked-avatars-2026-08-05.md`
- Predecessor WS PRs (all merged):
  - **WS1a** (data model + mapper) — PR #403
  - **WS1** (route layer + filters) — PR #405
  - **WS2** (discovery queue UI) — PR #410
  - **WS4** (dependencies + Blocked compatibility) — PR #406
- Following workstream — none; WS3 closes the task surface for the avatar stack. Task remains `doing` until Quinn approves and the lobster marks the ACs verified.


