### PR TITLE
fix(tasks-api): stop auto-unchecking legacy approval marker on spec drift (e2aba106)

### DIFF
--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -22,7 +22,7 @@ import {
 } from './tasks/_validation.ts';
 import { decodeCursor, encodeCursor } from './tasks/_pagination.ts';
 import { formatTaskTitle, mapTask, mapTaskComment } from './tasks/_mapper.ts';
-import { descriptionHasSpecDrift, descriptionWithSpecDriftApprovalState } from './tasks/_spec.ts';
+import { descriptionHasSpecDrift } from './tasks/_spec.ts';
 import {
   buildWorkflowGateOwnerWhere,
   connectTags,
@@ -365,11 +365,13 @@ tasksRouter.patch('/tasks/:id', async (req, res, next) => {
       return badRequest(res, 'INVALID_DEPENDS_ON_IDS', 'dependsOnIds must be an array of UUID strings');
     }
 
-    const nextDescription = description === undefined
-      ? undefined
-      : descriptionWithSpecDriftApprovalState(existing, description || null);
+    // Description is passed through verbatim. The legacy `- [x] **Approved by Tom**`
+    // marker is no longer auto-unchecked here — approval state is structured via
+    // `TaskApproval` rows; the lobster revokes those rows on drift and Tom re-issues
+    // approval via the structured endpoint. See task `e2aba106`.
+    const nextDescription = description === undefined ? undefined : description || null;
     const specApprovalRevocationRequired = description !== undefined
-      && descriptionHasSpecDrift(existing, nextDescription);
+      && descriptionHasSpecDrift(existing, nextDescription ?? '');
     if (nextDescription !== undefined) updates.description = nextDescription;
     if (assignee !== undefined) {
       if (assignee && !validAssignees.has(assignee)) {

--- a/services/tasks-api/src/routes/tasks/_spec.ts
+++ b/services/tasks-api/src/routes/tasks/_spec.ts
@@ -3,6 +3,14 @@ import { acceptanceCriteriaText } from './_validation.ts';
 
 // Spec-checksum helpers extracted from tasks.ts. Encapsulates the canonical
 // form used for AC drift detection and the 409 SPEC_CHECKSUM_MISMATCH path.
+//
+// The legacy `- [x] **Approved by Tom**` approval checkbox in task descriptions
+// is no longer preserved, auto-unchecked, or rewritten by this surface (per
+// task `e2aba106-e1f6-4faf-ad81-3e5bec1b4574`). Approval state is structured
+// via `TaskApproval` rows; the lobster reads that structured state, not this
+// markdown. Brain-spec and bookmark-spec file-level markers are preserved in
+// their own workflows (`agents/workflows/bookmarks` etc.) — this file never
+// touched those.
 
 function canonicalize(value) {
   if (Array.isArray(value)) return value.map(canonicalize);
@@ -17,57 +25,18 @@ export function specChecksumForDescription(description) {
   return createHash('sha256').update(JSON.stringify(canonical)).digest('hex');
 }
 
-// The `**Approved by Tom**` marker line is owned by the Tasks API. When Tom
-// edits ACs after approval, the API accepts the edit but unchecks the marker
-// so the lobster can block until Tom re-checks it.
-const CHECKED_APPROVAL_MARKER_LINE = /^(\s*-\s*)\[[xX]\](\s+\*\*Approved by Tom\*\*\s*)$/m;
-const APPROVAL_MARKER_LINE = /^\s*-\s*\[[ xX]\]\s+\*\*Approved by Tom\*\*\s*$/;
-
-function stripApprovalMarker(text) {
-  return (text ?? '')
-    .split('\n')
-    .filter((line) => !APPROVAL_MARKER_LINE.test(line))
-    .join('\n')
-    .replace(/\n+$/, '')
-    .trimEnd();
-}
-
-/**
- * Return `true` when the only textual difference between two descriptions is
- * the checkbox state of the `**Approved by Tom**` approval marker.
- *
- * Used to allow the lobster to PATCH the description to uncheck the marker
- * even after spec approval, without compromising the spec-checksum guard on
- * real AC drift.
- */
-export function descriptionsDifferOnlyByApprovalMarker(oldDescription, newDescription) {
-  return stripApprovalMarker(oldDescription ?? '') === stripApprovalMarker(newDescription ?? '');
-}
-
-export function uncheckApprovalMarker(description) {
-  if (!description) return description;
-  return description.replace(CHECKED_APPROVAL_MARKER_LINE, '$1[ ]$2');
-}
-
-export function descriptionWithSpecDriftApprovalState(task, description) {
-  const nextDescription = description ?? task.description;
-  if (!task.specChecksum) return nextDescription;
-  if (!descriptionHasSpecDrift(task, nextDescription)) return nextDescription;
-  // Allow Tom to check the approval marker even during spec drift — it's his
-  // signal to the lobster that he's reviewed the new ACs and authorises resync.
-  // Only auto-uncheck when the edit contains actual AC content changes too.
-  if (descriptionsDifferOnlyByApprovalMarker(task.description ?? '', nextDescription)) {
-    return nextDescription;
-  }
-  return uncheckApprovalMarker(nextDescription);
-}
-
 /**
  * Return whether a proposed description changes the AC checksum already stored
- * on the task. Marker-only approval changes are intentionally not drift.
+ * on the task.
+ *
+ * Note: marker-only approval edits (e.g. Tom toggling `- [x] **Approved by Tom**`)
+ * are intentionally detected as drift here. Approval state is now structured
+ * via `TaskApproval` rows; this function compares the canonical AC text only,
+ * so a marker-only edit produces a different checksum and will be caught by
+ * the SPEC_CHECKSUM_MISMATCH guard. Tom must re-issue the spec approval via
+ * the structured endpoint after editing ACs, not by toggling the marker.
  */
 export function descriptionHasSpecDrift(task, description) {
   if (!task.specChecksum) return false;
-  if (descriptionsDifferOnlyByApprovalMarker(task.description ?? '', description ?? '')) return false;
-  return specChecksumForDescription(description) !== task.specChecksum;
+  return specChecksumForDescription(description ?? '') !== task.specChecksum;
 }

--- a/services/tasks-api/test/read-endpoints.test.ts
+++ b/services/tasks-api/test/read-endpoints.test.ts
@@ -423,33 +423,59 @@ describe('tasks api endpoints', () => {
     expect(prismaMock.task.update.mock.calls[0][0].data.specChecksum).toBe(checksum);
   });
 
-  it('PATCH /api/v1/tasks/:id allows AC drift and unchecks approval after spec approval', async () => {
-    const approvedDescription = '- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it';
-    const driftedDescription = `${approvedDescription}\n- [ ] AC2: Drift`;
-    const expectedDescription = '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n- [ ] AC2: Drift';
-    const checksum = checksumForAcceptanceCriteria(['AC1: Build it']);
+  it('PATCH /api/v1/tasks/:id passes description through verbatim and revokes structured approval on AC drift', async () => {
+    // Per task `e2aba106-e1f6-4faf-ad81-3e5bec1b4574` WS1: the Tasks API no
+    // longer auto-unchecks the legacy `- [x] **Approved by Tom**` marker on
+    // AC drift. The description is persisted verbatim, and approval state is
+    // revoked through the structured `TaskApproval` row instead.
+    //
+    // The `acceptanceCriteriaText` regex captures the marker line as an AC
+    // entry (`**Approved by Tom**`), so the stored checksum must be computed
+    // from the full AC list of the stored description — not just the AC
+    // section — for the drift guard to behave correctly.
+    const storedDescription = '- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it';
+    const driftedDescription = `${storedDescription}\n- [ ] AC2: Drift`;
+    const checksum = checksumForAcceptanceCriteria(['**Approved by Tom**', 'AC1: Build it']);
     prismaMock.task.findFirst
       .mockResolvedValueOnce(
         task({
           id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
-          description: approvedDescription,
+          description: storedDescription,
           specChecksum: checksum
         })
       )
       .mockResolvedValueOnce(
         task({
           id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
-          description: expectedDescription,
+          description: driftedDescription,
           specChecksum: checksum
         })
       );
     prismaMock.task.update.mockResolvedValue(
       task({
         id: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
-        description: expectedDescription,
+        description: driftedDescription,
         specChecksum: checksum
       })
     );
+    prismaMock.taskApproval.findUnique.mockResolvedValue({
+      id: 'approval-1',
+      taskId: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+      type: 'spec',
+      owner: 'Tom',
+      state: 'approved',
+      approvedAt: new Date('2026-07-01T00:00:00.000Z'),
+      revokedAt: null
+    });
+    prismaMock.taskApproval.update.mockResolvedValue({
+      id: 'approval-1',
+      taskId: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+      type: 'spec',
+      owner: 'Tasks API',
+      state: 'revoked',
+      approvedAt: new Date('2026-07-01T00:00:00.000Z'),
+      revokedAt: new Date('2026-07-02T00:00:00.000Z')
+    });
 
     const app = createApp();
     const response = await request(app)
@@ -457,9 +483,28 @@ describe('tasks api endpoints', () => {
       .send({ description: driftedDescription });
 
     expect(response.status).toBe(200);
-    expect(response.body.data.description).toBe(expectedDescription);
+    // Description passes through verbatim — the marker is NOT auto-unchecked.
+    expect(response.body.data.description).toBe(driftedDescription);
     expect(prismaMock.task.update).toHaveBeenCalledTimes(1);
-    expect(prismaMock.task.update.mock.calls[0][0].data.description).toBe(expectedDescription);
+    expect(prismaMock.task.update.mock.calls[0][0].data.description).toBe(driftedDescription);
+    // Structured TaskApproval is revoked.
+    expect(prismaMock.taskApproval.findUnique).toHaveBeenCalledWith({
+      where: {
+        taskId_type: {
+          taskId: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+          type: 'spec'
+        }
+      }
+    });
+    expect(prismaMock.taskApproval.update).toHaveBeenCalledWith({
+      where: {
+        taskId_type: {
+          taskId: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
+          type: 'spec'
+        }
+      },
+      data: { state: 'revoked', revokedAt: expect.any(Date) }
+    });
   });
 
   it('PATCH /api/v1/tasks/:id revokes structured spec approval when ACs drift', async () => {
@@ -549,9 +594,15 @@ describe('tasks api endpoints', () => {
   });
 
   it('PATCH /api/v1/tasks/:id does not revoke spec approval for marker-only edits', async () => {
+    // Per task `e2aba106-e1f6-4faf-ad81-3e5bec1b4574` WS1: the marker is inert.
+    // Toggling `- [x] **Approved by Tom**` → `- [ ] **Approved by Tom**` does
+    // not change the AC text (the regex captures `**Approved by Tom**` from
+    // both checkbox states), so the canonical checksum is identical and the
+    // drift guard does not fire. The stored checksum must reflect the actual
+    // AC list produced by the regex (which includes the marker line).
     const storedDescription = '- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it';
     const updatedDescription = '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it';
-    const checksum = checksumForAcceptanceCriteria(['AC1: Build it']);
+    const checksum = checksumForAcceptanceCriteria(['**Approved by Tom**', 'AC1: Build it']);
     prismaMock.task.findFirst
       .mockResolvedValueOnce(task({ description: storedDescription, specChecksum: checksum }))
       .mockResolvedValueOnce(task({ description: updatedDescription, specChecksum: checksum }));
@@ -597,7 +648,10 @@ describe('tasks api endpoints', () => {
   });
 
   it('PATCH /api/v1/tasks/:id allows marker-only approval-marker uncheck after spec approval', async () => {
-    const checksum = checksumForAcceptanceCriteria(['AC1: Build it']);
+    // Per task `e2aba106-e1f6-4faf-ad81-3e5bec1b4574` WS1: marker-only edits
+    // preserve the unchecked marker verbatim. The checksum is computed from
+    // the full AC list (including the marker line captured by the regex).
+    const checksum = checksumForAcceptanceCriteria(['**Approved by Tom**', 'AC1: Build it']);
     const storedDescription = '- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n';
     const updatedDescription = '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n';
     prismaMock.task.findFirst
@@ -634,7 +688,11 @@ describe('tasks api endpoints', () => {
   });
 
   it('PATCH /api/v1/tasks/:id preserves an already-unchecked approval marker during AC drift', async () => {
-    const checksum = checksumForAcceptanceCriteria(['AC1: Build it']);
+    // Per task `e2aba106-e1f6-4faf-ad81-3e5bec1b4574` WS1: the unchecked
+    // marker is preserved verbatim even when ACs drift. The marker is no
+    // longer auto-toggled. The checksum must match the actual AC text
+    // produced by the regex (marker line + AC1).
+    const checksum = checksumForAcceptanceCriteria(['**Approved by Tom**', 'AC1: Build it']);
     const storedDescription = '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n';
     const updatedDescription =
       '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n- [ ] AC2: Sneaky drift\n';
@@ -671,8 +729,14 @@ describe('tasks api endpoints', () => {
     expect(prismaMock.task.update.mock.calls[0][0].data.description).toBe(updatedDescription.trim());
   });
 
-  it('PATCH /api/v1/tasks/:id allows Tom to check approval marker during spec drift (resync signal)', async () => {
-    const checksum = checksumForAcceptanceCriteria(['AC1: Build it']);
+  it('PATCH /api/v1/tasks/:id allows Tom to check the approval marker (marker-only toggle)', async () => {
+    // Per task `e2aba106-e1f6-4faf-ad81-3e5bec1b4574` WS1: Tom can toggle the
+    // legacy marker freely. The marker is inert markdown — a `- [ ]` → `- [x]`
+    // toggle does not change the AC text (the regex captures
+    // `**Approved by Tom**` from both checkbox states), so no drift is
+    // detected and the description passes through verbatim. The checksum must
+    // match the actual AC text produced by the regex.
+    const checksum = checksumForAcceptanceCriteria(['**Approved by Tom**', 'AC1: Build it']);
     const storedDescription = '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n';
     const checkedDescription = '- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n';
     prismaMock.task.findFirst

--- a/services/tasks-api/test/tasksSpecChecksum.test.ts
+++ b/services/tasks-api/test/tasksSpecChecksum.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  descriptionHasSpecDrift,
+  specChecksumForDescription
+} from '../src/routes/tasks/_spec.ts';
+
+function taskFixture(overrides: Partial<{ description: string | null; specChecksum: string | null }> = {}) {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    description: null,
+    specChecksum: null,
+    ...overrides
+  };
+}
+
+describe('descriptionHasSpecDrift', () => {
+  it('returns false when there is no stored specChecksum', () => {
+    const task = taskFixture({
+      description: '## Acceptance Criteria\n- [ ] AC1\n',
+      specChecksum: null
+    });
+    expect(descriptionHasSpecDrift(task, task.description ?? '')).toBe(false);
+  });
+
+  it('returns true when the proposed description produces a different checksum', () => {
+    const originalDescription = '## Acceptance Criteria\n- [ ] AC1\n';
+    const storedChecksum = specChecksumForDescription(originalDescription);
+    const task = taskFixture({
+      description: originalDescription,
+      specChecksum: storedChecksum
+    });
+    const driftedDescription = '## Acceptance Criteria\n- [ ] AC1\n- [ ] AC2\n';
+    expect(descriptionHasSpecDrift(task, driftedDescription)).toBe(true);
+  });
+
+  it('returns false when the proposed description produces the same checksum', () => {
+    const description = '## Acceptance Criteria\n- [ ] AC1\n';
+    const task = taskFixture({
+      description,
+      specChecksum: specChecksumForDescription(description)
+    });
+    expect(descriptionHasSpecDrift(task, description)).toBe(false);
+  });
+
+  // Per task `e2aba106-e1f6-4faf-ad81-3e5bec1b4574` AC2: the Tasks API no
+  // longer treats the legacy `- [x] **Approved by Tom**` marker as runtime
+  // state. A marker-only edit (Tom toggling the checkbox without changing
+  // any AC text) does NOT produce checksum drift here — the AC text is
+  // identical so the canonical form is identical. The marker is now an inert
+  // line in the description; approval state lives in `TaskApproval` rows.
+  // Re-issue approval via the structured endpoint after editing ACs.
+  it('marker-only edits do not produce checksum drift (AC2: marker is inert)', () => {
+    const description = [
+      '## Outcome',
+      '',
+      '- [x] **Approved by Tom**',
+      '',
+      '## Acceptance Criteria',
+      '- [ ] AC1'
+    ].join('\n');
+    const task = taskFixture({
+      description,
+      specChecksum: specChecksumForDescription(description)
+    });
+    const uncheckedMarker = description.replace('- [x] **Approved by Tom**', '- [ ] **Approved by Tom**');
+    expect(descriptionHasSpecDrift(task, uncheckedMarker)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Removes the Tasks API's runtime treatment of the legacy `- [x] **Approved by Tom**` task-description checkbox. Approval state is now exclusively structured via TaskApproval rows; the checkbox is inert markdown that the Tasks API no longer rewrites on spec drift.

This is PR **#1 of 3** in the e2aba106 implementation plan from the approved tech design (WS1 = Tasks API description-handling freeze). The lobster-side cleanup (PR #2) and the test sweep + `lint:no-legacy-approval-marker` script (PR #3) follow in subsequent PRs.

## What changed

- **services/tasks-api/src/routes/tasks/_spec.ts** — removed `uncheckApprovalMarker`, `descriptionWithSpecDriftApprovalState`, `descriptionsDifferOnlyByApprovalMarker`, `stripApprovalMarker`, `APPROVAL_MARKER_LINE`, and `CHECKED_APPROVAL_MARKER_LINE`. Kept the canonical `specChecksumForDescription` helper and a simplified `descriptionHasSpecDrift` that no longer special-cases the legacy marker.
- **services/tasks-api/src/routes/tasks.ts** — dropped the `descriptionWithSpecDriftApprovalState` import on PATCH /tasks/:id. The proposed description now passes through verbatim. The drift guard still fires when AC content actually changes (checksum mismatch), but the marker is no longer auto-unchecked. The structured `TaskApproval` revocation path is gated by `descriptionHasSpecDrift` so marker-only edits are inert.
- **services/tasks-api/test/tasksSpecChecksum.test.ts** — new test file covering the simplified `descriptionHasSpecDrift` behaviour, including the AC2 invariant that marker-only edits are now inert.
- **services/tasks-api/test/read-endpoints.test.ts** — updated five tests to lock in the WS1 contract per Quinn's review (commit 14d6362):
  - **"PATCH /api/v1/tasks/:id passes description through verbatim and revokes structured approval on AC drift"** (renamed from the old "allows AC drift and unchecks approval" test). Description passes through verbatim; structured TaskApproval revocation is asserted.
  - **"does not revoke spec approval for marker-only edits"** — checksum fixture corrected. The `acceptanceCriteriaText` regex captures the marker line (`**Approved by Tom**`) as an AC entry, so the stored checksum must reflect the full AC list — not just the AC section. The old fixture (checksum of `['AC1: Build it']`) caused `descriptionHasSpecDrift` to incorrectly return TRUE for marker-only edits, which is why the route called `findUnique` in the prior CI run. Pure fixture bug; route code is correct.
  - Three other tests with the same checksum fixture (marker-only uncheck, already-unchecked during AC drift, marker check toggle) updated for consistency. The "resync signal" test name was misleading — renamed.

## AC coverage

- [x] AC2: The Tasks API no longer preserves, auto-unchecks, or treats the legacy task-description checkbox as runtime state, and newly created or edited task descriptions do not add it. (🧪 testID: tasks-api-tasks-spec-checksum)
- [x] AC4: Brain-spec and bookmark-spec approval markers remain correctly supported as separate file-level workflows and are not accidentally removed by the task-description cleanup. (📄 not code: this PR only touches task-description code paths and the legacyApprovals detector continues to scope by source — comment-body branch only inspects structured brain_spec and bookmark_spec markers, not the task-description checkbox)

## Test plan

- [x] New unit tests in services/tasks-api/test/tasksSpecChecksum.test.ts: 4/4 cases pass locally covering the no-specChecksum, same-checksum, different-checksum, and marker-only-edits invariant cases.
- [x] read-endpoints.test.ts updated per Quinn's review (commit 14d6362): 40/40 tests pass locally with the corrected WS1 contract. The two prior CI failures (lines 426 and 551) were real test fixture bugs, not DB-related — Quinn flagged both on the 04:19Z review.
- [x] tasksApi CI: `pnpm test` (vitest, --exclude db-integration) — 310/310 tests pass locally across 22 files. CI should be green on the next push.
- [x] Approvals and workflow gate handling: existing `taskApprovals.test.ts`, `requiredApprovals.test.ts`, `approvalSessions.test.ts`, and `workflowGatesRouteLayer.test.ts` continue to drive approval state through TaskApproval rows exclusively.

## Out of scope (per tech design)

- PR #2 (lobster-side cleanup): rename `product_spec_approved_by_tom` → `brain_spec_approved_by_tom`, replace task-description checkbox reads with TaskApproval lookups, remove auto-uncheck helpers, convert lobster tests.
- PR #3 (test sweep + lint): `lint:no-legacy-approval-marker` pnpm script + comprehensive test conversion + approval systems doc update.
- Detector deletion in `legacyApprovals.ts` (deferred to a follow-up task once a release or two of confidence with the structured-only path is established).

## References

- Task: e2aba106-e1f6-4faf-ad81-3e5bec1b4574
- Tech design: https://github.com/Stoffer-Industries/sindustries/blob/task-e2aba106-remove-legacy-approval-tech-design/docs/specs/remove-legacy-task-description-approval-marker-tech-design.md (Quinn-approved 2026-08-10)