### PR TITLE
fix(ops): retry transient GitHub mergeable state

### DIFF
--- a/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
@@ -17,6 +17,7 @@ import os
 import pathlib
 import re
 import subprocess
+import time
 from typing import Any
 
 CLIENT_PATH = pathlib.Path(__file__).parents[1] / "tasks_api_client.py"
@@ -431,6 +432,24 @@ def fetch_pending_tech_design_approvals(base_url: str | None = None) -> list[dic
     return approvals
 
 
+def _fetch_github_pr_detail(
+    config_dir: str, token_env: str, number: int, retries: int = 3
+) -> dict[str, Any]:
+    """Fetch PR detail, retrying GitHub's transient null mergeable response.
+
+    GitHub computes ``mergeable`` asynchronously and may return null while that
+    calculation is in progress. A single fetch can therefore silently hide a
+    PR that is otherwise ready to merge from the heartbeat queue.
+    """
+    detail = _gh_api(config_dir, token_env, f"repos/{REPO}/pulls/{number}")
+    for _ in range(max(0, retries - 1)):
+        if detail.get("mergeable") is not None:
+            break
+        time.sleep(1)
+        detail = _gh_api(config_dir, token_env, f"repos/{REPO}/pulls/{number}")
+    return detail
+
+
 def fetch_github_prs(agent: str) -> list[dict[str, Any]]:
     """Read open PR state with the agent's own GitHub credentials; never mutate."""
     _, config_dir, token_env = GITHUB_IDENTITIES[agent.lower()]
@@ -446,7 +465,7 @@ def fetch_github_prs(agent: str) -> list[dict[str, Any]]:
         if author != login and login not in requested:
             continue
         number = summary["number"]
-        detail = _gh_api(config_dir, token_env, f"repos/{REPO}/pulls/{number}")
+        detail = _fetch_github_pr_detail(config_dir, token_env, number)
         detail["reviews"] = _gh_api(
             config_dir, token_env, f"repos/{REPO}/pulls/{number}/reviews?per_page=100"
         )
@@ -480,7 +499,7 @@ def fetch_linked_delivery_prs(
         pr_number = _pull_number_from_url(url)
         if pr_number is None:
             continue
-        detail = _gh_api(config_dir, token_env, f"repos/{REPO}/pulls/{pr_number}")
+        detail = _fetch_github_pr_detail(config_dir, token_env, pr_number)
         detail["reviews"] = _gh_api(
             config_dir, token_env, f"repos/{REPO}/pulls/{pr_number}/reviews?per_page=100"
         )

--- a/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
@@ -332,6 +332,36 @@ class AgentTaskQueueTest(unittest.TestCase):
         self.assertEqual(["quinnstoffer"], queue["authoredPrFeedback"][0]["changesRequestedBy"])
         self.assertEqual([], queue["mergeCandidates"])
 
+    def test_github_pr_detail_retries_transient_null_mergeable(self):
+        with (
+            patch.object(
+                agent_task_queue,
+                "_gh_api",
+                side_effect=[
+                    {"number": 42, "mergeable": None},
+                    {"number": 42, "mergeable": True},
+                ],
+            ) as gh_api,
+            patch.object(agent_task_queue.time, "sleep") as sleep,
+        ):
+            detail = agent_task_queue._fetch_github_pr_detail("~/.config/gh-rowan", "ROWAN_GITHUB_TOKEN", 42)
+
+        self.assertTrue(detail["mergeable"])
+        self.assertEqual(2, gh_api.call_count)
+        sleep.assert_called_once_with(1)
+
+    def test_github_pr_detail_does_not_retry_known_mergeable_value(self):
+        with patch.object(
+            agent_task_queue,
+            "_gh_api",
+            return_value={"number": 42, "mergeable": True},
+        ) as gh_api, patch.object(agent_task_queue.time, "sleep") as sleep:
+            detail = agent_task_queue._fetch_github_pr_detail("~/.config/gh-rowan", "ROWAN_GITHUB_TOKEN", 42)
+
+        self.assertTrue(detail["mergeable"])
+        gh_api.assert_called_once()
+        sleep.assert_not_called()
+
     def test_rowan_merge_candidate_requires_quinn_approval_and_green_ci(self):
         approved = pull_request(
             reviews=[


### PR DESCRIPTION
## Summary
- retry GitHub pull-request detail when `mergeable` is transiently null
- apply the retry to both heartbeat PR discovery paths
- add regression coverage for transient and already-resolved states

## Validation
- `python3 -m unittest agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py` (29 tests passed)
- `git diff --check`

Tom approval requested because Quinn authored this PR.