### PR TITLE
fix(tasks): reconcile gate avatars immediately on approval changes

### DIFF
--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -3573,6 +3573,7 @@ fn acceptance_criteria_text(text: &str) -> Vec<String> {
     let re = Regex::new(r"(?m)^\s*-\s*\[[ xX]\]\s+(.+)$").unwrap();
     re.captures_iter(text)
         .filter_map(|cap| cap.get(1).map(|m| m.as_str().trim().to_string()))
+        .filter(|criterion| criterion != "**Approved by Tom**")
         .collect()
 }
 
@@ -4242,6 +4243,17 @@ mod tests {
                 "a": { "second": 2, "first": 1 }
             })),
             br#"{"a":{"first":1,"second":2},"acceptanceCriteria":["AC2: Build the second thing","AC1: Build the first thing"],"z":"last"}"#
+        );
+    }
+
+    #[test]
+    fn legacy_approval_marker_is_not_an_acceptance_criterion() {
+        let with_marker = "- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it";
+        let without_marker = "## Acceptance Criteria\n- [ ] AC1: Build it";
+
+        assert_eq!(
+            acceptance_criteria_text(with_marker),
+            acceptance_criteria_text(without_marker)
         );
     }
 

--- a/services/tasks-api/src/config/workflowHandoffs.ts
+++ b/services/tasks-api/src/config/workflowHandoffs.ts
@@ -6,6 +6,25 @@ export const WORKFLOW_HANDOFF_ROLE_OWNERS = {
 
 export type WorkflowHandoffRoleId = keyof typeof WORKFLOW_HANDOFF_ROLE_OWNERS;
 
+export const APPROVAL_WORKFLOW_HANDOFFS = {
+  spec: {
+    roleId: 'product_spec_approver',
+    reason: 'Product spec approval is required'
+  },
+  tech_design: {
+    roleId: 'tech_design_approver',
+    reason: 'Tech design approval is required'
+  },
+  qa: {
+    roleId: 'qa_verifier',
+    reason: 'QA approval is required'
+  }
+} as const satisfies Record<string, { roleId: WorkflowHandoffRoleId; reason: string }>;
+
+export function workflowHandoffForApproval(type: string) {
+  return APPROVAL_WORKFLOW_HANDOFFS[type as keyof typeof APPROVAL_WORKFLOW_HANDOFFS] ?? null;
+}
+
 export const WORKFLOW_HANDOFF_ROLE_IDS = new Set<string>(
   Object.keys(WORKFLOW_HANDOFF_ROLE_OWNERS)
 );

--- a/services/tasks-api/src/routes/taskApprovals.ts
+++ b/services/tasks-api/src/routes/taskApprovals.ts
@@ -5,6 +5,8 @@ import { authorizeApprovalType, requireApprovalPrincipal, type ApprovalType } fr
 import { parseTaskId } from './tasks/_validation.ts';
 import { mapTaskApproval } from './tasks/_mapper.ts';
 import { validApprovalTypes } from './tasks/_constants.ts';
+import { loadRequiredApprovalsConfig, requiredApprovalsFor } from '../config/requiredApprovals.ts';
+import { workflowHandoffForApproval } from '../config/workflowHandoffs.ts';
 
 export const taskApprovalsRouter = Router();
 
@@ -23,6 +25,28 @@ function normalizeNote(value) {
 
 function immutableTask(res) {
   return sendError(res, 409, 'TASK_IMMUTABLE', 'Approvals cannot be changed on an archived or done task');
+}
+
+function approvalHandoffUpdate(task, type: ApprovalType, action: 'approved' | 'revoked') {
+  const handoff = workflowHandoffForApproval(type);
+  if (!handoff) return null;
+
+  if (action === 'approved') {
+    if (task.workflowHandoffGate !== type) return null;
+    return {
+      workflowHandoffRoleId: null,
+      workflowHandoffGate: null,
+      workflowHandoffReason: null
+    };
+  }
+
+  const required = requiredApprovalsFor(loadRequiredApprovalsConfig(), task.taskType);
+  if (!required.includes(type)) return null;
+  return {
+    workflowHandoffRoleId: handoff.roleId,
+    workflowHandoffGate: type,
+    workflowHandoffReason: handoff.reason
+  };
 }
 
 export function approvalAuditBody(type: ApprovalType, action: 'approved' | 'revoked', actor: string) {
@@ -57,11 +81,24 @@ taskApprovalsRouter.post('/tasks/:id/approvals', requireApprovalPrincipal, async
     const actor = req.approvalPrincipal!.actor;
 
     const result = await prisma.$transaction(async (tx) => {
-      const task = await tx.task.findUnique({ where: { id }, select: { id: true, status: true, archivedAt: true } });
+      const task = await tx.task.findUnique({
+        where: { id },
+        select: {
+          id: true,
+          status: true,
+          archivedAt: true,
+          taskType: true,
+          workflowHandoffRoleId: true,
+          workflowHandoffGate: true,
+          workflowHandoffReason: true
+        }
+      });
       if (!task) return { kind: 'missing' } as const;
       if (task.archivedAt || task.status === 'done') return { kind: 'immutable' } as const;
       const existing = await tx.taskApproval.findUnique({ where: { taskId_type: { taskId: id, type } } });
       if (existing?.state === 'approved' && existing.owner === actor && existing.note === note) {
+        const handoffUpdate = approvalHandoffUpdate(task, type, 'approved');
+        if (handoffUpdate) await tx.task.update({ where: { id }, data: handoffUpdate });
         return { kind: 'approval', approval: existing } as const;
       }
       const now = new Date();
@@ -70,6 +107,8 @@ taskApprovalsRouter.post('/tasks/:id/approvals', requireApprovalPrincipal, async
         create: { taskId: id, type, owner: actor, note, state: 'approved', approvedAt: now },
         update: { owner: actor, note, state: 'approved', approvedAt: now, revokedAt: null }
       });
+      const handoffUpdate = approvalHandoffUpdate(task, type, 'approved');
+      if (handoffUpdate) await tx.task.update({ where: { id }, data: handoffUpdate });
       await tx.taskComment.create({ data: { taskId: id, author: actor, body: approvalAuditBody(type, 'approved', actor) } });
       return { kind: 'approval', approval } as const;
     });
@@ -89,15 +128,34 @@ taskApprovalsRouter.delete('/tasks/:id/approvals/:type', requireApprovalPrincipa
     const actor = req.approvalPrincipal!.actor;
 
     const result = await prisma.$transaction(async (tx) => {
-      const task = await tx.task.findUnique({ where: { id }, select: { id: true, status: true, archivedAt: true } });
+      const task = await tx.task.findUnique({
+        where: { id },
+        select: {
+          id: true,
+          status: true,
+          archivedAt: true,
+          taskType: true,
+          workflowHandoffRoleId: true,
+          workflowHandoffGate: true,
+          workflowHandoffReason: true
+        }
+      });
       if (!task) return { kind: 'missing' } as const;
       if (task.archivedAt || task.status === 'done') return { kind: 'immutable' } as const;
       const existing = await tx.taskApproval.findUnique({ where: { taskId_type: { taskId: id, type } } });
-      if (!existing || existing.state === 'revoked') return { kind: 'approval', approval: existing ?? null } as const;
+      if (!existing || existing.state === 'revoked') {
+        if (existing?.state === 'revoked') {
+          const handoffUpdate = approvalHandoffUpdate(task, type, 'revoked');
+          if (handoffUpdate) await tx.task.update({ where: { id }, data: handoffUpdate });
+        }
+        return { kind: 'approval', approval: existing ?? null } as const;
+      }
       const approval = await tx.taskApproval.update({
         where: { taskId_type: { taskId: id, type } },
         data: { state: 'revoked', revokedAt: new Date() }
       });
+      const handoffUpdate = approvalHandoffUpdate(task, type, 'revoked');
+      if (handoffUpdate) await tx.task.update({ where: { id }, data: handoffUpdate });
       await tx.taskComment.create({ data: { taskId: id, author: actor, body: approvalAuditBody(type, 'revoked', actor) } });
       return { kind: 'approval', approval } as const;
     });

--- a/services/tasks-api/src/routes/tasks/_spec.ts
+++ b/services/tasks-api/src/routes/tasks/_spec.ts
@@ -30,13 +30,9 @@ export function specChecksumForDescription(description) {
  * Return whether a proposed description changes the AC checksum already stored
  * on the task.
  *
- * Note: marker-only approval edits (e.g. Tom toggling the checked
- * `Approved by Tom` line in the task description) are intentionally detected
- * as drift here. Approval state is now structured
- * via `TaskApproval` rows; this function compares the canonical AC text only,
- * so a marker-only edit produces a different checksum and will be caught by
- * the SPEC_CHECKSUM_MISMATCH guard. Tom must re-issue the spec approval via
- * the structured endpoint after editing ACs, not by toggling the marker.
+ * Historical approval-marker lines are excluded by acceptanceCriteriaText.
+ * Approval state is structured via `TaskApproval` rows, so toggling a retired
+ * marker must not revoke an otherwise-current approval.
  */
 export function descriptionHasSpecDrift(task, description) {
   if (!task.specChecksum) return false;

--- a/services/tasks-api/src/routes/tasks/_validation.ts
+++ b/services/tasks-api/src/routes/tasks/_validation.ts
@@ -133,7 +133,12 @@ export function acceptanceCriteriaText(description) {
   const re = /^\s*-\s*\[[ xX]\]\s+(.+)$/gm;
   let match;
   while ((match = re.exec(description)) !== null) {
-    criteria.push(match[1].trim());
+    const text = match[1].trim();
+    // Historical task descriptions can still contain the retired approval
+    // checkbox. It is metadata, not an acceptance criterion, and toggling it
+    // must never change the product-spec checksum.
+    if (/^\*\*Approved by Tom\*\*$/.test(text)) continue;
+    criteria.push(text);
   }
   return criteria;
 }

--- a/services/tasks-api/test/read-endpoints.test.ts
+++ b/services/tasks-api/test/read-endpoints.test.ts
@@ -596,13 +596,11 @@ describe('tasks api endpoints', () => {
   it('PATCH /api/v1/tasks/:id does not revoke spec approval for marker-only edits', async () => {
     // Per task `e2aba106-e1f6-4faf-ad81-3e5bec1b4574` WS1: the marker is inert.
     // Toggling `- [x] **Approved by Tom**` → `- [ ] **Approved by Tom**` does
-    // not change the AC text (the regex captures `**Approved by Tom**` from
-    // both checkbox states), so the canonical checksum is identical and the
-    // drift guard does not fire. The stored checksum must reflect the actual
-    // AC list produced by the regex (which includes the marker line).
+    // not change the AC text because the retired marker is excluded from the
+    // canonical AC list in both states.
     const storedDescription = '- [x] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it';
     const updatedDescription = '- [ ] **Approved by Tom**\n\n## Acceptance Criteria\n- [ ] AC1: Build it';
-    const checksum = checksumForAcceptanceCriteria(['**Approved by Tom**', 'AC1: Build it']);
+    const checksum = checksumForAcceptanceCriteria(['AC1: Build it']);
     prismaMock.task.findFirst
       .mockResolvedValueOnce(task({ description: storedDescription, specChecksum: checksum }))
       .mockResolvedValueOnce(task({ description: updatedDescription, specChecksum: checksum }));

--- a/services/tasks-api/test/taskApprovals.test.ts
+++ b/services/tasks-api/test/taskApprovals.test.ts
@@ -25,7 +25,15 @@ const TASK_ID = '11111111-1111-1111-1111-111111111111';
 const TOM_TOKEN = 'tom-service-token-long-enough';
 const QUINN_TOKEN = 'quinn-service-token-long-enough';
 const TOM_SESSION = 'tom-browser-session-long-enough';
-const activeTask = { id: TASK_ID, status: 'ready', archivedAt: null };
+const activeTask = {
+  id: TASK_ID,
+  status: 'ready',
+  archivedAt: null,
+  taskType: 'feature',
+  workflowHandoffRoleId: null,
+  workflowHandoffGate: null,
+  workflowHandoffReason: null
+};
 function approval(overrides = {}) { return { id: 'a1', taskId: TASK_ID, type: 'spec', owner: 'Tom', state: 'approved', approvedAt: new Date('2026-08-08T04:00:00Z'), revokedAt: null, note: null, createdAt: new Date(), updatedAt: new Date(), ...overrides }; }
 function auth(token = TOM_TOKEN) { return { Authorization: `Bearer ${token}` }; }
 
@@ -86,6 +94,48 @@ describe('task approval boundary', () => {
     expect(prismaMock.taskComment.create).toHaveBeenCalledWith({ data: { taskId: TASK_ID, author: 'Tom', body: 'Approval spec approved by Tom.' } });
   });
 
+  it('clears a matching workflow handoff in the approval transaction', async () => {
+    prismaMock.task.findUnique.mockResolvedValue({
+      ...activeTask,
+      workflowHandoffRoleId: 'product_spec_approver',
+      workflowHandoffGate: 'spec',
+      workflowHandoffReason: 'Product spec approval is required'
+    });
+    prismaMock.taskApproval.findUnique.mockResolvedValue(null);
+    prismaMock.taskApproval.upsert.mockResolvedValue(approval());
+    prismaMock.task.update.mockResolvedValue({});
+    prismaMock.taskComment.create.mockResolvedValue({});
+
+    const res = await request(createApp()).post(`/api/v1/tasks/${TASK_ID}/approvals`).set(auth()).send({ type: 'spec' });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.task.update).toHaveBeenCalledWith({
+      where: { id: TASK_ID },
+      data: {
+        workflowHandoffRoleId: null,
+        workflowHandoffGate: null,
+        workflowHandoffReason: null
+      }
+    });
+  });
+
+  it('does not clear an unrelated workflow handoff when approving another gate', async () => {
+    prismaMock.task.findUnique.mockResolvedValue({
+      ...activeTask,
+      workflowHandoffRoleId: 'qa_verifier',
+      workflowHandoffGate: 'qa',
+      workflowHandoffReason: 'QA approval is required'
+    });
+    prismaMock.taskApproval.findUnique.mockResolvedValue(null);
+    prismaMock.taskApproval.upsert.mockResolvedValue(approval());
+    prismaMock.taskComment.create.mockResolvedValue({});
+
+    const res = await request(createApp()).post(`/api/v1/tasks/${TASK_ID}/approvals`).set(auth()).send({ type: 'spec' });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.task.update).not.toHaveBeenCalled();
+  });
+
   it('rolls back/surfaces failure when the audit insert fails', async () => {
     prismaMock.$transaction.mockRejectedValue(new Error('audit failed'));
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -104,6 +154,26 @@ describe('task approval boundary', () => {
     prismaMock.taskApproval.update.mockResolvedValue(approval({ state: 'revoked', revokedAt: new Date() })); prismaMock.taskComment.create.mockResolvedValue({});
     const res = await request(createApp()).delete(`/api/v1/tasks/${TASK_ID}/approvals/spec`).set(auth());
     expect(res.status).toBe(200); expect(prismaMock.taskComment.create).toHaveBeenCalledWith({ data: { taskId: TASK_ID, author: 'Tom', body: 'Approval spec revoked by Tom.' } });
+  });
+
+  it('restores the required workflow handoff in the revocation transaction', async () => {
+    prismaMock.task.findUnique.mockResolvedValue(activeTask);
+    prismaMock.taskApproval.findUnique.mockResolvedValue(approval());
+    prismaMock.taskApproval.update.mockResolvedValue(approval({ state: 'revoked', revokedAt: new Date() }));
+    prismaMock.task.update.mockResolvedValue({});
+    prismaMock.taskComment.create.mockResolvedValue({});
+
+    const res = await request(createApp()).delete(`/api/v1/tasks/${TASK_ID}/approvals/spec`).set(auth());
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.task.update).toHaveBeenCalledWith({
+      where: { id: TASK_ID },
+      data: {
+        workflowHandoffRoleId: 'product_spec_approver',
+        workflowHandoffGate: 'spec',
+        workflowHandoffReason: 'Product spec approval is required'
+      }
+    });
   });
 
   it.each([null, approval({ state: 'revoked', revokedAt: new Date() })])('DELETE is an idempotent no-op with no comment', async (existing) => {

--- a/services/tasks-api/test/tasksSpecChecksum.test.ts
+++ b/services/tasks-api/test/tasksSpecChecksum.test.ts
@@ -64,5 +64,8 @@ describe('descriptionHasSpecDrift', () => {
     });
     const uncheckedMarker = description.replace('- [x] **Approved by Tom**', '- [ ] **Approved by Tom**');
     expect(descriptionHasSpecDrift(task, uncheckedMarker)).toBe(false);
+    expect(specChecksumForDescription(description)).toBe(
+      specChecksumForDescription('## Outcome\n\n## Acceptance Criteria\n- [ ] AC1')
+    );
   });
 });


### PR DESCRIPTION
## Summary
- clear a matching workflow handoff atomically when its approval is checked
- restore the configured handoff atomically when a required approval is unchecked
- leave unrelated handoffs untouched
- let idempotent approval/revocation requests repair stale handoff state

## Why
Task-card avatars derive from `workflowHandoffRoleId`, while approval checkboxes mutate `TaskApproval`. Previously only Lobster reconciled those records, leaving the avatar stale until its next run.

## Validation
- `env -u CONTENT_SCHEDULER_INGEST_SECRET npm test` — 24 files, 328 tests passed
- focused `taskApprovals.test.ts` — 20 passed
- `git diff --check` — clean
