### PR TITLE
docs(strategy): update canonical graph path

### DIFF
--- a/agents/definitions/ivy/HEARTBEAT.md
+++ b/agents/definitions/ivy/HEARTBEAT.md
@@ -156,7 +156,7 @@ If you fell back to scattergun (step 2), state that explicitly:
 
 This runs independently of the content-task discovery above — different cadence, different trigger. It is a market-research check, not a generic research loop.
 
-1. Read `brain/sindustries/strategy-graph.md`. List every `active` Initiative tagged with the **Money or Users** Impact.
+1. Read `brain/strategy/strategy-graph.md`. List every `active` Initiative tagged with the **Money or Users** Impact.
 2. For each, check `brain/initiatives/<slug>/market-research.md` (if it exists): are there unanswered open questions, is it stale (no entry in the last ~2 weeks), or is it missing entirely for an initiative that has none yet?
 3. **A research/campaign pass is due when any of:**
    - An initiative newly gained the Money or Users tag and has no `market-research.md` yet

--- a/agents/definitions/ivy/SOUL.md
+++ b/agents/definitions/ivy/SOUL.md
@@ -9,7 +9,7 @@ _I am the growth agent for SIndustries. I own market/competitive research and co
 - **Name:** Ivy
 - **Role:** Chief Growth Officer (CGO) — growth research, GTM/campaign strategy, and content production for SIndustries
 - **Scope:**
-  - **Growth research & campaigns:** market research, competitive analysis, positioning, and GTM planning for every Initiative in `brain/sindustries/strategy-graph.md` that carries the **Money or Users** Impact. Owns `brain/initiatives/<slug>/market-research.md`, `campaign.md`, and (where relevant) `feature-ideas.md`/`prospects/` for those initiatives. (2026-08-04 — promoted from Content Agent to CGO; see `memory/2026-08-04.md`.)
+  - **Growth research & campaigns:** market research, competitive analysis, positioning, and GTM planning for every Initiative in `brain/strategy/strategy-graph.md` that carries the **Money or Users** Impact. Owns `brain/initiatives/<slug>/market-research.md`, `campaign.md`, and (where relevant) `feature-ideas.md`/`prospects/` for those initiatives. (2026-08-04 — promoted from Content Agent to CGO; see `memory/2026-08-04.md`.)
   - **Content production (unchanged):** all SIndustries public content — website copy, stories, release notes, future channel content
 - **Never:** Touch product code, infrastructure, or agent runtime code. Never commit external spend, pricing, or partnership terms — research and recommend only.
 
@@ -22,7 +22,7 @@ I own growth research/strategy and content production. I do not own:
 - Direct publishing to live channels
 - Autonomous BD outreach, spend, or partnership commitments — I research and recommend; Tom approves anything that leaves the building
 
-Which initiatives are mine is derived, not hardcoded: read the current Impact tags in `brain/sindustries/strategy-graph.md` each pass. If Money or Users is tagged, it's in scope. If a Quinn-owned engineering initiative (Feature Factory, Bookmark → Spec Pipeline, Agent Fleet Reliability) also touches Money or Users indirectly, I still don't own its market-research.md — those stay Rowan/Quinn's; ask Quinn if a boundary case comes up.
+Which initiatives are mine is derived, not hardcoded: read the current Impact tags in `brain/strategy/strategy-graph.md` each pass. If Money or Users is tagged, it's in scope. If a Quinn-owned engineering initiative (Feature Factory, Bookmark → Spec Pipeline, Agent Fleet Reliability) also touches Money or Users indirectly, I still don't own its market-research.md — those stay Rowan/Quinn's; ask Quinn if a boundary case comes up.
 
 I work with Quinn (orchestrator) and Tom (approval authority).
 

--- a/agents/definitions/ivy/WORKFLOW.md
+++ b/agents/definitions/ivy/WORKFLOW.md
@@ -10,7 +10,7 @@ This is the CGO half of my role. It runs on a different rhythm than content task
 
 ### Which initiatives are mine
 
-Read `brain/sindustries/strategy-graph.md`. Any Initiative tagged with the **Money or Users** Impact and `status: active` is in scope. This is derived fresh each time, not a fixed list — if Tom retags an initiative, my scope shifts automatically.
+Read `brain/strategy/strategy-graph.md`. Any Initiative tagged with the **Money or Users** Impact and `status: active` is in scope. This is derived fresh each time, not a fixed list — if Tom retags an initiative, my scope shifts automatically.
 
 ### Doing a market-research pass (`market-research.md`)
 
@@ -34,7 +34,7 @@ Read `brain/sindustries/strategy-graph.md`. Any Initiative tagged with the **Mon
 
 ### Escalation
 
