### PR TITLE
fix(feature-task): skip spec drift gate for code tasks

### DIFF
--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -2733,6 +2733,14 @@ fn block_on_spec_drift_fluid(
     mut env: Envelope,
     action: &str,
 ) -> Result<Option<Envelope>> {
+    // Code tasks intentionally do not participate in the product-spec
+    // lifecycle. Their pipeline shares the delivery/feedback stages with
+    // feature tasks, but must not run feature-task spec checksum or approval
+    // handling here. In particular, historical `specChecksum` values on a
+    // code task must not make the shared stages require a `spec` approval.
+    if env.task.task_type.as_deref() == Some("code") {
+        return Ok(None);
+    }
     let raw_failures = spec_checksum_failures(&env.task);
     if raw_failures.is_empty() {
         return Ok(None);
@@ -4980,6 +4988,34 @@ mod tests {
         };
         let result =
             block_on_spec_drift_fluid(&args, env, "spec_check").expect("no-drift should not error");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn code_task_skips_feature_spec_drift_gate_even_with_historical_checksum() {
+        let args = StageArgs {
+            base_url: "http://example.invalid".to_string(),
+            repo: PathBuf::from("."),
+            workspace_root: None,
+            dry_run: false,
+        };
+        let task = Task {
+            task_type: Some("code".to_string()),
+            spec_checksum: Some("historical-checksum".to_string()),
+            status: "doing".to_string(),
+            ..Task::default()
+        };
+        let env = Envelope {
+            criteria_met: true,
+            already_past: false,
+            action_taken: String::new(),
+            task,
+            lobster_state: LobsterState::default(),
+            failures: Vec::new(),
+        };
+
+        let result = block_on_spec_drift_fluid(&args, env, "verify_delivery")
+            .expect("code tasks must bypass feature spec-drift handling");
         assert!(result.is_none());
     }
 


### PR DESCRIPTION
## Summary
- Prevent shared delivery stages from applying feature-task spec-drift checks to code tasks.
- Add a regression test covering code tasks with historical `specChecksum` values but no `spec` approval.

## System Spec
No system spec change — workflow correctness fix with no user-facing product behaviour.

## Test plan
- [x] 203 feature-task workflow unit tests pass.
- [x] Cargo clippy passes with warnings denied.
- [x] Code tasks bypass the feature spec-drift gate even when a historical checksum is present.

## Context
Tom reported code task `e2aba106-e1f6-4faf-ad81-3e5bec1b4574` remaining in `doing` after all linked PRs merged. The shared `verify_delivery` stage was invoking feature-task spec approval handling and blocking on a missing `spec` approval, despite the code-task pipeline intentionally skipping the product-spec lifecycle.