### PR TITLE
chore(code-garden): refresh mission-control ADR + fix phantom W28 marker [2026-W28]

### DIFF
--- a/docs/repo-audits/2026-W28.md
+++ b/docs/repo-audits/2026-W28.md
@@ -190,7 +190,7 @@ Five themes explain every finding this week.
 
 ### Milestone 0 — Safety net
 
-- **M0.1 — Add an ADR (or `docs/systems/pulse-shell.md`) documenting the iframe embed choice.** Locks the decision in prose so H1 and M4 can be revisited against a written baseline instead of tribal knowledge. Files: new `docs/systems/pulse-shell.md`. Acceptance: doc exists, links from `apps/mission-control/SPEC.md`. S / low risk. (Theme 2.) ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+- **M0.1 — Add an ADR (or `docs/systems/pulse-shell.md`) documenting the iframe embed choice.** Locks the decision in prose so H1 and M4 can be revisited against a written baseline instead of tribal knowledge. Files: new `docs/systems/pulse-shell.md`. Acceptance: doc exists, links from `apps/mission-control/SPEC.md`. S / low risk. (Theme 2.) ✅ [PR #193](https://github.com/Stoffer-Industries/sindustries/pull/193) (originally added as `docs/systems/pulse-shell.md`; renamed to `docs/systems/mission-control.md` in `bcbc19a` along with the Pulse→Mission Control rename on 2026-07-25; ADR's "Known gaps → H1" refreshed to reflect current `VITE_TASKS_APP_URL` resolution in PR #442)
 - **M0.2 — Add a repo-level lint rule that fails on absolute `~/` or `/Users/` strings in `apps/`, `services/`, `packages/`, `agents/workflows/`.** A ripgrep-based `scripts/check-no-absolute-paths.mjs` invoked in CI. Prevents Theme 4 regressions before they enter the repo. Files: new script + one CI step. Acceptance: script rejects a synthesized offender; passes today post-fixes. S / low risk. (Theme 4.) ✅ [PR #381](https://github.com/Stoffer-Industries/sindustries/pull/381)
 
 ### Milestone 1 — Critical fixes

--- a/docs/systems/mission-control.md
+++ b/docs/systems/mission-control.md
@@ -114,21 +114,21 @@ oriented (the W27 SPEC's flow 1 contract).
 The W28 audit flagged two structural issues with the current
 implementation that are tracked but not yet fixed.
 
-### H1 — hard-coded Tasks-app iframe URL
+### H1 — hard-coded Tasks-app iframe URL (resolved for dev)
 
-`apps/mission-control/src/tabs/TasksTab.jsx:6-18` builds the iframe
-URL from `window.location.port` via a `localhost:517X` lookup table
-and falls back to `http://localhost:5173`. There is no `VITE_TASKS_APP_URL`
-override, no discussion of production deploy, and no same-origin /
-frame-ancestor policy. This blocks single-URL production deploy until
-either the Tasks app is built into the Mission Control bundle or both apps are
-fronted by a reverse proxy. **Quick win Q3 in the W28 task plan** —
-env override + corrected port map — addresses the dev-side ergonomics;
-production deploy remains a separate piece of work.
+The dev-side half of H1 (no `VITE_TASKS_APP_URL` override) was
+resolved by `8d19ac2 refactor(tasks): update tasks app URL handling to
+use environment variable` (Tue Jul 7 2026). The iframe URL is now
+derived from `import.meta.env.VITE_TASKS_APP_URL ?? 'http://localhost:5173'`
+(`apps/mission-control/src/tabs/TasksTab.jsx`), with the Tilt dev
+environment exporting the variable per `infra/tilt/Tiltfile`. The
+single-URL production deploy half of H1 (no reverse proxy or bundled
+mount in place today) remains open — see [Production](#production) for
+the option set.
 
 ### M4 — no sandbox, referrerpolicy, or CSP frame-ancestors
 
-`apps/mission-control/src/tabs/TasksTab.jsx:24-31` emits the iframe
+`apps/mission-control/src/tabs/TasksTab.jsx` emits the iframe
 without `sandbox`, `referrerpolicy`, or a CSP header story on the
 Tasks-app side. Once Tasks auth lands, the Tasks app inside Mission Control
 will share the parent origin's cookies. Even in the Tailnet case,


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W28.md
- **Finding 1:** M0.1 (Theme 2 — write `docs/systems/pulse-shell.md` ADR) was marked done with a phantom `✅ [PR #TBD]` placeholder; the actual work shipped as PR #193 (`docs(code-garden): add pulse-shell iframe ADR [2026-W28]`, merged 2026-07-07) and was later renamed to `docs/systems/mission-control.md` in `bcbc19a` (Pulse→Mission Control rename, 2026-07-25).
- **Finding 2:** [Theme 2] — mission-control ADR's "Known gaps → H1" section described a port-map iframe URL resolver (`localhost:517X` neighbour-port lookup) that no longer exists; commit `8d19ac2` (Tue Jul 7 2026) refactored `apps/mission-control/src/tabs/TasksTab.jsx` to derive the URL from `import.meta.env.VITE_TASKS_APP_URL ?? 'http://localhost:5173'` before the ADR was even written.
- **Change:** Audit marker now points at PR #193 with the rename history; ADR's H1 entry now describes the env-var resolution and notes the dev-side half is resolved while the production-deploy half remains open. M4 (sandbox/referrerpolicy/CSP) unchanged.

## System Spec
docs/systems/mission-control.md (refreshed — Known gaps → H1 now reflects current `TasksTab.jsx` env-var resolution).

## Test plan
- [ ] `git diff origin/main HEAD` shows only `docs/systems/mission-control.md` and `docs/repo-audits/2026-W28.md`
- [ ] No `agents/skills/` or `agents/crons/` files in the diff (scope guard)
- [ ] No logic changes — diff is purely docs bookkeeping

🌱 Code garden — non-functional cleanup only