### PR TITLE
feat(feature-task): reconcile brain spec approvals

### DIFF
--- a/agents/skills/product/feature-task-create/SKILL.md
+++ b/agents/skills/product/feature-task-create/SKILL.md
@@ -95,9 +95,14 @@ Key constraints or non-obvious integration points. One paragraph max.
 ```
 
 Spec approval is a structured `TaskApproval` row. After Tom reviews the spec,
-he approves `spec` in the Tasks UI (or an authorized scoped service call does so
-on his behalf). Do not add or toggle an `Approved by Tom` markdown marker; the
-Lobster ignores legacy markers and fails closed on missing/revoked API state.
+he can approve `spec` in the Tasks UI, or check the exact marker
+`- [x] **Approved by Tom**` while the spec is under
+`brain/tasks/specs/open/`. The feature-task runner reconciles that checkbox
+through Tom's scoped Tasks API credential to the uniquely linked feature task.
+The API row remains authoritative: unchecked markers, missing/ambiguous links,
+and revoked rows fail closed, and already-approved rows are not written again.
+Do not use alternate checkbox wording or the marker for bookmark, tech-design,
+or QA approvals.
 
 Do not add a Quinn workstream. If Quinn needs to make `.openclaw` changes, Rowan posts `[openclaw-needed]` via the established handoff. The pr-open skill fills in Branch and PR when Rowan opens a PR.
 

--- a/agents/workflows/feature-task/WORKFLOW.md
+++ b/agents/workflows/feature-task/WORKFLOW.md
@@ -35,6 +35,29 @@ Both commands must exit zero locally before pushing. If clippy fails, fix the
 warning before requesting review — temporary exceptions must be called out in
 the PR description with a documented rationale.
 
+## Brain checkbox → structured spec approval reconciliation
+
+Before dispatching per-task workflows, `run.py` scans only
+`brain/tasks/specs/open/*.md`. An exact checked marker,
+`- [x] **Approved by Tom**`, is treated as Tom's request to grant the linked
+active feature task's structured `spec` approval. The reconciler requires one
+exact `**Spec:**` link and confirms that the Tasks API policy requires `spec`
+for feature tasks. It then writes through the authenticated approval endpoint;
+the resulting `TaskApproval` row remains the sole workflow gate source.
+
+The sweep is idempotent: an already-approved row produces no API write or
+second audit comment. Unchecked markers, revoked API rows, missing or duplicate
+links, inaccessible files, code tasks, and specs outside the open task-spec
+directory never grant approval and are reported as diagnostics. A revoked API
+row is deliberately not re-approved from a stale checked marker because API
+state is authoritative.
+
+The existing feature-task runner performs this reconciliation once per pass,
+so no separate cron is needed. Its environment must provide Tom's scoped
+`TASKS_API_APPROVAL_TOKEN` (the runner also loads that key from
+`~/.openclaw/.env`); the Tasks API still derives the actor and permitted
+approval type.
+
 ## Lobster PR-body evidence gate (opt-in)
 
 Set `CLIPPY_ENFORCE=true` to make the lobster's `verify_delivery` stage

--- a/agents/workflows/feature-task/run.py
+++ b/agents/workflows/feature-task/run.py
@@ -56,6 +56,13 @@ def workflow_env() -> dict[str, str]:
         token = _load_dotenv_token("LOBSTER_GITHUB_TOKEN")
         if token:
             env["GH_TOKEN"] = token
+    # The reconciliation command acts only on Tom's explicit checked marker,
+    # using Tom's server-scoped spec credential. The API still derives actor
+    # and permissions and remains the authoritative gate store.
+    if not env.get("TASKS_API_APPROVAL_TOKEN"):
+        token = _load_dotenv_token("TASKS_API_APPROVAL_TOKEN")
+        if token:
+            env["TASKS_API_APPROVAL_TOKEN"] = token
     return env
 
 
@@ -153,6 +160,37 @@ def run_workflow(task_id: str, base_url: str, dry_run: bool, pipeline: Path) -> 
     return result
 
 
+def run_brain_spec_approval_reconciliation(base_url: str, dry_run: bool) -> dict[str, Any]:
+    cmd = [
+        "cargo",
+        "run",
+        "--manifest-path",
+        str(REPO / "agents/workflows/feature-task/Cargo.toml"),
+        "--",
+        "reconcile-brain-spec-approvals",
+        "--base-url",
+        base_url,
+        "--dry-run",
+        str(dry_run).lower(),
+        "--workspace-root",
+        str(WORKSPACE_ROOT),
+    ]
+    proc = subprocess.run(cmd, text=True, capture_output=True, env=workflow_env())
+    result: dict[str, Any] = {
+        "returncode": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+    }
+    if proc.returncode != 0:
+        result["error"] = (proc.stderr or proc.stdout or "brain spec approval reconciliation failed").strip()
+        return result
+    try:
+        result["envelope"] = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        result["error"] = f"Could not parse brain spec approval reconciliation envelope: {exc}"
+    return result
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run one feature-task workflow pass for every active feature task")
     parser.add_argument("--base-url", default=os.environ.get("TASKS_API_BASE_URL", DEFAULT_BASE_URL))
@@ -160,6 +198,7 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
 
+    reconciliation = run_brain_spec_approval_reconciliation(args.base_url, args.dry_run)
     tasks = discover_tasks(args.base_url, args.limit)
     results = [
         run_workflow(
@@ -171,6 +210,13 @@ def main() -> int:
         for task in tasks
     ]
     errors = [result for result in results if result.get("returncode") != 0 or result.get("error")]
+    reconciliation_envelope = reconciliation.get("envelope") or {}
+    if (
+        reconciliation.get("returncode") != 0
+        or reconciliation.get("error")
+        or reconciliation_envelope.get("criteriaMet") is False
+    ):
+        errors.insert(0, reconciliation)
     pipelines = sorted({task.get("_pipeline", str(PIPELINE)) for task in tasks})
     print(
         json.dumps(
@@ -178,6 +224,7 @@ def main() -> int:
                 "ok": not errors,
                 "pipelines": pipelines,
                 "count": len(tasks),
+                "brainSpecApprovalReconciliation": reconciliation,
                 "results": results,
                 "errors": errors,
             },

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -44,6 +44,9 @@ enum Commands {
     CodeTaskTechDesignCheck(StageArgs),
     CodeTaskReadyChecks(StageArgs),
     CodeTaskVerifyDelivery(StageArgs),
+    /// Reconcile Tom's checked approval marker on open brain task specs into
+    /// the authoritative structured `spec` TaskApproval row.
+    ReconcileBrainSpecApprovals(ReconcileBrainSpecApprovalsArgs),
     /// Reconciliation sweep: visit every task with `status=done` (optionally
     /// filtered by `--assignee`) and archive any spec still under
     /// `brain/tasks/specs/in-progress/`. Used to close the historical backlog
@@ -65,6 +68,16 @@ struct ArchiveDoneTaskSpecsSweepArgs {
     workspace_root: Option<PathBuf>,
     #[arg(long)]
     assignee: Option<String>,
+}
+
+#[derive(Parser, Clone)]
+struct ReconcileBrainSpecApprovalsArgs {
+    #[arg(long, default_value = "http://localhost:4001/api/v1")]
+    base_url: String,
+    #[arg(long, default_value_t = false, action = ArgAction::Set)]
+    dry_run: bool,
+    #[arg(long)]
+    workspace_root: PathBuf,
 }
 
 #[derive(Parser, Clone)]
@@ -269,6 +282,7 @@ fn main() -> Result<()> {
         Commands::CodeTaskTechDesignCheck(args) => code_task_tech_design_check(args)?,
         Commands::CodeTaskReadyChecks(args) => code_task_ready_checks(args)?,
         Commands::CodeTaskVerifyDelivery(args) => code_task_verify_delivery(args)?,
+        Commands::ReconcileBrainSpecApprovals(args) => reconcile_brain_spec_approvals(args)?,
         Commands::ArchiveDoneTaskSpecsSweep(args) => archive_done_task_specs_sweep(args)?,
         Commands::Analytics(args) => analytics_replay(args)?,
     };
@@ -1422,6 +1436,216 @@ const TASK_SPECS_DIR: &str = "brain/tasks/specs";
 const TASK_SPECS_OPEN_DIR: &str = "brain/tasks/specs/open";
 const TASK_SPECS_IN_PROGRESS_DIR: &str = "brain/tasks/specs/in-progress";
 const TASK_SPECS_DONE_DIR: &str = "brain/tasks/specs/done";
+const BRAIN_SPEC_APPROVAL_NOTE_PREFIX: &str = "Reconciled from checked brain spec";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum BrainSpecApprovalPlan {
+    Grant { task_id: String },
+    AlreadyApproved { task_id: String },
+    Unchecked,
+    Revoked { task_id: String },
+    MissingLink,
+    Ambiguous { task_ids: Vec<String> },
+}
+
+/// Parse the single exact task/spec link used by approval reconciliation.
+/// Unlike the normal compatibility parser, duplicate Spec lines are rejected:
+/// a human approval must never be attached through an ambiguous description.
+fn reconciliation_spec_link(task: &Task) -> Option<String> {
+    let description = task.description.as_deref().unwrap_or("");
+    let line_re = Regex::new(r"(?im)^\s*\*\*Spec:\*\*\s+(.+?)\s*$").unwrap();
+    let mut captures = line_re.captures_iter(description);
+    let first = captures.next()?;
+    if captures.next().is_some() {
+        return None;
+    }
+    extract_spec_path_from_line(first.get(1)?.as_str()).map(|spec| normalize_rel_path(&spec.path))
+}
+
+fn plan_brain_spec_approval(
+    spec_path: &str,
+    spec_text: &str,
+    tasks: &[Task],
+) -> BrainSpecApprovalPlan {
+    if !product_spec_approved_by_tom(spec_text) {
+        return BrainSpecApprovalPlan::Unchecked;
+    }
+    let normalized = normalize_rel_path(spec_path);
+    let mut matches: Vec<&Task> = tasks
+        .iter()
+        .filter(|task| task.task_type.as_deref() == Some("feature"))
+        .filter(|task| reconciliation_spec_link(task).as_deref() == Some(normalized.as_str()))
+        .collect();
+    matches.sort_by(|a, b| a.id.cmp(&b.id));
+    if matches.is_empty() {
+        return BrainSpecApprovalPlan::MissingLink;
+    }
+    if matches.len() > 1 {
+        return BrainSpecApprovalPlan::Ambiguous {
+            task_ids: matches.iter().map(|task| task.id.clone()).collect(),
+        };
+    }
+    let task = matches[0];
+    if spec_is_approved(task) {
+        return BrainSpecApprovalPlan::AlreadyApproved {
+            task_id: task.id.clone(),
+        };
+    }
+    if task
+        .approvals
+        .iter()
+        .any(|approval| approval.approval_type == "spec" && approval.state == "revoked")
+    {
+        return BrainSpecApprovalPlan::Revoked {
+            task_id: task.id.clone(),
+        };
+    }
+    BrainSpecApprovalPlan::Grant {
+        task_id: task.id.clone(),
+    }
+}
+
+fn feature_policy_requires_spec(base_url: &str) -> Result<bool> {
+    let value: Value = api_get(base_url, "/task-types/feature/required-approvals")?;
+    let required = value
+        .get("requiredApprovals")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            anyhow!("feature required-approvals response omitted `requiredApprovals`")
+        })?;
+    Ok(required.iter().any(|value| value.as_str() == Some("spec")))
+}
+
+fn grant_reconciled_spec_approval(base_url: &str, task_id: &str, spec_path: &str) -> Result<()> {
+    let token = std::env::var("TASKS_API_APPROVAL_TOKEN")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            anyhow!("TASKS_API_APPROVAL_TOKEN is required to reconcile checked brain specs")
+        })?;
+    let url = format!(
+        "{}/tasks/{task_id}/approvals",
+        base_url.trim_end_matches('/')
+    );
+    let note = format!("{BRAIN_SPEC_APPROVAL_NOTE_PREFIX} `{spec_path}`.");
+    handle_api_result(
+        ureq::post(&url)
+            .set("Authorization", &format!("Bearer {token}"))
+            .send_json(json!({"type": "spec", "note": note})),
+    )?;
+    Ok(())
+}
+
+/// Scan only `brain/tasks/specs/open/*.md`, map checked specs to one active
+/// feature task, and grant the structured spec approval through the Tasks API.
+/// The API row remains the gate source; revoked rows, missing links, and
+/// ambiguous links are diagnostics and never trigger a write.
+fn reconcile_brain_spec_approvals(args: ReconcileBrainSpecApprovalsArgs) -> Result<Envelope> {
+    if !feature_policy_requires_spec(&args.base_url)? {
+        return Ok(output(
+            true,
+            false,
+            "brain_spec_approval_reconciliation_skipped: feature_policy_has_no_spec_gate",
+            Task::default(),
+            LobsterState::default(),
+            vec![],
+        ));
+    }
+
+    let tasks = list_all_active_tasks(&args.base_url)?;
+    let open_dir = args.workspace_root.join(TASK_SPECS_OPEN_DIR);
+    let entries = fs::read_dir(&open_dir)
+        .with_context(|| format!("reading open task specs directory `{}`", open_dir.display()))?;
+    let mut paths = Vec::new();
+    for entry in entries {
+        let entry = entry.with_context(|| format!("reading entry in `{}`", open_dir.display()))?;
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("md") {
+            continue;
+        }
+        if !entry
+            .file_type()
+            .map(|kind| kind.is_file())
+            .unwrap_or(false)
+        {
+            paths.push((path, false));
+        } else {
+            paths.push((path, true));
+        }
+    }
+    paths.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut checked = 0usize;
+    let mut granted = 0usize;
+    let mut already = 0usize;
+    let mut unchecked = 0usize;
+    let mut failures = Vec::new();
+    for (path, accessible_file) in paths {
+        let file_name = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("<invalid>");
+        let spec_rel = format!("{TASK_SPECS_OPEN_DIR}/{file_name}");
+        if !accessible_file {
+            failures.push(format!("Open task spec `{spec_rel}` is not an accessible regular file; no approval granted."));
+            continue;
+        }
+        let text = match fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(err) => {
+                failures.push(format!(
+                    "Could not read open task spec `{spec_rel}`: {err}; no approval granted."
+                ));
+                continue;
+            }
+        };
+        match plan_brain_spec_approval(&spec_rel, &text, &tasks) {
+            BrainSpecApprovalPlan::Unchecked => unchecked += 1,
+            BrainSpecApprovalPlan::AlreadyApproved { .. } => {
+                checked += 1;
+                already += 1;
+            }
+            BrainSpecApprovalPlan::Grant { task_id } => {
+                checked += 1;
+                if args.dry_run {
+                    granted += 1;
+                } else if let Err(err) =
+                    grant_reconciled_spec_approval(&args.base_url, &task_id, &spec_rel)
+                {
+                    failures.push(format!("Could not grant structured `spec` approval for task `{task_id}` linked from `{spec_rel}`: {err}."));
+                } else {
+                    granted += 1;
+                }
+            }
+            BrainSpecApprovalPlan::Revoked { task_id } => {
+                checked += 1;
+                failures.push(format!("Task `{task_id}` has a revoked structured `spec` approval; `{spec_rel}` remains checked, but API revocation is authoritative. Re-check through a fresh human action before granting."));
+            }
+            BrainSpecApprovalPlan::MissingLink => {
+                checked += 1;
+                failures.push(format!("Checked open task spec `{spec_rel}` has no exact, unambiguous `**Spec:**` link from an active feature task requiring `spec`; no approval granted."));
+            }
+            BrainSpecApprovalPlan::Ambiguous { task_ids } => {
+                checked += 1;
+                failures.push(format!("Checked open task spec `{spec_rel}` is linked by multiple active feature tasks ({}); no approval granted.", task_ids.join(", ")));
+            }
+        }
+    }
+
+    Ok(output(
+        failures.is_empty(),
+        false,
+        &format!(
+            "brain_spec_approval_reconciliation: checked={checked} granted={granted} already_approved={already} unchecked={unchecked} failures={}",
+            failures.len()
+        ),
+        Task::default(),
+        LobsterState::default(),
+        failures,
+    ))
+}
+
 const TASK_SPEC_LIFECYCLE_DIRS: [&str; 4] = ["open", "in-progress", "done", "archived"];
 
 // ---- Post-merge worktree cleanup (feature task ba116063) ----
@@ -4353,6 +4577,102 @@ mod tests {
         assert_eq!(
             active,
             vec!["https://github.com/Stoffer-Industries/sindustries/pull/128".to_string()]
+        );
+    }
+
+    // --- brain spec approval reconciliation ---
+    const OPEN_SPEC_PATH: &str = "brain/tasks/specs/open/reconcile-me.md";
+    const CHECKED_SPEC: &str = "# Spec\n\n- [x] **Approved by Tom**\n";
+    const UNCHECKED_SPEC: &str = "# Spec\n\n- [ ] **Approved by Tom**\n";
+
+    fn linked_approval_task(task_type: &str, approvals: Vec<TaskApproval>) -> Task {
+        Task {
+            id: format!("{task_type}-task"),
+            task_type: Some(task_type.to_string()),
+            description: Some(format!("**Spec:** {OPEN_SPEC_PATH}")),
+            approvals,
+            ..Task::default()
+        }
+    }
+
+    #[test]
+    fn checked_open_task_spec_plans_structured_spec_grant() {
+        let tasks = vec![linked_approval_task("feature", vec![])];
+        assert_eq!(
+            plan_brain_spec_approval(OPEN_SPEC_PATH, CHECKED_SPEC, &tasks),
+            BrainSpecApprovalPlan::Grant {
+                task_id: "feature-task".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn unchecked_open_task_spec_never_plans_grant() {
+        let tasks = vec![linked_approval_task("feature", vec![])];
+        assert_eq!(
+            plan_brain_spec_approval(OPEN_SPEC_PATH, UNCHECKED_SPEC, &tasks),
+            BrainSpecApprovalPlan::Unchecked
+        );
+    }
+
+    #[test]
+    fn already_approved_open_task_spec_is_idempotent() {
+        let tasks = vec![linked_approval_task(
+            "feature",
+            vec![approval_row("spec", "approved")],
+        )];
+        assert_eq!(
+            plan_brain_spec_approval(OPEN_SPEC_PATH, CHECKED_SPEC, &tasks),
+            BrainSpecApprovalPlan::AlreadyApproved {
+                task_id: "feature-task".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn checked_open_task_spec_without_link_fails_closed() {
+        assert_eq!(
+            plan_brain_spec_approval(OPEN_SPEC_PATH, CHECKED_SPEC, &[]),
+            BrainSpecApprovalPlan::MissingLink
+        );
+    }
+
+    #[test]
+    fn checked_open_task_spec_does_not_target_code_tasks() {
+        let tasks = vec![linked_approval_task("code", vec![])];
+        assert_eq!(
+            plan_brain_spec_approval(OPEN_SPEC_PATH, CHECKED_SPEC, &tasks),
+            BrainSpecApprovalPlan::MissingLink
+        );
+    }
+
+    #[test]
+    fn revoked_api_spec_approval_is_not_regranted_from_stale_checkbox() {
+        let tasks = vec![linked_approval_task(
+            "feature",
+            vec![approval_row("spec", "revoked")],
+        )];
+        assert_eq!(
+            plan_brain_spec_approval(OPEN_SPEC_PATH, CHECKED_SPEC, &tasks),
+            BrainSpecApprovalPlan::Revoked {
+                task_id: "feature-task".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn duplicate_task_spec_links_are_rejected_as_malformed() {
+        let task = Task {
+            task_type: Some("feature".to_string()),
+            description: Some(format!(
+                "**Spec:** {OPEN_SPEC_PATH}\n**Spec:** brain/tasks/specs/open/other.md"
+            )),
+            ..Task::default()
+        };
+        assert!(reconciliation_spec_link(&task).is_none());
+        assert_eq!(
+            plan_brain_spec_approval(OPEN_SPEC_PATH, CHECKED_SPEC, &[task]),
+            BrainSpecApprovalPlan::MissingLink
         );
     }
 

--- a/docs/systems/tasks.md
+++ b/docs/systems/tasks.md
@@ -636,7 +636,7 @@ The three workflows share the same Rust binary (feature + code). Gate approvals 
 
 ### Structured approval and authentication contract
 
-`TaskApproval` is the only source of truth for `spec`, `tech_design`, and `qa` gates. Missing or revoked rows fail closed. Legacy `[tech-design-approved] true`, `[qa-ac-verified] true`, and checked `Approved by Tom` text remain historical data only and cannot grant a runtime gate.
+`TaskApproval` is the only source of truth for `spec`, `tech_design`, and `qa` gates. Missing or revoked rows fail closed. Legacy `[tech-design-approved] true` and `[qa-ac-verified] true` comments remain historical data only. One narrow human-write projection is supported for feature specs: the feature-task runner reconciles the exact checked marker `- [x] **Approved by Tom**` from `brain/tasks/specs/open/*.md` into the uniquely linked task's structured `spec` row through the authenticated API. The checkbox never satisfies the gate by itself; unchecked/ambiguous/inaccessible inputs and revoked rows do not write, and the API row remains authoritative. Bookmark, `tech_design`, and `qa` semantics are unchanged.
 
 Browser approval writes require a durable login session:
 
@@ -658,7 +658,7 @@ The `.openclaw/` directory is outside this repo. Any required `.openclaw` change
 
 ## Spec Checksum Safeguards (factory-v2 last grandfathered edit)
 
-After a structured `spec` approval is granted, the task record stores `specChecksum` (sha256 of the canonical AC JSON with sorted keys). The brain spec remains the AC source of truth in `open`; the task description is the source of truth in every later status. Legacy markdown markers may still be manipulated by the drift-resync compatibility machinery, but they do not grant the spec gate—the `TaskApproval` row does.
+After a structured `spec` approval is granted, the task record stores `specChecksum` (sha256 of the canonical AC JSON with sorted keys). The brain spec remains the AC source of truth in `open`; the task description is the source of truth in every later status. The open brain-spec checkbox is an authenticated write surface into the API, not a second gate source. Markdown markers may also be manipulated by the drift-resync compatibility machinery, but only the resulting `TaskApproval` row grants the spec gate.
 
 ### Fluid AC lifecycle state machine
 


### PR DESCRIPTION
## Summary
- Reconcile the exact checked `- [x] **Approved by Tom**` marker from open brain task specs into the uniquely linked feature task's structured `spec` approval through the authenticated Tasks API.
- Fail closed for unchecked or inaccessible specs, malformed/missing/ambiguous links, non-feature tasks, policies without a spec gate, and revoked API rows; skip already-approved rows without duplicate writes or audit comments.
- Run reconciliation once at the start of the existing feature-task runner pass and document the checkbox projection while preserving the API as the authoritative workflow gate.

## System Spec
Updated `docs/systems/tasks.md` to document the open brain-spec checkbox reconciliation contract, scope, authentication, and API authority.

## Test plan
- [x] Rust workflow tests cover checked, unchecked, already-approved, missing-link, code-task/non-target, revoked-row, and duplicate-link cases.
- [x] All feature-task Rust tests pass (214/214).
- [x] Feature-task clippy is green with warnings denied.
- [x] Live read-only dry runs against the local Tasks API confirm the current open-spec sweep and fail-closed missing-link diagnostics.

## Deployment / scheduling
No new cron or OpenClaw wiring. The existing `agents/workflows/feature-task/run.py` pass runs reconciliation once before per-task dispatch and loads the provisioned Tom-scoped `TASKS_API_APPROVAL_TOKEN`.

🤖 Generated with OpenAI Codex