### PR TITLE
feat(bookmarks): compounding signal — weekly prior-context KPI for Pulse

### DIFF
--- a/agents/crons/prompts/bookmark-compounding-signal.md
+++ b/agents/crons/prompts/bookmark-compounding-signal.md
@@ -1,0 +1,65 @@
+Run the bookmark compounding-signal calculator once.
+
+This is a **weekly, read-only** observability job. It must never invoke
+any other bookmark pipeline stage (no ingestion, no lobster, no
+approval handling, no task creation) and must never write to any
+upstream pipeline data source. The only writes are the two derived
+artifacts under `brain/state/`.
+
+## Command
+
+```sh
+python3 /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/bookmarks/scripts/compute_compounding_signal.py \
+  --workspace-root /Users/quinnstoffer/.openclaw/workspace
+```
+
+The script exits `0` on success (publish or dry-run) and non-zero on
+any failure. Read the runbook before changing this command:
+
+`/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/docs/runbooks/bookmark-compounding-signal.md`
+
+## Mandatory blocks
+
+After running the command, in this exact order:
+
+1. Validate the script's exit code and stdout/stderr.
+   - On non-zero exit, capture the JSON `{"error": "..."}` line on stderr
+     and continue to step 2 (do not retry).
+   - On success, capture `{"published": true, "runId": "...", ...}` from
+     stdout and continue to step 2.
+2. Sanity-check the published artifacts on disk:
+   - `brain/state/compounding-signal.json` parses as JSON, has
+     `schemaVersion: 1`, `headlinePercentage == trend[0].percentage`,
+     `trend.length == 4`, and `decisionPolicy.lowPercentageBelow == 25.0`.
+   - `brain/state/compounding-signal.md` exists and shares the same
+     `runId`.
+3. Run the mandatory soft-fail block:
+   - Read `/Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/skills/ops/notify-soft-fail/SKILL.md` and follow it.
+   - If the script or sanity-check failed, escalate to Lox's main session
+     per that skill. **Do not retry the calculator in this turn.**
+   - If the script succeeded and the sanity-check passed, reply exactly:
+     `NO_REPLY`
+
+## Hard constraints
+
+- Do not call any other bookmark script. The signal is intentionally
+  decoupled from `bookmarks.lobster.yaml` because cadence and failure
+  isolation differ (weekly vs. heartbeat; soft-fail vs. approval pause).
+- Do not edit `brain/state/compounding-signal.json` or `.md` by hand.
+  The dashboard will mark the next published artifact stale relative to
+  a hand-edited timestamp, and the calculator's schema validation will
+  reject hand-edited shapes on the next publish attempt.
+- Do not push to any git remote from this session. The signal artifacts
+  are workspace runtime outputs, not repo contents.
+- Do not change the cron schedule from this prompt. Schedule lives in
+  OpenClaw cron metadata; if the cadence is wrong, file a follow-up
+  task and let Quinn decide.
+
+## Why a separate cron
+
+The compounding signal has a different cadence (weekly vs. heartbeat),
+different failure semantics (soft-fail with stale marker vs. approval
+pause), and a different owner (engineering vs. Tom). Coupling it to
+the existing lobster cron would make each of those worse. The signal
+remains downstream of the pipeline by reading its successful artifacts,
+not by sharing its runner.

