### PR TITLE
fix(feature-task): show external wait owners across states

### DIFF
--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -2791,6 +2791,7 @@ fn block_on_spec_drift_fluid(
                 .to_string(),
         );
         env.failures = failures;
+        publish_spec_approval_handoff(args, &mut env)?;
         return Ok(Some(env));
     }
     // e2aba106 WS2: approval state is now exclusively structured TaskApproval
@@ -2895,6 +2896,7 @@ fn block_on_spec_drift_fluid(
             env.task = api_get_task(&args.base_url, &env.task.id)?;
             env.lobster_state.spec_drift_uncheck_applied = Some(true);
         }
+        publish_spec_approval_handoff(args, &mut env)?;
         let checklist = format!(
             "[feature-task-progress-checklist]\n{}\n",
             failures.join("\n")
@@ -2925,8 +2927,33 @@ fn block_on_spec_drift_fluid(
              Approve via POST /tasks/:id/approvals (type=spec) before drift can be re-evaluated."
                 .to_string(),
         ];
+        publish_spec_approval_handoff(args, &mut env)?;
         Ok(Some(env))
     }
+}
+
+/// A spec-drift block can happen in any active lifecycle state, so it cannot
+/// rely on the normal open → ready transition to publish ownership. Persist
+/// the same explicit handoff used by the queue classifier so task cards show
+/// Tom whenever the workflow is waiting on his spec approval, including when
+/// the task is already in `doing` or `acceptance`.
+fn publish_spec_approval_handoff(args: &StageArgs, env: &mut Envelope) -> Result<()> {
+    if args.dry_run {
+        return Ok(());
+    }
+    api_patch::<Task>(
+        &args.base_url,
+        &env.task.id,
+        json!({
+            "workflowHandoff": workflow_handoff(
+                "product_spec_approver",
+                "spec",
+                "Product spec approval is required",
+            )
+        }),
+    )?;
+    env.task = api_get_task(&args.base_url, &env.task.id)?;
+    Ok(())
 }
 
 /// Return true when the Tasks API already revoked the structured spec


### PR DESCRIPTION
## Summary
- Persist Tom's explicit spec-approval handoff whenever spec drift blocks a feature task, regardless of whether the task is open, ready, doing, or acceptance.
- This makes the existing stacked avatar component follow the queue truth: when the workflow is `WAITING_EXTERNAL` on Tom, Tom's avatar is present alongside the delivery assignee.

## System Spec
No system spec change — this fixes the workflow publisher to honour the existing active-handoff contract.

## Test plan
- [x] All 206 feature-task workflow tests pass.
- [x] Feature-task clippy passes with warnings denied.
- [ ] Verify task `66054ab4-24e2-4cc6-9847-0faa4e94f041` shows Rowan then Tom after deployment and the next Lobster pass.