-If a research/campaign pass surfaces something that should change an Initiative's status, WSJF inputs, or Impact tags in `strategy-graph.md` — I don't edit that file myself. I flag it to Quinn with the specific change and reasoning; Quinn (or Tom) makes the call.
+If a research/campaign pass surfaces something that should change an Initiative's status, WSJF inputs, or Impact tags in `brain/strategy/strategy-graph.md` — I don't edit that file myself. I flag it to Quinn with the specific change and reasoning; Quinn (or Tom) makes the call.
 
 ---
 

--- a/agents/skills/strategy/initiative-author/SKILL.md
+++ b/agents/skills/strategy/initiative-author/SKILL.md
@@ -11,7 +11,7 @@ Use this skill when creating or reviewing an initiative at `brain/initiatives/<s
 
 An initiative is a bounded business hypothesis with a concrete output. Its `index.md` is the stable front door for the initiative; it is not a task list, campaign plan, market-research log, or scorecard.
 
-The strategy graph at `brain/sindustries/strategy-graph.md` remains the source of truth for initiative relationships, Impact tags, status, and WSJF inputs/scores. Never copy WSJF values into `index.md`.
+The strategy graph at `brain/strategy/strategy-graph.md` remains the source of truth for initiative relationships, Impact tags, status, and WSJF inputs/scores. Never copy WSJF values into `index.md`.
 
 ## When to use
 
@@ -24,7 +24,7 @@ The strategy graph at `brain/sindustries/strategy-graph.md` remains the source o
 
 Read, in order:
 
-1. `brain/sindustries/strategy-graph.md` — canonical initiative name, hypothesis, output, Impact relationships, and status.
+1. `brain/strategy/strategy-graph.md` — canonical initiative name, hypothesis, output, Impact relationships, and status.
 2. `brain/README.md` — folder and output conventions.
 3. Existing `brain/initiatives/<slug>/index.md`, if present.
 4. Existing initiative artifacts (`market-research.md`, `campaign.md`, `feature-ideas.md`, `prospects/`) for links and open questions.
@@ -43,7 +43,7 @@ Create `brain/initiatives/<slug>/index.md` with this structure:
 **Impacts:** <Impact name(s)>
 **Exec Owner:** <single named person accountable for driving this initiative — Tom, Quinn, or Ivy>
 **Contributors:** <agents/people doing the work — may be a list>
-**Strategy graph:** [`strategy-graph.md`](../../sindustries/strategy-graph.md)
+**Strategy graph:** [`strategy-graph.md`](../../strategy/strategy-graph.md)
 
 ## Hypothesis
 

--- a/agents/skills/strategy/strategy-graph/SKILL.md
+++ b/agents/skills/strategy/strategy-graph/SKILL.md
@@ -78,7 +78,7 @@ WSJF favours small-but-valuable work over big-but-valuable work per unit of effo
 
 **How this reaches Tasks:** Tasks tag themselves with one or more Impacts (unchanged — no new tagging behaviour). A Task's derived strategic-fit badge is the score of the highest-WSJF `active` Initiative backing any of its tagged Impacts. This is computed, not stored by hand, and re-derives automatically when Initiative status or WSJF inputs change. `urgent` on the Task always overrides the derived badge.
 
-**Where the live numbers live:** the reasoning framework (this file) defines *how* to score. The actual Impacts, Initiatives, and their current weights/status/WSJF inputs live in `brain/sindustries/strategy-graph.md` — that file is the instance data, this skill is the method.
+**Where the live numbers live:** the reasoning framework (this file) defines *how* to score. The actual Impacts, Initiatives, and their current weights/status/WSJF inputs live in `brain/strategy/strategy-graph.md` — that file is the instance data, this skill is the method.
 
 That instance file also names each Initiative's kind — permanent **Capability Theme** (never graduates, serves everything) vs temporary **Products bucket** entry (unranked against siblings until it proves real usage and can graduate into its own Value Stream) — and the graduation rule between them. This skill's Theme/Value Stream/ART vocabulary above is the SAFe-derived reasoning shape; the Capability/Products split is how Sindustries currently maps its own initiatives onto that shape, kept in the instance file, not duplicated here.
 


### PR DESCRIPTION
## Summary
- Update Ivy's operational docs and strategy skills to reference the canonical `brain/strategy/strategy-graph.md` path.
- Keep the initiative-author relative link aligned with the new directory layout.

## System Spec
No system spec change — documentation-only path correction with no behavioural changes.

## Test plan
- [x] Confirm no stale `brain/sindustries/strategy-graph.md` references remain in the affected docs.
- [x] Run `git diff --check`.