### PR TITLE
fix(tasks-api): restore dev watcher child spawn

### DIFF
--- a/services/tasks-api/package.json
+++ b/services/tasks-api/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "predev": "prisma generate",
-    "dev": "tsx watch --require @sindustries/otel-node/register src/server.ts",
+    "dev": "tsx watch src/server.ts",
     "prestart": "prisma generate",
     "start": "tsx --require @sindustries/otel-node/register src/server.ts",
     "pretest": "prisma generate",


### PR DESCRIPTION
## Summary
- Remove the OpenTelemetry `--require` preload from the tasks-api watch-mode command so `tsx watch` can spawn `src/server.ts` again.
- Keep the preload on the production `start` command and worker commands; this is limited to the broken local watcher path.

## System Spec
No system spec change — local development process fix only; API behaviour is unchanged.

## Test plan
- [x] `npm test` — 306 tests passed across 21 files.
- [x] `npm run dev` reached the spawned `src/server.ts` child; the isolated smoke then exited at expected config validation because `.env.example` contains placeholder credentials.
- [x] `git diff --check`.