### PR TITLE
content: record design system review pass (Tom approval)

### DIFF
--- a/apps/website/src/content/systems.json
+++ b/apps/website/src/content/systems.json
@@ -50,7 +50,7 @@
     "problem": "A product studio needs visual consistency without slowing down small experiments.",
     "howItWorks": "Shared tokens, components, and design constraints keep new surfaces coherent while remaining easy to ship.",
     "proof": "The Pencil design token package, sync checks, and shared UI integration are shipped, with day/night theme support enabled. The website, task app, and Mission Control render from the same component and token source; Mission Control now hosts the design-system viewer and owns the shared day/night preference that synchronises across embedded workspace surfaces.",
-    "updatedAt": "2026-07-10",
+    "updatedAt": "2026-08-15",
     "links": [],
     "image": "/brand/systems/design-system-hero.png",
     "visibility": "published"


### PR DESCRIPTION
## Needs Tom approval

This PR records the approved stale-content review pass without changing the public narrative.

## Acceptance criteria

- [x] EDIT system/design-system — mark stale-content review complete for this window (35 days old, no new design-system evidence this window). Tom approved 2026-08-15: no narrative change, just record the review pass.

Task: `09499477-0ac4-48f8-b142-641621f3afe3`

## Validation

- `python3 -m json.tool apps/website/src/content/systems.json`
