### PR TITLE
fix(tasks): stop legacy checkbox revoking spec approvals

### DIFF
--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -3573,6 +3573,7 @@ fn acceptance_criteria_text(text: &str) -> Vec<String> {
     let re = Regex::new(r"(?m)^\s*-\s*\[[ xX]\]\s+(.+)$").unwrap();
     re.captures_iter(text)
         .filter_map(|cap| cap.get(1).map(|m| m.as_str().trim().to_string()))
+        .filter(|criterion| criterion != "**Approved by Tom**")
         .collect()
 }
 
@@ -4242,6 +4243,17 @@ mod tests {
                 "a": { "second": 2, "first": 1 }
             })),
             br#"{"a":{"first":1,"second":2},"acceptanceCriteria":["AC2: Build the second thing","AC1: Build the first thing"],"z":"last"}"#
+        );
+    }
+
+    #[test]
+    fn legacy_approval_marker_is_not_an_acceptance_criterion() {
+        let with_marker = "- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it";
+        let without_marker = "## Acceptance Criteria\n- [ ] AC1: Build it";
+
+        assert_eq!(
+            acceptance_criteria_text(with_marker),
+            acceptance_criteria_text(without_marker)
         );
     }
 

--- a/services/tasks-api/src/routes/tasks/_spec.ts
+++ b/services/tasks-api/src/routes/tasks/_spec.ts
@@ -30,13 +30,9 @@ export function specChecksumForDescription(description) {
  * Return whether a proposed description changes the AC checksum already stored
  * on the task.
  *
- * Note: marker-only approval edits (e.g. Tom toggling the checked
- * `Approved by Tom` line in the task description) are intentionally detected
- * as drift here. Approval state is now structured
- * via `TaskApproval` rows; this function compares the canonical AC text only,
- * so a marker-only edit produces a different checksum and will be caught by
- * the SPEC_CHECKSUM_MISMATCH guard. Tom must re-issue the spec approval via
- * the structured endpoint after editing ACs, not by toggling the marker.
+ * Historical approval-marker lines are excluded by acceptanceCriteriaText.
+ * Approval state is structured via `TaskApproval` rows, so toggling a retired
+ * marker must not revoke an otherwise-current approval.
  */
 export function descriptionHasSpecDrift(task, description) {
   if (!task.specChecksum) return false;

--- a/services/tasks-api/src/routes/tasks/_validation.ts
+++ b/services/tasks-api/src/routes/tasks/_validation.ts
@@ -133,7 +133,12 @@ export function acceptanceCriteriaText(description) {
   const re = /^\s*-\s*\[[ xX]\]\s+(.+)$/gm;
   let match;
   while ((match = re.exec(description)) !== null) {
-    criteria.push(match[1].trim());
+    const text = match[1].trim();
+    // Historical task descriptions can still contain the retired approval
+    // checkbox. It is metadata, not an acceptance criterion, and toggling it
+    // must never change the product-spec checksum.
+    if (/^\*\*Approved by Tom\*\*$/.test(text)) continue;
+    criteria.push(text);
   }
   return criteria;
 }

--- a/services/tasks-api/test/read-endpoints.test.ts
+++ b/services/tasks-api/test/read-endpoints.test.ts
@@ -596,13 +596,11 @@ describe('tasks api endpoints', () => {
   it('PATCH /api/v1/tasks/:id does not revoke spec approval for marker-only edits', async () => {
     // Per task `e2aba106-e1f6-4faf-ad81-3e5bec1b4574` WS1: the marker is inert.
     // Toggling `- [x] **Approved by Tom**` → `- [ ] **Approved by Tom**` does
-    // not change the AC text (the regex captures `**Approved by Tom**` from
-    // both checkbox states), so the canonical checksum is identical and the
-    // drift guard does not fire. The stored checksum must reflect the actual
-    // AC list produced by the regex (which includes the marker line).
+    // not change the AC text because the retired marker is excluded from the
+    // canonical AC list in both states.
     const storedDescription = '- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it';
     const updatedDescription = '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it';
-    const checksum = checksumForAcceptanceCriteria(['**Approved by Tom**', 'AC1: Build it']);
+    const checksum = checksumForAcceptanceCriteria(['AC1: Build it']);
     prismaMock.task.findFirst
       .mockResolvedValueOnce(task({ description: storedDescription, specChecksum: checksum }))
       .mockResolvedValueOnce(task({ description: updatedDescription, specChecksum: checksum }));

--- a/services/tasks-api/test/tasksSpecChecksum.test.ts
+++ b/services/tasks-api/test/tasksSpecChecksum.test.ts
@@ -64,5 +64,8 @@ describe('descriptionHasSpecDrift', () => {
     });
     const uncheckedMarker = description.replace('- [x] **Approved by Tom**', '- [ ] **Approved by Tom**');
     expect(descriptionHasSpecDrift(task, uncheckedMarker)).toBe(false);
+    expect(specChecksumForDescription(description)).toBe(
+      specChecksumForDescription('## Outcome\n\n## Acceptance Criteria\n- [ ] AC1')
+    );
   });
 });


### PR DESCRIPTION
## Summary
- exclude the retired `Approved by Tom` description checkbox from Tasks API acceptance-criteria checksums
- keep the Rust feature-task checksum parser aligned
- add regression coverage on both surfaces

## Root cause
Historical task descriptions still contain the retired approval checkbox. The generic checkbox parser counted that metadata line as an acceptance criterion. After the structured approval endpoint updated the task, a subsequent description save recomputed a checksum that included the legacy marker and immediately revoked the approval.

## Validation
- `npm test -- --run test/tasksSpecChecksum.test.ts` — 4 passed
- `cargo test spec_checksum --manifest-path agents/workflows/feature-task/Cargo.toml` — 6 passed
- `cargo test legacy_approval_marker_is_not_an_acceptance_criterion --manifest-path agents/workflows/feature-task/Cargo.toml` — 1 passed
- `git diff --check` — clean

## Live repair
Task `55ac9240-d54a-4b2c-88c4-8bb8af85d2b2` was resynced to the checksum of its five real ACs. Tom can approve it once more; the stored checksum now matches the corrected canonical form.
