### PR TITLE
fix(tasks-api): scope sourceRef uniqueness to CTO Craft

### DIFF
--- a/docs/systems/content-scheduler.md
+++ b/docs/systems/content-scheduler.md
@@ -86,11 +86,11 @@ Terminal statuses: `published`, `removed`. Items in `removed` are kept in the ta
 
 The `autoPost*` fields landed in migration `20260717000000_add_content_scheduler_auto_post_fields`.
 
-#### Partial unique index: `(source, sourceRef)`
+#### CTO Craft partial unique index: `(source, sourceRef)`
 
-A partial unique index on `(source, sourceRef)` (where `sourceRef IS NOT NULL`) was added in migration `20260813000000_add_content_scheduler_source_ref_unique`. PostgreSQL permits multiple `NULL` values, so manual rows with `NULL sourceRef` remain valid; only non-null `(source, sourceRef)` pairs must be unique within a source. The migration runs a preflight query and aborts with a clear operator message if any existing non-null pairs would collide — it never silently deletes or merges rows.
+A partial unique index on `(source, sourceRef)` (where `source = 'cto_craft' AND sourceRef IS NOT NULL`) was added in migration `20260813000000_add_content_scheduler_source_ref_unique`. It enforces one row per canonical article URL for CTO Craft imports while allowing other workflows, such as weekly `ops_notes` reviews, to create multiple candidates from one source reference. The migration runs a scoped preflight query and aborts with a clear operator message if existing CTO Craft pairs would collide — it never silently deletes or merges rows.
 
-This index is the **domain idempotency key** for source-ingestion workflows (currently CTO Craft). Re-running the same import is a no-op at the DB layer; `createMany({ skipDuplicates: true })` returns the actual insert count and the API surfaces `skippedDuplicateCount`.
+This index is the **domain idempotency key** for the CTO Craft ingestion workflow. Re-running the same import is a no-op at the DB layer; `createMany({ skipDuplicates: true })` returns the actual insert count and the API surfaces `skippedDuplicateCount`.
 
 ### Status state machine
 

--- a/services/tasks-api/prisma/migrations/20260813000000_add_content_scheduler_source_ref_unique/migration.sql
+++ b/services/tasks-api/prisma/migrations/20260813000000_add_content_scheduler_source_ref_unique/migration.sql
@@ -1,4 +1,4 @@
--- Migration: composite unique on (source, sourceRef) for ContentSchedulerItem.
+-- Migration: CTO Craft composite unique on (source, sourceRef) for ContentSchedulerItem.
 -- Task: 9dfe56e4-13c4-4bb4-b53f-de7c77afd0d2 (CTO Craft tweet-draft pipeline).
 --
 -- The CTO Craft LangGraph workflow imports tweet drafts in batches via
@@ -7,14 +7,14 @@
 -- response loss, must not create duplicate ContentSchedulerItem rows
 -- for the same article URL within the same source.
 --
--- PostgreSQL permits multiple NULL values in a unique column, so the
--- constraint only enforces uniqueness on non-null (source, sourceRef)
--- pairs. Existing manual rows with NULL sourceRef remain valid; only
--- non-null pairs must be unique within a source.
+-- This idempotency invariant is specific to CTO Craft: other ingestion
+-- sources may intentionally create multiple candidate rows from one sourceRef.
+-- PostgreSQL permits multiple NULL values in a unique column, and the partial
+-- predicate also excludes every source other than cto_craft.
 --
--- Preflight: abort the migration with a clear operator message if any
--- existing non-null (source, sourceRef) pairs would collide. We never
--- silently delete or merge rows.
+-- Preflight: abort the migration with a clear operator message if existing
+-- non-null CTO Craft sourceRef values would collide. We never silently delete
+-- or merge rows.
 
 DO $$
 DECLARE
@@ -24,16 +24,18 @@ BEGIN
     FROM (
         SELECT "source", "sourceRef"
         FROM "ContentSchedulerItem"
-        WHERE "sourceRef" IS NOT NULL
+        WHERE "source" = 'cto_craft'
+          AND "sourceRef" IS NOT NULL
         GROUP BY "source", "sourceRef"
         HAVING COUNT(*) > 1
     ) AS dups;
 
     IF duplicate_count > 0 THEN
-        RAISE EXCEPTION 'Cannot add unique constraint on (source, sourceRef): % existing non-null duplicate pair(s) found. Resolve duplicates manually before re-running this migration.', duplicate_count;
+        RAISE EXCEPTION 'Cannot add CTO Craft unique constraint on (source, sourceRef): % existing non-null duplicate pair(s) found. Resolve duplicates manually before re-running this migration.', duplicate_count;
     END IF;
 END $$;
 
 CREATE UNIQUE INDEX "ContentSchedulerItem_source_sourceRef_key"
     ON "ContentSchedulerItem"("source", "sourceRef")
-    WHERE "sourceRef" IS NOT NULL;
+    WHERE "source" = 'cto_craft'
+      AND "sourceRef" IS NOT NULL;


### PR DESCRIPTION
## Summary
- scope the Content Scheduler `(source, sourceRef)` partial unique index and duplicate preflight to `cto_craft`, preserving CTO Craft import idempotency while allowing valid multi-candidate `ops_notes` provenance
- update the Content Scheduler system documentation to describe the source-specific invariant

## System Spec
docs/systems/content-scheduler.md

## Test plan
- [x] Apply the migration to PostgreSQL with duplicate `ops_notes` rows and confirm it succeeds.
- [x] Confirm another duplicate `ops_notes` row remains valid after migration.
- [x] Confirm a duplicate `cto_craft` sourceRef is rejected by the new partial unique index.

## Operational hold
Do not run `prisma migrate resolve` or redeploy this migration until Tom separately approves the prodlike recovery action.

🤖 Generated with OpenClaw