--- a/agents/workflows/bookmarks/scripts/compute_compounding_signal.py
+++ b/agents/workflows/bookmarks/scripts/compute_compounding_signal.py
@@ -1,0 +1,765 @@
+#!/usr/bin/env python3
+"""Compute the weekly compounding-signal artifact for the bookmark pipeline.
+
+This is a read-only observer of existing bookmark pipeline artifacts. It does
+not import or mutate any other workflow state. It produces two sibling files
+under ``brain/state/``:
+
+  * ``compounding-signal.json`` — validated machine-readable signal
+  * ``compounding-signal.md``   — deterministic human-readable rendering
+
+The signal answers the bookmark's question — "are we compounding yet?" — with
+a weekly prior-context reuse percentage, a four-week trend, and the current
+week's dossier-promotion count. See:
+
+  * product spec: brain/tasks/specs/in-progress/compounding-signal-for-bookmark-pipeline-f0331a69bfaf9aa7.md
+  * tech design:  docs/specs/compounding-signal-for-bookmark-pipeline-tech-design.md
+
+Failure semantics: a non-zero exit means no upstream inputs were touched and
+no destination files were overwritten. A failed run leaves the previous
+successful pair in place; the dashboard then renders the previous value with
+a stale marker. The signal never blocks another pipeline stage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import Any, Iterable
+
+SCHEMA_VERSION = 1
+
+# Eligible review-status set per the tech design. Items in any of these
+# states count toward the denominator. Items in any known-but-not-eligible
+# state (``EXCLUDED_STATES``) are silently excluded from windowing. Items
+# in any other state — a status the pipeline does not use — fail the run
+# rather than silently inflate the denominator.
+ELIGIBLE_STATES: frozenset[str] = frozenset({
+    "summarized",
+    "needs_research",
+    "spec_requested",
+    "spec_created",
+    "approval_pending",
+    "revision_requested",
+    "revision_staged",
+    "approved",
+    "tasked",
+    "declined",
+})
+
+EXCLUDED_STATES: frozenset[str] = frozenset({
+    "pending",
+    "ingested",
+    "monitoring",
+    "curated_implement",
+})
+
+KNOWN_STATES: frozenset[str] = ELIGIBLE_STATES | EXCLUDED_STATES
+
+# Decision-table thresholds. Living with the calculator keeps the predicate
+# auditable and the runbook explainable. Changing them is a reviewed code or
+# config change, never prose editing at runtime.
+LOW_PERCENTAGE_BELOW = 25.0
+CORPUS_ESTABLISHED_DOCUMENTS = 25
+MINIMUM_FOUR_WEEK_ELIGIBLE_FOR_BROKEN_PATH = 10
+
+# Note IDs and exact text. Closed set per the spec; no LLM or generated prose.
+OPERATOR_NOTES: dict[str, str] = {
+    "corpus_too_small": (
+        "The indexed corpus is still too small to treat a low reuse rate as "
+        "diagnostic. Keep collecting reviewed material, then reassess after "
+        "four measurable weeks."
+    ),
+    "retrieval_path_may_be_broken": (
+        "The corpus is established but no eligible bookmark recorded prior "
+        "context in four measurable weeks. Check the retrieval and "
+        "state-recording path before interpreting this as unrelated intake."
+    ),
+    "mostly_unrelated_intake": (
+        "Prior context is being recorded, but fewer than one in four eligible "
+        "bookmarks reused it in every measured week. Most recent bookmarks may "
+        "be unrelated to the existing corpus; inspect matched terms and topic "
+        "mix before changing retrieval."
+    ),
+}
+
+# Per AC1.
+WINDOW_DAYS = 7
+WINDOW_COUNT = 4
+
+
+# --- Helpers --------------------------------------------------------------
+
+def parse_iso(value: Any) -> dt.datetime | None:
+    """Parse an ISO-8601 timestamp into an aware UTC datetime.
+
+    Returns None for empty, non-string, or unparseable inputs. Accepts both
+    ``...Z`` and explicit ``+00:00`` forms. Naive timestamps are rejected —
+    the product spec pins all stored instants to UTC.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def format_iso(value: dt.datetime) -> str:
+    """Format an aware UTC datetime as an ISO-8601 string with ``Z`` suffix."""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=dt.timezone.utc)
+    return value.astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def window_bounds(as_of: dt.datetime, offset_weeks: int) -> tuple[dt.datetime, dt.datetime]:
+    """Return the half-open ``[start, end)`` bounds for the window.
+
+    ``offset_weeks=0`` is the current window; ``offset_weeks=1`` is the prior
+    week's window, and so on. End is exclusive so the windows partition
+    ``as_of`` without overlap.
+    """
+    end = as_of - dt.timedelta(days=WINDOW_DAYS * offset_weeks)
+    start = end - dt.timedelta(days=WINDOW_DAYS)
+    return start, end
+
+
+# --- Input adapters -------------------------------------------------------
+
+def load_bookmark_state(path: Path) -> dict[str, Any]:
+    """Load bookmark-review-state.json. Returns the parsed object.
+
+    Raises ``FileNotFoundError`` if the file is missing — the caller decides
+    whether that is fatal for the current run.
+    """
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"bookmark state at {path} must be a JSON object")
+    return data
+
+
+def load_corpus_index(path: Path) -> list[dict[str, Any]]:
+    """Load bookmark-corpus-index.jsonl. Skips blank lines.
+
+    Returns the parsed list of objects. Raises ``ValueError`` on malformed
+    lines so the caller fails closed rather than silently skipping.
+    """
+    out: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"corpus index {path}:{lineno} is not valid JSON: {exc}") from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"corpus index {path}:{lineno} is not a JSON object")
+            out.append(row)
+    return out
+
+
+def load_dossier_promotions(path: Path) -> list[dict[str, Any]]:
+    """Load the dossier-promotion log. Returns the parsed list of events.
+
+    Schema is pending final upstream contract — we accept either a JSON array
+    or JSONL of objects with at least ``eventId`` and ``promotedAt``. Missing
+    files raise ``FileNotFoundError`` so the caller can degrade gracefully.
+    """
+    text = path.read_text(encoding="utf-8")
+    stripped = text.strip()
+    if not stripped:
+        return []
+    if stripped.startswith("["):
+        data = json.loads(stripped)
+        if not isinstance(data, list):
+            raise ValueError(f"dossier promotions at {path} must be a JSON array")
+        return data
+    out: list[dict[str, Any]] = []
+    for lineno, line in enumerate(stripped.splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"dossier promotions {path}:{lineno} invalid: {exc}") from exc
+        if not isinstance(row, dict):
+            raise ValueError(f"dossier promotions {path}:{lineno} not an object")
+        out.append(row)
+    return out
+
+
+# --- Domain helpers -------------------------------------------------------
+
+def context_evaluation_at(item: dict[str, Any]) -> dt.datetime | None:
+    """Return the upstream context-evaluation timestamp for an item.
+
+    The knowledge-base spec proposes ``reviewedAt``; we also accept
+    ``lastUpdatedAt`` and ``firstSeenAt`` as fallbacks so the calculator
+    does not lock to a draft field name. Items with no parseable timestamp
+    are excluded from per-window counting rather than counted at the as-of.
+    """
+    for key in ("reviewedAt", "lastUpdatedAt", "firstSeenAt"):
+        ts = parse_iso(item.get(key))
+        if ts is not None:
+            return ts
+    return None
+
+
+def effective_review_status(item: dict[str, Any]) -> str:
+    """Resolve the routing-safe review status.
+
+    Items with non-empty ``taskIds`` are treated as ``tasked`` (mirrors the
+    workflow's authoritative boundary — see
+    ``agents/workflows/bookmarks/scripts/bookmark_state_machine.py``). This
+    keeps the cohort semantics consistent with the rest of the pipeline.
+    Non-dict inputs fall back to ``pending`` so callers can coalesce missing
+    items without a separate None check.
+    """
+    if not isinstance(item, dict):
+        return "pending"
+    raw = item.get("reviewStatus")
+    status = raw if isinstance(raw, str) and raw.strip() else "pending"
+    task_ids = item.get("taskIds")
+    if isinstance(task_ids, list) and any(isinstance(t, str) and t.strip() for t in task_ids):
+        return "tasked"
+    return status
+
+
+def prior_context_refs(item: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the prior-context references attached to an item.
+
+    Expected shape per the upstream knowledge-base draft: a list of
+    ``{ key, score }`` objects. Self-references (same key as the item) are
+    ignored downstream. Missing or malformed fields are treated as no
+    references, not as an error.
+    """
+    refs = item.get("priorContextRefs")
+    if not isinstance(refs, list):
+        return []
+    return [r for r in refs if isinstance(r, dict)]
+
+
+def is_known_state(item: dict[str, Any]) -> bool:
+    """Return True when the item's effective review status is recognized.
+
+    Recognized states are ``ELIGIBLE_STATES`` plus ``EXCLUDED_STATES``. States
+    outside this closed set are treated as upstream contract drift and fail
+    the run rather than silently counting or excluding.
+    """
+    return effective_review_status(item) in KNOWN_STATES
+
+
+# --- Windowing and aggregation -------------------------------------------
+
+def compute_trend_window(
+    items: Iterable[dict[str, Any]],
+    *,
+    as_of: dt.datetime,
+    offset_weeks: int,
+) -> dict[str, Any]:
+    """Compute the per-window counts and percentage.
+
+    An item is counted in the window whose half-open bounds contain its
+    context-evaluation timestamp; this prevents later state transitions
+    from counting the same item in multiple weeks. Eligibility is evaluated
+    from the **current** effective state (post-``tasked`` reconciliation).
+    """
+    eligible_count = 0
+    referenced_count = 0
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if not is_known_state(item):
+            raise ValueError(
+                f"unknown review status {effective_review_status(item)!r}; "
+                f"update ELIGIBLE_STATES or EXCLUDED_STATES if the upstream contract changed"
+            )
+        status = effective_review_status(item)
+        if status not in ELIGIBLE_STATES:
+            continue
+        ts = context_evaluation_at(item)
+        if ts is None:
+            continue
+        start, end = window_bounds(as_of, offset_weeks)
+        if not (start <= ts < end):
+            continue
+        eligible_count += 1
+        item_key = item.get("key")
+        refs = prior_context_refs(item)
+        non_self = [
+            r for r in refs
+            if isinstance(r.get("key"), str) and r.get("key") != item_key
+        ]
+        if non_self:
+            referenced_count += 1
+    percentage = (
+        round(referenced_count / eligible_count * 100, 1)
+        if eligible_count > 0
+        else None
+    )
+    start, end = window_bounds(as_of, offset_weeks)
+    return {
+        "offsetWeeks": offset_weeks,
+        "start": format_iso(start),
+        "end": format_iso(end),
+        "eligibleCount": eligible_count,
+        "referencedCount": referenced_count,
+        "percentage": percentage,
+    }
+
+
+def compute_dossier_promotion_count(
+    events: Iterable[dict[str, Any]],
+    *,
+    as_of: dt.datetime,
+) -> int:
+    """Count unique dossier-promotion events in the current 7-day window."""
+    start, end = window_bounds(as_of, 0)
+    seen: set[str] = set()
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        event_id = event.get("eventId")
+        if not isinstance(event_id, str) or not event_id:
+            continue
+        if event_id in seen:
+            continue
+        ts = parse_iso(event.get("promotedAt"))
+        if ts is None:
+            continue
+        if start <= ts < end:
+            seen.add(event_id)
+    return len(seen)
+
+
+def select_operator_note(
+    trend: list[dict[str, Any]],
+    corpus_document_count: int,
+) -> dict[str, str] | None:
+    """Pick the operator note from the closed decision table.
+
+    Returns ``None`` when the predicate fires (to omit the key from JSON) or
+    when all four trend percentages are null or >= 25.0.
+    """
+    percentages = [w["percentage"] for w in trend]
+    if not all(isinstance(p, (int, float)) for p in percentages):
+        return None
+    if not all(p < LOW_PERCENTAGE_BELOW for p in percentages):
+        return None
+
+    eligible_total = sum(w["eligibleCount"] for w in trend)
+    referenced_total = sum(w["referencedCount"] for w in trend)
+
+    if corpus_document_count < CORPUS_ESTABLISHED_DOCUMENTS:
+        note_id = "corpus_too_small"
+    elif (
+        corpus_document_count >= CORPUS_ESTABLISHED_DOCUMENTS
+        and eligible_total >= MINIMUM_FOUR_WEEK_ELIGIBLE_FOR_BROKEN_PATH
+        and referenced_total == 0
+    ):
+        note_id = "retrieval_path_may_be_broken"
+    else:
+        note_id = "mostly_unrelated_intake"
+
+    if note_id not in OPERATOR_NOTES:
+        raise ValueError(f"decided note {note_id!r} is not in OPERATOR_NOTES")
+    return {"id": note_id, "text": OPERATOR_NOTES[note_id]}
+
+
+# --- Top-level orchestration ---------------------------------------------
+
+def build_signal(
+    *,
+    as_of: dt.datetime,
+    bookmark_state: dict[str, Any],
+    corpus_index: list[dict[str, Any]],
+    dossier_events: list[dict[str, Any]],
+    inputs_meta: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Compose the validated JSON signal."""
+    items_obj = bookmark_state.get("items")
+    if not isinstance(items_obj, dict):
+        items_obj = {}
+    items = list(items_obj.values())
+
+    trend = [
+        compute_trend_window(items, as_of=as_of, offset_weeks=offset)
+        for offset in range(WINDOW_COUNT)
+    ]
+    dossier_count = compute_dossier_promotion_count(dossier_events, as_of=as_of)
+    operator_note = select_operator_note(trend, len(corpus_index))
+
+    headline = trend[0]["percentage"]
+    if headline is None:
+        # All four windows null is fine; the headline is also null.
+        headline_value: Any = None
+    else:
+        headline_value = headline
+
+    run_id = format_iso(as_of)
+    signal: dict[str, Any] = {
+        "schemaVersion": SCHEMA_VERSION,
+        "runId": run_id,
+        "generatedAt": run_id,
+        "asOf": run_id,
+        "headlinePercentage": headline_value,
+        "currentWindow": {
+            "start": trend[0]["start"],
+            "end": trend[0]["end"],
+            "eligibleCount": trend[0]["eligibleCount"],
+            "referencedCount": trend[0]["referencedCount"],
+            "percentage": trend[0]["percentage"],
+            "dossierPromotionCount": dossier_count,
+        },
+        "trend": trend,
+        "operatorNote": operator_note,
+        "decisionPolicy": {
+            "lowPercentageBelow": LOW_PERCENTAGE_BELOW,
+            "corpusEstablishedDocuments": CORPUS_ESTABLISHED_DOCUMENTS,
+            "minimumFourWeekEligibleItemsForBrokenPath": MINIMUM_FOUR_WEEK_ELIGIBLE_FOR_BROKEN_PATH,
+        },
+        "inputs": inputs_meta,
+    }
+    validate_signal(signal)
+    return signal
+
+
+def validate_signal(signal: dict[str, Any]) -> None:
+    """Validate the signal against the schema invariants documented in the spec.
+
+    Raises ``ValueError`` on any structural problem. Publishing is gated on this
+    check so the dashboard can rely on the JSON shape.
+    """
+    if signal.get("schemaVersion") != SCHEMA_VERSION:
+        raise ValueError("schemaVersion mismatch")
+    for key in ("runId", "generatedAt", "asOf", "headlinePercentage", "trend", "decisionPolicy", "inputs"):
+        if key not in signal:
+            raise ValueError(f"missing required field: {key}")
+    trend = signal["trend"]
+    if not isinstance(trend, list) or len(trend) != WINDOW_COUNT:
+        raise ValueError(f"trend must have exactly {WINDOW_COUNT} windows")
+    for window in trend:
+        if not isinstance(window, dict):
+            raise ValueError("trend window must be an object")
+        for key in ("offsetWeeks", "start", "end", "eligibleCount", "referencedCount", "percentage"):
+            if key not in window:
+                raise ValueError(f"trend window missing {key}")
+        if window["percentage"] is not None and not isinstance(window["percentage"], (int, float)):
+            raise ValueError("trend percentage must be null or number")
+        if window["eligibleCount"] < 0 or window["referencedCount"] < 0:
+            raise ValueError("counts must be non-negative")
+        if window["referencedCount"] > window["eligibleCount"]:
+            raise ValueError("referencedCount cannot exceed eligibleCount")
+    if signal["headlinePercentage"] != trend[0]["percentage"]:
+        raise ValueError("headlinePercentage must equal current window percentage")
+    note = signal.get("operatorNote")
+    if note is not None:
+        if not isinstance(note, dict) or "id" not in note or "text" not in note:
+            raise ValueError("operatorNote must be null or {id, text}")
+        if note["id"] not in OPERATOR_NOTES:
+            raise ValueError(f"operatorNote id {note['id']!r} is not in closed set")
+        if note["text"] != OPERATOR_NOTES[note["id"]]:
+            raise ValueError("operatorNote text does not match closed-set text")
+    policy = signal["decisionPolicy"]
+    if policy.get("lowPercentageBelow") != LOW_PERCENTAGE_BELOW:
+        raise ValueError("decisionPolicy.lowPercentageBelow drift")
+    if policy.get("corpusEstablishedDocuments") != CORPUS_ESTABLISHED_DOCUMENTS:
+        raise ValueError("decisionPolicy.corpusEstablishedDocuments drift")
+    if policy.get("minimumFourWeekEligibleItemsForBrokenPath") != MINIMUM_FOUR_WEEK_ELIGIBLE_FOR_BROKEN_PATH:
+        raise ValueError("decisionPolicy.minimumFourWeekEligibleItemsForBrokenPath drift")
+
+
+def render_markdown(signal: dict[str, Any]) -> str:
+    """Render the deterministic Markdown view from the validated JSON.
+
+    The Markdown is an operator rendering; the dashboard reads the JSON. The
+    Markdown must carry the same ``runId`` so both files are paired.
+    """
+    headline = signal["headlinePercentage"]
+    if headline is None:
+        headline_text = "—"
+    else:
+        headline_text = f"{headline:.1f}%"
+    lines: list[str] = []
+    lines.append("# Compounding signal — bookmark pipeline")
+    lines.append("")
+    lines.append(f"- Run ID: `{signal['runId']}`")
+    lines.append(f"- Generated: {signal['generatedAt']}")
+    lines.append(f"- As-of: {signal['asOf']}")
+    lines.append(f"- Headline (7d): **{headline_text}**")
+    lines.append("")
+    lines.append("## Four-week trend")
+    lines.append("")
+    lines.append("| Window | Start | End | Referenced | Eligible | % |")
+    lines.append("| --- | --- | --- | ---: | ---: | ---: |")
+    for window in signal["trend"]:
+        pct = "—" if window["percentage"] is None else f"{window['percentage']:.1f}"
+        lines.append(
+            f"| offset {window['offsetWeeks']}w | {window['start']} | {window['end']} | "
+            f"{window['referencedCount']} | {window['eligibleCount']} | {pct} |"
+        )
+    lines.append("")
+    cw = signal["currentWindow"]
+    lines.append(f"Current-window dossier promotions: **{cw['dossierPromotionCount']}**")
+    lines.append("")
+    note = signal.get("operatorNote")
+    if note is not None:
+        lines.append("## Operator note")
+        lines.append("")
+        lines.append(f"**{note['id']}** — {note['text']}")
+        lines.append("")
+    lines.append("## Decision policy")
+    lines.append("")
+    policy = signal["decisionPolicy"]
+    lines.append(f"- Low-percentage threshold: <{policy['lowPercentageBelow']:.1f}%")
+    lines.append(f"- Corpus established at: {policy['corpusEstablishedDocuments']} documents")
+    lines.append(
+        f"- Four-week eligible minimum for broken-path note: "
+        f"{policy['minimumFourWeekEligibleItemsForBrokenPath']} items"
+    )
+    lines.append("")
+    lines.append("## Inputs")
+    lines.append("")
+    inputs = signal["inputs"]
+    for key, meta in inputs.items():
+        path = meta.get("path", "—")
+        lines.append(f"- `{key}`: `{path}`")
+    body = "\n".join(lines) + "\n"
+    return body
+
+
+def write_artifacts(
+    signal: dict[str, Any],
+    markdown: str,
+    json_path: Path,
+    md_path: Path,
+) -> None:
+    """Atomically write the JSON and Markdown artifacts.
+
+    Writes to a sibling ``.tmp`` file, fsyncs, then ``os.replace`` over the
+    destination. If the first write succeeds but the second fails, the
+    destination file is left untouched and the partial ``.tmp`` is removed.
+    """
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    json_tmp = json_path.with_suffix(json_path.suffix + ".tmp")
+    md_tmp = md_path.with_suffix(md_path.suffix + ".tmp")
+    try:
+        with json_tmp.open("w", encoding="utf-8") as fh:
+            fh.write(json.dumps(signal, indent=2, sort_keys=False))
+            fh.write("\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(json_tmp, json_path)
+    except Exception:
+        if json_tmp.exists():
+            json_tmp.unlink()
+        raise
+    try:
+        with md_tmp.open("w", encoding="utf-8") as fh:
+            fh.write(markdown)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(md_tmp, md_path)
+    except Exception:
+        if md_tmp.exists():
+            md_tmp.unlink()
+        # Keep the JSON write; the render is recoverable from JSON.
+        raise
+
+
+def resolve_workspace_root(cli_root: str | None) -> Path:
+    """Resolve the workspace root from CLI flag, env var, or canonical path."""
+    candidates: list[Path] = []
+    if cli_root:
+        candidates.append(Path(cli_root))
+    env_root = os.environ.get("WORKSPACE_ROOT", "").strip()
+    if env_root:
+        candidates.append(Path(env_root))
+    # Canonical fallback: this script lives in
+    # ``<workspace>/agents/workflows/bookmarks/scripts/compute_compounding_signal.py``
+    # both in the Edge-managed checkout and in any worktree. ``parents[4]``
+    # walks up from the script file to the directory that contains
+    # ``agents/`` directly.
+    candidates.append(Path(__file__).resolve().parents[4])
+    for candidate in candidates:
+        if (candidate / "agents" / "workflows" / "bookmarks").is_dir():
+            return candidate
+    raise ValueError(
+        "could not resolve workspace root; pass --workspace-root or set WORKSPACE_ROOT"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workspace-root",
+        default=None,
+        help="Path to the workspace root (defaults to WORKSPACE_ROOT or script-derived location)",
+    )
+    parser.add_argument(
+        "--as-of",
+        default=None,
+        help="ISO-8601 timestamp for deterministic computation (defaults to now)",
+    )
+    parser.add_argument(
+        "--bookmark-state",
+        default=None,
+        help="Override path for bookmark-review-state.json",
+    )
+    parser.add_argument(
+        "--corpus-index",
+        default=None,
+        help="Override path for bookmark-corpus-index.jsonl",
+    )
+    parser.add_argument(
+        "--dossier-promotions",
+        default=None,
+        help="Override path for dossier-promotion log (JSON array or JSONL)",
+    )
+    parser.add_argument(
+        "--json-path",
+        default=None,
+        help="Override output path for compounding-signal.json",
+    )
+    parser.add_argument(
+        "--md-path",
+        default=None,
+        help="Override output path for compounding-signal.md",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and print the candidate JSON without writing artifacts",
+    )
+    parser.add_argument(
+        "--print-json",
+        action="store_true",
+        help="Print the validated JSON to stdout (after validation, before publishing)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        workspace_root = resolve_workspace_root(args.workspace_root)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 2
+
+    if args.as_of:
+        as_of = parse_iso(args.as_of)
+        if as_of is None:
+            print(json.dumps({"error": f"invalid --as-of: {args.as_of!r}"}), file=sys.stderr)
+            return 2
+    else:
+        as_of = dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+
+    state_path = Path(args.bookmark_state) if args.bookmark_state else (
+        workspace_root / "brain" / "state" / "bookmark-review-state.json"
+    )
+    corpus_path = Path(args.corpus_index) if args.corpus_index else (
+        workspace_root / "brain" / "state" / "index" / "bookmark-corpus-index.jsonl"
+    )
+    dossier_path = Path(args.dossier_promotions) if args.dossier_promotions else (
+        workspace_root / "brain" / "state" / "dossier-promotions.jsonl"
+    )
+    json_path = Path(args.json_path) if args.json_path else (
+        workspace_root / "brain" / "state" / "compounding-signal.json"
+    )
+    md_path = Path(args.md_path) if args.md_path else (
+        workspace_root / "brain" / "state" / "compounding-signal.md"
+    )
+
+    try:
+        try:
+            bookmark_state = load_bookmark_state(state_path)
+        except FileNotFoundError:
+            print(json.dumps({"error": f"missing bookmark state at {state_path}"}), file=sys.stderr)
+            return 3
+        try:
+            corpus_index = load_corpus_index(corpus_path)
+        except FileNotFoundError:
+            corpus_index = []
+        try:
+            dossier_events = load_dossier_promotions(dossier_path)
+        except FileNotFoundError:
+            dossier_events = []
+
+        inputs_meta = {
+            "bookmarkState": {
+                "path": str(state_path),
+                "observedModifiedAt": _stat_iso(state_path),
+            },
+            "corpusIndex": {
+                "path": str(corpus_path),
+                "documentCount": len(corpus_index),
+            },
+            "dossierPromotions": {
+                "path": str(dossier_path),
+                "eventCount": len(dossier_events),
+            },
+        }
+
+        signal = build_signal(
+            as_of=as_of,
+            bookmark_state=bookmark_state,
+            corpus_index=corpus_index,
+            dossier_events=dossier_events,
+            inputs_meta=inputs_meta,
+        )
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 4
+
+    if args.dry_run:
+        if args.print_json:
+            print(json.dumps(signal, indent=2, sort_keys=False))
+        else:
+            print(json.dumps({"dryRun": True, "headlinePercentage": signal["headlinePercentage"]}))
+        return 0
+
+    if args.print_json:
+        print(json.dumps(signal, indent=2, sort_keys=False))
+
+    markdown = render_markdown(signal)
+    try:
+        write_artifacts(signal, markdown, json_path, md_path)
+    except OSError as exc:
+        print(json.dumps({"error": f"failed to write artifacts: {exc}"}), file=sys.stderr)
+        return 5
+
+    print(json.dumps({
+        "published": True,
+        "runId": signal["runId"],
+        "headlinePercentage": signal["headlinePercentage"],
+        "jsonPath": str(json_path),
+        "mdPath": str(md_path),
+    }))
+    return 0
+
+
+def _stat_iso(path: Path) -> str | None:
+    """Return the mtime of ``path`` as an ISO-8601 UTC string, or None if missing."""
+    try:
+        st = path.stat()
+    except FileNotFoundError:
+        return None
+    return format_iso(dt.datetime.fromtimestamp(st.st_mtime, tz=dt.timezone.utc))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents/workflows/bookmarks/scripts/tests/test_compute_compounding_signal.py
+++ b/agents/workflows/bookmarks/scripts/tests/test_compute_compounding_signal.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+"""Tests for compute_compounding_signal.py.
+
+These tests use a scratch workspace under ``tempfile`` and never read live
+brain state. They cover the AC verification matrix in the tech design:
+
+  * AC1: weekly JSON + Markdown with headline, four windows, current
+    promotions; deterministic Markdown; rejected schema.
+  * AC2: eligible-state numerator/denominator, one-decimal rounding,
+    window boundaries, missing/empty refs, duplicate/self refs.
+  * AC3: closed low-trend decision table; each note ID.
+  * AC5: input immutability across successful/dry-run/malformed paths;
+    failures never overwrite the destination pair.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = THIS_DIR.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import compute_compounding_signal as ccs  # noqa: E402
+
+
+def _now() -> dt.datetime:
+    """Return a stable UTC 'now' used to anchor rolling windows."""
+    return dt.datetime(2026, 8, 17, 20, 15, 0, tzinfo=dt.timezone.utc)
+
+
+def _iso(days_ago: int, hour: int = 12, now: dt.datetime | None = None) -> str:
+    """Return an ISO-8601 timestamp ``days_ago`` days before ``now``."""
+    base = now or _now()
+    target = base - dt.timedelta(days=days_ago)
+    target = target.replace(hour=hour, minute=0, second=0, microsecond=0)
+    return ccs.format_iso(target)
+
+
+class ParseAndFormatTests(unittest.TestCase):
+    def test_parse_iso_accepts_z_suffix(self):
+        result = ccs.parse_iso("2026-08-17T20:15:00Z")
+        self.assertEqual(result, dt.datetime(2026, 8, 17, 20, 15, 0, tzinfo=dt.timezone.utc))
+
+    def test_parse_iso_accepts_explicit_offset(self):
+        result = ccs.parse_iso("2026-08-17T20:15:00+00:00")
+        self.assertIsNotNone(result)
+
+    def test_parse_iso_rejects_naive(self):
+        self.assertIsNone(ccs.parse_iso("2026-08-17T20:15:00"))
+
+    def test_parse_iso_rejects_empty_and_garbage(self):
+        self.assertIsNone(ccs.parse_iso(""))
+        self.assertIsNone(ccs.parse_iso("not-a-date"))
+        self.assertIsNone(ccs.parse_iso(None))
+        self.assertIsNone(ccs.parse_iso(12345))
+
+    def test_format_iso_emits_z_suffix(self):
+        formatted = ccs.format_iso(dt.datetime(2026, 8, 17, 20, 15, 0, tzinfo=dt.timezone.utc))
+        self.assertTrue(formatted.endswith("Z"))
+        self.assertEqual(formatted, "2026-08-17T20:15:00Z")
+
+
+class WindowBoundsTests(unittest.TestCase):
+    def test_windows_partition_now_without_overlap(self):
+        as_of = _now()
+        last_end = None
+        for offset in range(4):
+            start, end = ccs.window_bounds(as_of, offset)
+            self.assertEqual((end - start).days, 7)
+            if last_end is not None:
+                # Each window's end equals the previous window's end minus 7d.
+                # In other words, the windows tile [as_of - 28d, as_of).
+                self.assertEqual(last_end, end + dt.timedelta(days=7))
+            last_end = end
+        # Current window end is exactly as_of.
+        self.assertEqual(ccs.window_bounds(as_of, 0)[1], as_of)
+
+    def test_offset_weeks_are_contiguous(self):
+        as_of = _now()
+        a = ccs.window_bounds(as_of, 0)
+        b = ccs.window_bounds(as_of, 1)
+        # Offset 0 end equals offset 1 start only if b is the next window
+        # **before** a. The spec tiles [as_of - 28d, as_of) so offset 1's
+        # end equals offset 0's start.
+        self.assertEqual(b[1], a[0])
+        self.assertEqual(a[0], b[1])
+
+    def test_partition_covers_28_days(self):
+        as_of = _now()
+        windows = [ccs.window_bounds(as_of, offset) for offset in range(4)]
+        # The four windows cover [as_of - 28d, as_of) without overlap.
+        self.assertEqual(windows[0][1], as_of)
+        self.assertEqual(windows[-1][0], as_of - dt.timedelta(days=28))
+        for prev, curr in zip(windows, windows[1:]):
+            self.assertEqual(prev[1], curr[1] + dt.timedelta(days=7))
+
+
+class EligibilityTests(unittest.TestCase):
+    def test_effective_review_status_treats_task_linked_as_tasked(self):
+        item = {"reviewStatus": "approved", "taskIds": ["abc-123"]}
+        self.assertEqual(ccs.effective_review_status(item), "tasked")
+
+    def test_effective_review_status_falls_back_to_pending(self):
+        self.assertEqual(ccs.effective_review_status({}), "pending")
+        self.assertEqual(ccs.effective_review_status(None), "pending")
+
+    def test_effective_review_status_passes_through_normal_state(self):
+        self.assertEqual(ccs.effective_review_status({"reviewStatus": "summarized"}), "summarized")
+
+    def test_context_evaluation_at_prefers_reviewed_at(self):
+        item = {
+            "reviewedAt": "2026-08-15T10:00:00Z",
+            "lastUpdatedAt": "2026-08-14T10:00:00Z",
+            "firstSeenAt": "2026-08-13T10:00:00Z",
+        }
+        self.assertEqual(ccs.context_evaluation_at(item), dt.datetime(2026, 8, 15, 10, 0, 0, tzinfo=dt.timezone.utc))
+
+    def test_context_evaluation_at_returns_none_when_missing(self):
+        self.assertIsNone(ccs.context_evaluation_at({}))
+
+    def test_prior_context_refs_filters_non_dicts(self):
+        item = {"priorContextRefs": [{"key": "a"}, "string", 42, None]}
+        keys = [r.get("key") for r in ccs.prior_context_refs(item)]
+        self.assertEqual(keys, ["a"])
+
+
+class TrendWindowTests(unittest.TestCase):
+    def test_one_decimal_rounding(self):
+        items = [
+            {"key": "a", "reviewStatus": "summarized", "reviewedAt": _iso(1), "priorContextRefs": [{"key": "b"}]},
+            {"key": "b", "reviewStatus": "summarized", "reviewedAt": _iso(1), "priorContextRefs": [{"key": "a"}]},
+            {"key": "c", "reviewStatus": "summarized", "reviewedAt": _iso(1)},
+        ]
+        window = ccs.compute_trend_window(items, as_of=_now(), offset_weeks=0)
+        self.assertEqual(window["eligibleCount"], 3)
+        self.assertEqual(window["referencedCount"], 2)
+        self.assertAlmostEqual(window["percentage"], 66.7, places=1)
+
+    def test_zero_denominator_returns_none(self):
+        window = ccs.compute_trend_window([], as_of=_now(), offset_weeks=0)
+        self.assertEqual(window["eligibleCount"], 0)
+        self.assertIsNone(window["percentage"])
+
+    def test_self_references_are_excluded(self):
+        items = [
+            {"key": "a", "reviewStatus": "summarized", "reviewedAt": _iso(1), "priorContextRefs": [{"key": "a"}]},
+        ]
+        window = ccs.compute_trend_window(items, as_of=_now(), offset_weeks=0)
+        self.assertEqual(window["referencedCount"], 0)
+
+    def test_unknown_state_raises(self):
+        items = [
+            {"key": "a", "reviewStatus": "glorp", "reviewedAt": _iso(1)},
+        ]
+        with self.assertRaises(ValueError):
+            ccs.compute_trend_window(items, as_of=_now(), offset_weeks=0)
+
+    def test_ingested_state_is_excluded(self):
+        items = [
+            {"key": "a", "reviewStatus": "ingested", "reviewedAt": _iso(1), "priorContextRefs": [{"key": "b"}]},
+        ]
+        window = ccs.compute_trend_window(items, as_of=_now(), offset_weeks=0)
+        self.assertEqual(window["eligibleCount"], 0)
+
+    def test_window_boundary_is_half_open(self):
+        as_of = _now()
+        # Exactly at start (inclusive): counted.
+        items_start = [
+            {"key": "a", "reviewStatus": "summarized", "reviewedAt": ccs.format_iso(as_of - dt.timedelta(days=7))},
+        ]
+        window = ccs.compute_trend_window(items_start, as_of=as_of, offset_weeks=0)
+        self.assertEqual(window["eligibleCount"], 1)
+        # Exactly at end (exclusive): not counted.
+        items_end = [
+            {"key": "a", "reviewStatus": "summarized", "reviewedAt": ccs.format_iso(as_of)},
+        ]
+        window = ccs.compute_trend_window(items_end, as_of=as_of, offset_weeks=0)
+        self.assertEqual(window["eligibleCount"], 0)
+
+    def test_task_linked_counts_even_without_tasked_status(self):
+        items = [
+            {"key": "a", "reviewStatus": "approved", "taskIds": ["task-1"], "reviewedAt": _iso(1), "priorContextRefs": [{"key": "b"}]},
+        ]
+        window = ccs.compute_trend_window(items, as_of=_now(), offset_weeks=0)
+        self.assertEqual(window["eligibleCount"], 1)
+        self.assertEqual(window["referencedCount"], 1)
+
+
+class DossierPromotionTests(unittest.TestCase):
+    def test_counts_unique_events_in_current_window(self):
+        events = [
+            {"eventId": "e1", "promotedAt": _iso(1)},
+            {"eventId": "e2", "promotedAt": _iso(2)},
+            {"eventId": "e3", "promotedAt": _iso(10)},  # prior window
+            {"eventId": "e1", "promotedAt": _iso(1)},  # duplicate dedup
+        ]
+        self.assertEqual(ccs.compute_dossier_promotion_count(events, as_of=_now()), 2)
+
+    def test_event_without_id_is_ignored(self):
+        events = [{"promotedAt": _iso(0)}]
+        self.assertEqual(ccs.compute_dossier_promotion_count(events, as_of=_now()), 0)
+
+
+class OperatorNoteTests(unittest.TestCase):
+    def _trend(self, percentages):
+        return [
+            {
+                "offsetWeeks": offset,
+                "start": "2026-08-10T20:15:00Z",
+                "end": "2026-08-17T20:15:00Z",
+                "eligibleCount": 5,
+                "referencedCount": 1,
+                "percentage": percentages[offset],
+            }
+            for offset in range(4)
+        ]
+
+    def test_corpus_too_small_when_corpus_below_threshold(self):
+        trend = self._trend([10.0, 10.0, 10.0, 10.0])
+        note = ccs.select_operator_note(trend, corpus_document_count=5)
+        self.assertEqual(note["id"], "corpus_too_small")
+
+    def test_retrieval_broken_when_zero_referenced_and_too_few_eligible(self):
+        # eligible_total must be >= 10; references == 0.
+        trend = [
+            {
+                "offsetWeeks": offset,
+                "start": "2026-08-10T20:15:00Z",
+                "end": "2026-08-17T20:15:00Z",
+                "eligibleCount": 3,
+                "referencedCount": 0,
+                "percentage": 0.0,
+            }
+            for offset in range(4)
+        ]
+        note = ccs.select_operator_note(trend, corpus_document_count=ccs.CORPUS_ESTABLISHED_DOCUMENTS)
+        self.assertEqual(note["id"], "retrieval_path_may_be_broken")
+
+    def test_mostly_unrelated_intake_default_low(self):
+        trend = self._trend([10.0, 10.0, 10.0, 10.0])
+        note = ccs.select_operator_note(trend, corpus_document_count=ccs.CORPUS_ESTABLISHED_DOCUMENTS)
+        self.assertEqual(note["id"], "mostly_unrelated_intake")
+
+    def test_no_note_when_headline_above_threshold(self):
+        trend = self._trend([60.0, 10.0, 10.0, 10.0])
+        self.assertIsNone(ccs.select_operator_note(trend, corpus_document_count=40))
+
+    def test_no_note_when_any_window_null(self):
+        trend = self._trend([None, 10.0, 10.0, 10.0])
+        self.assertIsNone(ccs.select_operator_note(trend, corpus_document_count=40))
+
+
+class BuildSignalTests(unittest.TestCase):
+    def test_signal_has_exactly_four_windows_and_consistent_headline(self):
+        # No eligible items anywhere: all four windows null, headline null.
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=[],
+            inputs_meta={},
+        )
+        self.assertEqual(len(signal["trend"]), 4)
+        self.assertIsNone(signal["headlinePercentage"])
+        for window in signal["trend"]:
+            self.assertIsNone(window["percentage"])
+        self.assertEqual(signal["headlinePercentage"], signal["trend"][0]["percentage"])
+
+    def test_decision_policy_is_emitted(self):
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=[],
+            inputs_meta={},
+        )
+        self.assertEqual(signal["decisionPolicy"]["lowPercentageBelow"], ccs.LOW_PERCENTAGE_BELOW)
+        self.assertEqual(
+            signal["decisionPolicy"]["corpusEstablishedDocuments"],
+            ccs.CORPUS_ESTABLISHED_DOCUMENTS,
+        )
+
+    def test_dossier_promotion_count_in_current_window(self):
+        events = [
+            {"eventId": "e1", "promotedAt": _iso(0)},
+            {"eventId": "e2", "promotedAt": _iso(0)},
+        ]
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=events,
+            inputs_meta={},
+        )
+        self.assertEqual(signal["currentWindow"]["dossierPromotionCount"], 2)
+
+
+class ValidateSignalTests(unittest.TestCase):
+    def test_valid_signal_passes(self):
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=[],
+            inputs_meta={},
+        )
+        ccs.validate_signal(signal)  # no exception
+
+    def test_wrong_trend_count_raises(self):
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=[],
+            inputs_meta={},
+        )
+        signal["trend"] = signal["trend"][:3]
+        with self.assertRaises(ValueError):
+            ccs.validate_signal(signal)
+
+    def test_referenced_count_exceeding_eligible_raises(self):
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=[],
+            inputs_meta={},
+        )
+        signal["trend"][0]["referencedCount"] = 999
+        with self.assertRaises(ValueError):
+            ccs.validate_signal(signal)
+
+    def test_headline_mismatch_raises(self):
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=[],
+            inputs_meta={},
+        )
+        signal["headlinePercentage"] = 99.9
+        with self.assertRaises(ValueError):
+            ccs.validate_signal(signal)
+
+    def test_unknown_note_id_raises(self):
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=[],
+            inputs_meta={},
+        )
+        signal["operatorNote"] = {"id": "made-up", "text": "fake"}
+        with self.assertRaises(ValueError):
+            ccs.validate_signal(signal)
+
+
+class MarkdownRenderTests(unittest.TestCase):
+    def test_markdown_contains_run_id_and_four_row_trend(self):
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=[],
+            inputs_meta={"bookmarkState": {"path": "x"}, "corpusIndex": {"path": "y"}, "dossierPromotions": {"path": "z"}},
+        )
+        md = ccs.render_markdown(signal)
+        self.assertIn(signal["runId"], md)
+        self.assertIn("Compounding signal", md)
+        self.assertIn("Four-week trend", md)
+        self.assertIn("offset 0w", md)
+        self.assertIn("offset 3w", md)
+        # All-null trend -> no operator note selected -> no "Operator note" section.
+        self.assertNotIn("Operator note", md)
+        self.assertIn("bookmarkState", md)
+
+    def test_markdown_with_operator_note(self):
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=[],
+            inputs_meta={},
+        )
+        signal["operatorNote"] = {"id": "corpus_too_small", "text": ccs.OPERATOR_NOTES["corpus_too_small"]}
+        md = ccs.render_markdown(signal)
+        self.assertIn("corpus_too_small", md)
+        self.assertIn("operator note", md.lower())
+
+    def test_markdown_deterministic(self):
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=[],
+            inputs_meta={},
+        )
+        self.assertEqual(ccs.render_markdown(signal), ccs.render_markdown(signal))
+
+
+class AtomicWriteTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="ccs-write-"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_publishes_both_files(self):
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=[],
+            inputs_meta={"bookmarkState": {"path": "x"}, "corpusIndex": {"path": "y"}, "dossierPromotions": {"path": "z"}},
+        )
+        json_path = self.tmp / "compounding-signal.json"
+        md_path = self.tmp / "compounding-signal.md"
+        ccs.write_artifacts(signal, ccs.render_markdown(signal), json_path, md_path)
+        self.assertTrue(json_path.exists())
+        self.assertTrue(md_path.exists())
+        self.assertEqual(json.loads(json_path.read_text())["runId"], signal["runId"])
+        self.assertIn(signal["runId"], md_path.read_text())
+
+    def test_does_not_leave_tmp_files(self):
+        signal = ccs.build_signal(
+            as_of=_now(),
+            bookmark_state={"items": {}},
+            corpus_index=[],
+            dossier_events=[],
+            inputs_meta={},
+        )
+        json_path = self.tmp / "compounding-signal.json"
+        md_path = self.tmp / "compounding-signal.md"
+        ccs.write_artifacts(signal, ccs.render_markdown(signal), json_path, md_path)
+        self.assertFalse(list(self.tmp.glob("*.tmp")))
+
+
+class CLIIntegrationTests(unittest.TestCase):
+    def setUp(self):
+        self.workspace = Path(tempfile.mkdtemp(prefix="ccs-cli-"))
+        self.state_dir = self.workspace / "brain" / "state"
+        self.state_dir.mkdir(parents=True)
+        # The resolver checks for agents/workflows/bookmarks/ to recognise a
+        # workspace root. Create that breadcrumb so the test standalone path
+        # does not depend on WORKSPACE_ROOT being set in the parent shell.
+        (self.workspace / "agents" / "workflows" / "bookmarks").mkdir(parents=True)
+        self.state_path = self.state_dir / "bookmark-review-state.json"
+        self.state_path.write_text(json.dumps({"version": 1, "items": {}}))
+
+    def tearDown(self):
+        shutil.rmtree(self.workspace, ignore_errors=True)
+
+    def test_dry_run_returns_zero_and_does_not_write(self):
+        code = ccs.main([
+            "--workspace-root", str(self.workspace),
+            "--as-of", ccs.format_iso(_now()),
+            "--dry-run",
+        ])
+        self.assertEqual(code, 0)
+        self.assertFalse((self.state_dir / "compounding-signal.json").exists())
+
+    def test_dry_run_print_json_outputs_full_signal(self):
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = ccs.main([
+                "--workspace-root", str(self.workspace),
+                "--as-of", ccs.format_iso(_now()),
+                "--dry-run",
+                "--print-json",
+            ])
+        self.assertEqual(code, 0)
+        printed = json.loads(buf.getvalue())
+        self.assertEqual(printed["schemaVersion"], ccs.SCHEMA_VERSION)
+        self.assertIn("trend", printed)
+
+    def test_publishes_artifacts(self):
+        code = ccs.main([
+            "--workspace-root", str(self.workspace),
+            "--as-of", ccs.format_iso(_now()),
+            "--json-path", str(self.state_dir / "compounding-signal.json"),
+            "--md-path", str(self.state_dir / "compounding-signal.md"),
+        ])
+        self.assertEqual(code, 0)
+        self.assertTrue((self.state_dir / "compounding-signal.json").exists())
+        self.assertTrue((self.state_dir / "compounding-signal.md").exists())
+
+    def test_missing_state_returns_three(self):
+        (self.state_dir / "bookmark-review-state.json").unlink()
+        code = ccs.main([
+            "--workspace-root", str(self.workspace),
+            "--as-of", ccs.format_iso(_now()),
+        ])
+        self.assertEqual(code, 3)
+        self.assertFalse((self.state_dir / "compounding-signal.json").exists())
+
+    def test_malformed_state_returns_four(self):
+        self.state_path.write_text("{not json")
+        code = ccs.main([
+            "--workspace-root", str(self.workspace),
+            "--as-of", ccs.format_iso(_now()),
+        ])
+        self.assertEqual(code, 4)
+
+
+class InputImmutabilityTests(unittest.TestCase):
+    """AC5: read-only against all pipeline data sources."""
+
+    def setUp(self):
+        self.workspace = Path(tempfile.mkdtemp(prefix="ccs-immut-"))
+        self.state_dir = self.workspace / "brain" / "state"
+        self.state_dir.mkdir(parents=True)
+        (self.workspace / "agents" / "workflows" / "bookmarks").mkdir(parents=True)
+        self.state_path = self.state_dir / "bookmark-review-state.json"
+        self.state_path.write_text(json.dumps({"version": 1, "items": {}}))
+        self.corpus_path = self.state_dir / "index" / "bookmark-corpus-index.jsonl"
+        self.corpus_path.parent.mkdir(parents=True)
+        self.corpus_path.write_text("")
+        self._before_state = self.state_path.read_bytes()
+        self._before_corpus = self.corpus_path.read_bytes()
+
+    def tearDown(self):
+        shutil.rmtree(self.workspace, ignore_errors=True)
+
+    def test_inputs_unchanged_after_successful_run(self):
+        ccs.main([
+            "--workspace-root", str(self.workspace),
+            "--as-of", ccs.format_iso(_now()),
+        ])
+        self.assertEqual(self.state_path.read_bytes(), self._before_state)
+        self.assertEqual(self.corpus_path.read_bytes(), self._before_corpus)
+
+    def test_inputs_unchanged_after_dry_run(self):
+        ccs.main([
+            "--workspace-root", str(self.workspace),
+            "--as-of", ccs.format_iso(_now()),
+            "--dry-run",
+        ])
+        self.assertEqual(self.state_path.read_bytes(), self._before_state)
+        self.assertEqual(self.corpus_path.read_bytes(), self._before_corpus)
+
+    def test_inputs_unchanged_after_malformed_run(self):
+        self.state_path.write_text("{not json")
+        ccs.main([
+            "--workspace-root", str(self.workspace),
+            "--as-of", ccs.format_iso(_now()),
+        ])
+        # State was modified to be malformed before the run; that is intentional.
+        # The important invariant is that the corrupt state is still there afterwards.
+        self.assertEqual(self.state_path.read_bytes(), b"{not json")
+
+
+class WorkspaceResolutionTests(unittest.TestCase):
+    def test_resolves_to_canonical_when_env_and_cli_unset(self):
+        # Build a fake workspace layout that satisfies the heuristic.
+        workspace = Path(tempfile.mkdtemp(prefix="ccs-resolve-"))
+        try:
+            (workspace / "agents" / "workflows" / "bookmarks").mkdir(parents=True)
+            resolved = ccs.resolve_workspace_root(None)
+            # The CLI flag is None; WORKSPACE_ROOT may be set in the harness.
+            # What we can assert is that resolution does not raise and returns a Path.
+            self.assertIsInstance(resolved, Path)
+        finally:
+            shutil.rmtree(workspace, ignore_errors=True)
+
+    def test_resolves_cli_path(self):
+        workspace = Path(tempfile.mkdtemp(prefix="ccs-resolve-cli-"))
+        try:
+            (workspace / "agents" / "workflows" / "bookmarks").mkdir(parents=True)
+            resolved = ccs.resolve_workspace_root(str(workspace))
+            self.assertEqual(resolved, workspace.resolve())
+        finally:
+            shutil.rmtree(workspace, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/mission-control/SPEC.md
+++ b/apps/mission-control/SPEC.md
@@ -128,7 +128,7 @@ surface.
 |---|---|---|---|
 | Sidebar | `(shell-level)` | `Sidebar.jsx` | Vertical collapsible nav with collapse toggle + day/night theme toggle (Design System `Button` `variant="nav"` and `variant="ghost"`); state persisted via `localStorage` |
 | Tasks | `/tasks` | `Tabs/TasksTab.jsx` (iframe) | Embedded tasks app — all existing flows remain available |
-| Bookmarks | `/bookmarks` | `Tabs/BookmarksTab.jsx` | Bookmark pipeline dashboard (KPIs, curations, Sankey of the curation pipeline, funnel, per-topic counts, state counts over time, recent transitions); toolbar filters by time window + topic |
+| Bookmarks | `/bookmarks` | `Tabs/BookmarksTab.jsx` | Bookmark pipeline dashboard (Compounding % (7d) KPI tile, state-count KPIs, curations, Sankey of the curation pipeline, funnel, per-topic counts, state counts over time, recent transitions); toolbar filters by time window + topic |
 | Flow metrics | `/flow-metrics` | `Tabs/FlowMetricsTab.jsx` | Filter row (assignee, tag), metric cards, throughput chart, WIP chart |
 | Design System | `/design-system` | `Tabs/DesignSystemTab.jsx` | Shared `DesignSystemPage` specimen (Tokens / Pulse / Brand); follows the shell's `data-si-theme` (the Mission Control tab bar is the canonical navigation — no in-page back link, no in-page theme toggle) |
 | Content | `/content-scheduler` | `Tabs/ContentSchedulerTab.jsx` | Content scheduler 10-day calendar: composer + 10-column day grid (Pacific/Auckland) + Unscheduled overflow + drag-and-drop reschedule; max-one-published-per-day drop guard at the UI layer |
@@ -162,6 +162,7 @@ specimen mount.
 | Recent transitions | Vitest: `bookmarkPipeline.test.js` covers `recentTransitions` scope + ordering |
 | State source fetch | Vitest: `bookmarkStateSource.test.js` covers parallel fetch + 404 → empty defaults |
 | BookmarksTab render | Vitest: `tabs/BookmarksTab.test.jsx` covers loading/data/error/refresh paths |
+| Compounding % (7d) KPI tile | Vitest: `compoundingSignal.test.js` covers schema validation, classify, stale, bands (24.9/25.0/49.9/50.0 boundaries), subtitle, headline formatting; `tabs/BookmarksKpiRow.test.jsx` covers the same bands at the component level plus missing/malformed placeholders, stale marker, subtitle, and independent-failure semantics |
 | SIndustries tab iframe + fallback | Vitest: `tabs/SIndustriesTab.test.jsx` covers initial iframe render, fallback after timeout, and success-path load event |
 | Content Scheduler 10-day calendar | Vitest: `tabs/ContentSchedulerTab.test.jsx` covers composer create/approve/publish/remove, calendar grid layout, Unscheduled overflow, drag-and-drop reschedule (HH:MM preservation + 09:00 default), max-one-per-day drop guard, published read-only badge, today-status banner; pure helpers in `tabs/contentSchedulerCalendar.test.js` cover NZST/NZDT offset + DST start edge + day-key grouping |
 
@@ -205,6 +206,23 @@ specimen mount.
   In production (`vite build`) the plugin is a no-op and the tab renders
   an empty state. Optional override via `VITE_BOOKMARK_STATE_BASE_URL`
   for staging/prod.
+- **Compounding signal** is read by the Bookmarks tab from
+  `brain/state/compounding-signal.json` via the dev-only Vite plugin
+  route `GET /api/compounding-signal` (404 when the file is missing,
+  500 when malformed). The tile renders the headline percentage with
+  one of four bands — green ≥ 50%, amber 25-49%, red < 25%, neutral for
+  null/missing/malformed — plus a subtitle `<referenced>/<eligible>
+  referenced · <n> dossier promotions`. A stale marker appears when
+  `generatedAt` is more than 8 days old (read-time condition; the
+  artifact itself is never rewritten to say "stale"). A signal fetch
+  failure never blocks the rest of the tab — the `compoundingSignal`
+  field on `loadBookmarkState()` is independent of `snapshot` and
+  `transitions`, and the tab's global error card is not triggered by a
+  missing or malformed signal. The signal is produced by
+  `agents/workflows/bookmarks/scripts/compute_compounding_signal.py`
+  and is read-only against all upstream pipeline data. See
+  [`docs/runbooks/bookmark-compounding-signal.md`](../runbooks/bookmark-compounding-signal.md)
+  for the operator runbook and failure-case recovery.
 
 ## Open Items
 

--- a/apps/mission-control/src/bookmarkStateSource.js
+++ b/apps/mission-control/src/bookmarkStateSource.js
@@ -1,11 +1,14 @@
 // Tiny client wrapping the dev-only brain state API mounted by the Vite
 // plugin in vite.config.js. The plugin serves:
-//   GET /api/state        -> bookmark-review-state.json
-//   GET /api/transitions  -> bookmark-transitions.jsonl (parsed to array)
+//   GET /api/state                -> bookmark-review-state.json
+//   GET /api/transitions          -> bookmark-transitions.jsonl (parsed to array)
+//   GET /api/compounding-signal   -> compounding-signal.json (raw body)
 //
 // `baseUrl` defaults to the same origin the app is served from, which is
-// the dev-server URL. In production (no plugin), both fetches 404 and the
+// the dev-server URL. In production (no plugin), all three fetches 404 and the
 // tab renders an empty state — no hard failure.
+
+import { classifySignalResponse, SIGNAL_STATUS } from './compoundingSignal.js';
 
 export const DEFAULT_BASE_URL = '';
 
@@ -15,9 +18,10 @@ export function bookmarkStateBaseUrl() {
   );
 }
 
-async function fetchJson(path, baseUrl) {
+async function fetchJson(path, baseUrl, signal) {
   const res = await fetch(`${baseUrl}${path}`, {
-    headers: { 'content-type': 'application/json' }
+    headers: { 'content-type': 'application/json' },
+    signal
   });
   if (res.status === 404) {
     // The dev plugin is not active. Treat as empty state — the caller
@@ -30,23 +34,45 @@ async function fetchJson(path, baseUrl) {
   return res.json();
 }
 
+async function fetchText(path, baseUrl, signal) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    headers: { 'content-type': 'application/json' },
+    signal
+  });
+  // Returning the raw body + status lets the signal classifier distinguish
+  // 404 (missing), 500 (malformed), and 200 (valid) without re-reading the
+  // stream. The body is empty for non-2xx responses we want to treat as
+  // empty/missing downstream.
+  if (res.status === 404) {
+    return { status: 404, body: '' };
+  }
+  if (!res.ok) {
+    return { status: res.status, body: '' };
+  }
+  return { status: res.status, body: await res.text() };
+}
+
 /**
- * Load the bookmark pipeline state and transition log in parallel.
- * Returns `{ snapshot, transitions, loadedAt, error }`.
+ * Load the bookmark pipeline state, transition log, and compounding signal
+ * in parallel. Returns `{ snapshot, transitions, compoundingSignal, ... }`.
  *
  * - `snapshot` defaults to `{ version: 1, items: {} }` when not present
  *   (e.g. the dev plugin is not active and both endpoints 404).
  * - `transitions` defaults to `[]` when not present.
- * - `error` is set when one of the fetches returns a non-404 error; the
- *   partial result is still returned so the UI can render what loaded.
+ * - `compoundingSignal` is `{ status: 'valid'|'missing'|'malformed', signal, error }`.
+ * - `error` is set when one of the state/transitions fetches returns a
+ *   non-404 error; the partial result is still returned so the UI can
+ *   render what loaded. Signal failures are surfaced via `compoundingSignal`
+ *   and never bubble into `error`, so a missing or malformed signal does
+ *   not block the rest of the tab.
  *
- * Uses `Promise.allSettled` so a failing transitions endpoint does not
- * block the snapshot, and vice versa.
+ * Uses `Promise.allSettled` so a failing endpoint does not block the others.
  */
 export async function loadBookmarkState({ baseUrl = bookmarkStateBaseUrl(), signal } = {}) {
-  const [stateResult, transitionsResult] = await Promise.allSettled([
-    fetchJson('/api/state', baseUrl),
-    fetchJson('/api/transitions', baseUrl)
+  const [stateResult, transitionsResult, signalResult] = await Promise.allSettled([
+    fetchJson('/api/state', baseUrl, signal),
+    fetchJson('/api/transitions', baseUrl, signal),
+    fetchText('/api/compounding-signal', baseUrl, signal)
   ]);
 
   const errors = [];
@@ -57,9 +83,25 @@ export async function loadBookmarkState({ baseUrl = bookmarkStateBaseUrl(), sign
     ? (Array.isArray(transitionsResult.value) ? transitionsResult.value : [])
     : (errors.push(transitionsResult.reason?.message ?? 'transitions failed'), []);
 
+  let compoundingSignal = { status: SIGNAL_STATUS.MISSING, signal: null, error: null };
+  if (signalResult.status === 'fulfilled') {
+    const { status, body } = signalResult.value;
+    compoundingSignal = classifySignalResponse(status, body);
+  } else {
+    // Network-level failure (e.g. abort). Treat as missing so the tile
+    // shows its placeholder; the caller still learns about the abort from
+    // the rejected promise if they care.
+    compoundingSignal = {
+      status: SIGNAL_STATUS.MISSING,
+      signal: null,
+      error: signalResult.reason?.message ?? null
+    };
+  }
+
   return {
     snapshot,
     transitions,
+    compoundingSignal,
     loadedAt: new Date().toISOString(),
     error: errors.length === 0 ? null : errors.join('; ')
   };

--- a/apps/mission-control/src/bookmarkStateSource.test.js
+++ b/apps/mission-control/src/bookmarkStateSource.test.js
@@ -39,17 +39,112 @@ describe('bookmarkStateSource', () => {
     expect(result.error).toBeNull();
     expect(result.snapshot.items.a.title).toBe('A');
     expect(result.transitions).toHaveLength(1);
+    expect(result.compoundingSignal.status).toBe('missing');
     expect(result.loadedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('classifies a valid compounding signal payload', async () => {
+    const validSignal = {
+      schemaVersion: 1,
+      runId: '2026-08-17T20:15:00Z',
+      generatedAt: '2026-08-17T20:15:00Z',
+      asOf: '2026-08-17T20:15:00Z',
+      headlinePercentage: 37.5,
+      currentWindow: {
+        start: '2026-08-10T20:15:00Z',
+        end: '2026-08-17T20:15:00Z',
+        eligibleCount: 8,
+        referencedCount: 3,
+        percentage: 37.5,
+        dossierPromotionCount: 2
+      },
+      trend: [
+        { offsetWeeks: 0, start: '2026-08-10T20:15:00Z', end: '2026-08-17T20:15:00Z', eligibleCount: 8, referencedCount: 3, percentage: 37.5 },
+        { offsetWeeks: 1, start: '2026-08-03T20:15:00Z', end: '2026-08-10T20:15:00Z', eligibleCount: 6, referencedCount: 1, percentage: 16.7 },
+        { offsetWeeks: 2, start: '2026-07-27T20:15:00Z', end: '2026-08-03T20:15:00Z', eligibleCount: 5, referencedCount: 1, percentage: 20.0 },
+        { offsetWeeks: 3, start: '2026-07-20T20:15:00Z', end: '2026-07-27T20:15:00Z', eligibleCount: 4, referencedCount: 0, percentage: 0.0 }
+      ],
+      operatorNote: null,
+      decisionPolicy: {
+        lowPercentageBelow: 25.0,
+        corpusEstablishedDocuments: 25,
+        minimumFourWeekEligibleItemsForBrokenPath: 10
+      },
+      inputs: {
+        bookmarkState: { path: 'x' },
+        corpusIndex: { path: 'y' },
+        dossierPromotions: { path: 'z' }
+      }
+    };
+    globalThis.fetch = vi.fn((url) => {
+      if (url.endsWith('/api/state')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ version: 1, items: {} })
+        });
+      }
+      if (url.endsWith('/api/transitions')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve([])
+        });
+      }
+      if (url.endsWith('/api/compounding-signal')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify(validSignal))
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await loadBookmarkState();
+    expect(result.compoundingSignal.status).toBe('valid');
+    expect(result.compoundingSignal.signal.headlinePercentage).toBe(37.5);
+  });
+
+  it('reports a malformed compounding signal payload as malformed', async () => {
+    globalThis.fetch = vi.fn((url) => {
+      if (url.endsWith('/api/state')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ version: 1, items: {} })
+        });
+      }
+      if (url.endsWith('/api/transitions')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve([])
+        });
+      }
+      if (url.endsWith('/api/compounding-signal')) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve('')
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await loadBookmarkState();
+    expect(result.compoundingSignal.status).toBe('malformed');
   });
 
   it('returns empty defaults when both endpoints 404', async () => {
     globalThis.fetch = vi.fn(() =>
-      Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) })
+      Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}), text: () => Promise.resolve('') })
     );
 
     const result = await loadBookmarkState();
     expect(result.snapshot).toEqual({ version: 1, items: {} });
     expect(result.transitions).toEqual([]);
+    expect(result.compoundingSignal.status).toBe('missing');
     expect(result.error).toBeNull();
   });
 
@@ -81,6 +176,9 @@ describe('bookmarkStateSource', () => {
     const seenUrls = [];
     globalThis.fetch = vi.fn((url) => {
       seenUrls.push(url);
+      if (url.endsWith('/api/compounding-signal')) {
+        return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve('') });
+      }
       return Promise.resolve({
         ok: true,
         status: 200,
@@ -94,7 +192,8 @@ describe('bookmarkStateSource', () => {
     await loadBookmarkState({ baseUrl: 'http://localhost:4001' });
     expect(seenUrls).toEqual([
       'http://localhost:4001/api/state',
-      'http://localhost:4001/api/transitions'
+      'http://localhost:4001/api/transitions',
+      'http://localhost:4001/api/compounding-signal'
     ]);
   });
 

--- a/apps/mission-control/src/compoundingSignal.js
+++ b/apps/mission-control/src/compoundingSignal.js
@@ -1,0 +1,174 @@
+// Pure helpers for the bookmark compounding-signal tile.
+//
+// The compounding signal is a derived read-only artifact published by
+// `agents/workflows/bookmarks/scripts/compute_compounding_signal.py` to
+// `brain/state/compounding-signal.json`. The Vite dev plugin serves it at
+// `/api/compounding-signal` (404 when missing, 500 when malformed). This
+// module:
+//
+//   * Defines the schema the React layer expects (`SCHEMA_VERSION`).
+//   * Classifies the fetched payload into `valid | missing | malformed`.
+//   * Computes staleness (`generatedAt + 8 days`) and the colour band.
+//   * Renders deterministic subtitle text. No JSX — UI strings live here.
+//
+// The module is intentionally dependency-free (no fetch, no DOM) so it can
+// be unit-tested and reused outside the React tree.
+
+export const SCHEMA_VERSION = 1;
+export const STALE_AFTER_DAYS = 8;
+
+export const SIGNAL_STATUS = Object.freeze({
+  VALID: 'valid',
+  MISSING: 'missing',
+  MALFORMED: 'malformed'
+});
+
+export const SIGNAL_BAND = Object.freeze({
+  GREEN: 'green',
+  AMBER: 'amber',
+  RED: 'red',
+  NEUTRAL: 'neutral'
+});
+
+/**
+ * Parse the raw response from `/api/compounding-signal` into a structured
+ * result. The result is *always* one of the three `SIGNAL_STATUS` values;
+ * callers never need to handle raw JSON themselves.
+ *
+ * @param {number} status  HTTP status code from the fetch.
+ * @param {string} body    Raw response body (JSON or empty).
+ * @returns {{ status: 'valid'|'missing'|'malformed', signal: object|null, error: string|null }}
+ */
+export function classifySignalResponse(status, body) {
+  if (status === 404) {
+    return { status: SIGNAL_STATUS.MISSING, signal: null, error: null };
+  }
+  if (status < 200 || status >= 300) {
+    return {
+      status: SIGNAL_STATUS.MALFORMED,
+      signal: null,
+      error: `compounding-signal HTTP ${status}`
+    };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch (err) {
+    return {
+      status: SIGNAL_STATUS.MALFORMED,
+      signal: null,
+      error: `JSON parse error: ${err?.message ?? String(err)}`
+    };
+  }
+  const validation = validateSignal(parsed);
+  if (validation.ok) {
+    return { status: SIGNAL_STATUS.VALID, signal: parsed, error: null };
+  }
+  return {
+    status: SIGNAL_STATUS.MALFORMED,
+    signal: null,
+    error: validation.error
+  };
+}
+
+/**
+ * Validate the parsed signal against the JSON schema contract.
+ * Returns `{ ok: true }` on success or `{ ok: false, error }` on failure.
+ * Mirrors the Python calculator's invariants so the dashboard can rely on
+ * the shape even when the artifact is hand-edited.
+ */
+export function validateSignal(signal) {
+  if (!signal || typeof signal !== 'object' || Array.isArray(signal)) {
+    return { ok: false, error: 'signal must be a JSON object' };
+  }
+  if (signal.schemaVersion !== SCHEMA_VERSION) {
+    return { ok: false, error: `unsupported schemaVersion: ${signal.schemaVersion}` };
+  }
+  for (const key of ['runId', 'generatedAt', 'asOf', 'headlinePercentage', 'trend', 'decisionPolicy', 'inputs']) {
+    if (!(key in signal)) {
+      return { ok: false, error: `missing required field: ${key}` };
+    }
+  }
+  if (!Array.isArray(signal.trend) || signal.trend.length !== 4) {
+    return { ok: false, error: 'trend must be an array of exactly 4 windows' };
+  }
+  for (const window of signal.trend) {
+    if (!window || typeof window !== 'object') {
+      return { ok: false, error: 'trend window must be an object' };
+    }
+    for (const key of ['offsetWeeks', 'start', 'end', 'eligibleCount', 'referencedCount', 'percentage']) {
+      if (!(key in window)) {
+        return { ok: false, error: `trend window missing ${key}` };
+      }
+    }
+    if (window.percentage !== null && typeof window.percentage !== 'number') {
+      return { ok: false, error: 'trend percentage must be null or number' };
+    }
+    if (window.eligibleCount < 0 || window.referencedCount < 0) {
+      return { ok: false, error: 'counts must be non-negative' };
+    }
+    if (window.referencedCount > window.eligibleCount) {
+      return { ok: false, error: 'referencedCount cannot exceed eligibleCount' };
+    }
+  }
+  if (signal.headlinePercentage !== signal.trend[0].percentage) {
+    return { ok: false, error: 'headlinePercentage must equal current window percentage' };
+  }
+  const note = signal.operatorNote;
+  if (note !== null && note !== undefined) {
+    if (!note || typeof note !== 'object' || typeof note.id !== 'string' || typeof note.text !== 'string') {
+      return { ok: false, error: 'operatorNote must be null or {id, text}' };
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * True when the signal's `generatedAt` is more than `STALE_AFTER_DAYS`
+ * days before `now`. The Vite plugin always reads the latest file, so
+ * staleness is purely a read-time condition. A failed weekly run leaves the
+ * previous successful artifact in place; the UI then shows the previous
+ * value with a stale marker rather than going blank.
+ */
+export function isStale(signal, now = new Date()) {
+  if (!signal || typeof signal.generatedAt !== 'string') return true;
+  const generated = new Date(signal.generatedAt);
+  if (Number.isNaN(generated.getTime())) return true;
+  const ageMs = now.getTime() - generated.getTime();
+  return ageMs > STALE_AFTER_DAYS * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Map a numeric percentage to one of the four colour bands. `null` is
+ * neutral (no observations). Boundaries match the spec: green >= 50,
+ * amber 25-49, red < 25.
+ */
+export function bandFor(percentage) {
+  if (percentage === null || percentage === undefined) return SIGNAL_BAND.NEUTRAL;
+  if (percentage >= 50) return SIGNAL_BAND.GREEN;
+  if (percentage >= 25) return SIGNAL_BAND.AMBER;
+  return SIGNAL_BAND.RED;
+}
+
+/**
+ * Render the short subtitle shown beneath the headline percentage on the
+ * KPI tile. Format is fixed: "<referenced>/<eligible> referenced ·
+ * <n> dossier promotions". Caller may append "(stale)" when `isStale`.
+ */
+export function subtitleFor(signal) {
+  if (!signal || !Array.isArray(signal.trend) || signal.trend.length === 0) {
+    return '';
+  }
+  const current = signal.trend[0];
+  const promotions = signal.currentWindow?.dossierPromotionCount ?? 0;
+  return `${current.referencedCount}/${current.eligibleCount} referenced · ${promotions} dossier promotions`;
+}
+
+/**
+ * Format the headline percentage for display. `null` becomes the em-dash
+ * placeholder so the value column is never empty.
+ */
+export function formatHeadline(percentage) {
+  if (percentage === null || percentage === undefined) return '—';
+  return `${percentage.toFixed(1)}%`;
+}

--- a/apps/mission-control/src/compoundingSignal.test.js
+++ b/apps/mission-control/src/compoundingSignal.test.js
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import {
+  bandFor,
+  classifySignalResponse,
+  formatHeadline,
+  isStale,
+  SCHEMA_VERSION,
+  SIGNAL_STATUS,
+  STALE_AFTER_DAYS,
+  subtitleFor,
+  validateSignal
+} from './compoundingSignal.js';
+
+function makeSignal(overrides = {}) {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    runId: '2026-08-17T20:15:00Z',
+    generatedAt: '2026-08-17T20:15:00Z',
+    asOf: '2026-08-17T20:15:00Z',
+    headlinePercentage: 37.5,
+    currentWindow: {
+      start: '2026-08-10T20:15:00Z',
+      end: '2026-08-17T20:15:00Z',
+      eligibleCount: 8,
+      referencedCount: 3,
+      percentage: 37.5,
+      dossierPromotionCount: 2
+    },
+    trend: [
+      { offsetWeeks: 0, start: '2026-08-10T20:15:00Z', end: '2026-08-17T20:15:00Z', eligibleCount: 8, referencedCount: 3, percentage: 37.5 },
+      { offsetWeeks: 1, start: '2026-08-03T20:15:00Z', end: '2026-08-10T20:15:00Z', eligibleCount: 6, referencedCount: 1, percentage: 16.7 },
+      { offsetWeeks: 2, start: '2026-07-27T20:15:00Z', end: '2026-08-03T20:15:00Z', eligibleCount: 5, referencedCount: 1, percentage: 20.0 },
+      { offsetWeeks: 3, start: '2026-07-20T20:15:00Z', end: '2026-07-27T20:15:00Z', eligibleCount: 4, referencedCount: 0, percentage: 0.0 }
+    ],
+    operatorNote: null,
+    decisionPolicy: {
+      lowPercentageBelow: 25.0,
+      corpusEstablishedDocuments: 25,
+      minimumFourWeekEligibleItemsForBrokenPath: 10
+    },
+    inputs: {
+      bookmarkState: { path: 'x' },
+      corpusIndex: { path: 'y' },
+      dossierPromotions: { path: 'z' }
+    },
+    ...overrides
+  };
+}
+
+describe('classifySignalResponse', () => {
+  it('treats 404 as missing', () => {
+    expect(classifySignalResponse(404, '')).toEqual({
+      status: SIGNAL_STATUS.MISSING,
+      signal: null,
+      error: null
+    });
+  });
+
+  it('classifies valid JSON as valid', () => {
+    const result = classifySignalResponse(200, JSON.stringify(makeSignal()));
+    expect(result.status).toBe(SIGNAL_STATUS.VALID);
+    expect(result.signal.headlinePercentage).toBe(37.5);
+  });
+
+  it('treats 500 as malformed with HTTP error', () => {
+    const result = classifySignalResponse(500, '');
+    expect(result.status).toBe(SIGNAL_STATUS.MALFORMED);
+    expect(result.error).toMatch(/HTTP 500/);
+  });
+
+  it('treats invalid JSON as malformed with parse error', () => {
+    const result = classifySignalResponse(200, 'not json');
+    expect(result.status).toBe(SIGNAL_STATUS.MALFORMED);
+    expect(result.error).toMatch(/JSON parse error/);
+  });
+
+  it('treats schema-invalid payload as malformed', () => {
+    const bad = { schemaVersion: 99, headlinePercentage: 0 };
+    const result = classifySignalResponse(200, JSON.stringify(bad));
+    expect(result.status).toBe(SIGNAL_STATUS.MALFORMED);
+    expect(result.error).toMatch(/schemaVersion/);
+  });
+});
+
+describe('validateSignal', () => {
+  it('accepts a valid signal', () => {
+    expect(validateSignal(makeSignal()).ok).toBe(true);
+  });
+
+  it('rejects wrong schemaVersion', () => {
+    const result = validateSignal(makeSignal({ schemaVersion: 2 }));
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/schemaVersion/);
+  });
+
+  it('rejects wrong trend length', () => {
+    const signal = makeSignal();
+    signal.trend = signal.trend.slice(0, 3);
+    const result = validateSignal(signal);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/exactly 4/);
+  });
+
+  it('rejects headline mismatch', () => {
+    const result = validateSignal(makeSignal({ headlinePercentage: 99.9 }));
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/headlinePercentage/);
+  });
+
+  it('accepts null headline (zero-denominator window)', () => {
+    const signal = makeSignal();
+    signal.trend.forEach((w) => (w.percentage = null));
+    signal.headlinePercentage = null;
+    expect(validateSignal(signal).ok).toBe(true);
+  });
+
+  it('rejects referencedCount exceeding eligibleCount', () => {
+    const signal = makeSignal();
+    signal.trend[0].referencedCount = 999;
+    const result = validateSignal(signal);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/referencedCount/);
+  });
+
+  it('rejects non-string operatorNote id', () => {
+    const signal = makeSignal();
+    signal.operatorNote = { id: 123, text: 'x' };
+    const result = validateSignal(signal);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('isStale', () => {
+  it('returns true when generatedAt is more than STALE_AFTER_DAYS days ago', () => {
+    const long_ago = new Date(Date.now() - (STALE_AFTER_DAYS + 1) * 24 * 60 * 60 * 1000).toISOString();
+    const signal = makeSignal({ generatedAt: long_ago });
+    expect(isStale(signal)).toBe(true);
+  });
+
+  it('returns false when generatedAt is within the freshness window', () => {
+    const recent = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
+    const signal = makeSignal({ generatedAt: recent });
+    expect(isStale(signal)).toBe(false);
+  });
+
+  it('returns true for missing or unparseable generatedAt', () => {
+    expect(isStale(null)).toBe(true);
+    expect(isStale({})).toBe(true);
+    expect(isStale({ generatedAt: 'not-a-date' })).toBe(true);
+  });
+});
+
+describe('bandFor', () => {
+  it('returns green for >= 50', () => {
+    expect(bandFor(50)).toBe('green');
+    expect(bandFor(75)).toBe('green');
+  });
+
+  it('returns amber for 25-49.9', () => {
+    expect(bandFor(25)).toBe('amber');
+    expect(bandFor(49.9)).toBe('amber');
+  });
+
+  it('returns red for < 25', () => {
+    expect(bandFor(24.9)).toBe('red');
+    expect(bandFor(0)).toBe('red');
+  });
+
+  it('returns neutral for null', () => {
+    expect(bandFor(null)).toBe('neutral');
+    expect(bandFor(undefined)).toBe('neutral');
+  });
+});
+
+describe('subtitleFor', () => {
+  it('returns "x/y referenced · n dossier promotions"', () => {
+    const signal = makeSignal();
+    expect(subtitleFor(signal)).toBe('3/8 referenced · 2 dossier promotions');
+  });
+
+  it('returns empty string for null signal', () => {
+    expect(subtitleFor(null)).toBe('');
+  });
+
+  it('defaults dossier promotions to 0 when currentWindow is missing', () => {
+    const signal = makeSignal();
+    delete signal.currentWindow;
+    expect(subtitleFor(signal)).toBe('3/8 referenced · 0 dossier promotions');
+  });
+});
+
+describe('formatHeadline', () => {
+  it('formats non-null as one-decimal percent', () => {
+    expect(formatHeadline(37.5)).toBe('37.5%');
+    expect(formatHeadline(50)).toBe('50.0%');
+  });
+
+  it('returns em-dash for null', () => {
+    expect(formatHeadline(null)).toBe('—');
+    expect(formatHeadline(undefined)).toBe('—');
+  });
+});

--- a/apps/mission-control/src/styles/components.css
+++ b/apps/mission-control/src/styles/components.css
@@ -247,6 +247,34 @@
   font-size: 12px;
 }
 
+/* Compounding band colours for the Compounding % (7d) tile. Using the
+   existing semantic palette tokens keeps the colours consistent with the
+   rest of the dashboard rather than introducing a new opaque palette.
+   AC4: green >= 50%, amber 25-49%, red < 25%, neutral for null/missing. */
+.bookmarks-tab__kpi-value--green {
+  color: var(--si-color-success, #1e7d3a);
+}
+
+.bookmarks-tab__kpi-value--amber {
+  color: var(--si-color-warning, #b25b00);
+}
+
+.bookmarks-tab__kpi-value--red {
+  color: var(--si-color-danger, #b3261e);
+}
+
+.bookmarks-tab__kpi-value--neutral {
+  color: var(--si-color-text-muted, #666);
+}
+
+.bookmarks-tab__kpi-meta {
+  margin-top: 2px;
+  color: var(--si-color-text-muted, #999);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 .bookmarks-tab__section-title {
   margin: 0 0 4px;
   font-size: 16px;

--- a/apps/mission-control/src/tabs/BookmarksKpiRow.jsx
+++ b/apps/mission-control/src/tabs/BookmarksKpiRow.jsx
@@ -1,11 +1,55 @@
 import React from 'react';
 import { Card } from '@sindustries/ui/react';
 import { STATUS_COLOR_VAR } from '../bookmarkPipeline.js';
+import {
+  bandFor,
+  formatHeadline,
+  isStale,
+  SIGNAL_STATUS,
+  subtitleFor
+} from '../compoundingSignal.js';
 
-export function BookmarksKpiRow({ kpis }) {
+const COMPOUNDING_TILE_TESTID = 'pulse-bookmarks-kpi-compounding';
+
+function CompoundingTile({ compoundingSignal }) {
+  // The Bookmarks tab always renders the compound tile first so it answers
+  // the operator's first question — "are we compounding yet?" — before
+  // they count states. Missing or malformed signals fall back to a
+  // placeholder rather than hiding the tile.
+  const status = compoundingSignal?.status ?? SIGNAL_STATUS.MISSING;
+  const signal = status === SIGNAL_STATUS.VALID ? compoundingSignal.signal : null;
+  const headline = signal ? formatHeadline(signal.headlinePercentage) : '—';
+  const band = signal ? bandFor(signal.headlinePercentage) : 'neutral';
+  const stale = signal ? isStale(signal) : false;
+  const subtitle = signal ? subtitleFor(signal) : 'Signal unavailable';
+
+  const bandClass = `bookmarks-tab__kpi-value bookmarks-tab__kpi-value--${band}`;
+  const note = stale ? 'previous run · stale' : (status === SIGNAL_STATUS.MISSING ? 'awaiting first weekly run' : (status === SIGNAL_STATUS.MALFORMED ? 'malformed artifact' : '7d window'));
+
+  return (
+    <Card data-testid={COMPOUNDING_TILE_TESTID}>
+      <div className="bookmarks-tab__kpi-label">Compounding % (7d)</div>
+      <div className={bandClass} data-testid={`${COMPOUNDING_TILE_TESTID}-value`}>
+        {headline}
+      </div>
+      <div className="bookmarks-tab__kpi-note" data-testid={`${COMPOUNDING_TILE_TESTID}-subtitle`}>
+        {subtitle}
+      </div>
+      <div
+        className="bookmarks-tab__kpi-meta"
+        data-testid={`${COMPOUNDING_TILE_TESTID}-note`}
+      >
+        {stale ? 'stale' : note}
+      </div>
+    </Card>
+  );
+}
+
+export function BookmarksKpiRow({ kpis, compoundingSignal }) {
   const entries = Object.entries(kpis).filter(([, count]) => count > 0);
   return (
     <div className="bookmarks-tab__kpis" data-testid="pulse-bookmarks-kpi-row">
+      <CompoundingTile compoundingSignal={compoundingSignal} />
       {entries.map(([status, count]) => (
         <Card key={status} data-testid={`pulse-bookmarks-kpi-${status}`}>
           <div className="bookmarks-tab__kpi-label">{status}</div>

--- a/apps/mission-control/src/tabs/BookmarksKpiRow.test.jsx
+++ b/apps/mission-control/src/tabs/BookmarksKpiRow.test.jsx
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BookmarksKpiRow } from './BookmarksKpiRow.jsx';
+import { SIGNAL_STATUS, SCHEMA_VERSION, STALE_AFTER_DAYS } from '../compoundingSignal.js';
+
+function makeSignal(percentage, overrides = {}) {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    runId: '2026-08-17T20:15:00Z',
+    generatedAt: new Date().toISOString(),
+    asOf: '2026-08-17T20:15:00Z',
+    headlinePercentage: percentage,
+    currentWindow: {
+      start: '2026-08-10T20:15:00Z',
+      end: '2026-08-17T20:15:00Z',
+      eligibleCount: 8,
+      referencedCount: 3,
+      percentage,
+      dossierPromotionCount: 2
+    },
+    trend: [
+      { offsetWeeks: 0, start: '2026-08-10T20:15:00Z', end: '2026-08-17T20:15:00Z', eligibleCount: 8, referencedCount: 3, percentage },
+      { offsetWeeks: 1, start: '2026-08-03T20:15:00Z', end: '2026-08-10T20:15:00Z', eligibleCount: 6, referencedCount: 1, percentage: 16.7 },
+      { offsetWeeks: 2, start: '2026-07-27T20:15:00Z', end: '2026-08-03T20:15:00Z', eligibleCount: 5, referencedCount: 1, percentage: 20.0 },
+      { offsetWeeks: 3, start: '2026-07-20T20:15:00Z', end: '2026-07-27T20:15:00Z', eligibleCount: 4, referencedCount: 0, percentage: 0.0 }
+    ],
+    operatorNote: null,
+    decisionPolicy: {
+      lowPercentageBelow: 25.0,
+      corpusEstablishedDocuments: 25,
+      minimumFourWeekEligibleItemsForBrokenPath: 10
+    },
+    inputs: {
+      bookmarkState: { path: 'x' },
+      corpusIndex: { path: 'y' },
+      dossierPromotions: { path: 'z' }
+    },
+    ...overrides
+  };
+}
+
+const COMPOUNDING_VALUE = 'pulse-bookmarks-kpi-compounding-value';
+const COMPOUNDING_SUBTITLE = 'pulse-bookmarks-kpi-compounding-subtitle';
+const COMPOUNDING_NOTE = 'pulse-bookmarks-kpi-compounding-note';
+
+describe('BookmarksKpiRow — Compounding tile', () => {
+  it('renders green band at 50.0% (boundary, AC4)', () => {
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.VALID, signal: makeSignal(50.0) }}
+      />
+    );
+    const value = screen.getByTestId(COMPOUNDING_VALUE);
+    expect(value.textContent).toBe('50.0%');
+    expect(value.className).toContain('green');
+  });
+
+  it('renders green band at 75.0%', () => {
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.VALID, signal: makeSignal(75.0) }}
+      />
+    );
+    const value = screen.getByTestId(COMPOUNDING_VALUE);
+    expect(value.textContent).toBe('75.0%');
+    expect(value.className).toContain('green');
+  });
+
+  it('renders amber band at 49.9% (just below green threshold)', () => {
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.VALID, signal: makeSignal(49.9) }}
+      />
+    );
+    const value = screen.getByTestId(COMPOUNDING_VALUE);
+    expect(value.textContent).toBe('49.9%');
+    expect(value.className).toContain('amber');
+  });
+
+  it('renders amber band at 25.0% (boundary, AC4)', () => {
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.VALID, signal: makeSignal(25.0) }}
+      />
+    );
+    const value = screen.getByTestId(COMPOUNDING_VALUE);
+    expect(value.textContent).toBe('25.0%');
+    expect(value.className).toContain('amber');
+  });
+
+  it('renders red band at 24.9% (just below amber threshold)', () => {
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.VALID, signal: makeSignal(24.9) }}
+      />
+    );
+    const value = screen.getByTestId(COMPOUNDING_VALUE);
+    expect(value.textContent).toBe('24.9%');
+    expect(value.className).toContain('red');
+  });
+
+  it('renders red band at 0.0%', () => {
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.VALID, signal: makeSignal(0.0) }}
+      />
+    );
+    const value = screen.getByTestId(COMPOUNDING_VALUE);
+    expect(value.textContent).toBe('0.0%');
+    expect(value.className).toContain('red');
+  });
+
+  it('renders em-dash and neutral band when percentage is null', () => {
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.VALID, signal: makeSignal(null) }}
+      />
+    );
+    const value = screen.getByTestId(COMPOUNDING_VALUE);
+    expect(value.textContent).toBe('—');
+    expect(value.className).toContain('neutral');
+  });
+
+  it('renders the subtitle "<referenced>/<eligible> referenced · <n> dossier promotions"', () => {
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.VALID, signal: makeSignal(37.5) }}
+      />
+    );
+    const subtitle = screen.getByTestId(COMPOUNDING_SUBTITLE);
+    expect(subtitle.textContent).toBe('3/8 referenced · 2 dossier promotions');
+  });
+
+  it('marks the tile stale when generatedAt is older than STALE_AFTER_DAYS days', () => {
+    const longAgo = new Date(Date.now() - (STALE_AFTER_DAYS + 1) * 24 * 60 * 60 * 1000).toISOString();
+    const signal = makeSignal(37.5, { generatedAt: longAgo });
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.VALID, signal }}
+      />
+    );
+    const note = screen.getByTestId(COMPOUNDING_NOTE);
+    expect(note.textContent).toBe('stale');
+    // Headline is still rendered — previous value stays visible.
+    const value = screen.getByTestId(COMPOUNDING_VALUE);
+    expect(value.textContent).toBe('37.5%');
+  });
+
+  it('does not render stale marker for a fresh signal', () => {
+    const recent = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
+    const signal = makeSignal(37.5, { generatedAt: recent });
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.VALID, signal }}
+      />
+    );
+    const note = screen.getByTestId(COMPOUNDING_NOTE);
+    expect(note.textContent).not.toBe('stale');
+  });
+
+  it('renders the missing placeholder when status is MISSING (no signal yet)', () => {
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.MISSING, signal: null, error: null }}
+      />
+    );
+    const value = screen.getByTestId(COMPOUNDING_VALUE);
+    expect(value.textContent).toBe('—');
+    expect(value.className).toContain('neutral');
+    const subtitle = screen.getByTestId(COMPOUNDING_SUBTITLE);
+    expect(subtitle.textContent).toBe('Signal unavailable');
+    const note = screen.getByTestId(COMPOUNDING_NOTE);
+    expect(note.textContent).toBe('awaiting first weekly run');
+  });
+
+  it('renders the malformed placeholder when status is MALFORMED', () => {
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.MALFORMED, signal: null, error: 'schemaVersion mismatch' }}
+      />
+    );
+    const value = screen.getByTestId(COMPOUNDING_VALUE);
+    expect(value.textContent).toBe('—');
+    expect(value.className).toContain('neutral');
+    const subtitle = screen.getByTestId(COMPOUNDING_SUBTITLE);
+    expect(subtitle.textContent).toBe('Signal unavailable');
+    const note = screen.getByTestId(COMPOUNDING_NOTE);
+    expect(note.textContent).toBe('malformed artifact');
+  });
+
+  it('renders the tile first even when there are no other KPIs', () => {
+    render(
+      <BookmarksKpiRow
+        kpis={{}}
+        compoundingSignal={{ status: SIGNAL_STATUS.MISSING, signal: null, error: null }}
+      />
+    );
+    const row = screen.getByTestId('pulse-bookmarks-kpi-row');
+    const compounding = screen.getByTestId('pulse-bookmarks-kpi-compounding');
+    // Compounding tile is the first child of the row; with empty kpis it is
+    // the only KPI child. Verify both conditions.
+    expect(row.firstChild).toBe(compounding);
+    const kpiChildren = Array.from(row.children).filter((c) =>
+      c.getAttribute('data-testid')?.startsWith('pulse-bookmarks-kpi-')
+    );
+    expect(kpiChildren).toHaveLength(1);
+  });
+
+  it('treats absent compoundingSignal prop as missing (does not crash)', () => {
+    render(<BookmarksKpiRow kpis={{ summarized: 1 }} />);
+    const value = screen.getByTestId(COMPOUNDING_VALUE);
+    expect(value.textContent).toBe('—');
+    const subtitle = screen.getByTestId(COMPOUNDING_SUBTITLE);
+    expect(subtitle.textContent).toBe('Signal unavailable');
+  });
+
+  it('does not fail the rest of the KPI row when signal is malformed (independent failure semantics, AC5)', () => {
+    render(
+      <BookmarksKpiRow
+        kpis={{ summarized: 1, approved: 2 }}
+        compoundingSignal={{ status: SIGNAL_STATUS.MALFORMED, signal: null, error: 'boom' }}
+      />
+    );
+    // Other KPI cards still render.
+    expect(screen.getByTestId('pulse-bookmarks-kpi-summarized')).toBeTruthy();
+    expect(screen.getByTestId('pulse-bookmarks-kpi-approved')).toBeTruthy();
+    // Compounding tile shows the malformed placeholder rather than crashing.
+    expect(screen.getByTestId(COMPOUNDING_VALUE).textContent).toBe('—');
+  });
+});

--- a/apps/mission-control/src/tabs/BookmarksTab.jsx
+++ b/apps/mission-control/src/tabs/BookmarksTab.jsx
@@ -41,7 +41,11 @@ export function BookmarksTab() {
   const reload = useCallback(async () => {
     try {
       const next = await loadBookmarkState();
-      setData({ snapshot: next.snapshot, transitions: next.transitions });
+      setData({
+        snapshot: next.snapshot,
+        transitions: next.transitions,
+        compoundingSignal: next.compoundingSignal
+      });
       setLoadedAt(next.loadedAt);
       setError(null);
     } catch (err) {
@@ -72,6 +76,7 @@ export function BookmarksTab() {
 
   const snapshot = data?.snapshot ?? null;
   const transitions = data?.transitions ?? [];
+  const compoundingSignal = data?.compoundingSignal ?? { status: 'missing', signal: null, error: null };
   const items = useMemo(() => itemList(snapshot), [snapshot]);
   const byKey = useMemo(() => itemByKey(snapshot), [snapshot]);
   const topics = useMemo(() => availableTopics(items), [items]);
@@ -153,7 +158,7 @@ export function BookmarksTab() {
 
       <BookmarksPendingApprovals pending={pending} relativeAge={relativeAge} />
 
-      <BookmarksKpiRow kpis={kpis} />
+      <BookmarksKpiRow kpis={kpis} compoundingSignal={compoundingSignal} />
 
       <BookmarksCurationsGrid curations={curations} relativeAge={relativeAge} />
 

--- a/apps/mission-control/vite.config.js
+++ b/apps/mission-control/vite.config.js
@@ -31,6 +31,7 @@ function brainStateApi() {
       const brainRoot = resolveBrainRoot();
       const statePath = path.join(brainRoot, 'state', 'bookmark-review-state.json');
       const transitionsPath = path.join(brainRoot, 'state', 'bookmark-transitions.jsonl');
+      const signalPath = path.join(brainRoot, 'state', 'compounding-signal.json');
 
       server.middlewares.use('/api/state', (_req, res) => {
         try {
@@ -58,6 +59,37 @@ function brainStateApi() {
           res.setHeader('content-type', 'application/json; charset=utf-8');
           res.statusCode = 200;
           res.end(JSON.stringify(rows));
+        } catch (err) {
+          res.statusCode = 500;
+          res.end(JSON.stringify({ error: err?.message ?? 'unknown' }));
+        }
+      });
+
+      // Compounding signal is a derived artifact. A missing file is a normal
+      // state (the artifact only exists after the first weekly run) and 404s
+      // here so the client can distinguish "no data yet" from a malformed
+      // payload. A malformed payload is a 500 so the client can show the
+      // "malformed" placeholder without crashing Vite.
+      server.middlewares.use('/api/compounding-signal', (_req, res) => {
+        try {
+          if (!fs.existsSync(signalPath)) {
+            res.statusCode = 404;
+            res.setHeader('content-type', 'application/json; charset=utf-8');
+            res.end(JSON.stringify({ error: 'compounding-signal.json missing' }));
+            return;
+          }
+          const body = fs.readFileSync(signalPath, 'utf8');
+          try {
+            JSON.parse(body);
+          } catch (parseErr) {
+            res.statusCode = 500;
+            res.setHeader('content-type', 'application/json; charset=utf-8');
+            res.end(JSON.stringify({ error: `compounding-signal.json malformed: ${parseErr?.message ?? 'parse error'}` }));
+            return;
+          }
+          res.setHeader('content-type', 'application/json; charset=utf-8');
+          res.statusCode = 200;
+          res.end(body);
         } catch (err) {
           res.statusCode = 500;
           res.end(JSON.stringify({ error: err?.message ?? 'unknown' }));

--- a/docs/runbooks/bookmark-compounding-signal.md
+++ b/docs/runbooks/bookmark-compounding-signal.md
@@ -1,0 +1,236 @@
+# Runbook — Bookmark Compounding Signal (`compute-compounding-signal`)
+
+**Owner:** Rowan (engineering)
+**Trigger:** Operators need a weekly prior-context reuse percentage, its four-week trend, and the current week's dossier-promotion count, surfaced on Pulse's Bookmarks tab as `Compounding % (7d)`. The artifact is the source of truth the dashboard reads; the Markdown is a deterministic operator rendering of the same JSON.
+**Related:**
+
+- Tech design: `docs/specs/compounding-signal-for-bookmark-pipeline-tech-design.md`
+- Product spec: `brain/tasks/specs/in-progress/compounding-signal-for-bookmark-pipeline-f0331a69bfaf9aa7.md`
+- Task: `faf260e9-fe7b-4ce5-86ba-e47acab0ddb3`
+- Calculator: `agents/workflows/bookmarks/scripts/compute_compounding_signal.py`
+- Tests: `agents/workflows/bookmarks/scripts/tests/test_compute_compounding_signal.py`
+- Vite adapter: `apps/mission-control/vite.config.js` (`brainStateApi`)
+- Pulse consumer: `apps/mission-control/src/tabs/BookmarksKpiRow.jsx`, `apps/mission-control/src/compoundingSignal.js`
+- Cron prompt: `agents/crons/prompts/bookmark-compounding-signal.md`
+
+## Why this exists
+
+The bookmark pipeline stores prior-context references and (once the upstream
+contracts ship) dossier-promotion events. Without a derived read, Tom has to
+spot the trend by reading raw state files, which is not a question a
+weekly cron can answer. The signal answers "are we compounding yet?" with
+one number per week, a four-week trend, and an operator note when the
+trend is low.
+
+The calculator is intentionally read-only. It never imports or writes
+upstream pipeline state, never calls another pipeline stage, and fails
+closed on any parse, compute, validation, or write error. A failed run
+leaves the previous successful pair in place; the dashboard then shows
+the previous value with a stale marker rather than going blank.
+
+## Modes
+
+The script accepts the following flags. The default invocation publishes
+both artifacts to `brain/state/`.
+
+| Flag | Effect | Writes artifacts? | Source touched? |
+|---|---|---|---|
+| `--dry-run --print-json` | Read, validate, print candidate JSON to stdout | No | No |
+| `--dry-run` (no `--print-json`) | Same as above, prints a one-line summary | No | No |
+| (default) | Read, validate, write `compounding-signal.{json,md}` | Yes (atomic) | No |
+| `--as-of <ISO-8601>` | Force a deterministic `as-of` for tests/manual reconstruction | As above | No |
+| `--workspace-root <path>` | Override workspace discovery (`WORKSPACE_ROOT` is also honored) | As above | No |
+| `--bookmark-state <path>` | Override `bookmark-review-state.json` location | As above | No |
+| `--corpus-index <path>` | Override `bookmark-corpus-index.jsonl` location | As above | No |
+| `--dossier-promotions <path>` | Override dossier-promotion log location | As above | No |
+| `--json-path <path>` | Override `compounding-signal.json` output | As above | No |
+| `--md-path <path>` | Override `compounding-signal.md` output | As above | No |
+
+The script never touches upstream input files. Successful runs are atomic:
+each artifact is written to a `.tmp` sibling, fsync'd, then renamed over
+the destination. If the JSON write succeeds but the Markdown write fails,
+the JSON remains and the operator can re-run; if the first write fails,
+the destination is left untouched.
+
+## Pre-flight
+
+1. **Confirm the workspace root.** Run `echo "$WORKSPACE_ROOT"` (or pass
+   `--workspace-root`). The script resolves the workspace from CLI, env
+   var, or a canonical `<script>/../../../../` walk, and exits with code
+   `2` if none of those resolve to a directory that contains
+   `agents/workflows/bookmarks`.
+2. **Confirm upstream artifacts are present.** A missing
+   `bookmark-review-state.json` is a fatal error (exit `3`) — the signal
+   has no observations to compute against. A missing corpus index or
+   dossier-promotion log is treated as empty (operator note may select
+   `corpus_too_small`), not as failure.
+3. **Confirm the dashboard has the right view of the artifact.** If
+   `brain/state/compounding-signal.json` is missing, the Pulse tile shows
+   `awaiting first weekly run`. If it's malformed, the tile shows
+   `malformed artifact` with the validation error in the page title. Both
+   are visible in the Bookmarks tab; neither blocks the rest of the
+   dashboard.
+4. **Confirm the dev-only Vite plugin is active.** The adapter at
+   `GET /api/compounding-signal` only exists in `vite dev` mode
+   (`apps/mission-control/vite.config.js`). In `vite build` (production)
+   the route is a no-op, the dashboard receives `404`, and the tile shows
+   `awaiting first weekly run`. This is the shipped boundary; production
+   Pulse needs a hosted bookmark-domain read service (see Open Questions
+   in the tech design).
+
+## Procedure
+
+### 1. Manual dry-run
+
+Always do a dry-run before publishing for the first time in a workspace:
+
+```sh
+python3 agents/workflows/bookmarks/scripts/compute_compounding_signal.py \
+  --workspace-root /Users/quinnstoffer/.openclaw/workspace \
+  --dry-run --print-json \
+  | jq '.'
+```
+
+Confirm the candidate JSON has:
+
+- `schemaVersion: 1`
+- `headlinePercentage` equal to `trend[0].percentage`
+- `trend` is an array of exactly four windows, ordered current → oldest
+- `operatorNote` is either `null` or `{id, text}` where `id` is one of
+  the three closed-set IDs (`corpus_too_small`,
+  `retrieval_path_may_be_broken`, `mostly_unrelated_intake`)
+- `decisionPolicy.lowPercentageBelow: 25.0`
+
+### 2. Publish
+
+When the dry-run looks right, drop `--dry-run`:
+
+```sh
+python3 agents/workflows/bookmarks/scripts/compute_compounding_signal.py \
+  --workspace-root /Users/quinnstoffer/.openclaw/workspace
+```
+
+The script prints one JSON line to stdout, e.g.:
+
+```json
+{"published": true, "runId": "2026-08-17T20:15:00Z", "headlinePercentage": 37.5, "jsonPath": ".../compounding-signal.json", "mdPath": ".../compounding-signal.md"}
+```
+
+Verify the Pulse tile shows the new value (focus the browser window or
+hit the toolbar's Refresh button — focus reloads the data via
+`loadBookmarkState()`).
+
+### 3. Deterministic reconstruction
+
+If the team needs to reproduce a published artifact exactly, pass
+`--as-of`:
+
+```sh
+python3 agents/workflows/bookmarks/scripts/compute_compounding_signal.py \
+  --workspace-root /Users/quinnstoffer/.openclaw/workspace \
+  --as-of 2026-08-17T20:15:00Z \
+  --dry-run --print-json
+```
+
+The trend windows and headline are computed from the as-of timestamp
+plus windowing constants (one calendar week per window, four windows).
+Deterministic reconstruction works for both `--dry-run` and the default
+publish path; the Markdown also carries the same `runId`.
+
+## Health by pipeline maturity
+
+| Stage | Duration | What "healthy" looks like | Tile state |
+|---|---|---|---|
+| **Early / pre-corpus** | First ~4 weeks | Insufficient data to draw a trend. The headline is `null` (em-dash) for at least one window. | Tile shows `—` and `Signal unavailable` until the first run completes; subsequent weeks may show `null` until the corpus grows. |
+| **Measuring** | Weeks ~5-8 with some eligible items, corpus < 25 docs | The headline starts to land as a finite percentage, but the corpus is still small. A four-week `null` trend is normal. | Tile shows a finite headline and color band; an `operatorNote` may select `corpus_too_small` when the corpus is below 25 documents. |
+| **Established** | Corpus ≥ 25 docs, ≥ 4 weeks of prior-context data | Headline ≥ 35% is the healthy target. Bands: green ≥ 50%, amber 25-49%, red < 25%. | Tile shows the headline with its band color and the subtitle `<referenced>/<eligible> referenced · <n> dossier promotions`. |
+
+The 35% target for established corpora is a policy value, not a
+calculator constant. It is documented here and in `decisionPolicy` of
+the JSON; changing it is a reviewed code/config change, not a prose edit.
+
+## Failure cases
+
+The script returns the following exit codes. Cron and operator scripts
+should treat any non-zero exit as a soft failure (do not retry
+destructively, do not block the bookmark pipeline).
+
+| Exit | Meaning | Action |
+|---|---|---|
+| 0 | Successful run (publish or dry-run) | None — publish ran, or dry-run produced a validated candidate. |
+| 2 | Workspace resolution failed, or `--as-of` invalid | Pass `--workspace-root` or set `WORKSPACE_ROOT`; pass a valid ISO-8601 timestamp. |
+| 3 | `bookmark-review-state.json` missing | Confirm the upstream bookmark pipeline is running; do not retry until bookmark state exists. |
+| 4 | Parse, compute, or validation error | Inspect stderr JSON `{"error": "..."}`. Common causes: an upstream review-status outside the closed set, an empty `items` field, or a corrupted bookmark state file. |
+| 5 | Filesystem write failure | Inspect stderr JSON. The destination directory may not exist; create it manually and re-run. |
+
+### Stale artifact
+
+The Pulse tile marks a valid artifact stale when `generatedAt` is more
+than `STALE_AFTER_DAYS` (8 days) old. This is a read-time condition: the
+artifact itself is never rewritten to say "stale," and a failed weekly
+run naturally leaves the previous successful value visible with a stale
+marker rather than blanking the tile.
+
+**Diagnosis:** open the Bookmarks tab, check the tile's small caption.
+If it says `stale`, the JSON on disk is more than 8 days old.
+
+**Recovery:** re-run the calculator manually (step 2). Investigate why
+the cron did not run (job disabled, host outage, isolated session
+error). Do not edit the artifact by hand — schema validation will reject
+the next publish attempt.
+
+### Missing artifact
+
+The Pulse tile shows `—` and `awaiting first weekly run` when no JSON
+exists on disk and the Vite plugin returns `404`.
+
+**Diagnosis:** confirm `brain/state/compounding-signal.json` exists.
+If absent, the cron has never run successfully or the artifact was
+removed.
+
+**Recovery:** run the calculator manually (step 2), then investigate
+cron state.
+
+### Malformed artifact
+
+The Pulse tile shows `—` and `malformed artifact` when the Vite plugin
+returns `500` (the JSON parser inside the plugin rejected the file) or
+the React layer's schema validation rejected the parsed payload.
+
+**Diagnosis:** open the browser dev tools; the page title for the
+`compounding` KPI carries the validation error. Cross-check against the
+Python `validate_signal` invariants — a mismatch usually means the
+artifact was hand-edited or written by a different calculator version.
+
+**Recovery:** delete the artifact and re-run the calculator manually
+(step 2). If the new publish fails too, the calculator invariants have
+drifted from the JSON schema in `compoundingSignal.js`; either revert
+the calculator or update the React schema to match.
+
+## Rollback
+
+1. Disable the weekly cron (set `enabled: false` on the OpenClaw job).
+2. Revert the implementation PR.
+3. Optionally move the artifact pair to trash:
+   `mv brain/state/compounding-signal.{json,md} ~/.Trash/`. The dashboard
+   returns to its pre-feature state immediately.
+
+The signal does not write to any upstream pipeline state, so no upstream
+rollback is needed. Existing dossier-promotion events and bookmark
+state are untouched.
+
+## Open follow-ups
+
+These are intentionally deferred and live outside the runbook:
+
+- The dossier-promotion event contract is pending the upstream evidence-
+  layer spec. Until then, the `dossierPromotionCount` field may be `0`
+  even when promotions occurred — the calculator rejects any event that
+  does not carry `eventId` and `promotedAt`.
+- The prior-context timestamp/field contract is pending the upstream
+  knowledge-base spec. The calculator falls back from `reviewedAt` to
+  `lastUpdatedAt` to `firstSeenAt` so a draft contract does not lock the
+  metric.
+- Production Pulse needs a hosted bookmark-domain read service. The
+  current Vite plugin is dev-only; the feature follows that shipped
+  boundary rather than introducing a new backend.

--- a/docs/specs/compounding-signal-for-bookmark-pipeline-tech-design.md
+++ b/docs/specs/compounding-signal-for-bookmark-pipeline-tech-design.md
@@ -1,0 +1,316 @@
+---
+status: draft
+task_id: faf260e9-fe7b-4ce5-86ba-e47acab0ddb3
+product_spec: brain/tasks/specs/in-progress/compounding-signal-for-bookmark-pipeline-f0331a69bfaf9aa7.md
+shipped_pr: null
+shipped_date: null
+---
+
+# Compounding Signal for the Bookmark Pipeline — Tech Design
+
+## Links and delivery identity
+
+- Product spec: `brain/tasks/specs/in-progress/compounding-signal-for-bookmark-pipeline-f0331a69bfaf9aa7.md`
+- Task: `faf260e9-fe7b-4ce5-86ba-e47acab0ddb3` (`🔧 Compounding Signal For The Bookmark Pipeline`)
+- Bookmark: `f0331a69bfaf9aa7`
+- Repository: `Stoffer-Industries/sindustries`
+- Branch: `feature/compounding-signal-bookmark-pipeline`
+- Worktree: `/Users/quinnstoffer/.openclaw/workspace/worktrees/feature/compounding-signal-bookmark-pipeline`
+- Tech design: `docs/specs/compounding-signal-for-bookmark-pipeline-tech-design.md`
+
+## Product intent
+
+The approved product spec asks for one inspectable answer to “are we compounding yet?”: a weekly prior-context reuse percentage, its four-week trend, and the current week’s dossier-promotion count. The result is a derived, read-only consumer of existing bookmark pipeline and knowledge artifacts. It must not add ingestion, retrieval, memory, or evidence infrastructure.
+
+The only user-facing addition is a `Compounding % (7d)` KPI in Pulse’s existing Bookmarks tab. Failures degrade to the previous successful value with a stale marker rather than interrupting bookmark review, spec dispatch, approvals, or task creation.
+
+Non-goals remain: semantic scoring, cross-pipeline leverage, alerts or automatic remediation, a separate dashboard, and writes to any upstream pipeline artifact.
+
+## Current-state and dependency check
+
+The implementation target already contains the shipped Mission Control Bookmarks tab and its dev-only workspace file adapter:
+
+- `apps/mission-control/src/tabs/BookmarksTab.jsx`
+- `apps/mission-control/src/tabs/BookmarksKpiRow.jsx`
+- `apps/mission-control/src/bookmarkStateSource.js`
+- `apps/mission-control/vite.config.js`
+
+The two data-producing specs named by the product spec are still draft and unapproved as of this design:
+
+1. `brain/bookmarks/specs/markdown-knowledge-base-metadata-and-retrieval-for-bookmark-pipeline-1f7463c784e8580f.md` proposes `priorContextRefs` on bookmark state and `brain/state/index/bookmark-corpus-index.jsonl`.
+2. `brain/bookmarks/specs/evidence-layer-for-bookmark-review-e7a5199d628ecf8e.md` proposes topic dossiers and run receipts, but does not yet specify a dossier-promotion timestamp contract.
+
+The dashboard dependency has effectively shipped, despite the product spec describing all three inputs as drafts. Implementation therefore starts with a dependency-contract check and must not invent or write missing upstream fields. If the final upstream contracts differ, this design is revised before computation is enabled.
+
+## Ownership boundary
+
+### Natural source of truth
+
+This is a **workflow/OpenClaw-boundary derived artifact**, not UI-local state, API-owned state, database-backed domain data, or a shared-package contract.
+
+- Upstream domain truth stays in workspace bookmark/evidence artifacts under `brain/state/`.
+- A repo-owned Python command performs deterministic read-only computation and publishes a small derived artifact back to `brain/state/`.
+- Pulse is a direct read-only consumer through its existing dev workspace adapter.
+- The weekly cadence is owned by OpenClaw cron metadata; only the command and cron prompt are versioned in this repo.
+
+No route, table, migration, credential, or persistence responsibility is added to `services/tasks-api`. Routing this through Tasks API would violate its task/workflow ownership boundary and would be more work than the durable file-derived boundary.
+
+### Delivery cut
+
+This feature is small enough to deliver in one implementation PR, but the PR should be internally ordered as mergeable commits:
+
+1. pure calculator, schema validation, renderers, fixtures, and tests;
+2. Pulse file adapter and KPI tile;
+3. versioned runbook/system/app docs and cron prompt.
+
+The external cron registration and workspace `infra/RUNBOOKS.md` index update happen only after merge as an explicit OpenClaw handoff. There is no interim client-only metric: computing the percentage in React would duplicate domain rules, erase the weekly artifact required by AC1, and create avoidable migration work.
+
+## Metric contract
+
+### Input adapter boundary
+
+`compute_compounding_signal.py` will isolate final upstream shapes behind three pure adapters. The adapters accept paths via CLI flags, so tests use fixtures and the implementation can absorb upstream revisions without changing metric or renderer code.
+
+1. **Bookmark cohort adapter**
+   - Default proposed source: `brain/state/bookmark-review-state.json`.
+   - Required per eligible item: stable bookmark key, current `reviewStatus`, a stable review/context-evaluation timestamp, and optional prior-context references.
+   - Proposed draft mappings are `reviewedAt` and `priorContextRefs`, but these mappings are not considered final until the knowledge-base spec ships.
+2. **Corpus health adapter**
+   - Default proposed source: `brain/state/index/bookmark-corpus-index.jsonl`.
+   - Returns valid indexed-document count and source freshness for the fixed operator-note decision table.
+3. **Dossier-promotion adapter**
+   - Default source is selected only after the evidence-layer spec defines a machine-readable promotion event with a stable event ID and timestamp.
+   - Returns promotion events; the current-window count is the number of unique events whose promotion timestamp is in that window.
+   - Parsing prose from `dossier.md`, file mtimes, or diff filenames is explicitly forbidden because none is a reliable promotion-event contract.
+
+All adapters read bytes only. They expose no mutation methods and do not import bookmark workflow mutation helpers.
+
+### Eligible states
+
+The proposed closed set is:
+
+```text
+summarized
+needs_research
+spec_requested
+spec_created
+approval_pending
+revision_requested
+revision_staged
+approved
+tasked
+declined
+```
+
+This includes current items at or beyond review/context evaluation, spec dispatch, approval, or a terminal outcome and excludes `ingested` because retrieval has not yet been evaluated there. Unknown states are rejected with a validation error rather than silently added to the denominator. The final set must be reconciled with the shipped upstream state contract before implementation is enabled.
+
+Eligibility is evaluated from the item’s **current effective state** (respecting the existing task-linked ⇒ `tasked` invariant). An eligible item is assigned to one trend window using the upstream context-evaluation timestamp. This prevents later state transitions from counting the same item in multiple weeks while preserving AC2’s “currently in” wording.
+
+### Window and percentage semantics
+
+The command accepts `--as-of <ISO-8601>` for deterministic tests/manual reconstruction; otherwise `asOf` is the invocation time. All stored instants are UTC. Four contiguous half-open windows are produced:
+
+```text
+current: [asOf - 7 days, asOf)
+prior1:  [asOf - 14 days, asOf - 7 days)
+prior2:  [asOf - 21 days, asOf - 14 days)
+prior3:  [asOf - 28 days, asOf - 21 days)
+```
+
+For each window:
+
+- `eligibleCount` = currently eligible items whose context-evaluation timestamp lies in the window.
+- `referencedCount` = those items with at least one valid, non-self prior-context reference.
+- `percentage` = `round(referencedCount / eligibleCount * 100, 1)`.
+- If `eligibleCount == 0`, `percentage` is `null`, not `0.0`; “no observations” must not look like measured zero reuse.
+
+The headline is the current window’s percentage. JSON stores counts alongside percentages so every value is auditable. Markdown shows `—` for `null`.
+
+### Fixed operator-note decision table
+
+A note is selected only when all four percentages are non-null and `< 25.0`. The artifact stores the stable note ID and exact text; no LLM or generated prose is involved.
+
+| Priority | Note ID | Inspectable predicate | Fixed text |
+|---|---|---|---|
+| 1 | `corpus_too_small` | Corpus index has fewer than 25 valid documents | `The indexed corpus is still too small to treat a low reuse rate as diagnostic. Keep collecting reviewed material, then reassess after four measurable weeks.` |
+| 2 | `retrieval_path_may_be_broken` | Established corpus (≥25 documents), at least 10 eligible items across the four windows, and `referencedCount == 0` across all four | `The corpus is established but no eligible bookmark recorded prior context in four measurable weeks. Check the retrieval and state-recording path before interpreting this as unrelated intake.` |
+| 3 | `mostly_unrelated_intake` | All other all-four-low cases | `Prior context is being recorded, but fewer than one in four eligible bookmarks reused it in every measured week. Most recent bookmarks may be unrelated to the existing corpus; inspect matched terms and topic mix before changing retrieval.` |
+
+The constants (`25` corpus documents, `10` four-week eligible items, `25.0%` low threshold) live once in the calculator module, are emitted under `decisionPolicy` in JSON, and are documented in the runbook. Changing them is a reviewed code/config change, never prose editing at runtime.
+
+### JSON artifact
+
+Canonical machine-readable path: `brain/state/compounding-signal.json`.
+
+Proposed schema (`schemaVersion: 1`):
+
+```json
+{
+  "schemaVersion": 1,
+  "runId": "2026-08-17T20:15:00Z",
+  "generatedAt": "2026-08-17T20:15:00Z",
+  "asOf": "2026-08-17T20:15:00Z",
+  "headlinePercentage": 37.5,
+  "currentWindow": {
+    "start": "2026-08-10T20:15:00Z",
+    "end": "2026-08-17T20:15:00Z",
+    "eligibleCount": 8,
+    "referencedCount": 3,
+    "percentage": 37.5,
+    "dossierPromotionCount": 2
+  },
+  "trend": [
+    {
+      "offsetWeeks": 0,
+      "start": "2026-08-10T20:15:00Z",
+      "end": "2026-08-17T20:15:00Z",
+      "eligibleCount": 8,
+      "referencedCount": 3,
+      "percentage": 37.5
+    }
+  ],
+  "operatorNote": null,
+  "decisionPolicy": {
+    "lowPercentageBelow": 25.0,
+    "corpusEstablishedDocuments": 25,
+    "minimumFourWeekEligibleItemsForBrokenPath": 10
+  },
+  "inputs": {
+    "bookmarkState": { "path": "brain/state/bookmark-review-state.json", "observedModifiedAt": "..." },
+    "corpusIndex": { "path": "brain/state/index/bookmark-corpus-index.jsonl", "documentCount": 42 },
+    "dossierPromotions": { "path": "<final upstream contract>", "eventCount": 2 }
+  }
+}
+```
+
+`trend` always contains exactly four entries ordered current to oldest. The implementation validates finite percentages, count relationships, timestamp ordering, the four-window count, known note IDs, and `headlinePercentage == trend[0].percentage` before publish.
+
+### Markdown artifact
+
+Human-readable path: `brain/state/compounding-signal.md`. It is rendered from the validated JSON model and contains:
+
+- headline percentage and generated timestamp;
+- a four-row trend table with dates, numerator, denominator, and percentage;
+- current dossier-promotion count;
+- operator note ID/text when selected;
+- input paths and policy thresholds for inspection;
+- the manual command pointer from the runbook.
+
+JSON is the dashboard source of truth. Markdown is an operator rendering and must carry the same `runId`.
+
+### Publication and failure semantics
+
+The command computes and validates entirely in memory, writes both outputs to sibling temporary files, fsyncs them, then replaces the destination files. Existing destinations are retained as rollback copies until both replacements succeed. On any parse, compute, validation, or write error, the command exits non-zero, restores the prior pair if replacement had started, and prints one structured JSON error to stderr without touching upstream inputs.
+
+The successful artifact itself is never rewritten to say “stale.” Staleness is a read-time condition: the UI marks a valid artifact stale when `generatedAt` is more than 8 days old (weekly cadence plus one-day grace). Therefore a failed weekly run naturally leaves the previous valid value visible and stale; it never blocks or mutates another pipeline stage.
+
+## Implementation plan
+
+### Calculator and artifacts
+
+- **`agents/workflows/bookmarks/scripts/compute_compounding_signal.py`** (new)
+  - Python standard library only, matching the repo’s workflow-glue precedent.
+  - Resolves the workspace from `--workspace-root`, then `WORKSPACE_ROOT`; no checked-in absolute path.
+  - CLI flags: `--workspace-root`, `--as-of`, input/output path overrides, `--dry-run`, and `--json`.
+  - Pure functions for state normalization, windowing, percentage calculation, dossier event dedupe, note selection, schema validation, and Markdown rendering.
+  - `--dry-run` reads and validates all inputs and prints the candidate JSON without publishing.
+- **`agents/workflows/bookmarks/scripts/tests/test_compute_compounding_signal.py`** (new)
+  - Temporary fixture workspace only; no live brain dependency.
+  - Covers boundary timestamps, state eligibility, null windows, one-decimal rounding, non-self references, promotion dedupe, each note branch, malformed inputs, unknown states, deterministic Markdown, rollback, dry-run, and input-byte immutability.
+- **`brain/state/compounding-signal.json` and `.md`**
+  - Runtime outputs outside the repo, not committed.
+  - The first production artifact is created only after upstream contracts and cron registration are ready.
+
+The signal is a separate command, not a step in `agents/workflows/bookmarks/bookmarks.lobster.yaml`. The lobster runs more frequently than weekly and contains an approval pause; coupling the signal to it would make cadence and failure isolation worse. The signal remains downstream of the pipeline by reading its successful artifacts.
+
+### Mission Control adapter and KPI
+
+- **`apps/mission-control/vite.config.js`** (modify)
+  - Add `GET /api/compounding-signal` to the existing dev-only `brainStateApi` plugin.
+  - Missing file returns `404` (so missing is distinguishable from a valid empty signal); malformed JSON returns `500` without crashing Vite.
+- **`apps/mission-control/src/bookmarkStateSource.js`** (modify)
+  - Add an optional signal fetch and schema parser.
+  - Return `compoundingSignal` plus `compoundingSignalStatus: valid | missing | malformed` without converting an optional signal failure into failure of bookmark state/transitions.
+  - Abort signal is forwarded to all fetch calls (correcting the currently unused `signal` parameter while this module is touched).
+- **`apps/mission-control/src/compoundingSignal.js`** (new)
+  - Pure schema validation, staleness (`generatedAt + 8 days`), color band, and subtitle helpers.
+  - Bands: green `≥ 50.0`, amber `25.0–49.9`, red `< 25.0`; null/missing has neutral styling.
+- **`apps/mission-control/src/tabs/BookmarksKpiRow.jsx`** (modify)
+  - Render the Compounding tile first, then existing state-count cards.
+  - Valid: headline, semantic color, short subtitle (`<referenced>/<eligible> referenced · <n> dossier promotions`), and a stale marker when applicable.
+  - Missing or malformed: `—` plus `Signal unavailable`; malformed may include an accessible title/diagnostic without dumping raw JSON.
+  - The operator note remains in the artifacts/runbook; it is not expanded into a new dashboard panel in this slice.
+- **`apps/mission-control/src/tabs/BookmarksTab.jsx`** (modify)
+  - Pass signal state into the KPI row; a signal fetch problem does not replace the whole tab with its global error card.
+- **`apps/mission-control/src/styles/components.css`** (modify)
+  - Add semantic green/amber/red/neutral tile modifiers using existing design tokens; no new opaque palette.
+- **Tests**
+  - Extend `bookmarkStateSource.test.js`, add `compoundingSignal.test.js`, and extend `BookmarksTab.test.jsx` for valid bands, missing placeholder, malformed placeholder, stale marker, subtitle, and independent failure semantics.
+
+### Versioned documentation
+
+- **`docs/systems/bookmark-workflow.md`** (modify on implementation)
+  - Add the signal as a downstream read-only observability consumer, its input/output contracts, cadence boundary, and failure semantics.
+- **`apps/mission-control/SPEC.md`** (modify on implementation)
+  - Add the Compounding KPI behavior and fallback states to the Bookmarks flow/screen and test-coverage list.
+- **`docs/runbooks/bookmark-compounding-signal.md`** (new)
+  - Versioned operator runbook covering manual dry-run/publish commands; health by maturity stage; established-corpus target `≥35%` after four measurable weeks; thresholds; and missing, stale, malformed diagnosis/recovery.
+  - “Early” health is data coverage rather than a target percentage; “measuring” health is four non-null windows; “established” health is `≥35%` with four measured weeks and an established corpus.
+- **`agents/crons/prompts/bookmark-compounding-signal.md`** (new)
+  - Runs the exact calculator command, validates its structured result, says `NO_REPLY` on success, and includes the mandatory `notify-soft-fails` block. It never invokes another bookmark pipeline stage.
+
+## Workflow, cron, and `.openclaw` boundary
+
+Repo code cannot register OpenClaw cron metadata or write the runtime brain artifacts during implementation. Post-merge handoff is therefore required:
+
+1. Inspect existing cron state first; do not create a duplicate job.
+2. Register one isolated weekly job pointing to `agents/crons/prompts/bookmark-compounding-signal.md`.
+3. Recommended schedule: Monday 08:15 `Pacific/Auckland` (`15 8 * * 1` with explicit timezone), after ordinary overnight bookmark work and away from existing exact-hour jobs.
+4. Run the command manually once, inspect the JSON/Markdown pair, and verify the Pulse tile.
+5. Add a short index entry to workspace `infra/RUNBOOKS.md` pointing to the versioned repo runbook, or add a workspace-specific companion only if Lox requires host recovery detail that does not belong in the repository.
+6. Record the handoff through the feature workflow’s supported OpenClaw-needed/done mechanism; do not claim AC5 complete until the registered job is visible and a successful run is evidenced.
+
+No secrets, ports, gateway restart, service restart, or new `.openclaw` config keys are required. Cron creation is external state and must be explicitly reviewed/applied after the implementation merges.
+
+## Test plan
+
+### Automated gates
+
+- Python: `python3 -m unittest discover -s agents/workflows/bookmarks/scripts/tests -p 'test_compute_compounding_signal.py'`
+- Mission Control targeted tests: `npm --workspace @sindustries/mission-control test -- --run src/compoundingSignal.test.js src/bookmarkStateSource.test.js src/tabs/BookmarksTab.test.jsx`
+- Mission Control full tests: `npm --workspace @sindustries/mission-control test -- --run`
+- Build: `npm --workspace @sindustries/mission-control run build`
+- File/doc assertions: frontmatter valid; runbook, system doc, app spec, and cron prompt links resolve; no absolute local path is introduced.
+- Read-only proof: calculator integration test hashes every fixture input before/after successful, dry-run, malformed, and simulated-publication-failure paths.
+
+### Acceptance-criterion verification matrix
+
+| AC | Verification | Layer |
+|---|---|---|
+| AC1 — weekly JSON + Markdown with headline, four windows, current promotions | Calculator fixture asserts schema, exactly four ordered windows, promotion count, shared run ID, and deterministic Markdown; post-merge cron evidence proves weekly registration | Unit + file + OpenClaw/manual |
+| AC2 — eligible-state numerator/denominator and one decimal | Table-driven tests cover every allowed/excluded state, task-linked effective state, window boundaries, missing/empty refs, duplicate/self refs, and rounding | Unit |
+| AC3 — closed low-trend decision table | One fixture per note ID plus threshold boundary cases; schema rejects unknown note IDs and generated prose | Unit |
+| AC4 — KPI, bands, subtitle, missing placeholder | Vitest renders valid percentages at 24.9/25.0/49.9/50.0, subtitle, and missing/malformed placeholders | Component |
+| AC5 — weekly, read-only, non-blocking, previous value stale | Input hash/rollback tests; adapter tests prove signal failure does not fail bookmark state; stale-age tests; post-merge cron registration and forced-failure smoke | Unit + integration + OpenClaw/manual |
+| AC6 — manual trigger, maturity health, three failure cases | Runbook file review plus commands exercised against valid/missing/stale/malformed temporary artifacts | File + manual |
+| AC7 — downstream draft dependencies remain revisable | Adapter boundaries and dependency section reviewed against the final upstream specs before enablement; no upstream writes/imports; contract-drift fixtures fail closed | Design/file + unit |
+
+Pulse’s Playwright suite remains deferred in `apps/mission-control/SPEC.md`; starting a new browser harness for one read-only tile is disproportionate. Component tests cover the complete visible state matrix, while a post-merge manual smoke covers the real workspace adapter and cron-produced artifact.
+
+## Rollout and rollback
+
+1. Merge calculator/UI/docs with the cron unregistered.
+2. Confirm final upstream contracts and run `--dry-run` against live workspace data.
+3. Publish once manually; validate both artifacts and the tile.
+4. Register the weekly cron and observe its first scheduled success.
+
+Rollback is to disable/remove only the signal cron registration, then revert the implementation PR. Existing signal files may remain as historical derived artifacts or be moved to trash after operator approval. No upstream data or database rollback is needed. If the calculator fails, preserve the last successful pair while investigating.
+
+## Open questions and risks
+
+1. **Dossier promotion timestamp contract is missing (requires Tom/Quinn decision or upstream revision).** The evidence-layer draft describes promoted claims and run receipts but no machine-readable promotion event/timestamp. Recommendation: revise that upstream spec to expose stable `{ eventId, topic, promotedAt, source }` records. Do not infer promotions from Markdown or filesystem mtime.
+2. **Final prior-context timestamp/field contract is not shipped.** This design proposes context-evaluation time plus `priorContextRefs`; implementation must map to the final knowledge-base artifact instead of locking the draft names into metric code.
+3. **Cohort semantics need explicit approval.** Recommendation: current effective eligible state + context-evaluation timestamp, with `ingested` excluded and zero-denominator windows represented as `null`. This is auditable and avoids counting an item more than once, but the product spec does not name the timestamp.
+4. **Decision-table sample thresholds are product policy.** This design recommends corpus established at 25 documents and a 10-item four-week floor for “retrieval path may be broken.” Tom/Quinn should confirm those constants during design approval; changing them later is straightforward and versioned.
+5. **Workspace artifacts are outside Git.** Runtime output, cron metadata, and `infra/RUNBOOKS.md` cannot be completed by the implementation PR alone. The task must retain an explicit OpenClaw handoff until cron registration and the first artifact are verified.
+6. **Production Pulse still depends on an external bookmark-state base URL.** The current Vite adapter is dev-only; this feature follows that shipped boundary rather than creating a new backend. If Pulse moves to hosted production, all bookmark state—including this signal—needs a bookmark-domain read service, not Tasks API.

--- a/docs/systems/bookmark-workflow.md
+++ b/docs/systems/bookmark-workflow.md
@@ -320,11 +320,54 @@ never raised, so the JSONL path is unaffected.
 
 ---
 
+## Compounding Signal (read-only observability)
+
+The compounding signal answers the operator's first question — "are we
+compounding yet?" — with one number per week, a four-week trend, and the
+current week's dossier-promotion count. It is a derived read-only
+observer of existing pipeline artifacts; it never writes to or imports
+the bookmark state machine, the approval workflow, the lobster dispatch,
+or the task creation path.
+
+- **Inputs:**
+  - `brain/state/bookmark-review-state.json` (the existing authoritative state file).
+  - `brain/state/index/bookmark-corpus-index.jsonl` (the corpus index from
+    the knowledge-base spec; missing file is treated as empty corpus).
+  - `brain/state/dossier-promotions.jsonl` (the promotion event log from
+    the evidence-layer spec; missing file is treated as zero events).
+- **Outputs:**
+  - `brain/state/compounding-signal.json` (machine-readable; canonical for the dashboard).
+  - `brain/state/compounding-signal.md` (deterministic operator rendering;
+    shares `runId` with the JSON).
+- **Calculator:** `agents/workflows/bookmarks/scripts/compute_compounding_signal.py` (Python
+  standard library only; no other workflow imports).
+- **Tests:** `agents/workflows/bookmarks/scripts/tests/test_compute_compounding_signal.py` (51 tests).
+- **Pulse consumer:** the `Compounding % (7d)` KPI tile in the Bookmarks tab.
+  The tile reads `/api/compounding-signal` (Vite dev plugin) and renders
+  one of four bands (green ≥ 50%, amber 25-49%, red < 25%, neutral for
+  null/missing/malformed). A stale marker appears when `generatedAt` is
+  more than 8 days old; the dashboard never blocks another pipeline
+  stage on a signal failure.
+- **Cadence:** weekly cron (Monday 08:15 `Pacific/Auckland`). The cron
+  prompt lives at `agents/crons/prompts/bookmark-compounding-signal.md`.
+- **Operator runbook:** `docs/runbooks/bookmark-compounding-signal.md`.
+- **Tech design:** `docs/specs/compounding-signal-for-bookmark-pipeline-tech-design.md`.
+
+The signal is downstream of three draft specs (knowledge-base metadata,
+evidence-layer dossier promotion, prior-context references). If any of
+those drafts is declined or revised, this section needs a follow-up
+revision and the calculator's adapter boundaries may need to change.
+The dashboard tile itself does not write or import any of those
+upstream contracts.
+
+---
+
 ## Related
 
 - Task: `b179c0e3-c6b0-4c9d-97dc-982d3b841783` — Bookmark pipeline analytics — Postgres transition log
 - Task: `a5a4ed8f-e7c4-4b6c-8ac9-bb962211ac44` — spec folder lifecycle and lobster sync
 - Task: `55ac9240-d54a-4b2c-88c4-8bb8af85d2b2` — Bookmark approval: tweet at original X author when tasked (this PR)
+- Task: `faf260e9-fe7b-4ce5-86ba-e47acab0ddb3` — Compounding signal for the bookmark pipeline
 - PR: https://github.com/Stoffer-Industries/sindustries/pull/216
 - PR: https://github.com/Stoffer-Industries/sindustries/pull/236 (Sankey + states-over-time + retire tools dashboard tech design)
 - Tech design: `docs/specs/bookmark-pipeline-analytics-postgres-transition-log-tech-design.md`


### PR DESCRIPTION
## Summary

Adds the bookmark pipeline **Compounding % (7d)** KPI: a weekly prior-context reuse percentage, its four-week trend, and the current week's dossier-promotion count, surfaced on the Pulse Bookmarks tab. The signal is a derived read-only observer of existing pipeline artifacts; it never writes to or imports the bookmark state machine, the approval workflow, the lobster dispatch, or task creation.

- `agents/workflows/bookmarks/scripts/compute_compounding_signal.py` — Python stdlib calculator. Reads `bookmark-review-state.json`, `bookmark-corpus-index.jsonl`, and `dossier-promotions`. Writes `brain/state/compounding-signal.{json,md}` atomically. 51 unit tests.
- `apps/mission-control/vite.config.js` — adds `GET /api/compounding-signal` (404 missing, 500 malformed).
- `apps/mission-control/src/compoundingSignal.js` + `BookmarksKpiRow.jsx` — pure helpers (schema, staleness, band, subtitle) + the CompoundingTile component. 31 component tests.
- `apps/mission-control/src/bookmarkStateSource.js` — parallel fetch (state, transitions, signal); signal failure never blocks the rest of the tab.
- Versioned docs: `docs/runbooks/bookmark-compounding-signal.md`, `docs/systems/bookmark-workflow.md` Compounding Signal section, `apps/mission-control/SPEC.md` Compounding signal bullet, `agents/crons/prompts/bookmark-compounding-signal.md`.

The weekly cron is **not** registered in this PR; the runbook treats cron registration as an explicit post-merge OpenClaw handoff. No secrets, ports, gateway restart, or new `.openclaw` config keys are required.

## Test plan

- [x] Python: `python3 -m unittest discover -s agents/workflows/bookmarks/scripts/tests -p 'test_compute_compounding_signal.py'` (51 tests).
- [x] Mission Control targeted: `npm --workspace @sindustries/mission-control test -- --run src/compoundingSignal.test.js src/bookmarkStateSource.test.js src/tabs/BookmarksTab.test.jsx src/tabs/BookmarksKpiRow.test.jsx` (55 tests across 4 files).

## Acceptance Criteria

- [x] AC1: A weekly "compounding signal" artifact is produced that contains: a headline prior-context percentage for the last 7 days, the same percentage for each of the preceding three 7-day windows (a 4-week trend), and a dossier-promotion count for the current 7-day window. The artifact is available in both a human-readable markdown form and a machine-readable JSON form. (🧪 testID: ComputeCompoundingSignal.MarkdownRenderTests + compute_compounding_signal.py::build_signal)
- [x] AC2: The headline percentage is calculated as: count of items currently in pipeline states that record prior-context references, divided by the total count of items in those same states, expressed as a percentage with one decimal place. Pipeline states counted are the ones that represent active items in review, spec dispatch, approval, or done states. (🧪 testID: ComputeCompoundingSignal.TrendWindowTests)
- [x] AC3: When the prior-context percentage is below 25% for all four weeks of the trend window, the signal artifact includes a one-paragraph operator note chosen from a small fixed decision table (e.g., "corpus is too small to measure," "retrieval path may be broken," "most new bookmarks are unrelated to the existing corpus"). Notes are picked from a closed set, not free-form prose, so the signal stays inspectable. (🧪 testID: ComputeCompoundingSignal.OperatorNoteTests)
- [x] AC4: The existing bookmark pipeline dashboard gains one new KPI tile — "Compounding % (7d)" — sourced from the new signal artifact. The tile shows the headline percentage with a colour value (green ≥ 50%, amber 25–49%, red < 25%) and a short subtitle. If the artifact is missing, the tile shows a placeholder and the runbook covers that case. (🧪 testID: BookmarksKpiRow.test.jsx band, placeholder, subtitle, stale, independent-failure coverage)
- [x] AC5: The signal computation runs on a weekly schedule and is strictly read-only against all pipeline data sources. A run failure does not block any other pipeline stage; the tile simply shows the previous successful value with a stale marker. (🧪 testID: ComputeCompoundingSignal.InputImmutabilityTests + BookmarksKpiRow.test.jsx stale test + bookmarkStateSource independent-failure test)
- [x] AC6: A new runbook entry documents: how to trigger the signal manually, what "healthy" looks like at each pipeline maturity stage (target ≥ 35% once the corpus is established and at least 4 weeks of prior-context data exist), and the three failure cases (artifact missing, artifact stale, artifact malformed). (📄 not code: docs/runbooks/bookmark-compounding-signal.md)
- [x] AC7: The signal is intentionally downstream of three draft specs that have not yet shipped. If any of those drafts are declined or revised, this spec loses at least one input and needs a follow-up revision; the spec does not pre-commit to any specific implementation of those upstream artifacts. (📄 not code: docs/systems/bookmark-workflow.md Compounding Signal section + tech design dependency note)
