### PR TITLE
fix(tasks-api): do not require X_ACTOR_SECRET at boot

### DIFF
--- a/services/tasks-api/src/config/env.ts
+++ b/services/tasks-api/src/config/env.ts
@@ -96,7 +96,14 @@ const schema = z.object({
   OTEL_SDK_DISABLED: z.string().optional()
 }).superRefine((cfg, ctx) => {
   if (cfg.X_CLIENT === 'real') {
-    for (const key of ['X_API_KEY', 'X_API_SECRET', 'X_ACCESS_TOKEN', 'X_ACCESS_TOKEN_SECRET', 'X_ACTOR_SECRET'] as const) {
+    // X_ACTOR_SECRET is intentionally NOT in this list: it is an opt-in
+    // x-actor-secret header gate for the content-scheduler X publish path
+    // (see src/routes/contentSchedulerPublish.ts). When unset, that gate
+    // passes through (dev / local / CI), matching the route contract
+    // covered by test/contentScheduler.test.ts. Adding it here would
+    // block boot whenever X_CLIENT=real without the secret configured
+    // (e.g. the local prodlike .env, which intentionally omits it).
+    for (const key of ['X_API_KEY', 'X_API_SECRET', 'X_ACCESS_TOKEN', 'X_ACCESS_TOKEN_SECRET'] as const) {
       if (!cfg[key]) {
         ctx.addIssue({
           code: 'custom',

--- a/services/tasks-api/test/config.test.ts
+++ b/services/tasks-api/test/config.test.ts
@@ -89,11 +89,13 @@ describe('tasks-api config schema', () => {
     await expect(loadEnvFresh()).rejects.toThrow(/ConfigValidationError/);
     const payload = JSON.parse(capturedExit.payload ?? '{}');
     const names = payload.issues.map((i: { path: string }) => i.path);
+    // X_ACTOR_SECRET is intentionally NOT in this list: it is an opt-in
+    // x-actor-secret header gate, not a hard X integration requirement.
+    // See env.ts superRefine.
     expect(names).toContain('X_API_KEY');
     expect(names).toContain('X_API_SECRET');
     expect(names).toContain('X_ACCESS_TOKEN');
     expect(names).toContain('X_ACCESS_TOKEN_SECRET');
-    expect(names).toContain('X_ACTOR_SECRET');
   });
 
   it('accepts X_CLIENT=real when all OAuth credentials are present', async () => {
@@ -166,8 +168,8 @@ describe('tasks-api config schema', () => {
     process.env.X_API_KEY = 'TOP-SECRET-do-not-log';
     process.env.X_API_SECRET = 'SHOULD-NOT-APPEAR';
     process.env.X_ACCESS_TOKEN = 'ALSO-SECRET';
-    process.env.X_ACCESS_TOKEN_SECRET = 'ALSO-SECRET';
-    // Intentionally omit X_ACTOR_SECRET to trigger validation failure.
+    // Intentionally omit X_ACCESS_TOKEN_SECRET to trigger validation failure
+    // (X_ACTOR_SECRET is opt-in and intentionally not required at boot).
     await expect(loadEnvFresh()).rejects.toThrow(/ConfigValidationError/);
     const payload = JSON.stringify(capturedExit.payload ?? '');
     expect(payload).not.toContain('TOP-SECRET-do-not-log');


### PR DESCRIPTION
# fix(tasks-api): do not require X_ACTOR_SECRET at boot

## What

The cross-field guard in `services/tasks-api/src/config/env.ts` was over-requiring `X_ACTOR_SECRET` when `X_CLIENT=real`. That overreach blocked boot for every deployment that sets `X_CLIENT=real` for real X integration but leaves the `x-actor-secret` header gate unset — including the local prodlike `.env`, which intentionally omits it.

`X_ACTOR_SECRET` is an **opt-in header gate** on the content-scheduler X publish path, not a hard X integration requirement. The route contract at `src/routes/contentSchedulerPublish.ts` (covered by `test/contentScheduler.test.ts` "passes through when X_ACTOR_SECRET is unset (dev / local / CI)") explicitly treats an unset value as pass-through. Schema should match.

## Why this is a regression

`PR #414` (task `206927ed`, production runtime configuration contract) introduced this cross-field guard for the first time. Before that PR, `X_ACTOR_SECRET` was read directly from `process.env` at call time in `checkActorSecret`, with no boot-time validation.

The intent in `PR #414`'s body was that "the schema validates the `X_CLIENT=real` contract at boot" — and `X_ACTOR_SECRET` was treated as part of that contract. That is wrong: `X_ACTOR_SECRET` is a **different** "real" — a deployment-configured secret gate that protects the X publish path — not an OAuth credential. The four OAuth credentials (`X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`) are the ones that are *required* for real X integration; `X_ACTOR_SECRET` is only required if you've chosen to enable the header gate.

## Impact of the regression

- `services/tasks-api/.env.prodlike` sets `X_CLIENT=real` + the four OAuth tokens but intentionally omits `X_ACTOR_SECRET` (the prodlike plane doesn't have the secret gate configured). After `PR #414` merged, `tasks-api` fails to boot against the prodlike plane with `config_validation_failed: X_ACTOR_SECRET is required when X_CLIENT=real`.
- Any cloud deployment that follows the runbook but stages the secret gate in a follow-up would hit the same boot failure.

## Changes

- **`services/tasks-api/src/config/env.ts`** — drop `X_ACTOR_SECRET` from the `X_CLIENT=real` superRefine required-for-boot loop, with an inline comment pointing at the route contract. The `.optional()` on the field declaration and the `min 32 chars when present` validation are unchanged, so an empty-or-too-short value is still rejected when set.
- **`services/tasks-api/test/config.test.ts`** — two assertions that depended on the overreach:
  - `refuses to boot when X_CLIENT=real without the OAuth credentials` — remove the `X_ACTOR_SECRET` from the assertion list, add a comment explaining why it's not required at boot.
  - `throws ConfigValidationError with structured issues when validation fails` — change the "intentionally omitted" key from `X_ACTOR_SECRET` to `X_ACCESS_TOKEN_SECRET` so the test still triggers validation failure (and still exercises the redaction contract for the four OAuth secrets).

## Validation

- Local: `npx vitest run test/config.test.ts test/contentScheduler.test.ts test/body-limit.test.ts test/rate-limit.test.ts` → **41/41 tests pass**.
- Regression-only impact: this change only relaxes the boot contract for `X_ACTOR_SECRET`; all other env-validation paths are unchanged.
- AC2 (secrets not in logs / source control) is preserved: the `min 32 chars` schema validation still applies when set, and `TASKS_API_SECRET_KEYS` still includes `X_ACTOR_SECRET`, so the logger redactor still scrubs it from structured log rows.

## Out of scope (intentionally left for a future PR)

- A `.env.prodlike` regeneration step that materialises any operator-defined secret into the local prodlike file. The runbook (`docs/runbooks/production-runtime-config.md`) already documents this; the prodlike file is generated from `scripts/dev/up.sh`. If we want the prodlike plane to also exercise the actor-secret gate, the right place to wire that is the runbook + `up.sh`, not the schema.
- Renaming the runbook's "required for `X_CLIENT=real`" tables to clarify that `X_ACTOR_SECRET` is optional-by-design. Small follow-up.

## Follow-up note

I'll rebase `fix/414-x-actor-secret-boot-block` onto `main` once `PR #414` is fully settled in CI. No rebase needed at the moment — branch was pushed from `origin/main` immediately after the merge.
