### PR TITLE
fix(feature-task): skip approved spec mutation

### DIFF
--- a/agents/workflows/feature-task/WORKFLOW.md
+++ b/agents/workflows/feature-task/WORKFLOW.md
@@ -47,11 +47,15 @@ for feature tasks. It then writes through the authenticated approval endpoint;
 the resulting `TaskApproval` row remains the sole workflow gate source.
 
 The sweep is idempotent: an already-approved row produces no API write or
-second audit comment. Unchecked markers, revoked API rows, missing or duplicate
-links, inaccessible files, code tasks, and specs outside the open task-spec
-directory never grant approval and are reported as diagnostics. A revoked API
-row is deliberately not re-approved from a stale checked marker because API
-state is authoritative.
+second audit comment. The per-task `spec-check` stage applies the same defensive
+guard before legacy brain-spec/task-description reconciliation: if any actor
+already owns an approved structured `spec` row, it skips that mutation entirely
+while continuing normal gate evaluation. This preserves approval ownership and
+avoids retrying the mutation with a principal that cannot own `spec` approval.
+Unchecked markers, revoked API rows, missing or duplicate links, inaccessible
+files, code tasks, and specs outside the open task-spec directory never grant
+approval and are reported as diagnostics. A revoked API row is deliberately not
+re-approved from a stale checked marker because API state is authoritative.
 
 The existing feature-task runner performs this reconciliation once per pass,
 so no separate cron is needed. Its environment must provide Tom's scoped

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -482,7 +482,11 @@ fn spec_check(args: StageArgs) -> Result<Envelope> {
             "[feature-task-blocked]",
         );
     }
-    if !args.dry_run {
+    // Structured approval is authoritative. Once any actor has an approved
+    // `spec` row, do not try to reconcile the legacy brain-spec path/marker:
+    // that mutation is both redundant and may run under a principal that is
+    // intentionally forbidden from owning spec approvals.
+    if !args.dry_run && !spec_check_should_skip_legacy_mutation(&env.task) {
         env = move_approved_chat_spec_if_needed(&args, env)?;
     }
     if is_past(&env.task, "open") {
@@ -952,6 +956,13 @@ fn task_approval_granted(task: &Task, approval_type: &str) -> bool {
     task.approvals
         .iter()
         .any(|a| a.approval_type == approval_type && a.state == "approved")
+}
+
+/// The structured approval row is the source of truth regardless of actor.
+/// Spec-check may still advance the task and snapshot its checksum, but must
+/// not rewrite the linked brain spec or task description after approval.
+fn spec_check_should_skip_legacy_mutation(task: &Task) -> bool {
+    task_approval_granted(task, "spec")
 }
 fn qa_ac_verified_structured(task: &Task) -> bool {
     task_approval_granted(task, "qa")
@@ -4139,6 +4150,31 @@ mod tests {
     //   AC3 (Rust unit tests cover both accept and reject cases):
     //     all seven tests above.
     //
+
+    #[test]
+    fn spec_check_skips_legacy_mutation_for_any_approved_spec_actor() {
+        let task = Task {
+            approvals: vec![TaskApproval {
+                approval_type: "spec".to_string(),
+                state: "approved".to_string(),
+                owner: Some("Quinn".to_string()),
+                ..TaskApproval::default()
+            }],
+            ..Task::default()
+        };
+
+        assert!(spec_check_should_skip_legacy_mutation(&task));
+    }
+
+    #[test]
+    fn spec_check_keeps_legacy_mutation_available_without_approved_spec() {
+        let task = Task {
+            approvals: vec![approval_row("spec", "revoked")],
+            ..Task::default()
+        };
+
+        assert!(!spec_check_should_skip_legacy_mutation(&task));
+    }
 
     #[test]
     fn spec_gate_accepts_structured_approval_row() {


### PR DESCRIPTION
## Summary
- make `spec-check` treat any existing approved structured `spec` row as authoritative and skip legacy brain-spec/task-description mutation entirely
- preserve normal gate evaluation and checksum transition behavior without changing approval principals or tokens
- document the idempotent boundary and cover approved versus revoked/missing behavior with focused unit tests

## System Spec
No system spec change — defensive workflow idempotency fix; the feature-task workflow guide documents the behavior.

## Test plan
- [x] Approved structured `spec` rows skip the legacy mutation regardless of owner.
- [x] Revoked or missing structured `spec` rows retain the existing reconciliation path.
- [x] Full feature-task Rust test suite passes (209 tests).
- [x] Feature-task clippy passes with warnings denied.

No cron wiring needed: the existing feature-task runner already invokes `spec-check` on each pass.
