### PR TITLE
feat(tasks-api): authenticate mutations with existing user credentials (task 0719a8e3)

### DIFF
--- a/agents/skills/ops/tasks-api/tasks_api_client.py
+++ b/agents/skills/ops/tasks-api/tasks_api_client.py
@@ -25,13 +25,20 @@ import urllib.parse
 import urllib.request
 
 
-def api_request(method: str, base_url: str, path: str, payload=None):
+def api_request(method: str, base_url: str, path: str, payload=None, *, token: str | None = None):
     url = f"{base_url.rstrip('/')}{path}"
     data = None
     headers = {"content-type": "application/json"}
-    service_token = (os.getenv("TASKS_API_APPROVAL_TOKEN") or "").strip()
-    if service_token:
-        headers["authorization"] = f"Bearer {service_token}"
+    # Per-call `token` overrides the default TASKS_API_APPROVAL_TOKEN. This
+    # lets trusted agent processes (bookmark_lobster, content-tasks Lobster,
+    # feature_task_lobster) authenticate with their own per-agent service
+    # credential so the API derives the comment author / audit-trail actor
+    # correctly (task 0719a8e3). Falls back to TASKS_API_APPROVAL_TOKEN when
+    # `token` is None so existing call sites that don't know about the
+    # per-agent env vars keep working.
+    resolved_token = (token if token is not None else os.getenv("TASKS_API_APPROVAL_TOKEN") or "").strip()
+    if resolved_token:
+        headers["authorization"] = f"Bearer {resolved_token}"
     if payload is not None:
         data = json.dumps(payload).encode("utf-8")
 
@@ -43,6 +50,19 @@ def api_request(method: str, base_url: str, path: str, payload=None):
     except Exception as e:  # noqa: BLE001
         print(f"API {method} {path} failed: {e}", file=sys.stderr)
         raise
+
+
+def service_token_env(name: str) -> str | None:
+    """Read a per-agent service-token env var; return None if unset/empty.
+
+    Use this to fetch a per-agent credential for the tasks-api mutation
+    surface. Pass the returned value to `api_request(..., token=...)` so
+    the API derives the comment author / audit-trail actor correctly
+    (task 0719a8e3). Falls back to TASKS_API_APPROVAL_TOKEN when the
+    per-agent env var is unset, mirroring the prior single-token flow.
+    """
+    value = (os.getenv(name) or "").strip()
+    return value or None
 
 
 def get_base_url() -> str:

--- a/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py
+++ b/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py
@@ -25,7 +25,13 @@ SCRIPT_ROOT = WORKSPACE / "codebases" / "sindustries" / "agents" / "skills" / "o
 if str(SCRIPT_ROOT) not in sys.path:
     sys.path.insert(0, str(SCRIPT_ROOT))
 
-from tasks_api_client import api_request, list_tasks  # noqa: E402
+from tasks_api_client import api_request, list_tasks, service_token_env  # noqa: E402
+
+# Per-agent service credential for the tasks-api mutation surface
+# (task 0719a8e3). Read once at module load so the env var can be set in
+# the calling agent's shell / .env. Falls back to TASKS_API_APPROVAL_TOKEN
+# inside api_request when unset.
+BOOKMARK_LOBSTER_TOKEN = service_token_env('BOOKMARK_LOBSTER_TOKEN')
 
 
 TASK_SPECS_IN_PROGRESS = 'brain/tasks/specs/in-progress'
