### PR TITLE
fix(cron): stop bookmark-review-lobster process kills from flipping cron status

### DIFF
--- a/agents/crons/prompts/bookmark-review-lobster.md
+++ b/agents/crons/prompts/bookmark-review-lobster.md
@@ -1,3 +1,7 @@
+## Process hygiene
+
+Do not spawn detached/background processes during this run, and never kill a running process or session as part of a probe. If any exec step hangs, let it hit its own timeout rather than killing it — a manual kill flips the cron run to `error` even when the pipeline work underneath succeeded.
+
 ## Pre-check — bail early if nothing to do
 
 Run this first:


### PR DESCRIPTION
## Summary
- Lox's heartbeat triage found two cron jobs reporting `status: error` while the underlying pipeline work actually succeeded.
- **Task Lobsters** (`3c2fa067`): fixed directly via cron config — removed `get_goal`/`create_goal`/`update_goal` from its `toolsAllow` since the workflow never creates a goal, and MiniMax-M3 was unconditionally calling `update_goal(complete)` at the end of the run, failing with "session not found".
- **Bookmark Review Lobster** (`1d8a3cf1`): this PR adds explicit process-hygiene guidance to the prompt so the model lets hung probe steps time out instead of manually killing the process/session, which was flipping the cron run to `error` after a healthy `waiting_on_approval` result.

## Test plan
- [x] Verified both crons' recent run diagnostics (`openclaw cron runs --id <id>`) match the exact failure signatures described
- [x] Confirmed via `openclaw cron get` that Task Lobsters' `toolsAllow` no longer includes goal tools
- [ ] Next scheduled runs of Bookmark Review Lobster should complete without a `Process: ... failed` diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)