### PR TITLE
chore(code-garden): mark 2026-W29 mission-control SPEC.md Content Scheduler finding done

### DIFF
--- a/docs/repo-audits/2026-W29.md
+++ b/docs/repo-audits/2026-W29.md
@@ -175,7 +175,7 @@ No new performance concerns this week. The Content Scheduler endpoints load all 
 
 ### Documentation
 
-**[Low] `apps/mission-control/SPEC.md` lists four tabs in MVP (Tasks, Bookmarks, Flow metrics, Design System) but does not mention Content Scheduler.**
+**[Low] `apps/mission-control/SPEC.md` lists four tabs in MVP (Tasks, Bookmarks, Flow metrics, Design System) but does not mention Content Scheduler.** ✅ [PR #221](https://github.com/Stoffer-Industries/sindustries/pull/221)
 - *Where:* `apps/mission-control/SPEC.md:9`
 - *Why it matters:* Content Scheduler tab shipped this week (`eb8e4bd`) but the SPEC.md still lists the original four tabs. The spec is a behavioral contract — any divergence between SPEC and code is a maintenance debt.
 - *Severity:* Low


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W29.md
- **Finding:** [Low] `apps/mission-control/SPEC.md` lists four tabs in MVP but does not mention Content Scheduler.
- One-line audit-hygiene edit: `apps/mission-control/SPEC.md` already documents the Content Scheduler tab (`§7 Manage the Content Scheduler 10-day calendar` at line 80, the `Content` row in the e2e coverage table at line 134, and `Content Scheduler` mentions at lines 166, 186), and the W29 Milestone plan already cites ✅ [PR #221](https://github.com/Stoffer-Industries/sindustries/pull/221) as the implementing PR. The body finding line on the audit lacked the marker. This PR appends the marker so the audit reflects reality.

## Test plan
- [x] No logic changes — diff is purely an audit-file marker append (single line, +1/-1 on `docs/repo-audits/2026-W29.md`)
- [x] Scope guard clean — no `agents/skills/` or `agents/crons/` paths touched
- [x] SPEC.md not modified (already correct; PR #221 was the implementing PR)

🌱 Code garden — non-functional cleanup only