@@ -77,7 +83,7 @@ def patch_task_spec_line(base_url: str, task_id: str, old_path: str, new_path: s
     desc = str(task_data.get('description') or '')
     new_desc = rewrite_spec_line(desc, old_path, new_path)
     if new_desc != desc:
-        api_request('PATCH', base_url, f'/tasks/{task_id}', {'description': new_desc})
+        api_request('PATCH', base_url, f'/tasks/{task_id}', {'description': new_desc}, token=BOOKMARK_LOBSTER_TOKEN)
 
 
 def proposal_marker(bookmark_key: str, spec_docs: list[str], proposal: dict) -> str:
@@ -246,7 +252,7 @@ def create_task_for_spec(
         'status': 'open',
         'tags': task_tags(topic, bookmark_key, [task_spec_destination(d) for d in spec_docs], marker),
     }
-    response = api_request('POST', base_url, '/tasks', payload)
+    response = api_request('POST', base_url, '/tasks', payload, token=BOOKMARK_LOBSTER_TOKEN)
     task = response.get('data') if isinstance(response, dict) else None
     task_id = task.get('id') if isinstance(task, dict) else None
     if task_id is None:

--- a/agents/workflows/bookmarks/tests/test_spec_lifecycle.py
+++ b/agents/workflows/bookmarks/tests/test_spec_lifecycle.py
@@ -71,7 +71,7 @@ class BookmarkSpecLifecycleTests(unittest.TestCase):
             wiki = load_module('wiki_catalog_lifecycle_test', '../../wiki/wiki_catalog.py', workspace)
             wiki.upsert_entry('spec', source_rel, 'Example', 'Ship it')
 
-            def fake_api(method, base_url, path, payload=None):
+            def fake_api(method, base_url, path, payload=None, *, token=None):
                 seen_payloads.append((method, path, payload))
                 if method == 'POST':
                     return {'data': {'id': 'task-1', 'description': payload['description'], 'tags': payload['tags']}}
@@ -111,7 +111,7 @@ class BookmarkSpecLifecycleTests(unittest.TestCase):
             wiki.upsert_entry('spec', source_rel, 'Example', 'Ship it')
             source.unlink()
 
-            def fake_api(method, base_url, path, payload=None):
+            def fake_api(method, base_url, path, payload=None, *, token=None):
                 if method == 'GET':
                     return {'data': {'id': 'task-1', 'description': f'**Spec:** {source_rel}\n'}}
                 if method == 'PATCH':

--- a/agents/workflows/content-tasks/scripts/common.py
+++ b/agents/workflows/content-tasks/scripts/common.py
@@ -23,14 +23,20 @@ TASKS_CLIENT_DIR = _SINDUSTRIES_ROOT / "agents" / "skills" / "ops" / "tasks-api"
 if str(TASKS_CLIENT_DIR) not in sys.path:
     sys.path.insert(0, str(TASKS_CLIENT_DIR))
 
-from tasks_api_client import api_request, get_base_url, get_task, list_tasks  # noqa: E402
+from tasks_api_client import api_request, get_base_url, get_task, list_tasks, service_token_env  # noqa: E402
 
 STATE_TAG = "[lobster-state]"
 IVY_PRS_TAG = "[ivy-prs]"
 IVY_TWEETS_QUEUED_TAG = "[ivy-tweets-queued]"
 IVY_TWEETS_QUEUED_RE = re.compile(r"^\[ivy-tweets-queued\]\s+theme:\s+\S")
 WEEKLY_CONTENT_TITLE_RE = re.compile(r"weekly\s+(review|content\s+updates?)", re.I)
-AUTHOR = "Lobster"
+# Author is now derived from the authenticated session (task 0719a8e3).
+# The legacy `AUTHOR = "Lobster"` constant is removed; the API rejects any
+# body-supplied author that disagrees with the authenticated actor. The
+# content-tasks Lobster authenticates with its own CONTENT_TASKS_TOKEN so
+# the comment author surfaces as `Lobster` (the actor name on the token).
+# AUTHOR = "Lobster"  # deprecated: use the authenticated actor instead
+CONTENT_TASKS_TOKEN = service_token_env("CONTENT_TASKS_TOKEN")
 STATUS_ORDER = {"open": 0, "ready": 1, "doing": 2, "acceptance": 3, "done": 4}
 PR_URL_RE = re.compile(r"https?://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/pull/(\d+)", re.I)
 # Use horizontal whitespace for indentation. `\s` also matches newlines, so
@@ -142,7 +148,7 @@ def normalize_state(state: dict[str, Any]) -> dict[str, Any]:
 
 def add_comment(task_id: str, text: str, base_url: str | None = None) -> dict[str, Any]:
     base = base_url or get_base_url()
-    return api_request("POST", base, f"/tasks/{task_id}/comments", {"author": AUTHOR, "text": text})
+    return api_request("POST", base, f"/tasks/{task_id}/comments", {"text": text}, token=CONTENT_TASKS_TOKEN)
 
 
 def write_lobster_state(task_id: str, state: dict[str, Any], note: str | None = None, base_url: str | None = None) -> dict[str, Any]:
@@ -155,7 +161,7 @@ def write_lobster_state(task_id: str, state: dict[str, Any], note: str | None = 
 
 def patch_task(task_id: str, payload: dict[str, Any], base_url: str | None = None) -> dict[str, Any]:
     base = base_url or get_base_url()
-    resp = api_request("PATCH", base, f"/tasks/{task_id}", payload)
+    resp = api_request("PATCH", base, f"/tasks/{task_id}", payload, token=CONTENT_TASKS_TOKEN)
     if isinstance(resp, dict) and isinstance(resp.get("data"), dict):
         return resp["data"]
     return resp if isinstance(resp, dict) else {}

--- a/agents/workflows/feature-task/src/analytics.rs
+++ b/agents/workflows/feature-task/src/analytics.rs
@@ -108,12 +108,35 @@ fn sha256_hex(bytes: &[u8]) -> String {
 /// POST a single analytics event to the Tasks API. Best-effort: errors are
 /// logged to stderr and swallowed so analytics observability never blocks
 /// task progression.
+///
+/// Auth (task 0719a8e3): the analytics-events endpoint is now gated by the
+/// general-mutation auth middleware. We authenticate with
+/// FEATURE_TASK_LOBSTER_TOKEN (preferred) and fall back to
+/// TASKS_API_APPROVAL_TOKEN (Quinn actor) so this continues to work
+/// before Quinn provisions the per-agent token. When both env vars are
+/// unset we still attempt the POST so that locally-developed flows
+/// without secrets can iterate (the API will 401 in that case and we
+/// log+swallow, matching the existing best-effort posture).
 fn post_event_best_effort(args: &StageArgs, payload: Value) {
     let url = format!(
         "{}/feature-task-analytics/events",
         args.base_url.trim_end_matches('/')
     );
-    match ureq::post(&url).send_json(payload) {
+    let token = std::env::var("FEATURE_TASK_LOBSTER_TOKEN")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            std::env::var("TASKS_API_APPROVAL_TOKEN")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        });
+    let mut request = ureq::post(&url);
+    if let Some(ref token) = token {
+        request = request.set("Authorization", &format!("Bearer {token}"));
+    }
+    match request.send_json(payload) {
         Ok(_) => {}
         Err(err) => {
             eprintln!("warning: analytics POST failed for {url}: {err}");

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -15,7 +15,7 @@ use std::{
 mod ac_parsing;
 mod analytics;
 
-const AUTHOR: &str = "Lobster";
+const AUTHOR: &str = "Lobster"; // deprecated: comment author is now derived from the authenticated actor (task 0719a8e3); retained for log messages only
 const WORKFLOW: &str = "feature-task-workflow";
 const CODE_TASK_WORKFLOW: &str = "code-task-workflow";
 const STATE_TAG: &str = "[lobster-state]";
@@ -3134,7 +3134,30 @@ fn add_comment(base_url: &str, task_id: &str, text: &str) -> Result<()> {
         "{}/tasks/{task_id}/comments",
         base_url.trim_end_matches('/')
     );
-    handle_api_result(ureq::post(&url).send_json(json!({"author": AUTHOR, "text": text})))?;
+    // The comment author is now derived from the authenticated session
+    // (task 0719a8e3). Body-supplied author is rejected with 403 if it
+    // disagrees with the authenticated actor, so we never set it here.
+    // We authenticate with FEATURE_TASK_LOBSTER_TOKEN (preferred) or fall
+    // back to TASKS_API_APPROVAL_TOKEN (Quinn actor) when the per-agent
+    // token is not provisioned yet.
+    let token = std::env::var("FEATURE_TASK_LOBSTER_TOKEN")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            std::env::var("TASKS_API_APPROVAL_TOKEN")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .ok_or_else(|| {
+            anyhow!("FEATURE_TASK_LOBSTER_TOKEN (or TASKS_API_APPROVAL_TOKEN) is required to post comments")
+        })?;
+    handle_api_result(
+        ureq::post(&url)
+            .set("Authorization", &format!("Bearer {token}"))
+            .send_json(json!({"text": text})),
+    )?;
     Ok(())
 }
 

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -15,7 +15,9 @@ use std::{
 mod ac_parsing;
 mod analytics;
 
-const AUTHOR: &str = "Lobster"; // deprecated: comment author is now derived from the authenticated actor (task 0719a8e3); retained for log messages only
+// Comment author is derived from the authenticated actor at the API
+// boundary (task 0719a8e3); this workflow no longer carries a literal
+// "Lobster" author fallback.
 const WORKFLOW: &str = "feature-task-workflow";
 const CODE_TASK_WORKFLOW: &str = "code-task-workflow";
 const STATE_TAG: &str = "[lobster-state]";

--- a/docs/specs/tasks-api-mutations-auth-tech-design.md
+++ b/docs/specs/tasks-api-mutations-auth-tech-design.md
@@ -1,0 +1,312 @@
+---
+status: draft
+task_id: 0719a8e3-8502-4554-8080-77d53fe91514
+product_spec: n/a (security task from repo-audit-2026-W33, tag `repo-audit-2026-w33`)
+shipped_pr: null
+shipped_date: null
+---
+
+# Tasks-api: authenticate mutations with existing user credentials
+
+## Links
+
+- Product spec: n/a — task is from the weekly repo audit (`repo-audit-2026-w33`); goal is "protect the current tasks-api mutation surface using the existing username/password authentication until Tasks moves to the cloud and adopts the shared cloud authentication system"
+- Tech design: `docs/specs/tasks-api-mutations-auth-tech-design.md`
+- Task: `0719a8e3-8502-4554-8080-77d53fe91514`
+- Tasks API record: `http://localhost:4001/api/v1/tasks/0719a8e3-8502-4554-8080-77d53fe91514`
+- Tags: `security`, `tasks-api`, `auth`, `repo-audit-2026-w33`
+- Follow-up (cloud auth): task `206927ed-d851-47af-8864-0056487e0c4e` — "Define and secure production runtime configuration"
+- Related sibling work: PR #316 (budget-api sessions middleware, task `ec42d3a1`), PR #341 (budget-api encrypted tokens, task `f1175b18`) — the same "browser session OR service credential" pattern was already adopted for budget-api; this task ports it to tasks-api for the broader mutation surface
+
+## Problem statement
+
+The tasks-api mutation surface is currently unauthenticated save for one carve-out (the approval endpoints). Today the API trusts `localhost`: any script on the same host can `POST /api/v1/tasks`, `PATCH /api/v1/tasks/:id`, `DELETE /api/v1/tasks/:id`, `POST /api/v1/tasks/:id/comments`, mutate `tags`, and mutate `content-scheduler/items` without credentials. The single existing identity claim — the `x-actor` header on content-scheduler writes — defaults to `"unknown"` and is caller-supplied, so it is not a real authentication signal.
+
+A second gap is comment-author impersonation: `POST /api/v1/tasks/:id/comments` accepts `{ author, text }` with the author taken verbatim from the request body. Today nothing stops Tom from posting a comment credited as Quinn, and nothing stops a script from posting as Tom without a session.
+
+The fix is a temporary username/password + service-credential boundary that mirrors the existing `approvalAuth.ts` pattern: the same `TASKS_API_APPROVAL_USERS` env (scrypt-hashed username/password list) plus an expanded `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` env that options per-agent actors. The middleware is the seam; the cloud-auth migration (task `206927ed`) replaces the credential-verification implementation behind that seam without touching the route handlers.
+
+## Scope
+
+In scope:
+
+- `POST /api/v1/tasks` (create)
+- `PATCH /api/v1/tasks/:id` (update)
+- `DELETE /api/v1/tasks/:id` (archive)
+- `POST /api/v1/tasks/:id/comments` (create — plus derive author from auth)
+- `POST /api/v1/tags`, `PATCH /api/v1/tags/:id`, `DELETE /api/v1/tags/:id` (if present)
+- `POST /api/v1/content-scheduler/items`, `PATCH /items/:id`, `POST /items/:id/approve`, `POST /items/:id/unapprove`, `POST /items/:id/publish`, `POST /items/:id/remove`, `POST /content-scheduler/reorder`
+- `POST /api/v1/feature-task-analytics/events`
+- Not yet gated today but analog writes to investigate: `POST /api/v1/required-approvals`, `PATCH /api/v1/required-approvals/:id`, `POST /api/v1/content-scheduler/imports/cto-craft`
+
+Out of scope (deferred to cloud auth task `206927ed`):
+
+- Replacing username/password with the shared cloud auth system
+- LAN/network-level auth (the API still trusts `localhost`; only the application layer is being hardened)
+- GET endpoints — read traffic stays open so dashboards, the agent task queue, and the tasks app ship without friction
+
+## Current state
+
+### Auth surface that exists today
+
+- `POST /api/v1/auth/session` (`services/tasks-api/src/routes/approvalSessions.ts`) — verifies username/password against `TASKS_API_APPROVAL_USERS` (scrypt-hashed), creates an `ApprovalSession` row keyed by `tokenHash`, sets the `tasks_api_session` cookie (HttpOnly, SameSite=Lax, Secure in production).
+- `requireApprovalPrincipal` middleware (`services/tasks-api/src/middleware/approvalAuth.ts`) — accepts either the session cookie OR a Bearer service credential from `TASKS_API_APPROVAL_SERVICE_CREDENTIALS`, sets `req.approvalPrincipal = { actor, approvalTypes, kind }`. Currently only `taskApprovalsRouter` and `requiredApprovalsRouter` use it.
+- `TASKS_API_APPROVAL_USERS` and `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` are parsed at module load; malformed config fails process boot.
+- `x-actor` header on content-scheduler writes (`services/tasks-api/src/routes/contentScheduler.ts:54`) — currently the audit-trail signal, defaults to `"unknown"`. After auth, this becomes redundant with `req.user.actor` and should be derived from auth.
+- `x-actor-secret` header gate on the content-scheduler publish path (`services/tasks-api/src/routes/contentScheduler.ts:348`) — layered defense, only active when `X_ACTOR_SECRET` is set. Stays unchanged.
+
+### Comment-author impersonation
+
+`POST /api/v1/tasks/:id/comments` (`services/tasks-api/src/routes/tasks.ts:558`) takes `{ author, text }` from the body and persists `author` verbatim. The author is then surfaced via `mapTaskComment` and `TaskComment.author` in the Prisma schema. Impersonation is undetectable after the fact.
+
+### Trusted task-writing agents today (AC3 inventory)
+
+| Agent | Mutating calls | Audit-trail actor today | Notes |
+| --- | --- | --- | --- |
+| `agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py` | `POST /tasks`, `PATCH /tasks/:id` | no `x-actor`; defaults to `"unknown"` | Needs own service credential |
+| `agents/workflows/content-tasks/scripts/common.py` (`AUTHOR = "Lobster"`) | `POST /tasks/:id/comments`, `PATCH /tasks/:id` | `Lobster` (body-supplied author) | Comment author must be derived from auth, not body |
+| `agents/workflows/feature-task/src/main.rs` (approval writes) | already uses `TASKS_API_APPROVAL_TOKEN` (Bearer) | `Quinn` (approval service credential actor) | Approved; stays as-is |
+| `agents/workflows/feature-task/src/analytics.rs` | `POST /feature-task-analytics/events` (idempotent) | `x-actor` header from the Rust call | Needs own service credential OR reuses parent |
+| `agents/skills/ops/tasks-api/tasks_api_client.py` | arbitrary CRUD from terminals and agents | depends on caller | Caller supplies the credential; the client already supports `TASKS_API_APPROVAL_TOKEN` |
+| `agents/skills/ops/tasks-api/scripts/pending_tech_design_approvals.py` | GET only | n/a | Not a mutation; no change |
+| Tasks app UI (browser) | POST/PATCH/DELETE via the app | session cookie | Already supported via `auth/session` + cookie |
+
+The actor list will extend with two new entries for the agents that don't have one today: `bookmark_lobster` and `feature_task_lobster`. The `Lobster` actor for content-tasks stays as-is, but it moves from body-supplied to auth-derived.
+
+## Architecture approach
+
+### Source of truth for identity
+
+The natural source of truth for "who is making this mutation" is the database-backed `ApprovalSession` cookie and the `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` env-driven service credentials. Today this surface is wired exclusively to the approval routes. The fix is to **widen the use of the existing identity primitive, not introduce a new one**. The username/password + service-credential mechanism is the temporary boundary; the middleware boundary is the seam.
+
+Cross-cutting principle: do not introduce a second identity system. Use the same `cookie OR Bearer` parsing, the same `approvalSession` cookie name, the same `TASKS_API_APPROVAL_USERS` schema, and the same `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` schema. The cloud-auth migration (`206927ed`) will swap the credential-verification implementation in one place.
+
+### New middleware: `requireAuthenticatedUser`
+
+Add `requireAuthenticatedUser` to `services/tasks-api/src/middleware/`. It mirrors `requireApprovalPrincipal`:
+
+- Parse the `tasks_api_session` cookie. If present and valid, look up the `ApprovalSession` row; on success set `req.user = { username, actor, kind: 'browser_session' }`.
+- Else, parse `Authorization: Bearer <token>`. If the token matches a configured service credential, set `req.user = { actor, kind: 'service' }`.
+- If neither succeeds, return `401 AUTH_REQUIRED` with a body like `{ error: { code: 'AUTH_REQUIRED', message: 'A valid session or service credential is required' } }`.
+- The middleware never enforces a permission boundary; it only authenticates. Per-route authorization (e.g. "comments are allowed for any authenticated user") is the route's responsibility.
+
+This is intentionally a near-clone of `requireApprovalPrincipal`. The pattern is `authenticate-then-route-handler`; the only seam that will be replaced by the cloud-auth migration is the credential verification function.
+
+### Apply it to every mutation route
+
+In `services/tasks-api/src/app.ts`, mount the middleware on the mutation paths via `app.use` ordering or per-router. The simplest expression is a path-prefix + method matcher:
+
+```ts
+const requireAuth = requireAuthenticatedUser();
+app.use('/api/v1/tasks', (req, res, next) =>
+  req.method === 'POST' || req.method === 'PATCH' || req.method === 'DELETE' ? requireAuth(req, res, next) : next()
+);
+app.use('/api/v1/tags', (req, res, next) =>
+  req.method === 'POST' || req.method === 'PATCH' || req.method === 'DELETE' ? requireAuth(req, res, next) : next()
+);
+app.use('/api/v1/content-scheduler', (req, res, next) =>
+  req.method === 'POST' || req.method === 'PATCH' || req.method === 'DELETE' ? requireAuth(req, res, next) : next()
+);
+app.use('/api/v1/feature-task-analytics/events', (req, res, next) =>
+  req.method === 'POST' ? requireAuth(req, res, next) : next()
+);
+```
+
+GET requests stay open. Tests that already bypass auth via `createApp()` continue to work for read paths; only write paths need updated fixtures.
+
+### Comment author derivation (AC2)
+
+In `services/tasks-api/src/routes/tasks.ts:558`, replace the body-driven `author` lookup with the authenticated actor:
+
+```ts
+const author = req.user!.actor;                  // derived from auth; never body
+const requestedAuthor = normalizeString(req.body?.author);
+if (requestedAuthor && requestedAuthor !== author) {
+  return sendError(res, 403, 'COMMENT_AUTHOR_FORBIDDEN',
+    'author is derived from the authenticated session; body.author is ignored');
+}
+const text = normalizeString(req.body?.text);
+if (!text) return badRequest(res, 'COMMENT_TEXT_REQUIRED', 'text is required');
+```
+
+This makes impersonation impossible: even if a caller sets `author: "Tom"`, the persisted author is `req.user.actor`. If a caller passes a *different* author than the authenticated one, the request is rejected with 403 (visible security signal instead of silent overwrite).
+
+### Service credential per agent (AC3)
+
+Each trusted agent gets its own service credential entry. The credential schema (already defined in `approvalAuth.ts`) is reused unchanged:
+
+```json
+[
+  { "token": "<32+ chars>", "actor": "Quinn", "approvalTypes": ["tech_design"] },
+  { "token": "<32+ chars>", "actor": "bookmark_lobster", "approvalTypes": [] },
+  { "token": "<32+ chars>", "actor": "feature_task_lobster", "approvalTypes": [] },
+  { "token": "<32+ chars>", "actor": "Lobster", "approvalTypes": [] }
+]
+```
+
+Note the empty `approvalTypes` for the new write actors — that field is for `requireApprovalPrincipal`, not `requireAuthenticatedUser`. Empty is fine; the new middleware ignores it. The `.openclaw` boundary is the operational deployment of these credentials (Tom or Quinn provisions them in `.env`; agents read their own token from a per-agent env).
+
+Update the call sites:
+
+- `agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py` — set `Authorization: Bearer $BOOKMARK_LOBSTER_TOKEN` (or rely on `tasks_api_client.api_request` which already reads `TASKS_API_APPROVAL_TOKEN` — rename the env to `TASKS_API_SERVICE_TOKEN` if cleaner, or keep the existing env and document which actor maps to it).
+- `agents/workflows/content-tasks/scripts/common.py` — drop the `AUTHOR = "Lobster"` constant from `POST /tasks/:id/comments`; the API will derive the author. Continue to set `Authorization: Bearer $CONTENT_TASKS_TOKEN`.
+- `agents/workflows/feature-task/src/analytics.rs` — add a `feature_task_lobster` Bearer credential and wire it into the request layer.
+
+### x-actor header treatment
+
+The `x-actor` header on content-scheduler writes was the audit-trail fallback. After auth, it is redundant. Plan:
+
+- **Phase 1 (this task):** keep the `x-actor` header as an audit-trail redundancy. If the header is set, log a warning if it disagrees with `req.user.actor`. Do not reject on disagreement — the audit log is the safer place.
+- **Phase 2 (cloud auth):** drop the header entirely and rely on `req.user.actor`.
+
+### `x-actor-secret` header gate
+
+The `x-actor-secret` header on the content-scheduler publish path stays as a layered defense. It is already only active when `X_ACTOR_SECRET` is set, and it applies to a single endpoint. No change.
+
+### Browser session compatibility
+
+The Tasks app UI already uses `POST /api/v1/auth/session` to log in (per `docs/systems/tasks.md:643`). The session cookie is accepted by `requireAuthenticatedUser` exactly as it is by `requireApprovalPrincipal`. No UI change is required.
+
+### Dev mode behavior
+
+When `TASKS_API_APPROVAL_USERS` and `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` are both empty (typical local dev), `requireAuthenticatedUser` will reject every mutation. Two options:
+
+- **Recommended:** require at least one user OR service credential in dev. Log a loud warning at boot if both are empty. Force developers to set `TASKS_API_APPROVAL_USERS` for the local dev environment.
+- **Alternative:** bypass auth entirely when `NODE_ENV !== 'production'` and both env vars are empty. Reject all mutations in production if both are empty.
+
+This is **Open question 1**; see below.
+
+## Data model / API contract changes
+
+- No new Prisma models. The `ApprovalSession` row is reused as the session backing store.
+- `TASKS_API_APPROVAL_USERS` — schema unchanged. New users may be added (e.g. a `rowan` user for the Tasks app; the existing `tom`/`quinn` users continue).
+- `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` — schema unchanged. New entries for `bookmark_lobster`, `feature_task_lobster`, `Lobster` (content-tasks).
+- `POST /api/v1/tasks/:id/comments` — `author` field in the response is now derived from the authenticated user. The request body may include `author` only if it matches the authenticated actor; mismatch is a 403.
+- `x-actor` header on content-scheduler writes — accepted as before but ignored for the audit trail; the authenticated actor is authoritative. Documented in `docs/systems/tasks.md`.
+
+## `.openclaw` boundary
+
+This task does not require any `.openclaw` changes. Per-agent service tokens are deployed via the existing `.env` mechanism or a per-agent shell env. The `.openclaw` boundary is only touched if Rowan's heartbeat needs to surface a new prompt variable; it does not.
+
+## Implementation plan
+
+### File/module scope
+
+Files to create:
+
+- `services/tasks-api/src/middleware/requireAuth.ts` — the new middleware (or `sessions.ts`; see naming question below)
+- `services/tasks-api/test/requireAuth.test.ts` — middleware unit tests
+- `services/tasks-api/test/mutation-auth-integration.test.ts` — integration tests for each mutation route
+
+Files to modify:
+
+- `services/tasks-api/src/app.ts` — mount the middleware on the mutation paths
+- `services/tasks-api/src/routes/tasks.ts` — fix the comment route to derive author; drop the body-supplied author
+- `services/tasks-api/src/routes/tasks.ts` — apply middleware to `POST /tasks`, `PATCH /tasks/:id`, `DELETE /tasks/:id`
+- `services/tasks-api/src/routes/tasks.ts` — apply middleware to `POST /tasks/:id/comments`
+- `services/tasks-api/src/routes/tags.ts` — apply middleware to `POST /tags`, `PATCH /tags/:id`, `DELETE /tags/:id`
+- `services/tasks-api/src/routes/contentScheduler.ts` — apply middleware to all write paths; deprecate `x-actor` as audit-trail
+- `services/tasks-api/src/routes/featureTaskAnalytics.ts` — apply middleware to `POST /events`
+- `services/tasks-api/src/config/env.ts` — no schema change; ensure the existing config supports the new entries
+- `services/tasks-api/src/lib/http.ts` — add a `sendError(res, 401, 'AUTH_REQUIRED', ...)` helper if not already present
+- `agents/skills/ops/tasks-api/tasks_api_client.py` — generalize the credential env variable name and document the per-agent tokens
+- `agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py` — adopt the new service credential
+- `agents/workflows/content-tasks/scripts/common.py` — drop `AUTHOR = "Lobster"` from the comment request; rely on auth
+- `agents/workflows/feature-task/src/analytics.rs` — adopt the new service credential
+- `docs/systems/tasks.md` — document the new auth boundary, the deprecation of `x-actor` as audit signal, and the migration path
+
+### Workstream order
+
+1. **Middleware skeleton + tests** (Rowan). Add `requireAuthenticatedUser`, unit tests for cookie-only, Bearer-only, neither, both, expired, revoked. Independent of any route.
+2. **Route mounting** (Rowan). Wire the middleware in `app.ts` and start skipping auth on existing tests where appropriate (mark those tests as needing credentials).
+3. **Comment author derivation** (Rowan). Fix `POST /tasks/:id/comments`. Update content-tasks caller.
+4. **Per-agent service credentials** (Rowan + Quinn). Provision tokens for `bookmark_lobster`, `feature_task_lobster`, `Lobster` (content-tasks). Update call sites.
+5. **Integration tests** (Rowan). `mutation-auth-integration.test.ts` covers each gated route with auth success, missing auth, invalid auth, and comment-author impersonation.
+6. **Docs** (Rowan). Update `docs/systems/tasks.md` to reflect the new boundary and the migration path.
+
+### Naming question
+
+Internet latency/import name: `requireAuthenticatedUser` vs. `requireAuth` vs. `requireSession`. The existing convention is `requireApprovalPrincipal`. Recommend `requireAuthenticatedUser` for clarity; the path is short and the existing-approval middleware is named after its principal.
+
+## Test plan (AC verification matrix)
+
+| AC | Test layer | Coverage |
+| --- | --- | --- |
+| AC1 — POST/PATCH/DELETE require valid credentials | integration | `mutation-auth-integration.test.ts` covers each of `POST /tasks`, `PATCH /tasks/:id`, `DELETE /tasks/:id`, `POST /tags`, `POST /content-scheduler/items`, `PATCH /items/:id`, etc. Assertions: no auth → 401, wrong Bearer → 401, missing cookie → 401, valid session → 200/201, valid Bearer → 200/201. |
+| AC2 — comment author is derived from auth | integration | `mutation-auth-integration.test.ts` plus a focused test in `tasks.test.ts` (or `comments.test.ts` if it exists). Cases: (a) no body.author → comment author = `req.user.actor`; (b) body.author = `req.user.actor` → accepted; (c) body.author ≠ `req.user.actor` → 403 `COMMENT_AUTHOR_FORBIDDEN`. |
+| AC3 — trusted agents inventoried and updated | integration + manual | Each agent has an integration test that authenticates with its own service credential and successfully performs the mutation it performs today. Also a `docs/systems/tasks.md` section listing the actor-to-process mapping. |
+| AC4 — automated tests cover auth success/rejection/forged-author | integration | Cross-cuts the prior three; the test file is the single artifact. Edge cases: expired session, revoked session, wrong credential, malformed Bearer header, missing scheme prefix. |
+| AC5 — tech design documents username/password boundary + cloud migration | docs | This document is the deliverable. The migration path is the "Open questions" answered and the "Phase 2" section in `docs/systems/tasks.md`. |
+
+### E2E coverage
+
+The user-visible AC is "the Tasks app UI cannot perform a mutation without first logging in via `auth/session`." The existing `tasks app e2e (ui + api + db)` CI job already exercises the full login → create → patch → comment flow. Run that job against the new middleware and confirm green. Add a single explicit E2E test that asserts the unauthenticated path is rejected (the existing tests authenticate via UI, so they implicitly prove the auth path; the new test asserts the unauthenticated path now 401s).
+
+### Lower-layer fallback
+
+Auth behavior is a middleware contract, not a UI behavior. Unit tests on the middleware plus integration tests on each route are sufficient — there is no per-page UI surface to test. E2E is a confidence check, not a primary coverage layer.
+
+## Migration path (AC5)
+
+Phase 2 (cloud auth, task `206927ed`) replaces the credential-verification implementation behind `requireAuthenticatedUser` without changing the route handlers. The seam is the function that resolves `req.user` from the request. Today:
+
+```ts
+// services/tasks-api/src/middleware/requireAuth.ts (Phase 1)
+async function authenticate(req: Request): Promise<User | null> {
+  // 1. Try tasks_api_session cookie → ApprovalSession row
+  // 2. Try Authorization Bearer → TASKS_API_APPROVAL_SERVICE_CREDENTIALS
+  // 3. Return null
+}
+```
+
+Phase 2 swaps the body of `authenticate` for a call to the shared cloud auth library:
+
+```ts
+// Phase 2
+async function authenticate(req: Request): Promise<User | null> {
+  return await cloudAuth.verify(req); // talks to the shared cloud auth system
+}
+```
+
+The route handlers, the cookie name, the `Authorization` header shape, and the `TASKS_API_APPROVAL_USERS` env all become bridge-glue during the cutover. The middleware boundary is the only thing callers depend on.
+
+Concrete migration steps:
+
+1. Provision per-agent identities in the shared cloud auth system (mirroring `TASKS_API_APPROVAL_SERVICE_CREDENTIALS`).
+2. Deploy a phase-2 `authenticate` that accepts both the temporary cookie/Bearer and the cloud auth token.
+3. Roll agents over one at a time, swapping their token source.
+4. Drop the cookie/Bearer fallback once the agents are migrated.
+5. Remove the temporary `TASKS_API_APPROVAL_USERS` env.
+
+This is identical to the budget-api migration (PR #316 → future cloud auth work) and reuses the same playbook.
+
+## Open questions and risks
+
+1. **Dev mode behavior.** When `TASKS_API_APPROVAL_USERS` and `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` are both empty, do we hard-fail or auto-bypass? Recommend hard-fail with a clear log message naming the env vars to set. The bypass choice is too easy to leave enabled in production. **Needs Quinn's call.**
+2. **GET endpoints.** ACs mention POST/PATCH/DELETE only. Confirmed: GETs stay open. If a future audit demands GET gating, that's a separate task — `tasks_api_client.py` is called by many reads-only paths that would all need updating.
+3. **`x-actor` header treatment.** Keep as audit-trail redundancy (Phase 1) and drop (Phase 2)? Confirmed above.
+4. **Per-agent token distribution.** Quinn provisions tokens via `.env` or per-agent env. Recommend per-agent env so each agent only knows its own token. **Needs Quinn's operational preference.**
+5. **`tasks_api_client` env naming.** Today the client reads `TASKS_API_APPROVAL_TOKEN`. Rename to `TASKS_API_SERVICE_TOKEN` for clarity, or keep the existing name and document the actor mapping? Keeping the existing name avoids a breaking change for everyone who already sets it. **Recommend: keep the existing env name; document the actor mapping in `docs/systems/tasks.md`.**
+6. **`x-actor` header mismatch on content-scheduler writes.** If a script sets `x-actor: Tom` but authenticates as `Rowan`, do we reject? Recommend: log a warning, accept the request, use `req.user.actor` for the audit field. That gives operators a signal to clean up the script without breaking the flow during the migration window.
+7. **Password rotation.** `TASKS_API_APPROVAL_USERS` is parsed at module load. Rotating a password requires a process restart. Phase 2 should address this properly; for Phase 1, document the restart requirement.
+8. **`ApprovalSession` reuse.** The user's session for `/auth/session` is currently typed as an approval session. After this task, the same session gates both approvals and general mutations. The cookie name and table are reused; the actor is the same. Acceptable for the temporary boundary.
+
+## Risks
+
+- **Trust-localhost assumption.** The API still trusts `localhost`. This task is application-layer hardening; LAN exposure is a separate concern. The `tasks-api` is currently `127.0.0.1` only on the dev plane (per `services/tasks-api/src/config/env.ts` defaults); exposure is a deployment question, not a code question.
+- **Adapter change.** The opener may discover that some existing tests rely on unauthenticated mutation paths. The integration test pass should catch these, but the task `0719a8e3` description already requires it ("automated tests cover authenticated mutation success, unauthenticated rejection, invalid-credential rejection, and forged comment-author rejection"), so this is in scope.
+- **Migration to `x-actor` header treatment.** Phase 2 must drop the header. This is a breaking change for any external script that sets `x-actor` and depends on it being persisted. None known today, but call this out in the cloud-auth task.
+
+## `.openclaw` follow-up
+
+None. Service tokens are env-driven; their deployment is operational, not `.openclaw`.
+
+## Acceptance criteria mapping
+
+| AC | Where it is verified in this design |
+| --- | --- |
+| AC1 — POST/PATCH/DELETE reject without valid credentials | "Apply it to every mutation route" + "Workstream order" step 2 + test plan row 1 |
+| AC2 — comment author is derived from auth | "Comment author derivation (AC2)" + test plan row 2 |
+| AC3 — trusted agents inventoried and updated with own credentials | "Service credential per agent (AC3)" + "Trusted task-writing agents today" + workstream step 4 + test plan row 3 |
+| AC4 — automated tests cover auth success/rejection/forged-author | test plan rows 1–4 |
+| AC5 — tech design documents temporary boundary + cloud migration path | This document + "Migration path" section + `docs/systems/tasks.md` update |

--- a/docs/systems/tasks.md
+++ b/docs/systems/tasks.md
@@ -648,6 +648,32 @@ Agent writes use `Authorization: Bearer <service-token>` with a separately scope
 
 Approval POST/DELETE and their ordinary audit comment execute in one Prisma transaction. A real transition creates exactly one comment (`Approval <type> approved|revoked by <actor>.`); identical POST and absent/already-revoked DELETE are no-ops with no duplicate history. Archived and `done` tasks are immutable.
 
+### General-mutation authentication boundary (task `0719a8e3`)
+
+Every `POST` / `PATCH` / `DELETE` on the tasks-api mutation surface requires the same `tasks_api_session` cookie or `Authorization: Bearer <token>` credential that the approval routes use. The credential store is the shared `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` env var — no second identity system. The middleware in `services/tasks-api/src/middleware/requireAuth.ts` sets `req.user = { actor, kind }` on success and returns `401 AUTH_REQUIRED` on failure. GET endpoints stay open so the Tasks UI and agent task queue keep reading without friction.
+
+Gated surfaces (mounted ahead of every router in `app.ts`):
+
+- `POST /tasks`, `PATCH /tasks/:id`, `DELETE /tasks/:id`, `POST /tasks/:id/comments`
+- `POST /tags` (and any future `PATCH`/`DELETE` on `/tags`)
+- All write paths under `/content-scheduler/*` (items CRUD, approve/unapprove/publish/remove, reorder, the `cto-craft` trusted ingest)
+- `POST /feature-task-analytics/events`
+
+Comment author is derived from the authenticated actor (task `0719a8e3` AC2). A body-supplied `author` field on `POST /tasks/:id/comments` is rejected with `403 COMMENT_AUTHOR_FORBIDDEN` when it disagrees with the authenticated actor; matching it is accepted (and ignored otherwise). This makes impersonation impossible: even a request with `author: "Quinn"` is persisted as the authenticated actor, never the body-supplied value.
+
+The content-scheduler `x-actor` header is kept as a backwards-compatible audit-trail signal (Phase 1). When set, the API logs a warning if the header disagrees with the authenticated actor and uses the authenticated actor as authoritative. Phase 2 (cloud auth, task `206927ed`) will drop the header entirely.
+
+Per-agent service credentials — each trusted writer has its own token so the comment author / audit-trail actor surfaces correctly:
+
+| Env var | Actor (derived) | Used by |
+|---|---|---|
+| `TASKS_API_APPROVAL_TOKEN` | `Quinn` | Approval writes (existing) — Quinn-only `tech_design` gate |
+| `BOOKMARK_LOBSTER_TOKEN` | `bookmark_lobster` | `agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py` |
+| `CONTENT_TASKS_TOKEN` | `Lobster` | `agents/workflows/content-tasks/scripts/common.py` |
+| `FEATURE_TASK_LOBSTER_TOKEN` | `feature_task_lobster` | `agents/workflows/feature-task/src/main.rs` (`add_comment`), `agents/workflows/feature-task/src/analytics.rs` |
+
+When both `TASKS_API_APPROVAL_USERS` and `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` are empty the API refuses every mutation with `401 AUTH_REQUIRED`. Local dev must provision at least one user or service credential — see `services/tasks-api/test/mutationAuthIntegration.test.ts` for the contract. Quinn provisions the four per-agent tokens in `~/.openclaw/.env` and the relevant agent env files; each agent only learns its own token.
+
 ---
 
 ## `.openclaw` boundary

--- a/services/tasks-api/src/app.ts
+++ b/services/tasks-api/src/app.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { helmetPreset } from './middleware/helmetPreset';
 import { createRateLimit } from './middleware/rateLimit';
+import { requireAuthenticatedUser } from './middleware/requireAuth.ts';
 import { healthRouter } from './routes/health';
 import { config } from './config/index.ts';
 import { tasksRouter } from './routes/tasks';
@@ -105,6 +106,27 @@ export function createApp() {
   app.use('/api/v1/content-scheduler/items/:id/publish', writeEndpointRateLimit);
   app.use('/api/v1/auth/session', (req, res, next) =>
     req.method === 'POST' ? writeEndpointRateLimit(req, res, next) : next()
+  );
+
+  // General-mutation authentication gate (task 0719a8e3). Every
+  // POST/PATCH/DELETE on the task, tag, content-scheduler, and analytics
+  // surfaces requires a valid session cookie or Bearer service credential.
+  // GET endpoints stay open so the UI / agent queue / tasks app continue
+  // to read without friction.
+  //
+  // The middleware is mounted ahead of the routers so 401s are returned
+  // before any handler runs (and before Prisma is hit). Per-route
+  // authorization (e.g. "comments allowed for any authenticated user") is
+  // the route's responsibility; this middleware only authenticates.
+  const mutationMethods = new Set(['POST', 'PATCH', 'DELETE']);
+  const gateMutations = (req: express.Request, res: express.Response, next: express.NextFunction) =>
+    mutationMethods.has(req.method) ? requireAuthenticatedUser(req, res, next) : next();
+
+  app.use('/api/v1/tasks', gateMutations);
+  app.use('/api/v1/tags', gateMutations);
+  app.use('/api/v1/content-scheduler', gateMutations);
+  app.use('/api/v1/feature-task-analytics/events', (req, _res, next) =>
+    req.method === 'POST' ? requireAuthenticatedUser(req, _res, next) : next()
   );
 
   app.get('/health', (_req, res) => {

--- a/services/tasks-api/src/middleware/requireAuth.ts
+++ b/services/tasks-api/src/middleware/requireAuth.ts
@@ -1,0 +1,147 @@
+// General mutation authentication middleware for tasks-api.
+//
+// Widen the existing ApprovalSession cookie + TASKS_API_APPROVAL_SERVICE_CREDENTIALS
+// identity primitive to gate every mutation route (POST/PATCH/DELETE) instead of
+// only the structured-approval routes. The shape is intentionally a near-clone
+// of `requireApprovalPrincipal`:
+//   - cookie `tasks_api_session` parsed first; looks up the ApprovalSession row
+//   - `Authorization: Bearer <token>` parsed second; matches against the same
+//     TASKS_API_APPROVAL_SERVICE_CREDENTIALS env-var schema (shared credential
+//     store, no second identity system)
+//   - on success, sets `req.user = { actor, kind }`
+//   - on failure, returns 401 AUTH_REQUIRED with a uniform error body
+//
+// Unlike `requireApprovalPrincipal`, this middleware does NOT enforce any
+// permission policy. Per-route authorization (e.g. "comments are allowed for
+// any authenticated user") lives in the route handler. This is the seam that
+// the cloud-auth migration (task 206927ed) will replace behind the existing
+// cookie + Bearer parsing — no route handlers need to change when the
+// credential-verification implementation swaps out.
+//
+// Tech design: docs/specs/tasks-api-mutations-auth-tech-design.md (task 0719a8e3)
+
+import crypto from 'node:crypto';
+import type { NextFunction, Request, Response } from 'express';
+import { prisma } from '../lib/prisma.ts';
+import { sendError } from '../lib/http.ts';
+import { config } from '../config/index.ts';
+
+export type MutationUser =
+  | { actor: string; kind: 'browser_session' }
+  | { actor: string; kind: 'service' };
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: MutationUser;
+    }
+  }
+}
+
+type ServiceCredential = { token: string; actor: string; approvalTypes: string[] };
+
+/**
+ * Parse TASKS_API_APPROVAL_SERVICE_CREDENTIALS at module load so malformed
+ * config fails process boot (not the first authenticated request). This is
+ * the same module-load-time parse as `approvalAuth.ts`; the credential store
+ * is intentionally shared so we don't run two parsers with potentially
+ * different error handling.
+ */
+function loadServiceCredentials(): ServiceCredential[] {
+  const raw = config.TASKS_API_APPROVAL_SERVICE_CREDENTIALS;
+  if (!raw || raw === '[]') return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(
+      `TASKS_API_APPROVAL_SERVICE_CREDENTIALS must be valid JSON: ${(e as Error).message}`
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error('TASKS_API_APPROVAL_SERVICE_CREDENTIALS must be a JSON array');
+  }
+  return parsed.map((value, index) => {
+    const item = value as Partial<ServiceCredential>;
+    if (
+      typeof item?.token !== 'string' ||
+      item.token.length < 16 ||
+      typeof item.actor !== 'string' ||
+      !Array.isArray(item.approvalTypes)
+    ) {
+      throw new Error(`TASKS_API_APPROVAL_SERVICE_CREDENTIALS[${index}] is invalid`);
+    }
+    return item as ServiceCredential;
+  });
+}
+
+// Parse once at module load; the frozen reference is reused per request.
+const SERVICE_CREDENTIALS: ReadonlyArray<ServiceCredential> = loadServiceCredentials();
+
+function cookie(req: Request, name: string): string | null {
+  for (const part of (req.headers.cookie ?? '').split(';')) {
+    const [key, ...rest] = part.trim().split('=');
+    if (key === name) return decodeURIComponent(rest.join('='));
+  }
+  return null;
+}
+
+function tokenHash(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+function tokenMatches(a: string, b: string): boolean {
+  const x = Buffer.from(a);
+  const y = Buffer.from(b);
+  return x.length === y.length && crypto.timingSafeEqual(x, y);
+}
+
+/**
+ * Middleware: authenticate the request via session cookie OR Bearer service
+ * credential. On success sets `req.user`. On failure returns 401 AUTH_REQUIRED
+ * with a uniform error body shape (`{ error: { code, message } }`).
+ *
+ * The middleware never enforces a permission boundary — any authenticated
+ * user can call any gated mutation route. Per-route authorization (e.g.
+ * "comments are allowed for any authenticated user; task updates require
+ * actor in {Quinn, Tom}") is the route handler's responsibility. Phase 1
+ * intentionally allows every authenticated actor through; permission
+ * refinement comes in Phase 2 (cloud auth).
+ */
+export async function requireAuthenticatedUser(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const sessionToken = cookie(req, 'tasks_api_session');
+    if (sessionToken) {
+      const session = await prisma.approvalSession.findUnique({
+        where: { tokenHash: tokenHash(sessionToken) }
+      });
+      if (session && !session.revokedAt && session.expiresAt > new Date()) {
+        req.user = { actor: session.actor, kind: 'browser_session' };
+        return next();
+      }
+    }
+
+    const match = /^Bearer\s+(.+)$/i.exec(req.headers.authorization ?? '');
+    const credential = match
+      ? SERVICE_CREDENTIALS.find((entry) => tokenMatches(match[1], entry.token))
+      : null;
+    if (!credential) {
+      return sendError(
+        res,
+        401,
+        'AUTH_REQUIRED',
+        'A valid session or service credential is required'
+      );
+    }
+    req.user = { actor: credential.actor, kind: 'service' };
+    return next();
+  } catch (error) {
+    return next(error);
+  }
+}
+
+export const requireAuthTokenHash = tokenHash;

--- a/services/tasks-api/src/routes/contentScheduler.ts
+++ b/services/tasks-api/src/routes/contentScheduler.ts
@@ -51,8 +51,22 @@ import { publishContentSchedulerItem } from './contentSchedulerPublishService.ts
 
 
 function actor(req: any): string {
+  // After the requireAuthenticatedUser middleware (task 0719a8e3), the
+  // authenticated actor is authoritative. The `x-actor` header is kept as
+  // a backwards-compatible audit-trail signal: if it is set and disagrees
+  // with the authenticated actor, we log a warning but accept the
+  // authenticated value. Phase 2 (cloud auth) will drop the header.
+  const authenticated = req.user?.actor;
   const header = req.headers['x-actor'];
-  if (typeof header === 'string' && header.trim().length > 0) return header.trim();
+  const headerValue = typeof header === 'string' && header.trim().length > 0 ? header.trim() : null;
+  if (headerValue && authenticated && headerValue !== authenticated) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[content-scheduler] x-actor header '${headerValue}' disagrees with authenticated actor '${authenticated}'; using authenticated actor`
+    );
+  }
+  if (authenticated) return authenticated;
+  if (headerValue) return headerValue;
   return 'unknown';
 }
 

--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -566,16 +566,34 @@ tasksRouter.post('/tasks/:id/comments', async (req, res, next) => {
     // creation. Checking here blocks all discussion on drifted tasks, which
     // is the opposite of what we want — the new ACs need to be discussed.
 
-    const author = normalizeString(req.body?.author);
+    // Comment author is derived from the authenticated user (task 0719a8e3).
+    // The `author` field on the request body is ignored unless it matches
+    // the authenticated actor; a mismatch is a hard 403 rather than a
+    // silent overwrite, so the caller gets a visible security signal.
+    const authenticatedActor = req.user?.actor;
+    if (!authenticatedActor) {
+      // Defensive: the requireAuthenticatedUser middleware runs ahead of
+      // this handler and would have already returned 401. Reaching here
+      // means the middleware was bypassed (e.g. direct handler invocation
+      // in a test) — refuse rather than fall back to body-supplied author.
+      return sendError(res, 401, 'AUTH_REQUIRED', 'A valid session or service credential is required');
+    }
+    const requestedAuthor = normalizeString(req.body?.author);
+    if (requestedAuthor && requestedAuthor !== authenticatedActor) {
+      return sendError(
+        res,
+        403,
+        'COMMENT_AUTHOR_FORBIDDEN',
+        'author is derived from the authenticated session; body.author must match'
+      );
+    }
     const text = normalizeString(req.body?.text);
-
-    if (!author) return badRequest(res, 'COMMENT_AUTHOR_REQUIRED', 'author is required');
     if (!text) return badRequest(res, 'COMMENT_TEXT_REQUIRED', 'text is required');
 
     const comment = await prisma.taskComment.create({
       data: {
         taskId: id,
-        author,
+        author: authenticatedActor,
         body: text
       }
     });

--- a/services/tasks-api/test/body-limit.test.ts
+++ b/services/tasks-api/test/body-limit.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { authedRequest } from './helpers/auth';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const originalLimit = process.env.TASKS_API_JSON_LIMIT;
@@ -20,7 +21,7 @@ describe('JSON body limit', () => {
   it('returns 413 for an oversized JSON request', async () => {
     process.env.TASKS_API_JSON_LIMIT = '1kb';
     const { createApp } = await import('../src/app.ts');
-    const response = await request(createApp())
+    const response = await authedRequest(createApp())
       .post('/api/v1/tasks')
       .set('Content-Type', 'application/json')
       .send({ value: 'x'.repeat(2048) });
@@ -32,7 +33,7 @@ describe('JSON body limit', () => {
   it('accepts a small JSON request for normal route handling', async () => {
     process.env.TASKS_API_JSON_LIMIT = '1kb';
     const { createApp } = await import('../src/app.ts');
-    const response = await request(createApp()).post('/api/v1/tasks').send({ value: 'x' });
+    const response = await authedRequest(createApp()).post('/api/v1/tasks').send({ value: 'x' });
     expect(response.status).toBe(400);
     expect(response.body.error.code).not.toBe('PAYLOAD_TOO_LARGE');
   });

--- a/services/tasks-api/test/config.test.ts
+++ b/services/tasks-api/test/config.test.ts
@@ -51,6 +51,9 @@ describe('tasks-api config schema', () => {
     process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:5173,http://localhost:4173';
     process.env.X_CLIENT = 'fake';
     process.env.CONTENT_SCHEDULER_JOB_ADAPTER = 'in-process';
+    // Reset the integration-test credential seeded by test/setup.ts so the
+    // dev-env expectation of an empty credential store holds (task 0719a8e3).
+    process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS = '[]';
 
     const { config } = await loadEnvFresh();
     expect(config.NODE_ENV).toBe('development');

--- a/services/tasks-api/test/contentScheduler.test.ts
+++ b/services/tasks-api/test/contentScheduler.test.ts
@@ -297,15 +297,19 @@ describe('contentScheduler routes', () => {
 
   it('POST /content-scheduler/items/:id/approve sets approvedAt + approvedBy', async () => {
     prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(itemFixture({ status: 'queued' }));
-    prismaMock.contentSchedulerItem.update.mockResolvedValue(itemFixture({ status: 'approved', approvedAt: new Date(), approvedBy: 'Tom' }));
+    prismaMock.contentSchedulerItem.update.mockResolvedValue(itemFixture({ status: 'approved', approvedAt: new Date(), approvedBy: 'IntegrationTest' }));
     const app = createApp();
+    // Per task 0719a8e3 (requireAuthenticatedUser + AC2 actor authority),
+    // the authenticated actor overrides the x-actor audit-trail header.
+    // authedRequest() authenticates as 'IntegrationTest' so the route
+    // uses that as approvedBy and logs a warn about the header mismatch.
     const res = await authedRequest(app)
       .post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/approve')
       .set('x-actor', 'Tom');
     expect(res.status).toBe(200);
     expect(prismaMock.contentSchedulerItem.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ approvedBy: 'Tom', status: 'approved' })
+        data: expect.objectContaining({ approvedBy: 'IntegrationTest', status: 'approved' })
       })
     );
   });

--- a/services/tasks-api/test/contentScheduler.test.ts
+++ b/services/tasks-api/test/contentScheduler.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { authedRequest } from './helpers/auth';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   guardPublish,
@@ -248,7 +249,7 @@ describe('contentScheduler routes', () => {
   it('GET /api/v1/content-scheduler/items lists non-removed items', async () => {
     prismaMock.contentSchedulerItem.findMany.mockResolvedValue([itemFixture()]);
     const app = createApp();
-    const res = await request(app).get('/api/v1/content-scheduler/items');
+    const res = await authedRequest(app).get('/api/v1/content-scheduler/items');
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
     expect(prismaMock.contentSchedulerItem.findMany).toHaveBeenCalledWith(
@@ -258,14 +259,14 @@ describe('contentScheduler routes', () => {
 
   it('GET /api/v1/content-scheduler/items rejects unknown status filter', async () => {
     const app = createApp();
-    const res = await request(app).get('/api/v1/content-scheduler/items?status=bogus');
+    const res = await authedRequest(app).get('/api/v1/content-scheduler/items?status=bogus');
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe('INVALID_STATUS_FILTER');
   });
 
   it('POST /api/v1/content-scheduler/items rejects empty body', async () => {
     const app = createApp();
-    const res = await request(app)
+    const res = await authedRequest(app)
       .post('/api/v1/content-scheduler/items')
       .send({ body: '   ' });
     expect(res.status).toBe(400);
@@ -274,7 +275,7 @@ describe('contentScheduler routes', () => {
 
   it('POST /api/v1/content-scheduler/items rejects body > 1000 chars', async () => {
     const app = createApp();
-    const res = await request(app)
+    const res = await authedRequest(app)
       .post('/api/v1/content-scheduler/items')
       .send({ body: 'x'.repeat(1001) });
     expect(res.status).toBe(400);
@@ -285,7 +286,7 @@ describe('contentScheduler routes', () => {
     prismaMock.contentSchedulerItem.aggregate.mockResolvedValue({ _max: { position: 4 } });
     prismaMock.contentSchedulerItem.create.mockResolvedValue(itemFixture({ position: 5 }));
     const app = createApp();
-    const res = await request(app)
+    const res = await authedRequest(app)
       .post('/api/v1/content-scheduler/items')
       .send({ body: 'Tweet body', source: 'ops_notes' });
     expect(res.status).toBe(201);
@@ -298,7 +299,7 @@ describe('contentScheduler routes', () => {
     prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(itemFixture({ status: 'queued' }));
     prismaMock.contentSchedulerItem.update.mockResolvedValue(itemFixture({ status: 'approved', approvedAt: new Date(), approvedBy: 'Tom' }));
     const app = createApp();
-    const res = await request(app)
+    const res = await authedRequest(app)
       .post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/approve')
       .set('x-actor', 'Tom');
     expect(res.status).toBe(200);
@@ -312,7 +313,7 @@ describe('contentScheduler routes', () => {
   it('POST /content-scheduler/items/:id/approve returns 409 on already published', async () => {
     prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(itemFixture({ status: 'published' }));
     const app = createApp();
-    const res = await request(app).post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/approve');
+    const res = await authedRequest(app).post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/approve');
     expect(res.status).toBe(409);
     expect(res.body.error.code).toBe('ALREADY_PUBLISHED');
   });
@@ -320,7 +321,7 @@ describe('contentScheduler routes', () => {
   it('POST /content-scheduler/items/:id/publish refuses NOT_APPROVED', async () => {
     prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(itemFixture({ status: 'queued' }));
     const app = createApp();
-    const res = await request(app).post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/publish');
+    const res = await authedRequest(app).post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/publish');
     expect(res.status).toBe(409);
     expect(res.body.error.code).toBe('NOT_APPROVED');
   });
@@ -333,7 +334,7 @@ describe('contentScheduler routes', () => {
     );
     prismaMock.contentSchedulerItem.findMany.mockResolvedValue([{ id: otherId }]);
     const app = createApp();
-    const res = await request(app).post(`/api/v1/content-scheduler/items/${itemId}/publish`);
+    const res = await authedRequest(app).post(`/api/v1/content-scheduler/items/${itemId}/publish`);
     expect(res.status).toBe(409);
     expect(res.body.error.code).toBe('DAY_CAP_REACHED');
   });
@@ -349,7 +350,7 @@ describe('contentScheduler routes', () => {
     prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]); // today-status empty
     prismaMock.contentSchedulerItem.update.mockResolvedValue({ ...item, status: 'published', publishedUrl: 'https://x.com/sindustries/status/abc', publishedAt: new Date() });
     const app = createApp();
-    const res = await request(app).post('/api/v1/content-scheduler/items/cccc1111-1111-1111-1111-111111111111/publish');
+    const res = await authedRequest(app).post('/api/v1/content-scheduler/items/cccc1111-1111-1111-1111-111111111111/publish');
     expect(res.status).toBe(200);
     expect(res.body.data.status).toBe('published');
     expect(res.body.data.publishedUrl).toMatch(/^https:\/\/x\.com\//);
@@ -369,7 +370,7 @@ describe('contentScheduler routes', () => {
     prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
     prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
     const app = createApp();
-    const res = await request(app).post('/api/v1/content-scheduler/items/dddd1111-1111-1111-1111-111111111111/publish');
+    const res = await authedRequest(app).post('/api/v1/content-scheduler/items/dddd1111-1111-1111-1111-111111111111/publish');
     expect(res.status).toBe(503);
     expect(res.body.error.code).toBe('MISSING_CREDENTIALS');
     delete process.env.X_CLIENT;
@@ -384,7 +385,7 @@ describe('contentScheduler routes', () => {
     prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
     prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
     const app = createApp();
-    const res = await request(app).post(`/api/v1/content-scheduler/items/${itemId}/publish`);
+    const res = await authedRequest(app).post(`/api/v1/content-scheduler/items/${itemId}/publish`);
     expect(res.status).toBe(401);
     expect(res.body.error.code).toBe('UNAUTHORIZED');
     expect(res.body.error.message).toMatch(/Missing x-actor-secret/i);
@@ -401,7 +402,7 @@ describe('contentScheduler routes', () => {
     prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(item);
     prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
     const app = createApp();
-    const res = await request(app)
+    const res = await authedRequest(app)
       .post(`/api/v1/content-scheduler/items/${itemId}/publish`)
       .set('x-actor-secret', 'not-the-right-value');
     expect(res.status).toBe(401);
@@ -425,7 +426,7 @@ describe('contentScheduler routes', () => {
       publishedAt: new Date()
     });
     const app = createApp();
-    const res = await request(app)
+    const res = await authedRequest(app)
       .post(`/api/v1/content-scheduler/items/${itemId}/publish`)
       .set('x-actor-secret', 'deploy-secret');
     expect(res.status).toBe(200);
@@ -449,7 +450,7 @@ describe('contentScheduler routes', () => {
     });
     const app = createApp();
     // No x-actor-secret header sent — should still succeed because the gate is disabled.
-    const res = await request(app).post(`/api/v1/content-scheduler/items/${itemId}/publish`);
+    const res = await authedRequest(app).post(`/api/v1/content-scheduler/items/${itemId}/publish`);
     expect(res.status).toBe(200);
     expect(res.body.data.status).toBe('published');
     delete process.env.X_CLIENT;
@@ -466,7 +467,7 @@ describe('contentScheduler routes', () => {
     ]);
     prismaMock.contentSchedulerItem.update.mockImplementation(async ({ where, data }: any) => ({ id: where.id, position: data.position }));
     const app = createApp();
-    const res = await request(app)
+    const res = await authedRequest(app)
       .post('/api/v1/content-scheduler/reorder')
       .send({ ids: [idC, idA, idB] });
     expect(res.status).toBe(200);
@@ -483,7 +484,7 @@ describe('contentScheduler routes', () => {
       { id: idA, status: 'published' }
     ]);
     const app = createApp();
-    const res = await request(app)
+    const res = await authedRequest(app)
       .post('/api/v1/content-scheduler/reorder')
       .send({ ids: [idA] });
     expect(res.status).toBe(409);
@@ -494,7 +495,7 @@ describe('contentScheduler routes', () => {
     prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(itemFixture({ status: 'queued' }));
     prismaMock.contentSchedulerItem.update.mockResolvedValue(itemFixture({ status: 'removed', removedAt: new Date() }));
     const app = createApp();
-    const res = await request(app).post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/remove');
+    const res = await authedRequest(app).post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/remove');
     expect(res.status).toBe(200);
     expect(prismaMock.contentSchedulerItem.update).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ status: 'removed' }) })
@@ -504,7 +505,7 @@ describe('contentScheduler routes', () => {
   it('POST /content-scheduler/items/:id/remove refuses when already published', async () => {
     prismaMock.contentSchedulerItem.findUnique.mockResolvedValue(itemFixture({ status: 'published' }));
     const app = createApp();
-    const res = await request(app).post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/remove');
+    const res = await authedRequest(app).post('/api/v1/content-scheduler/items/11111111-1111-1111-1111-111111111111/remove');
     expect(res.status).toBe(409);
     expect(res.body.error.code).toBe('ALREADY_PUBLISHED');
   });
@@ -512,7 +513,7 @@ describe('contentScheduler routes', () => {
   it('GET /content-scheduler/today-status returns publishedCount + cap', async () => {
     prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
     const app = createApp();
-    const res = await request(app).get('/api/v1/content-scheduler/today-status');
+    const res = await authedRequest(app).get('/api/v1/content-scheduler/today-status');
     expect(res.status).toBe(200);
     expect(res.body.data.publishedCount).toBe(0);
     expect(res.body.data.cap).toBe(1);

--- a/services/tasks-api/test/contentSchedulerImport.test.ts
+++ b/services/tasks-api/test/contentSchedulerImport.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { authedRequest } from './helpers/auth';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // --- Prisma mock ---------------------------------------------------------
@@ -64,7 +65,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
       ]);
 
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items });
 
@@ -87,7 +88,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
 
     it('returns 1–5 items (boundary)', async () => {
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items: [] });
       expect(res.status).toBe(400);
@@ -99,7 +100,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
         itemBody(`item ${i}`, `https://example.com/${i}`)
       );
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items });
       expect(res.status).toBe(400);
@@ -123,7 +124,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
       ]);
 
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items });
 
@@ -146,7 +147,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
       ]);
 
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items });
 
