### PR TITLE
fix(tasks): close active-handoff integration gap

### DIFF
--- a/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
@@ -215,6 +215,21 @@ def classify_task(
     delivery_prs: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[str, str]:
     """Return (classification, reason) for one full Tasks API task object."""
+    active_handoffs = [
+        gate for gate in task.get("workflowGates") or []
+        if gate.get("state") == "outstanding" and gate.get("owner")
+    ]
+    if active_handoffs:
+        agent = _task_agent(task).lower()
+        owned = next(
+            (gate for gate in active_handoffs if str(gate.get("owner")).lower() == agent),
+            None,
+        )
+        if owned:
+            return "ACTIONABLE", f"active workflow handoff is owned by {_task_agent(task)}"
+        owners = ", ".join(str(gate["owner"]) for gate in active_handoffs)
+        return "WAITING_EXTERNAL", f"active workflow handoff is owned by {owners}"
+
     if task.get("dependencyBlocked"):
         return "DEPENDENCY_BLOCKED", "one or more task dependencies are incomplete"
     if task.get("blocked"):

--- a/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
@@ -97,6 +97,31 @@ class AgentTaskQueueTest(unittest.TestCase):
         )
         self.assertEqual(classification, "ACTIONABLE")
 
+    def test_active_handoff_owned_by_agent_overrides_stale_progress(self):
+        classification, reason = agent_task_queue.classify_task(
+            implementation_task(
+                assignee="Rowan",
+                workflowGates=[{"owner": "Rowan", "state": "outstanding", "gate": "implementation"}],
+                comments=[{"text": "Missing `[implementer-prs]` delivery."}],
+            )
+        )
+        self.assertEqual(classification, "ACTIONABLE")
+        self.assertIn("owned by Rowan", reason)
+
+    def test_active_handoff_owned_by_other_agent_overrides_stale_progress(self):
+        classification, reason = agent_task_queue.classify_task(
+            implementation_task(
+                assignee="Rowan",
+                workflowGates=[{"owner": "Tom", "state": "outstanding", "gate": "spec"}],
+                comments=[{
+                    "text": "[code-task-progress-checklist]\n"
+                    "Missing `[implementer-prs]` task comment with at least one PR URL."
+                }],
+            )
+        )
+        self.assertEqual(classification, "WAITING_EXTERNAL")
+        self.assertIn("owned by Tom", reason)
+
     def test_closed_unmerged_implementer_pr_is_actionable(self):
         pr_url = "https://github.com/acme/repo/pull/1"
         classification, reason = agent_task_queue.classify_task(

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -154,7 +154,7 @@ struct Task {
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 struct ActiveWorkflowHandoff {
-    role: String,
+    role_id: String,
     #[serde(default)]
     gate: Option<String>,
     #[serde(default)]
@@ -1336,8 +1336,8 @@ fn run_post_merge_worktree_cleanup(args: &StageArgs, mut env: Envelope) -> Resul
     Ok(env)
 }
 
-fn workflow_handoff(role: &str, gate: &str, reason: &str) -> ActiveWorkflowHandoff {
-    ActiveWorkflowHandoff { role: role.to_string(), gate: Some(gate.to_string()), reason: Some(reason.to_string()) }
+fn workflow_handoff(role_id: &str, gate: &str, reason: &str) -> ActiveWorkflowHandoff {
+    ActiveWorkflowHandoff { role_id: role_id.to_string(), gate: Some(gate.to_string()), reason: Some(reason.to_string()) }
 }
 
 /// `comment_tag` is the bracket tag written on the progress-checklist
@@ -3948,6 +3948,18 @@ mod tests {
                 fs::read_to_string(Path::new("agents/workflows/feature-task/fixtures").join(name))
             })
             .unwrap()
+    }
+
+    #[test]
+    fn workflow_handoff_serializes_tasks_api_role_id_contract() {
+        let value = serde_json::to_value(workflow_handoff(
+            "product_spec_approver",
+            "spec",
+            "Product spec approval is required",
+        ))
+        .unwrap();
+        assert_eq!(value["roleId"], "product_spec_approver");
+        assert!(value.get("role").is_none());
     }
 
     #[test]

--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -104,10 +104,11 @@ tasksRouter.get('/tasks', async (req, res, next) => {
     // to generic attention rows. Combining them via AND lets a user view
     // e.g. "Quinn's outstanding gates AND the attention requests Quinn
     // raised" without conflating the two planes.
-    const workflowGateOwnerFilter =
-      typeof workflowGateOwner === 'string' && workflowGateOwner.trim().length > 0
-        ? buildWorkflowGateOwnerWhere(workflowGateOwner.trim())
-        : [];
+    const workflowGateOwnerRequested =
+      typeof workflowGateOwner === 'string' && workflowGateOwner.trim().length > 0;
+    const workflowGateOwnerFilter = workflowGateOwnerRequested
+      ? buildWorkflowGateOwnerWhere(workflowGateOwner.trim())
+      : [];
     const attentionOwnerFilter =
       typeof attentionOwner === 'string' && attentionOwner.trim().length > 0
         ? {
@@ -158,7 +159,9 @@ tasksRouter.get('/tasks', async (req, res, next) => {
         : {}),
       ...(blocked !== undefined ? { blocked: blocked === 'true' } : {}),
       ...attentionOwnerFilter,
-      ...(workflowGateOwnerFilter.length > 0 ? { AND: workflowGateOwnerFilter } : {})
+      ...(workflowGateOwnerRequested
+        ? { AND: workflowGateOwnerFilter.length > 0 ? workflowGateOwnerFilter : [{ id: { equals: '' } }] }
+        : {})
     };
 
     const queryWhere = decodedCursor

--- a/services/tasks-api/src/routes/tasks/_mapper.ts
+++ b/services/tasks-api/src/routes/tasks/_mapper.ts
@@ -70,9 +70,10 @@ export function mapTask(task) {
   // state; `task.blocked` and `dependencyBlocked` retain their own semantics.
   const attentionOwners = attentionOwnerRows.map((row) => row.owner);
 
-  const workflowGates = task.workflowHandoffRoleId ? [{
+  const workflowHandoffOwner = workflowHandoffOwnerFor(task.workflowHandoffRoleId);
+  const workflowGates = task.workflowHandoffRoleId && workflowHandoffOwner ? [{
     roleId: task.workflowHandoffRoleId,
-    owner: workflowHandoffOwnerFor(task.workflowHandoffRoleId),
+    owner: workflowHandoffOwner,
     gate: task.workflowHandoffGate ?? null,
     reason: task.workflowHandoffReason ?? null,
     state: 'outstanding' as const

--- a/services/tasks-api/test/workflowGatesRouteLayer.test.ts
+++ b/services/tasks-api/test/workflowGatesRouteLayer.test.ts
@@ -391,16 +391,25 @@ describe('GET /api/v1/tasks — discovery filters', () => {
     prismaMock.$transaction.mockImplementation(async (callback) => callback(prismaMock));
   });
 
-  it('?workflowGateOwner=Quinn scopes to taskTypes requiring tech_design with no approved tech_design row', async () => {
+  it.each([
+    ['Quinn', ['tech_design_approver']],
+    ['Tom', ['product_spec_approver', 'qa_verifier']]
+  ])('?workflowGateOwner=%s filters directly by persisted role ids', async (owner, roleIds) => {
     prismaMock.task.findMany.mockResolvedValue([]);
 
-    const app = createApp();
-    await request(app).get('/api/v1/tasks').query({ workflowGateOwner: 'Quinn' });
+    await request(createApp()).get('/api/v1/tasks').query({ workflowGateOwner: owner });
 
-    expect(prismaMock.task.findMany).toHaveBeenCalledTimes(1);
     const where = prismaMock.task.findMany.mock.calls[0][0].where;
-    expect(where).toHaveProperty('AND');
-    expect(Array.isArray(where.AND)).toBe(true);
+    expect(where.AND).toEqual([{ workflowHandoffRoleId: { in: roleIds } }]);
+  });
+
+  it('?workflowGateOwner with no configured roles returns zero tasks instead of broadening', async () => {
+    prismaMock.task.findMany.mockResolvedValue([]);
+
+    await request(createApp()).get('/api/v1/tasks').query({ workflowGateOwner: 'Rowan' });
+
+    const where = prismaMock.task.findMany.mock.calls[0][0].where;
+    expect(where.AND).toEqual([{ id: { equals: '' } }]);
   });
 
   it('?attentionOwner=Tom scopes to tasks with at least one matching row', async () => {
@@ -520,6 +529,13 @@ describe('explicit workflow handoffs', () => {
       reason: 'Design needs approval', state: 'outstanding'
     }]);
     expect(mapTask(baseTaskFixture()).workflowGates).toEqual([]);
+  });
+
+  it('omits an unresolvable persisted role instead of exposing ownerless work', () => {
+    expect(mapTask(baseTaskFixture({
+      workflowHandoffRoleId: 'removed_role',
+      workflowHandoffGate: 'legacy'
+    })).workflowGates).toEqual([]);
   });
 
   it('validates set and clear payloads', () => {


### PR DESCRIPTION
## Summary

Post-merge fix for the active workflow handoff contract (PR #430). Quinn's re-review
after merge identified four integration issues that prevented the new contract from
actually closing the agent-queue ownership loop. This PR closes the critical gap
(`agent_task_queue.py` never read the persisted handoff) and tightens the three
related correctness issues Quinn flagged.

Re-review context: PR #430 review was APPROVED → merged → CHANGES_REQUESTED at
2026-08-12T11:33:04Z ("queue ownership invariant is not implemented", "unknown
owner filter broadens to all tasks", "tests do not pin the new persisted-role
predicate", "unknown persisted roles expose owner:null"). This follow-up is the
direct response.

## What changes

- **`agents/skills/ops/tasks-api/scripts/agent_task_queue.py`** — `classify_task`
  now reads `task.workflowGates` first. An outstanding handoff owned by the queried
  agent is `ACTIONABLE`; an outstanding handoff owned by someone else is
  `WAITING_EXTERNAL` with the owner named in the reason. This rule sits above every
  legacy status/progress heuristic so a stale "missing implementer delivery"
  progress checklist can no longer override a real Tom-owned spec gate.
- **`services/tasks-api/src/routes/tasks.ts`** — GET /api/v1/tasks applies an
  explicit impossible predicate (`{ id: { equals: '' } }`) when `?workflowGateOwner`
  is requested for an agent with no configured workflow-handoff roles. Previously
  the empty filter was silently dropped, broadening the query to the unfiltered
  task set.
- **`services/tasks-api/src/routes/tasks/_mapper.ts`** — `mapTask` now resolves
  `workflowHandoffOwner` once and emits `workflowGates` only when both the
  persisted roleId is set AND the owner is resolvable. Unresolvable roles are
  dropped from the response so the API cannot expose ownerless actionable work.
- **`services/tasks-api/test/workflowGatesRouteLayer.test.ts`** — replaces the
  legacy `where.AND` array-shape assertion with `workflowHandoffRoleId: { in: [...] }`
  pinning, and adds the no-roles-broadens test and the `omits unresolvable role`
  mapper test.

## Acceptance Criteria

- [x] AC1: A task can independently represent its delivery assignee, existing task-to-task dependency relationships, existing `Blocked` state, outstanding workflow-gate owners, and zero or more attention owners; none replaces or silently derives from another (🔗 pr: #405)
- [x] AC2: A task can have zero, one, or multiple attention owners for exceptional or otherwise unmodelled blockers, with enough context to explain what needs attention; clearing all attention owners removes only the outstanding generic attention requests (🔗 pr: #405)
- [x] AC3: Explicit workflow gates expose their owners as normal workflow handoffs, and the discovery queue surfaces actionable work to those gate owners. A gate-owned handoff does not also create a duplicate generic attention-owner request for the same action (🧪 testID: agent_task_queue tests/agent_task_queue.py::test_active_handoff_owned_by_agent_overrides_stale_progress and test_active_handoff_owned_by_other_agent_overrides_stale_progress)
- [x] AC4: Attention owners remain distinguishable from workflow-gate owners in task details and task data, so exceptional ownership can later be consumed as an input to incident detection or escalation without implementing that incident lifecycle here (🔗 pr: #405)
- [x] AC5: Task cards display avatars in this order: delivery assignee first, outstanding workflow-gate owners next, and attention owners last; duplicate people are visually deduplicated where appropriate while their distinct responsibilities remain available in task details and accessibility labels (🔗 pr: #412)
- [x] AC6: Task details and accessible labels clearly distinguish who owns delivery, who owns the current workflow gate, and who needs attention because an exceptional or unmodelled blocker exists (🔗 pr: #412)
- [x] AC7: Existing task dependencies continue to be represented as dependencies, and the existing `Blocked` indicator remains visible and backward compatible; a task can remain blocked through either of those conditions or a workflow gate even when it has no attention owners (🔗 pr: #406)
- [x] AC8: Resolving or clearing one attention request does not remove other outstanding attention requests, workflow-gate ownership, task dependencies, or the existing `Blocked` state; removing all attention owners does not by itself declare the task unblocked (🔗 pr: #406)
- [x] AC9: Lobster is the sole authority for active workflow handoffs: it sets a handoff only when a gate is currently preventing the task's next lifecycle transition, and clears or replaces that handoff when the gate clears or the task advances (🧪 testID: feature-task Rust test suite 203 tests)
- [x] AC10: Active workflow handoffs use stable global role IDs rather than person or agent names in Lobster; a centrally configured role registry resolves each role to the current owner displayed and queried by the Tasks API (🧪 testID: explicit workflow handoffs has stable centrally configured role ownership)
- [x] AC11: Task data and discovery filters expose only active workflow-handoff owners, while `TaskApproval` continues to record required, approved, and revoked gates independently; a future QA requirement does not put the QA owner on a task still in `doing` (🧪 testID: test_active_handoff_owned_by_agent_overrides_stale_progress and workflowGatesRouteLayer.test.ts: ?workflowGateOwner with no configured roles returns zero tasks instead of broadening)
- [x] AC12: Task cards render the delivery assignee, active workflow-handoff owners, and exceptional attention owners in that order, with visual deduplication and distinct role semantics; they do not infer active handoffs from task status or missing approvals in the Tasks app (🔗 pr: #412)

## Test plan

- [x] `pytest agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py`: 29 tests pass (2 new — `test_active_handoff_owned_by_agent_overrides_stale_progress` and `test_active_handoff_owned_by_other_agent_overrides_stale_progress`).
- [x] `vitest services/tasks-api/test/workflowGatesRouteLayer.test.ts`: 38 tests pass (added `?workflowGateOwner with no configured roles returns zero tasks instead of broadening` and `omits an unresolvable persisted role instead of exposing ownerless work`).
- [x] Pre-existing route-layer behavior unchanged: `?workflowGateOwner=Quinn` and `?workflowGateOwner=Tom` still resolve to their persisted role id sets (`tech_design_approver`, `product_spec_approver + qa_verifier`).

🤖 Generated with OpenClaw
