### PR TITLE
chore(code-garden): extend python-workflow-tests discovery [2026-W30]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
           python -m unittest discover -s agents/workflows/bookmarks/scripts/tests -p 'test_*.py'
           python -m unittest discover -s agents/workflows/bookmarks/tests -p 'test_*.py'
           python -m unittest discover -s agents/lib -p 'test_*.py'
+          python -m unittest discover -s agents/workflows/content-tasks/tests -p 'test_*.py'
+          python -m unittest discover -s agents/skills/ops/tasks-api/tests -p 'test_*.py'
+          python -m unittest discover -s agents/skills/ops/tasks-api/scripts -p 'test_*.py'
 
   otel-node-tests:
     name: otel-node unit tests

--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -212,7 +212,7 @@ No new performance concerns this week. The Content Scheduler auto-post correctly
 - *Why it matters:* Fact — the `eas-update-on-main` job publishes an OTA update on every push to `main`. Judgment — for TestFlight distribution to Tom this is fine at the current cadence, but there is no guard against publishing a broken update (no health-check, no post-publish rollback path documented). The blast radius today is one user; consider it before broadening distribution.
 - *Severity:* Medium (new — mild future risk, not an immediate defect)
 
-**[Low] CI `python-workflow-tests` uses `PYTHONPATH: agents/skills/tasks-api-ops` which only covers one scripts dir.**
+**[Low] CI `python-workflow-tests` uses `PYTHONPATH: agents/skills/tasks-api-ops` which only covers one scripts dir.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
 - *Where:* `.github/workflows/ci.yml:52-55`
 - *Why it matters:* The workflow imports `tasks_api_ops` from `agents/skills/tasks-api-ops`, but the new bookmarks scripts import from `agents/workflows/bookmarks/scripts/`. Without extending discovery, new Python subsystems land untested.
 - *Severity:* Low (new — related to High testing finding above)

--- a/docs/repo-audits/2026-W30.md
+++ b/docs/repo-audits/2026-W30.md
@@ -212,7 +212,7 @@ No new performance concerns this week. The Content Scheduler auto-post correctly
 - *Why it matters:* Fact — the `eas-update-on-main` job publishes an OTA update on every push to `main`. Judgment — for TestFlight distribution to Tom this is fine at the current cadence, but there is no guard against publishing a broken update (no health-check, no post-publish rollback path documented). The blast radius today is one user; consider it before broadening distribution.
 - *Severity:* Medium (new — mild future risk, not an immediate defect)
 
-**[Low] CI `python-workflow-tests` uses `PYTHONPATH: agents/skills/tasks-api-ops` which only covers one scripts dir.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**[Low] CI `python-workflow-tests` uses `PYTHONPATH: agents/skills/tasks-api-ops` which only covers one scripts dir.** ✅ [PR #426](https://github.com/Stoffer-Industries/sindustries/pull/426)
 - *Where:* `.github/workflows/ci.yml:52-55`
 - *Why it matters:* The workflow imports `tasks_api_ops` from `agents/skills/tasks-api-ops`, but the new bookmarks scripts import from `agents/workflows/bookmarks/scripts/`. Without extending discovery, new Python subsystems land untested.
 - *Severity:* Low (new — related to High testing finding above)


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W30.md
- **Finding:** [Low] CI `python-workflow-tests` uses `PYTHONPATH: agents/skills/tasks-api-ops` which only covers one scripts dir.
- Extend the `python-workflow-tests` job to discover 3 additional Python test directories (content-tasks, tasks-api client, tasks-api scripts) so existing tests run on every PR. Pure CI extension — no source code, imports, or behavior change.

The PYTHONPATH was already extended past the original W30 wording (now includes `agents/workflows/bookmarks/scripts` and `agents/lib`), and 4 discover lines run tests/, bookmarks/scripts/tests, bookmarks/tests, and agents/lib. This PR adds the remaining 3 unittest-discoverable subsystems.

## System Spec
No system spec change — CI-only fix, no user-facing behaviour.

## Test plan
- [ ] python-workflow-tests job passes on PR (now runs ~7 discover invocations covering all Python subsystems)
- [ ] No logic changes — diff is purely CI config + audit marker update

Verified locally: `python3 -m unittest discover` for all 3 new paths passes against current `origin/main`. The pytest-based `agents/skills/bookmarks/x-ingest/tests/test_linked_articles.py` is intentionally out of scope (would require adding `pip install pytest` to the CI job).

🌱 Code garden — non-functional cleanup only

🤖 Generated with Claude Code