@@ -160,7 +161,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
     it('rejects body longer than 280 characters', async () => {
       const items = [itemBody('x'.repeat(281), STRONG_REF)];
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items });
       expect(res.status).toBe(400);
@@ -171,7 +172,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
     it('rejects non-http sourceRef', async () => {
       const items = [itemBody('a body', 'javascript:alert(1)')];
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items });
       expect(res.status).toBe(400);
@@ -184,7 +185,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
         itemBody('second', STRONG_REF)
       ];
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items });
       expect(res.status).toBe(400);
@@ -194,7 +195,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
     it('rejects empty body', async () => {
       const items = [itemBody('   ', STRONG_REF)];
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items });
       expect(res.status).toBe(400);
@@ -203,7 +204,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
 
     it('rejects items that are not an array', async () => {
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items: 'not-an-array' });
       expect(res.status).toBe(400);
@@ -215,7 +216,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
     it('rejects with 401 when secret is configured and header is missing', async () => {
       process.env.CONTENT_SCHEDULER_INGEST_SECRET = 'a'.repeat(64);
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items: [itemBody('body', STRONG_REF)] });
       expect(res.status).toBe(401);
@@ -226,7 +227,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
     it('rejects with 401 when secret is configured and header mismatches', async () => {
       process.env.CONTENT_SCHEDULER_INGEST_SECRET = 'a'.repeat(64);
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .set('x-content-ingest-secret', 'b'.repeat(64))
         .send({ items: [itemBody('body', STRONG_REF)] });
@@ -241,7 +242,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
       prismaMock.contentSchedulerItem.findMany.mockResolvedValue([asPersisted(STRONG_REF, 'id-1')]);
 
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .set('x-content-ingest-secret', secret)
         .send({ items: [itemBody('body', STRONG_REF)] });
@@ -254,7 +255,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
       prismaMock.contentSchedulerItem.findMany.mockResolvedValue([asPersisted(STRONG_REF, 'id-1')]);
 
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items: [itemBody('body', STRONG_REF)] });
       expect(res.status).toBe(201);
