### PR TITLE
chore(code-garden): add gymtrack-mcp CI job [2026-W33]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,32 @@ jobs:
       - name: Run unit/component tests
         run: npm test --workspace apps/gymtrack
 
+  gymtrack-mcp-tests:
+    # W33 audit QW1: the gymtrack-mcp OAuth server (incl. refresh-token
+    # rotation) holds the most security-sensitive new code, but the
+    # package's `npm test` script was never wired into CI. Adding this
+    # job so `services/gymtrack-mcp/**` changes are validated against
+    # the existing vitest suite on every PR. Mirrors the gymtrack-tests
+    # job above; no Rollup native binary needed (vitest, not rollup).
+    name: gymtrack-mcp tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Run gymtrack-mcp tests
+        run: npm test --workspace @sindustries/gymtrack-mcp
+
   design-system-sync:
     name: design system sync
     runs-on: ubuntu-latest

--- a/docs/repo-audits/2026-W33.md
+++ b/docs/repo-audits/2026-W33.md
@@ -91,7 +91,7 @@
 
 **Quick wins (high impact, S effort):**
 
-- **QW1 — Add gymtrack-mcp CI job.** Add a `gymtrack-mcp-tests` job to `ci.yml` mirroring the gymtrack app job but running `npm test --workspace services/gymtrack-mcp`. *Files:* `.github/workflows/ci.yml`. *AC:* CI shows a passing gymtrack-mcp job on PRs touching `services/gymtrack-mcp/**`. *Effort:* S. *Risk:* Low. *Deps:* none. ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+- **QW1 — Add gymtrack-mcp CI job.** Add a `gymtrack-mcp-tests` job to `ci.yml` mirroring the gymtrack app job but running `npm test --workspace services/gymtrack-mcp`. *Files:* `.github/workflows/ci.yml`. *AC:* CI shows a passing gymtrack-mcp job on PRs touching `services/gymtrack-mcp/**`. *Effort:* S. *Risk:* Low. *Deps:* none. ✅ [PR #419](https://github.com/Stoffer-Industries/sindustries/pull/419)
 
 **Milestone 0 — Safety net**
 

--- a/docs/repo-audits/2026-W33.md
+++ b/docs/repo-audits/2026-W33.md
@@ -91,7 +91,7 @@
 
 **Quick wins (high impact, S effort):**
 
-- **QW1 — Add gymtrack-mcp CI job.** Add a `gymtrack-mcp-tests` job to `ci.yml` mirroring the gymtrack app job but running `npm test --workspace services/gymtrack-mcp`. *Files:* `.github/workflows/ci.yml`. *AC:* CI shows a passing gymtrack-mcp job on PRs touching `services/gymtrack-mcp/**`. *Effort:* S. *Risk:* Low. *Deps:* none.
+- **QW1 — Add gymtrack-mcp CI job.** Add a `gymtrack-mcp-tests` job to `ci.yml` mirroring the gymtrack app job but running `npm test --workspace services/gymtrack-mcp`. *Files:* `.github/workflows/ci.yml`. *AC:* CI shows a passing gymtrack-mcp job on PRs touching `services/gymtrack-mcp/**`. *Effort:* S. *Risk:* Low. *Deps:* none. ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 
 **Milestone 0 — Safety net**
 


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W33.md
- **Finding:** QW1 — Add gymtrack-mcp CI job
- Adds a `gymtrack-mcp-tests` job to `.github/workflows/ci.yml` so the OAuth server's vitest suite (incl. refresh-token rotation) runs on every PR. No code or runtime behavior change; the test script already exists in `services/gymtrack-mcp/package.json` and passes locally (5/5).

## Test plan
- [ ] CI: `gymtrack-mcp-tests` job shows green on this PR
- [ ] No logic changes — diff is purely a new CI job plus an audit-marker comment

🌱 Code garden — non-functional cleanup only