### PR TITLE
fix(tasks-app): remove duplicate assignee avatar

### DIFF
--- a/apps/tasks/src/App.test.jsx
+++ b/apps/tasks/src/App.test.jsx
@@ -262,8 +262,8 @@ describe('tasks ui', () => {
     expect(within(card).getByText('api')).toBeInTheDocument();
     expect(within(card).getByText('backend')).toBeInTheDocument();
     expect(within(card).getByText('urgent')).toBeInTheDocument();
-    const assigneeAvatar = within(card).getByLabelText('Assignee Quinn');
-    expect(assigneeAvatar).toHaveClass('si-avatar');
+    const assigneeAvatar = within(card).getByLabelText('delivery assignee Quinn');
+    expect(assigneeAvatar.querySelector('.si-avatar')).not.toBeNull();
     const assigneeImg = assigneeAvatar.querySelector('img');
     expect(assigneeImg).not.toBeNull();
     expect(assigneeImg).toHaveAttribute('src', '/avatars/quinn.png');

--- a/apps/tasks/src/components/TaskCardSummary.jsx
+++ b/apps/tasks/src/components/TaskCardSummary.jsx
@@ -1,8 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import { Avatar, Badge } from '@sindustries/ui/react';
-import { assigneeInitial } from '../utils/helpers.js';
+import { Badge } from '@sindustries/ui/react';
 import { PRIORITIES } from '../utils/constants.js';
-import { assigneeDisplayName, findAssigneeUser } from '../users/assignees.js';
 import { StackedAvatarGroup } from './StackedAvatarGroup.jsx';
 
 function priorityVariant(priority) {
@@ -27,10 +25,6 @@ function taskCardTags(task) {
 export function TaskCardSummary({ task, hasDraft, onTitleClick, showCopyId = true }) {
   const date = taskCardDate(task);
   const tags = taskCardTags(task);
-  const assigneeLetter = assigneeInitial(task.assignee);
-  const assigneeUser = findAssigneeUser(task.assignee);
-  const assigneeLabel = assigneeDisplayName(task.assignee);
-  const avatarSrc = assigneeUser?.avatarSrc ?? null;
   const TitleTag = onTitleClick ? 'button' : 'div';
   const [didCopy, setDidCopy] = useState(false);
   const copyTimeoutRef = useRef(null);
@@ -84,15 +78,6 @@ export function TaskCardSummary({ task, hasDraft, onTitleClick, showCopyId = tru
             >
               {didCopy ? 'Copied' : 'ID'}
             </button>
-          ) : null}
-          {assigneeLetter ? (
-            <Avatar
-              src={avatarSrc ?? undefined}
-              alt={assigneeLabel || undefined}
-              aria-label={assigneeLabel ? `Assignee ${assigneeLabel}` : undefined}
-            >
-              {assigneeLetter}
-            </Avatar>
           ) : null}
           <StackedAvatarGroup task={task} />
           {date ? <time className="task-card-date" dateTime={date}>{date}</time> : null}

--- a/apps/tasks/src/components/TaskCardSummary.test.jsx
+++ b/apps/tasks/src/components/TaskCardSummary.test.jsx
@@ -73,11 +73,11 @@ describe('TaskCardSummary', () => {
           />
         );
 
-        const avatar = screen.getByLabelText('Assignee Quinn');
-        expect(avatar).toHaveClass('si-avatar');
-        expect(avatar).toHaveTextContent('Q');
+        const avatar = screen.getByLabelText('delivery assignee Quinn');
+        expect(avatar.querySelector('.si-avatar')).not.toBeNull();
+        expect(avatar.querySelector('.si-avatar')).toHaveTextContent('Q');
         // No <img> should render when avatarSrc is null.
-        expect(avatar.querySelector('img')).toBeNull();
+        expect(avatar.querySelector('.si-avatar img')).toBeNull();
       });
     });
 
@@ -95,10 +95,10 @@ describe('TaskCardSummary', () => {
         />
       );
 
-      const avatar = screen.getByLabelText('Assignee someone-new');
-      expect(avatar).toHaveClass('si-avatar');
-      expect(avatar).toHaveTextContent('S');
-      expect(avatar.querySelector('img')).toBeNull();
+      const avatar = screen.getByLabelText('delivery assignee someone-new');
+      expect(avatar.querySelector('.si-avatar')).not.toBeNull();
+      expect(avatar.querySelector('.si-avatar')).toHaveTextContent('S');
+      expect(avatar.querySelector('.si-avatar img')).toBeNull();
     });
 
     it('omits the avatar entirely when the assignee is empty / whitespace', () => {
@@ -134,7 +134,7 @@ describe('TaskCardSummary', () => {
         />
       );
 
-      expect(screen.getByLabelText('Assignee Quinn')).toBeInTheDocument();
+      expect(screen.getByLabelText('delivery assignee Quinn')).toBeInTheDocument();
     });
 
     it('falls back to the raw assignee label for unknown free-form assignees', () => {
@@ -151,7 +151,7 @@ describe('TaskCardSummary', () => {
         />
       );
 
-      expect(screen.getByLabelText('Assignee someone-new')).toBeInTheDocument();
+      expect(screen.getByLabelText('delivery assignee someone-new')).toBeInTheDocument();
     });
   });
 
@@ -191,7 +191,7 @@ describe('TaskCardSummary', () => {
           />
         );
 
-        const avatar = screen.getByLabelText('Assignee Quinn');
+        const avatar = screen.getByLabelText('delivery assignee Quinn');
         const img = avatar.querySelector('img');
         expect(img).not.toBeNull();
         expect(img).toHaveAttribute('src', '/avatars/__test-fixture__.png');

--- a/apps/tasks/src/styles/task.css
+++ b/apps/tasks/src/styles/task.css
@@ -79,6 +79,21 @@
   margin-left: auto;
 }
 
+.task-owner-stack {
+  align-items: center;
+  display: flex;
+}
+
+/* Avatars are 24px wide; pull each subsequent owner left by 8px (33%). */
+.task-owner-stack > * + * {
+  margin-left: -8px;
+}
+
+.task-owner-stack-item {
+  display: inline-flex;
+  position: relative;
+}
+
 .task-id-copy-btn {
   align-items: center;
   background: var(--si-color-bg-field);


### PR DESCRIPTION
## Summary
- Remove the superseded standalone assignee avatar from task cards so the assignee appears only once in the stacked ownership group.
- Overlap consecutive stacked avatars by 8px, which is one third of their 24px width.
- Update task-card tests to assert the stacked avatar's role-aware accessible label.

Original ask from Tom: remove the duplicate avatar on the left because the stacked avatar group supersedes it, and overlap stacked avatars by 33%.

## System Spec
No system spec change — this fixes an unintended duplicate rendering and adjusts presentation without changing ownership semantics or API contracts.

## Test plan
- [x] Task-card, stacked-avatar, and app tests pass (44 tests).
- [x] Tasks app production build succeeds.
- [x] Confirm the legacy standalone avatar is absent and the stack still renders the assignee avatar image/fallback.

🤖 Generated with OpenClaw