@@ -268,7 +269,7 @@ describe('POST /content-scheduler/imports/cto-craft', () => {
       prismaMock.contentSchedulerItem.findMany.mockResolvedValue([asPersisted(STRONG_REF, 'id-1')]);
 
       const app = await createApp();
-      const res = await request(app)
+      const res = await authedRequest(app)
         .post('/api/v1/content-scheduler/imports/cto-craft')
         .send({ items });
 

--- a/services/tasks-api/test/db-integration.test.ts
+++ b/services/tasks-api/test/db-integration.test.ts
@@ -34,16 +34,19 @@ describe('tasks api db integration', () => {
 
     const commented = await authedRequest(app)
       .post(`/api/v1/tasks/${taskId}/comments`)
-      .send({ author: 'CI', text: 'Happy-path integration comment' });
+      .send({ text: 'Happy-path integration comment' });
 
     expect(commented.status).toBe(201);
-    expect(commented.body.data.author).toBe('CI');
+    // Per task 0719a8e3 AC2: comment author is derived from the authenticated
+    // user. authedRequest() authenticates as 'IntegrationTest' (seeded by
+    // test/setup.ts), so the comment is persisted under that actor.
+    expect(commented.body.data.author).toBe('IntegrationTest');
     expect(commented.body.data.text).toBe('Happy-path integration comment');
 
     const detail = await authedRequest(app).get(`/api/v1/tasks/${taskId}`);
     expect(detail.status).toBe(200);
     expect(detail.body.data.comments).toEqual([
-      expect.objectContaining({ author: 'CI', text: 'Happy-path integration comment' })
+      expect.objectContaining({ author: 'IntegrationTest', text: 'Happy-path integration comment' })
     ]);
 
     const archived = await authedRequest(app).delete(`/api/v1/tasks/${taskId}`);

--- a/services/tasks-api/test/db-integration.test.ts
+++ b/services/tasks-api/test/db-integration.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { authedRequest } from './helpers/auth';
 import { describe, expect, it } from 'vitest';
 import { createApp } from '../src/app';
 
@@ -6,13 +7,13 @@ describe('tasks api db integration', () => {
   it('reads seeded rows and persists create/update/archive through postgres', async () => {
     const app = createApp();
 
-    const seeded = await request(app).get('/api/v1/tasks').query({ limit: 5 });
+    const seeded = await authedRequest(app).get('/api/v1/tasks').query({ limit: 5 });
     expect(seeded.status).toBe(200);
     expect(seeded.body.data.length).toBeGreaterThan(0);
 
     const title = `CI integration task ${Date.now()}`;
 
-    const created = await request(app).post('/api/v1/tasks').send({
+    const created = await authedRequest(app).post('/api/v1/tasks').send({
       title,
       priority: 'high',
       tags: ['ci-integration']
@@ -24,14 +25,14 @@ describe('tasks api db integration', () => {
 
     const taskId = created.body.data.id;
 
-    const moved = await request(app)
+    const moved = await authedRequest(app)
       .patch(`/api/v1/tasks/${taskId}`)
       .send({ status: 'doing' });
 
     expect(moved.status).toBe(200);
     expect(moved.body.data.status).toBe('doing');
 
-    const commented = await request(app)
+    const commented = await authedRequest(app)
       .post(`/api/v1/tasks/${taskId}/comments`)
       .send({ author: 'CI', text: 'Happy-path integration comment' });
 
@@ -39,17 +40,17 @@ describe('tasks api db integration', () => {
     expect(commented.body.data.author).toBe('CI');
     expect(commented.body.data.text).toBe('Happy-path integration comment');
 
-    const detail = await request(app).get(`/api/v1/tasks/${taskId}`);
+    const detail = await authedRequest(app).get(`/api/v1/tasks/${taskId}`);
     expect(detail.status).toBe(200);
     expect(detail.body.data.comments).toEqual([
       expect.objectContaining({ author: 'CI', text: 'Happy-path integration comment' })
     ]);
 
-    const archived = await request(app).delete(`/api/v1/tasks/${taskId}`);
+    const archived = await authedRequest(app).delete(`/api/v1/tasks/${taskId}`);
     expect(archived.status).toBe(200);
     expect(archived.body.data.id).toBe(taskId);
 
-    const afterArchive = await request(app).get(`/api/v1/tasks/${taskId}`);
+    const afterArchive = await authedRequest(app).get(`/api/v1/tasks/${taskId}`);
     expect(afterArchive.status).toBe(404);
   });
 });

--- a/services/tasks-api/test/featureTaskAnalytics.test.ts
+++ b/services/tasks-api/test/featureTaskAnalytics.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { authedRequest } from './helpers/auth';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // --- Prisma mock ---------------------------------------------------------
@@ -58,7 +59,7 @@ describe('POST /api/v1/feature-task-analytics/events', () => {
     });
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/feature-task-analytics/events')
       .send({
         taskId: VALID_UUID,
@@ -104,7 +105,7 @@ describe('POST /api/v1/feature-task-analytics/events', () => {
     });
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/feature-task-analytics/events')
       .send({
         taskId: VALID_UUID,
@@ -148,7 +149,7 @@ describe('POST /api/v1/feature-task-analytics/events', () => {
     });
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/feature-task-analytics/events')
       .send({
         events: [
@@ -178,7 +179,7 @@ describe('POST /api/v1/feature-task-analytics/events', () => {
 
   it('rejects malformed taskId with 400', async () => {
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/feature-task-analytics/events')
       .send({
         taskId: 'not-a-uuid',
@@ -194,7 +195,7 @@ describe('POST /api/v1/feature-task-analytics/events', () => {
 
   it('rejects invalid eventType with 400', async () => {
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/feature-task-analytics/events')
       .send({
         taskId: VALID_UUID,
@@ -208,7 +209,7 @@ describe('POST /api/v1/feature-task-analytics/events', () => {
 
   it('rejects gate_failure events missing gate', async () => {
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/feature-task-analytics/events')
       .send({
         taskId: VALID_UUID,
@@ -224,7 +225,7 @@ describe('POST /api/v1/feature-task-analytics/events', () => {
 
   it('rejects gate_failure events missing cause', async () => {
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/feature-task-analytics/events')
       .send({
         taskId: VALID_UUID,
@@ -240,7 +241,7 @@ describe('POST /api/v1/feature-task-analytics/events', () => {
 
   it('rejects terminal_summary events that include gate', async () => {
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/feature-task-analytics/events')
       .send({
         taskId: VALID_UUID,
@@ -256,7 +257,7 @@ describe('POST /api/v1/feature-task-analytics/events', () => {
 
   it('rejects terminal_summary events with invalid terminalStatus', async () => {
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/feature-task-analytics/events')
       .send({
         taskId: VALID_UUID,
@@ -271,7 +272,7 @@ describe('POST /api/v1/feature-task-analytics/events', () => {
 
   it('rejects terminal_summary events with non-integer counts', async () => {
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/feature-task-analytics/events')
       .send({
         taskId: VALID_UUID,
@@ -286,7 +287,7 @@ describe('POST /api/v1/feature-task-analytics/events', () => {
 
   it('rejects empty batch', async () => {
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/feature-task-analytics/events')
       .send({ events: [] });
 
@@ -304,7 +305,7 @@ describe('POST /api/v1/feature-task-analytics/events', () => {
     }));
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/feature-task-analytics/events')
       .send({ events });
 
@@ -340,7 +341,7 @@ describe('GET /api/v1/feature-task-analytics/tasks/:taskId/events', () => {
     ]);
 
     const app = createApp();
-    const response = await request(app).get(`/api/v1/feature-task-analytics/tasks/${VALID_UUID}/events`);
+    const response = await authedRequest(app).get(`/api/v1/feature-task-analytics/tasks/${VALID_UUID}/events`);
 
     expect(response.status).toBe(200);
     expect(response.body.data).toHaveLength(1);
@@ -354,7 +355,7 @@ describe('GET /api/v1/feature-task-analytics/tasks/:taskId/events', () => {
     prismaMock.task.findFirst.mockResolvedValue(null);
 
     const app = createApp();
-    const response = await request(app).get(`/api/v1/feature-task-analytics/tasks/${VALID_UUID}/events`);
+    const response = await authedRequest(app).get(`/api/v1/feature-task-analytics/tasks/${VALID_UUID}/events`);
 
     expect(response.status).toBe(404);
     expect(response.body.error.code).toBe('TASK_NOT_FOUND');
@@ -362,7 +363,7 @@ describe('GET /api/v1/feature-task-analytics/tasks/:taskId/events', () => {
 
   it('rejects malformed taskId', async () => {
     const app = createApp();
-    const response = await request(app).get('/api/v1/feature-task-analytics/tasks/nope/events');
+    const response = await authedRequest(app).get('/api/v1/feature-task-analytics/tasks/nope/events');
 
     expect(response.status).toBe(400);
     expect(response.body.error.code).toBe('INVALID_TASK_ID');
@@ -398,7 +399,7 @@ describe('GET /api/v1/feature-task-analytics/weekly', () => {
     prismaMock.featureTaskAnalyticsEvent.findMany.mockResolvedValue([]);
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .get('/api/v1/feature-task-analytics/weekly')
       .query({});
 
@@ -457,7 +458,7 @@ describe('GET /api/v1/feature-task-analytics/weekly', () => {
     ]);
 
     const app = createApp();
-    const response = await request(app).get('/api/v1/feature-task-analytics/weekly');
+    const response = await authedRequest(app).get('/api/v1/feature-task-analytics/weekly');
 
     expect(response.status).toBe(200);
     const currentWeek = response.body.data[7];
@@ -488,7 +489,7 @@ describe('GET /api/v1/feature-task-analytics/weekly', () => {
     ]);
 
     const app = createApp();
-    const response = await request(app).get('/api/v1/feature-task-analytics/weekly');
+    const response = await authedRequest(app).get('/api/v1/feature-task-analytics/weekly');
 
     expect(response.status).toBe(200);
     const currentWeek = response.body.data[7];
@@ -499,7 +500,7 @@ describe('GET /api/v1/feature-task-analytics/weekly', () => {
 
   it('rejects invalid weeks query', async () => {
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .get('/api/v1/feature-task-analytics/weekly')
       .query({ weeks: 0 });
 
@@ -509,7 +510,7 @@ describe('GET /api/v1/feature-task-analytics/weekly', () => {
 
   it('rejects weeks > 52', async () => {
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .get('/api/v1/feature-task-analytics/weekly')
       .query({ weeks: 100 });
 
@@ -534,7 +535,7 @@ describe('GET /api/v1/feature-task-analytics/weekly', () => {
     );
 
     const app = createApp();
-    const response = await request(app).get('/api/v1/feature-task-analytics/weekly');
+    const response = await authedRequest(app).get('/api/v1/feature-task-analytics/weekly');
 
     expect(response.status).toBe(200);
     const currentWeek = response.body.data[7];

--- a/services/tasks-api/test/helpers/auth.ts
+++ b/services/tasks-api/test/helpers/auth.ts
@@ -1,0 +1,25 @@
+// Test helper that injects the integration-test Bearer credential into every
+// supertest call so the general-mutation auth gate (task 0719a8e3) accepts
+// the request. Tests that need to assert rejection paths use plain
+// `request(app)` instead.
+//
+// The credential must match the seeded entry in setup.ts
+// (`integration-test-token-long-enough` / actor "IntegrationTest"). Tests
+// that mock prisma and want a different actor override this token at the
+// call site with `.set('Authorization', 'Bearer <their-token>')`.
+
+import request from 'supertest';
+import type { Express } from 'express';
+
+export const INTEGRATION_TEST_BEARER = 'Bearer integration-test-token-long-enough';
+
+export function authedRequest(app: Express) {
+  const headers = { Authorization: INTEGRATION_TEST_BEARER };
+  return {
+    get: (path: string) => request(app).get(path).set(headers),
+    post: (path: string) => request(app).post(path).set(headers),
+    put: (path: string) => request(app).put(path).set(headers),
+    patch: (path: string) => request(app).patch(path).set(headers),
+    delete: (path: string) => request(app).delete(path).set(headers)
+  };
+}

--- a/services/tasks-api/test/mutationAuthIntegration.test.ts
+++ b/services/tasks-api/test/mutationAuthIntegration.test.ts
@@ -1,0 +1,367 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Set service credentials BEFORE the dynamic import of app.ts (which
+// transitively imports requireAuth.ts) so the module-load-time parse
+// captures the test credentials instead of an empty value. The shape
+// matches TASKS_API_APPROVAL_SERVICE_CREDENTIALS — same shared credential
+// store as the existing approval auth (task 0719a8e3).
+process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS = JSON.stringify([
+  { token: 'quinn-service-token-long-enough', actor: 'Quinn', approvalTypes: ['tech_design'] },
+  { token: 'bookmark-lobster-token-long-enough', actor: 'bookmark_lobster', approvalTypes: [] },
+  { token: 'content-tasks-token-long-enough', actor: 'Lobster', approvalTypes: [] },
+  { token: 'feature-task-lobster-token-long', actor: 'feature_task_lobster', approvalTypes: [] }
+]);
+
+const prismaMock: any = {
+  task: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn()
+  },
+  taskComment: { create: vi.fn(), findMany: vi.fn() },
+  taskTag: { deleteMany: vi.fn(), createMany: vi.fn() },
+  tag: { findMany: vi.fn(), upsert: vi.fn() },
+  taskDependency: { findFirst: vi.fn(), deleteMany: vi.fn(), createMany: vi.fn() },
+  taskApproval: { findMany: vi.fn(), findUnique: vi.fn(), upsert: vi.fn(), update: vi.fn() },
+  approvalSession: { findUnique: vi.fn(), create: vi.fn(), updateMany: vi.fn() },
+  tag: { findMany: vi.fn(), upsert: vi.fn() },
+  contentSchedulerItem: {
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    aggregate: vi.fn()
+  },
+  featureTaskAnalyticsEvent: { findMany: vi.fn(), upsert: vi.fn() },
+  $transaction: vi.fn()
+};
+
+vi.mock('../src/lib/prisma.ts', () => ({ prisma: prismaMock }));
+
+const { createApp } = await import('../src/app.ts');
+
+const TASK_ID = '11111111-1111-1111-1111-111111111111';
+const QUINN_TOKEN = 'quinn-service-token-long-enough';
+const BOOKMARK_TOKEN = 'bookmark-lobster-token-long-enough';
+const FEATURE_TASK_TOKEN = 'feature-task-lobster-token-long';
+const TOM_SESSION = 'tom-browser-session-long-enough';
+
+function bearer(token: string) { return { Authorization: `Bearer ${token}` }; }
+
+describe('mutation auth gate (task 0719a8e3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.approvalSession.findUnique.mockResolvedValue(null);
+    prismaMock.$transaction.mockImplementation(async (cbOrOps: any) => {
+      if (typeof cbOrOps === 'function') return cbOrOps(prismaMock);
+      return Promise.all(cbOrOps);
+    });
+  });
+
+  // AC1 — every mutation route requires valid credentials.
+
+  describe('AC1: POST /tasks requires credentials', () => {
+    it('rejects an unauthenticated POST /tasks with 401 AUTH_REQUIRED', async () => {
+      const res = await request(createApp()).post('/api/v1/tasks').send({ title: 'X' });
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe('AUTH_REQUIRED');
+      expect(prismaMock.task.create).not.toHaveBeenCalled();
+    });
+
+    it('accepts POST /tasks with a valid Bearer service credential', async () => {
+      prismaMock.tag.findMany.mockResolvedValue([]);
+      prismaMock.task.create.mockResolvedValue({ id: TASK_ID, title: 'X' });
+      const res = await request(createApp())
+        .post('/api/v1/tasks')
+        .set(bearer(BOOKMARK_TOKEN))
+        .send({ title: 'X', priority: 'medium', status: 'open' });
+      expect(res.status).toBe(201);
+      expect(prismaMock.task.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts POST /tasks with a valid browser session cookie', async () => {
+      prismaMock.approvalSession.findUnique.mockResolvedValue({
+        actor: 'Quinn',
+        expiresAt: new Date(Date.now() + 60_000),
+        revokedAt: null
+      });
+      prismaMock.tag.findMany.mockResolvedValue([]);
+      prismaMock.task.create.mockResolvedValue({ id: TASK_ID, title: 'X' });
+      const res = await request(createApp())
+        .post('/api/v1/tasks')
+        .set('Cookie', `tasks_api_session=${TOM_SESSION}`)
+        .send({ title: 'X', priority: 'medium', status: 'open' });
+      expect(res.status).toBe(201);
+    });
+
+    it('rejects POST /tasks with an expired session', async () => {
+      prismaMock.approvalSession.findUnique.mockResolvedValue({
+        actor: 'Quinn',
+        expiresAt: new Date(Date.now() - 60_000),
+        revokedAt: null
+      });
+      const res = await request(createApp())
+        .post('/api/v1/tasks')
+        .set('Cookie', `tasks_api_session=${TOM_SESSION}`)
+        .send({ title: 'X' });
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects POST /tasks with a revoked session', async () => {
+      prismaMock.approvalSession.findUnique.mockResolvedValue({
+        actor: 'Quinn',
+        expiresAt: new Date(Date.now() + 60_000),
+        revokedAt: new Date()
+      });
+      const res = await request(createApp())
+        .post('/api/v1/tasks')
+        .set('Cookie', `tasks_api_session=${TOM_SESSION}`)
+        .send({ title: 'X' });
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects POST /tasks with a malformed Authorization header', async () => {
+      const res = await request(createApp())
+        .post('/api/v1/tasks')
+        .set('Authorization', 'NotBearer xyz')
+        .send({ title: 'X' });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('AC1: PATCH /tasks/:id requires credentials', () => {
+    it('rejects an unauthenticated PATCH', async () => {
+      const res = await request(createApp())
+        .patch(`/api/v1/tasks/${TASK_ID}`)
+        .send({ priority: 'high' });
+      expect(res.status).toBe(401);
+      expect(prismaMock.task.update).not.toHaveBeenCalled();
+    });
+
+    it('accepts PATCH with a valid Bearer credential', async () => {
+      prismaMock.task.findFirst.mockResolvedValue({ id: TASK_ID, archivedAt: null });
+      prismaMock.task.update.mockResolvedValue({});
+      prismaMock.task.findFirst.mockResolvedValueOnce({ id: TASK_ID, archivedAt: null });
+      const res = await request(createApp())
+        .patch(`/api/v1/tasks/${TASK_ID}`)
+        .set(bearer(BOOKMARK_TOKEN))
+        .send({ priority: 'high' });
+      // 200 OK or 404 (depending on lookup order) — either way not 401
+      expect([200, 404]).toContain(res.status);
+      expect(res.status).not.toBe(401);
+    });
+  });
+
+  describe('AC1: DELETE /tasks/:id requires credentials', () => {
+    it('rejects an unauthenticated DELETE', async () => {
+      const res = await request(createApp()).delete(`/api/v1/tasks/${TASK_ID}`);
+      expect(res.status).toBe(401);
+      expect(prismaMock.task.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('AC1: POST /tags requires credentials', () => {
+    it('rejects an unauthenticated POST /tags', async () => {
+      const res = await request(createApp()).post('/api/v1/tags').send({ name: 'foo' });
+      expect(res.status).toBe(401);
+    });
+
+    it('accepts POST /tags with a Bearer credential', async () => {
+      prismaMock.tag.upsert.mockResolvedValue({ id: 't1', name: 'foo' });
+      const res = await request(createApp())
+        .post('/api/v1/tags')
+        .set(bearer(BOOKMARK_TOKEN))
+        .send({ name: 'foo' });
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('AC1: content-scheduler mutations require credentials', () => {
+    it('rejects an unauthenticated POST /content-scheduler/items', async () => {
+      const res = await request(createApp())
+        .post('/api/v1/content-scheduler/items')
+        .send({ body: 'hi' });
+      expect(res.status).toBe(401);
+    });
+
+    it('accepts POST /content-scheduler/items with a Bearer credential', async () => {
+      prismaMock.contentSchedulerItem.aggregate.mockResolvedValue({ _max: { position: null } });
+      prismaMock.contentSchedulerItem.create.mockResolvedValue({ id: 'c1', body: 'hi' });
+      const res = await request(createApp())
+        .post('/api/v1/content-scheduler/items')
+        .set(bearer(BOOKMARK_TOKEN))
+        .send({ body: 'hi' });
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('AC1: feature-task-analytics events require credentials', () => {
+    it('rejects an unauthenticated POST /feature-task-analytics/events', async () => {
+      const res = await request(createApp())
+        .post('/api/v1/feature-task-analytics/events')
+        .send({
+          taskId: TASK_ID,
+          eventKey: 'k1',
+          eventType: 'gate_failure',
+          gate: 'ready_checks',
+          cause: 'quality',
+          message: 'fail'
+        });
+      expect(res.status).toBe(401);
+    });
+
+    it('accepts POST /feature-task-analytics/events with a Bearer credential', async () => {
+      prismaMock.featureTaskAnalyticsEvent.upsert.mockResolvedValue({
+        id: 'e1',
+        createdAt: new Date(),
+        updatedAt: new Date()
+      });
+      const res = await request(createApp())
+        .post('/api/v1/feature-task-analytics/events')
+        .set(bearer(FEATURE_TASK_TOKEN))
+        .send({
+          taskId: TASK_ID,
+          eventKey: 'k1',
+          eventType: 'gate_failure',
+          gate: 'ready_checks',
+          cause: 'quality',
+          message: 'fail'
+        });
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('GET endpoints stay open', () => {
+    it('GET /tasks is accessible without credentials', async () => {
+      prismaMock.task.findMany.mockResolvedValue([]);
+      const res = await request(createApp()).get('/api/v1/tasks?limit=5');
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /tags is accessible without credentials', async () => {
+      prismaMock.tag.findMany.mockResolvedValue([]);
+      const res = await request(createApp()).get('/api/v1/tags');
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /content-scheduler/items is accessible without credentials', async () => {
+      prismaMock.contentSchedulerItem.findMany.mockResolvedValue([]);
+      const res = await request(createApp()).get('/api/v1/content-scheduler/items');
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // AC2 — comment author is derived from auth; body-supplied mismatch is 403.
+
+  describe('AC2: comment author derivation', () => {
+    const existingTask = { id: TASK_ID, archivedAt: null };
+
+    it('derives comment author from the authenticated actor (no body.author)', async () => {
+      prismaMock.task.findFirst.mockResolvedValue(existingTask);
+      prismaMock.taskComment.create.mockResolvedValue({
+        id: 'c1',
+        taskId: TASK_ID,
+        author: 'bookmark_lobster',
+        body: 'hello',
+        createdAt: new Date()
+      });
+      const res = await request(createApp())
+        .post(`/api/v1/tasks/${TASK_ID}/comments`)
+        .set(bearer(BOOKMARK_TOKEN))
+        .send({ text: 'hello' });
+      expect(res.status).toBe(201);
+      expect(prismaMock.taskComment.create).toHaveBeenCalledWith({
+        data: { taskId: TASK_ID, author: 'bookmark_lobster', body: 'hello' }
+      });
+    });
+
+    it('accepts body.author when it matches the authenticated actor', async () => {
+      prismaMock.task.findFirst.mockResolvedValue(existingTask);
+      prismaMock.taskComment.create.mockResolvedValue({
+        id: 'c2',
+        taskId: TASK_ID,
+        author: 'feature_task_lobster',
+        body: 'matched',
+        createdAt: new Date()
+      });
+      const res = await request(createApp())
+        .post(`/api/v1/tasks/${TASK_ID}/comments`)
+        .set(bearer(FEATURE_TASK_TOKEN))
+        .send({ author: 'feature_task_lobster', text: 'matched' });
+      expect(res.status).toBe(201);
+      expect(prismaMock.taskComment.create).toHaveBeenCalledWith({
+        data: { taskId: TASK_ID, author: 'feature_task_lobster', body: 'matched' }
+      });
+    });
+
+    it('rejects body.author that disagrees with the authenticated actor (403 COMMENT_AUTHOR_FORBIDDEN)', async () => {
+      prismaMock.task.findFirst.mockResolvedValue(existingTask);
+      const res = await request(createApp())
+        .post(`/api/v1/tasks/${TASK_ID}/comments`)
+        .set(bearer(BOOKMARK_TOKEN))
+        .send({ author: 'Quinn', text: 'forged' });
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('COMMENT_AUTHOR_FORBIDDEN');
+      expect(prismaMock.taskComment.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects unauthenticated comment creation with 401 (no fallback to body.author)', async () => {
+      const res = await request(createApp())
+        .post(`/api/v1/tasks/${TASK_ID}/comments`)
+        .send({ author: 'Tom', text: 'unauthenticated' });
+      expect(res.status).toBe(401);
+      expect(prismaMock.taskComment.create).not.toHaveBeenCalled();
+    });
+
+    it('still rejects missing text with 400 COMMENT_TEXT_REQUIRED when authenticated', async () => {
+      prismaMock.task.findFirst.mockResolvedValue(existingTask);
+      const res = await request(createApp())
+        .post(`/api/v1/tasks/${TASK_ID}/comments`)
+        .set(bearer(BOOKMARK_TOKEN))
+        .send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('COMMENT_TEXT_REQUIRED');
+    });
+  });
+
+  // AC4 — covers automated tests for the matrix above; this block asserts
+  // that expired/revoked sessions are distinguished from missing credentials.
+
+  describe('AC4: session lifetime enforcement', () => {
+    it('rejects an expired session and tries the Bearer fallback', async () => {
+      prismaMock.approvalSession.findUnique.mockResolvedValue({
+        actor: 'Quinn',
+        expiresAt: new Date(Date.now() - 1_000),
+        revokedAt: null
+      });
+      const res = await request(createApp())
+        .post('/api/v1/tasks')
+        .set('Cookie', `tasks_api_session=${TOM_SESSION}`)
+        .set(bearer(QUINN_TOKEN))
+        .send({ title: 'X' });
+      expect(res.status).toBe(201);
+      expect(prismaMock.task.create).toHaveBeenCalled();
+    });
+
+    it('rejects a revoked session even with a valid Bearer token afterwards? — Bearer wins', async () => {
+      // Sanity: when both cookie and Bearer are present, the middleware
+      // tries cookie first; on failure (revoked) it falls back to Bearer.
+      prismaMock.approvalSession.findUnique.mockResolvedValue({
+        actor: 'Quinn',
+        expiresAt: new Date(Date.now() + 60_000),
+        revokedAt: new Date()
+      });
+      prismaMock.tag.findMany.mockResolvedValue([]);
+      prismaMock.task.create.mockResolvedValue({ id: TASK_ID, title: 'X' });
+      const res = await request(createApp())
+        .post('/api/v1/tasks')
+        .set('Cookie', `tasks_api_session=${TOM_SESSION}`)
+        .set(bearer(QUINN_TOKEN))
+        .send({ title: 'X' });
+      expect(res.status).toBe(201);
+    });
+  });
+});

--- a/services/tasks-api/test/rate-limit.test.ts
+++ b/services/tasks-api/test/rate-limit.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { authedRequest } from './helpers/auth';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const originalMax = process.env.TASKS_API_RATE_LIMIT_MAX;
@@ -26,8 +27,8 @@ describe('sensitive endpoint rate limit', () => {
     process.env.TASKS_API_RATE_LIMIT_WINDOW_MS = '60000';
     const { createApp } = await import('../src/app.ts');
     const app = createApp();
-    expect((await request(app).post('/api/v1/tasks').send({})).status).toBe(400);
-    const blocked = await request(app).post('/api/v1/tasks').send({});
+    expect((await authedRequest(app).post('/api/v1/tasks').send({})).status).toBe(400);
+    const blocked = await authedRequest(app).post('/api/v1/tasks').send({});
     expect(blocked.status).toBe(429);
     expect(blocked.headers['retry-after']).toBeDefined();
     expect(blocked.body.error.code).toBe('RATE_LIMITED');

--- a/services/tasks-api/test/read-endpoints.test.ts
+++ b/services/tasks-api/test/read-endpoints.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { authedRequest } from './helpers/auth';
 import { createHash } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -79,7 +80,7 @@ describe('tasks api endpoints', () => {
     ]);
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .get('/api/v1/tasks')
       .query({ status: 'open', limit: 2, q: 'task' });
 
@@ -116,7 +117,7 @@ describe('tasks api endpoints', () => {
     ]);
 
     const app = createApp();
-    const response = await request(app).get('/api/v1/tasks');
+    const response = await authedRequest(app).get('/api/v1/tasks');
 
     expect(response.status).toBe(200);
     expect(response.body.data[0].dependsOn).toEqual([
@@ -138,7 +139,7 @@ describe('tasks api endpoints', () => {
     ]);
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .get('/api/v1/tasks')
       .query({ includeArchived: 'true' });
 
@@ -154,7 +155,7 @@ describe('tasks api endpoints', () => {
     ]);
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .get('/api/v1/tasks')
       .query({ taskType: 'feature' });
 
@@ -168,7 +169,7 @@ describe('tasks api endpoints', () => {
   it('GET /api/v1/tasks rejects invalid taskType filters', async () => {
     const app = createApp();
 
-    const response = await request(app).get('/api/v1/tasks').query({ taskType: 'invalid' });
+    const response = await authedRequest(app).get('/api/v1/tasks').query({ taskType: 'invalid' });
 
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
@@ -180,7 +181,7 @@ describe('tasks api endpoints', () => {
   it('GET /api/v1/tasks validates bad status filter', async () => {
     const app = createApp();
 
-    const response = await request(app).get('/api/v1/tasks').query({ status: 'blocked' });
+    const response = await authedRequest(app).get('/api/v1/tasks').query({ status: 'blocked' });
 
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
@@ -225,7 +226,7 @@ describe('tasks api endpoints', () => {
     );
 
     const app = createApp();
-    const response = await request(app).get('/api/v1/tasks/22222222-2222-2222-2222-222222222222');
+    const response = await authedRequest(app).get('/api/v1/tasks/22222222-2222-2222-2222-222222222222');
 
     expect(response.status).toBe(200);
     expect(response.body.data.id).toBe('22222222-2222-2222-2222-222222222222');
@@ -265,7 +266,7 @@ describe('tasks api endpoints', () => {
     });
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/tasks/11111111-1111-1111-1111-111111111111/comments')
       .send({ author: '  Rowan  ', text: '  Investigated API contract  ' });
 
@@ -290,7 +291,7 @@ describe('tasks api endpoints', () => {
     const app = createApp();
 
     prismaMock.task.findFirst.mockResolvedValueOnce(task());
-    const missingAuthor = await request(app)
+    const missingAuthor = await authedRequest(app)
       .post('/api/v1/tasks/11111111-1111-1111-1111-111111111111/comments')
       .send({ text: 'hello' });
     expect(missingAuthor.status).toBe(400);
@@ -299,7 +300,7 @@ describe('tasks api endpoints', () => {
     });
 
     prismaMock.task.findFirst.mockResolvedValueOnce(task());
-    const missingText = await request(app)
+    const missingText = await authedRequest(app)
       .post('/api/v1/tasks/11111111-1111-1111-1111-111111111111/comments')
       .send({ author: 'Rowan', text: '   ' });
     expect(missingText.status).toBe(400);
@@ -308,7 +309,7 @@ describe('tasks api endpoints', () => {
     });
 
     prismaMock.task.findFirst.mockResolvedValueOnce(null);
-    const missingTask = await request(app)
+    const missingTask = await authedRequest(app)
       .post('/api/v1/tasks/99999999-9999-9999-9999-999999999999/comments')
       .send({ author: 'Rowan', text: 'hello' });
     expect(missingTask.status).toBe(404);
@@ -354,7 +355,7 @@ describe('tasks api endpoints', () => {
   ])('$label with 400 INVALID_TASK_ID and skips the prisma lookup', async ({ method, path, body }) => {
     const app = createApp();
 
-    const req = request(app)[method](path);
+    const req = authedRequest(app)[method](path);
     const response = body ? await req.send(body) : await req;
 
     expect(response.status).toBe(400);
@@ -374,7 +375,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.findFirst.mockResolvedValueOnce(null);
 
     const app = createApp();
-    const response = await request(app).get('/api/v1/tasks/99999999-9999-9999-9999-999999999999');
+    const response = await authedRequest(app).get('/api/v1/tasks/99999999-9999-9999-9999-999999999999');
 
     expect(response.status).toBe(404);
     expect(response.body).toEqual({
@@ -390,7 +391,7 @@ describe('tasks api endpoints', () => {
     );
 
     const app = createApp();
-    const response = await request(app).post('/api/v1/tasks').send({
+    const response = await authedRequest(app).post('/api/v1/tasks').send({
       title: 'Created task',
       priority: 'high',
       taskType: 'feature',
@@ -414,7 +415,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.update.mockResolvedValue(task({ status: 'ready', specChecksum: checksum }));
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
       .send({ status: 'ready', specChecksum: checksum });
 
@@ -478,7 +479,7 @@ describe('tasks api endpoints', () => {
     });
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/2527ff9d-4369-444f-995d-4d4bb0ac7b70')
       .send({ description: driftedDescription });
 
@@ -562,7 +563,7 @@ describe('tasks api endpoints', () => {
     });
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/2527ff9d-4369-444f-995d-4d4bb0ac7b70')
       .send({ description: driftedDescription });
 
@@ -607,7 +608,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.update.mockResolvedValue(task({ description: updatedDescription, specChecksum: checksum }));
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
       .send({ description: updatedDescription });
 
@@ -635,7 +636,7 @@ describe('tasks api endpoints', () => {
     });
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .post('/api/v1/tasks/2527ff9d-4369-444f-995d-4d4bb0ac7b70/comments')
       .send({ author: 'Rowan', text: 'trying to comment' });
 
@@ -676,7 +677,7 @@ describe('tasks api endpoints', () => {
     );
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/2527ff9d-4369-444f-995d-4d4bb0ac7b70')
       .send({ description: updatedDescription });
 
@@ -718,7 +719,7 @@ describe('tasks api endpoints', () => {
     );
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/2527ff9d-4369-444f-995d-4d4bb0ac7b70')
       .send({ description: updatedDescription });
 
@@ -761,7 +762,7 @@ describe('tasks api endpoints', () => {
     );
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/2527ff9d-4369-444f-995d-4d4bb0ac7b70')
       .send({ description: checkedDescription });
 
@@ -779,7 +780,7 @@ describe('tasks api endpoints', () => {
     ]);
 
     const app = createApp();
-    const response = await request(app).get('/api/v1/tasks');
+    const response = await authedRequest(app).get('/api/v1/tasks');
 
     expect(response.status).toBe(200);
     expect(response.body.data.map((item) => item.title)).toEqual(
@@ -789,7 +790,7 @@ describe('tasks api endpoints', () => {
 
   it('POST /api/v1/tasks rejects invalid taskType values', async () => {
     const app = createApp();
-    const response = await request(app).post('/api/v1/tasks').send({
+    const response = await authedRequest(app).post('/api/v1/tasks').send({
       title: 'Created task',
       taskType: 'invalid'
     });
@@ -808,7 +809,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.update.mockResolvedValue(task({ title: 'Updated title', status: 'doing' }));
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
       .send({ title: 'Updated title', status: 'doing' });
 
@@ -839,7 +840,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.update.mockResolvedValue(task());
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
       .send({ dependsOnIds: [dependencyId, dependencyId] });
 
@@ -862,7 +863,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.update.mockResolvedValue(task());
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
       .send({ dependsOnIds: [] });
 
@@ -877,7 +878,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.findFirst.mockResolvedValue(task());
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
       .send({ dependsOnIds: ['not-a-uuid'] });
 
@@ -892,7 +893,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.findFirst.mockResolvedValue(task());
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
       .send({ dependsOnIds: ['11111111-1111-1111-1111-111111111111'] });
 
@@ -907,7 +908,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.findMany.mockResolvedValue([]);
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
       .send({ dependsOnIds: [dependencyId] });
 
@@ -922,7 +923,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.findMany.mockResolvedValue([{ id: dependencyId, archivedAt: new Date('2026-03-01T00:00:00.000Z') }]);
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
       .send({ dependsOnIds: [dependencyId] });
 
@@ -938,7 +939,7 @@ describe('tasks api endpoints', () => {
     prismaMock.taskDependency.findFirst.mockResolvedValue({ taskId: dependencyId });
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
       .send({ dependsOnIds: [dependencyId] });
 
@@ -955,7 +956,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.update.mockResolvedValue(task({ taskType: 'feature' }));
 
     const app = createApp();
-    const feature = await request(app)
+    const feature = await authedRequest(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
       .send({ taskType: 'feature' });
 
@@ -963,7 +964,7 @@ describe('tasks api endpoints', () => {
     expect(feature.body.data.taskType).toBe('feature');
     expect(prismaMock.task.update.mock.calls[0][0].data.taskType).toBe('feature');
 
-    const invalid = await request(app)
+    const invalid = await authedRequest(app)
       .patch('/api/v1/tasks/11111111-1111-1111-1111-111111111111')
       .send({ taskType: 'invalid' });
 
@@ -982,7 +983,7 @@ describe('tasks api endpoints', () => {
     });
 
     const app = createApp();
-    const response = await request(app).delete('/api/v1/tasks/11111111-1111-1111-1111-111111111111');
+    const response = await authedRequest(app).delete('/api/v1/tasks/11111111-1111-1111-1111-111111111111');
 
     expect(response.status).toBe(200);
     expect(response.body.data.id).toBe('11111111-1111-1111-1111-111111111111');
@@ -993,7 +994,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.findFirst.mockResolvedValue(null);
 
     const app = createApp();
-    const response = await request(app).get('/api/v1/tasks/99999999-9999-9999-9999-999999999999');
+    const response = await authedRequest(app).get('/api/v1/tasks/99999999-9999-9999-9999-999999999999');
 
     expect(response.status).toBe(404);
     expect(response.body).toEqual({
@@ -1008,7 +1009,7 @@ describe('tasks api endpoints', () => {
     ]);
 
     const app = createApp();
-    const response = await request(app).get('/api/v1/tags');
+    const response = await authedRequest(app).get('/api/v1/tags');
 
     expect(response.status).toBe(200);
     expect(response.body.data.map((tag) => tag.name)).toEqual(['backend', 'frontend']);
@@ -1019,7 +1020,7 @@ describe('tasks api endpoints', () => {
     prismaMock.tag.upsert.mockResolvedValue({ id: 'tag-1', name: 'backend', createdAt: new Date() });
 
     const app = createApp();
-    const response = await request(app).post('/api/v1/tags').send({ name: 'Backend' });
+    const response = await authedRequest(app).post('/api/v1/tags').send({ name: 'Backend' });
 
     expect(response.status).toBe(201);
     expect(response.body.data.name).toBe('backend');

--- a/services/tasks-api/test/read-endpoints.test.ts
+++ b/services/tasks-api/test/read-endpoints.test.ts
@@ -259,21 +259,24 @@ describe('tasks api endpoints', () => {
     prismaMock.taskComment.create.mockResolvedValue({
       id: 'comment-1',
       taskId: '11111111-1111-1111-1111-111111111111',
-      author: 'Rowan',
+      author: 'IntegrationTest',
       body: 'Investigated API contract',
       createdAt: new Date('2026-03-12T00:00:00.000Z'),
       updatedAt: new Date('2026-03-12T00:00:00.000Z')
     });
 
     const app = createApp();
+    // Per task 0719a8e3 AC2: comment author is derived from the authenticated
+    // user. authedRequest() authenticates as 'IntegrationTest', so the body
+    // omits author entirely (the route uses req.user.actor as the author).
     const response = await authedRequest(app)
       .post('/api/v1/tasks/11111111-1111-1111-1111-111111111111/comments')
-      .send({ author: '  Rowan  ', text: '  Investigated API contract  ' });
+      .send({ text: '  Investigated API contract  ' });
 
     expect(response.status).toBe(201);
     expect(response.body.data).toEqual({
       id: 'comment-1',
-      author: 'Rowan',
+      author: 'IntegrationTest',
       text: 'Investigated API contract',
       createdAt: '2026-03-12T00:00:00.000Z',
       updatedAt: '2026-03-12T00:00:00.000Z'
@@ -281,7 +284,7 @@ describe('tasks api endpoints', () => {
     expect(prismaMock.taskComment.create).toHaveBeenCalledWith({
       data: {
         taskId: '11111111-1111-1111-1111-111111111111',
-        author: 'Rowan',
+        author: 'IntegrationTest',
         body: 'Investigated API contract'
       }
     });
@@ -290,19 +293,16 @@ describe('tasks api endpoints', () => {
   it('POST /api/v1/tasks/:id/comments validates required fields and missing task', async () => {
     const app = createApp();
 
-    prismaMock.task.findFirst.mockResolvedValueOnce(task());
-    const missingAuthor = await authedRequest(app)
-      .post('/api/v1/tasks/11111111-1111-1111-1111-111111111111/comments')
-      .send({ text: 'hello' });
-    expect(missingAuthor.status).toBe(400);
-    expect(missingAuthor.body).toEqual({
-      error: { code: 'COMMENT_AUTHOR_REQUIRED', message: 'author is required' }
-    });
+    // Per task 0719a8e3 AC2: comment author is derived from the authenticated
+    // user, so a missing body.author is no longer a validation error — the
+    // route uses req.user.actor as the author. We assert missing-text and
+    // missing-task paths here; forged-author and missing-auth coverage lives
+    // in mutationAuthIntegration.test.ts.
 
     prismaMock.task.findFirst.mockResolvedValueOnce(task());
     const missingText = await authedRequest(app)
       .post('/api/v1/tasks/11111111-1111-1111-1111-111111111111/comments')
-      .send({ author: 'Rowan', text: '   ' });
+      .send({ text: '   ' });
     expect(missingText.status).toBe(400);
     expect(missingText.body).toEqual({
       error: { code: 'COMMENT_TEXT_REQUIRED', message: 'text is required' }
@@ -311,7 +311,7 @@ describe('tasks api endpoints', () => {
     prismaMock.task.findFirst.mockResolvedValueOnce(null);
     const missingTask = await authedRequest(app)
       .post('/api/v1/tasks/99999999-9999-9999-9999-999999999999/comments')
-      .send({ author: 'Rowan', text: 'hello' });
+      .send({ text: 'hello' });
     expect(missingTask.status).toBe(404);
     expect(missingTask.body).toEqual({
       error: { code: 'TASK_NOT_FOUND', message: 'Task not found' }
@@ -629,19 +629,22 @@ describe('tasks api endpoints', () => {
     prismaMock.taskComment.create.mockResolvedValueOnce({
       id: 'c1000000-0000-0000-0000-000000000000',
       taskId: '2527ff9d-4369-444f-995d-4d4bb0ac7b70',
-      author: 'Rowan',
+      author: 'IntegrationTest',
       body: 'trying to comment',
       createdAt: new Date('2026-07-01T00:00:00.000Z'),
       updatedAt: new Date('2026-07-01T00:00:00.000Z')
     });
 
     const app = createApp();
+    // Per task 0719a8e3 AC2: comment author comes from the authenticated user
+    // (authedRequest() → 'IntegrationTest'). Body author omitted because a
+    // mismatched body.author would 403 instead of succeeding.
     const response = await authedRequest(app)
       .post('/api/v1/tasks/2527ff9d-4369-444f-995d-4d4bb0ac7b70/comments')
-      .send({ author: 'Rowan', text: 'trying to comment' });
+      .send({ text: 'trying to comment' });
 
     expect(response.status).toBe(201);
-    expect(response.body.data.author).toBe('Rowan');
+    expect(response.body.data.author).toBe('IntegrationTest');
     expect(response.body.data.text).toBe('trying to comment');
     expect(prismaMock.taskComment.create).toHaveBeenCalledTimes(1);
   });

--- a/services/tasks-api/test/setup.ts
+++ b/services/tasks-api/test/setup.ts
@@ -8,3 +8,16 @@ process.env.NODE_ENV = process.env.NODE_ENV ?? 'test';
 process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgresql://postgres:postgres@localhost:6432/sindustries_test?schema=tasks_api';
 process.env.X_CLIENT = process.env.X_CLIENT ?? 'fake';
 process.env.CONTENT_SCHEDULER_JOB_ADAPTER = process.env.CONTENT_SCHEDULER_JOB_ADAPTER ?? 'in-process';
+// Seed a default test service credential so the general-mutation auth gate
+// (task 0719a8e3) accepts the integration tests' Bearer header. Tests that
+// need to assert auth-rejection paths override TASKS_API_APPROVAL_SERVICE_CREDENTIALS
+// before dynamically importing app.ts (see mutationAuthIntegration.test.ts).
+process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS =
+  process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS ??
+  JSON.stringify([
+    {
+      token: 'integration-test-token-long-enough',
+      actor: 'IntegrationTest',
+      approvalTypes: []
+    }
+  ]);

--- a/services/tasks-api/test/taskApprovals.test.ts
+++ b/services/tasks-api/test/taskApprovals.test.ts
@@ -51,8 +51,13 @@ describe('task approval boundary', () => {
   });
 
   it('rejects an unauthenticated mutation before database access', async () => {
+    // The general-mutation auth gate (task 0719a8e3) runs ahead of the
+    // approval-specific gate; an unauthenticated request now returns 401
+    // AUTH_REQUIRED before reaching the approval-route handler. The intent
+    // (rejected before any DB access) is preserved — see
+    // requireAuthenticatedUser in src/middleware/requireAuth.ts.
     const res = await request(createApp()).post(`/api/v1/tasks/${TASK_ID}/approvals`).send({ type: 'spec' });
-    expect(res.status).toBe(401); expect(res.body.error.code).toBe('APPROVAL_AUTH_REQUIRED');
+    expect(res.status).toBe(401); expect(res.body.error.code).toBe('AUTH_REQUIRED');
     expect(prismaMock.$transaction).not.toHaveBeenCalled();
   });
 

--- a/services/tasks-api/test/workflowGatesRouteLayer.test.ts
+++ b/services/tasks-api/test/workflowGatesRouteLayer.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { authedRequest } from './helpers/auth';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mirrors the route-layer prisma mock pattern from taskApprovals.test.ts:
@@ -229,7 +230,7 @@ describe('PATCH /api/v1/tasks/:id — attentionOwners', () => {
       }); // post-update fetch
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch(`/api/v1/tasks/${TASK_ID}`)
       .send({ attentionOwners: ['Tom'] });
 
@@ -247,7 +248,7 @@ describe('PATCH /api/v1/tasks/:id — attentionOwners', () => {
       .mockResolvedValueOnce(baseTaskFixture({ attentionOwners: [] }));
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch(`/api/v1/tasks/${TASK_ID}`)
       .send({ attentionOwners: [] });
 
@@ -267,7 +268,7 @@ describe('PATCH /api/v1/tasks/:id — attentionOwners', () => {
       }));
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch(`/api/v1/tasks/${TASK_ID}`)
       .send({ status: 'doing' });
 
@@ -281,7 +282,7 @@ describe('PATCH /api/v1/tasks/:id — attentionOwners', () => {
     prismaMock.task.findFirst.mockResolvedValueOnce({ id: TASK_ID, taskType: 'feature', archivedAt: null });
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch(`/api/v1/tasks/${TASK_ID}`)
       .send({ attentionOwners: 'Tom' });
 
@@ -294,7 +295,7 @@ describe('PATCH /api/v1/tasks/:id — attentionOwners', () => {
     const many = Array.from({ length: MAX_ATTENTION_OWNERS + 1 }, (_, i) => `p${i}`);
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch(`/api/v1/tasks/${TASK_ID}`)
       .send({ attentionOwners: many });
 
@@ -318,7 +319,7 @@ describe('PATCH /api/v1/tasks/:id — attentionOwners', () => {
       });
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch(`/api/v1/tasks/${TASK_ID}`)
       .send({ attentionOwners: [] });
 
@@ -363,7 +364,7 @@ describe('PATCH /api/v1/tasks/:id — attentionOwners', () => {
       });
 
     const app = createApp();
-    const response = await request(app)
+    const response = await authedRequest(app)
       .patch(`/api/v1/tasks/${TASK_ID}`)
       .send({ attentionOwners: [] });
 
@@ -397,7 +398,7 @@ describe('GET /api/v1/tasks — discovery filters', () => {
   ])('?workflowGateOwner=%s filters directly by persisted role ids', async (owner, roleIds) => {
     prismaMock.task.findMany.mockResolvedValue([]);
 
-    await request(createApp()).get('/api/v1/tasks').query({ workflowGateOwner: owner });
+    await authedRequest(createApp()).get('/api/v1/tasks').query({ workflowGateOwner: owner });
 
     const where = prismaMock.task.findMany.mock.calls[0][0].where;
     expect(where.AND).toEqual([{ workflowHandoffRoleId: { in: roleIds } }]);
@@ -406,7 +407,7 @@ describe('GET /api/v1/tasks — discovery filters', () => {
   it('?workflowGateOwner with no configured roles returns zero tasks instead of broadening', async () => {
     prismaMock.task.findMany.mockResolvedValue([]);
 
-    await request(createApp()).get('/api/v1/tasks').query({ workflowGateOwner: 'Rowan' });
+    await authedRequest(createApp()).get('/api/v1/tasks').query({ workflowGateOwner: 'Rowan' });
 
     const where = prismaMock.task.findMany.mock.calls[0][0].where;
     expect(where.AND).toEqual([{ id: { equals: '' } }]);
@@ -416,7 +417,7 @@ describe('GET /api/v1/tasks — discovery filters', () => {
     prismaMock.task.findMany.mockResolvedValue([]);
 
     const app = createApp();
-    await request(app).get('/api/v1/tasks').query({ attentionOwner: 'Tom' });
+    await authedRequest(app).get('/api/v1/tasks').query({ attentionOwner: 'Tom' });
 
     const where = prismaMock.task.findMany.mock.calls[0][0].where;
     expect(where.attentionOwners).toEqual({
@@ -427,7 +428,7 @@ describe('GET /api/v1/tasks — discovery filters', () => {
   it('includes attentionOwners in the findMany include so the response can map them', async () => {
     prismaMock.task.findMany.mockResolvedValue([]);
     const app = createApp();
-    await request(app).get('/api/v1/tasks');
+    await authedRequest(app).get('/api/v1/tasks');
     const include = prismaMock.task.findMany.mock.calls[0][0].include;
     expect(include).toHaveProperty('attentionOwners', true);
   });
@@ -435,7 +436,7 @@ describe('GET /api/v1/tasks — discovery filters', () => {
   it('does not apply the workflow-gate filter when the param is empty', async () => {
     prismaMock.task.findMany.mockResolvedValue([]);
     const app = createApp();
-    await request(app).get('/api/v1/tasks').query({ workflowGateOwner: '' });
+    await authedRequest(app).get('/api/v1/tasks').query({ workflowGateOwner: '' });
     const where = prismaMock.task.findMany.mock.calls[0][0].where;
     expect(where).not.toHaveProperty('AND');
   });
@@ -560,7 +561,7 @@ describe('explicit workflow handoffs', () => {
       taskTag: prismaMock.taskTag, taskDependency: prismaMock.taskDependency,
       taskAttentionOwner: prismaMock.taskAttentionOwner
     }));
-    const response = await request(createApp()).patch(`/api/v1/tasks/${TASK_ID}`)
+    const response = await authedRequest(createApp()).patch(`/api/v1/tasks/${TASK_ID}`)
       .send({ workflowHandoff: { roleId: 'qa_verifier', gate: 'qa' } });
     expect(response.status).toBe(200);
     expect(response.body.data.workflowGates).toEqual([{
@@ -570,7 +571,7 @@ describe('explicit workflow handoffs', () => {
 
   it('rejects unknown role ids before writing', async () => {
     prismaMock.task.findFirst.mockResolvedValueOnce(baseTaskFixture());
-    const response = await request(createApp()).patch(`/api/v1/tasks/${TASK_ID}`)
+    const response = await authedRequest(createApp()).patch(`/api/v1/tasks/${TASK_ID}`)
       .send({ workflowHandoff: { roleId: 'unknown' } });
     expect(response.status).toBe(400);
     expect(response.body.error.code).toBe('INVALID_WORKFLOW_HANDOFF');

--- a/services/tasks-api/vitest.integration.config.ts
+++ b/services/tasks-api/vitest.integration.config.ts
@@ -8,6 +8,11 @@ export default defineConfig({
     include: ['test/db-integration.test.ts'],
     env: {
       DATABASE_URL: process.env.DATABASE_URL || defaultDevDatabaseUrl
-    }
+    },
+    // Load the same setup.ts as the unit-test config so the
+    // TASKS_API_APPROVAL_SERVICE_CREDENTIALS seeded for authedRequest()
+    // (task 0719a8e3) is available to integration tests too.
+    // setup.ts uses `??` for DATABASE_URL so the dev DB set above wins.
+    setupFiles: ['./test/setup.ts']
   }
 });


### PR DESCRIPTION
## Summary

Widen the existing ApprovalSession cookie + `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` identity primitive to gate every `POST`/`PATCH`/`DELETE` on the tasks-api mutation surface instead of only the structured-approval routes. The middleware seam is the migration point for the cloud-auth replacement (task `206927ed`).

- New `requireAuthenticatedUser` middleware mirrors `requireApprovalPrincipal` (same cookie + Bearer parsing, same credential store). Sets `req.user = { actor, kind }` on success; returns `401 AUTH_REQUIRED` on failure.
- Mounted ahead of the tasks, tags, content-scheduler, and feature-task-analytics routers; GET endpoints stay open.
- Comment author is now derived from `req.user.actor` (AC2). Mismatched body-supplied `author` → `403 COMMENT_AUTHOR_FORBIDDEN`.
- `x-actor` header kept as backwards-compatible audit-trail signal (Phase 1); mismatch logs a warning. Phase 2 (cloud auth) drops it.
- Per-agent tokens (`BOOKMARK_LOBSTER_TOKEN`, `CONTENT_TASKS_TOKEN`, `FEATURE_TASK_LOBSTER_TOKEN`) so the comment author / audit-trail actor surfaces correctly for each trusted writer.
- `tasks_api_client.api_request` gains an optional `token` parameter; per-call-site scripts thread their own credential.

## Acceptance Criteria

- [x] AC1: POST, PATCH, and DELETE task mutations reject requests without valid existing username/password credentials. (🧪 testID: services/tasks-api/test/mutationAuthIntegration.test.ts)
- [x] AC2: POST /tasks/:id/comments derives the comment author from the authenticated user and ignores or rejects caller-supplied author impersonation. (🧪 testID: services/tasks-api/test/mutationAuthIntegration.test.ts)
- [x] AC3: Existing trusted task-writing agents and applications are inventoried and updated to authenticate without sharing another user's credentials. (📄 not code: docs/systems/tasks.md general-mutation auth section)
- [x] AC4: Automated tests cover authenticated mutation success, unauthenticated rejection, invalid-credential rejection, and forged comment-author rejection. (🧪 testID: services/tasks-api/test/mutationAuthIntegration.test.ts)
- [x] AC5: A tech design documents the temporary username/password boundary and the later migration path to the shared cloud authentication system. (📄 not code: docs/specs/tasks-api-mutations-auth-tech-design.md)

## Test plan

- `pnpm --filter @sindustries/tasks-api test` (CI runs vitest against services/tasks-api/test/mutationAuthIntegration.test.ts plus existing approval, content-scheduler, analytics, and read-endpoints tests)
- Local verification: the new middleware is a near-clone of `requireApprovalPrincipal` so existing tests continue to exercise the shared credential-store parsing path.
- E2E: `tasks app e2e (ui + api + db)` exercises the full login → create → patch → comment flow with a browser session cookie; the new middleware accepts that cookie as it accepts the approval cookie.

## Migration / operational notes

- Quinn will provision `BOOKMARK_LOBSTER_TOKEN`, `CONTENT_TASKS_TOKEN`, and `FEATURE_TASK_LOBSTER_TOKEN` in `~/.openclaw/.env` and the relevant agent env files before this ships.
- The existing `TASKS_API_APPROVAL_TOKEN` (Quinn actor) continues to work for general mutations; Quinn approval writes are unchanged.
- Dev mode with both `TASKS_API_APPROVAL_USERS` and `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` empty hard-fails every mutation with `401 AUTH_REQUIRED`. Set at least one user entry explicitly.
- Phase 2 (cloud auth, task `206927ed`) swaps the credential-verification implementation behind the middleware seam without touching any route handler.

## Risk / rollback

- The new middleware is mounted ahead of every router; a misconfiguration that returns 401 for every mutation will lock out all writers. Mitigation: the same shared `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` env var is already in use for approval writes, so any production env that works for approvals works for general mutations.
- Rollback: revert this PR. The previous behaviour (no auth on mutations) is restored immediately; no DB migration is included.
