### PR TITLE
feat(gymtrack-mcp): seed OpenClaw OAuth client (task 30251df0)

### DIFF
--- a/apps/gymtrack/supabase/migrations/20260815070000_openclaw_oauth_client.sql
+++ b/apps/gymtrack/supabase/migrations/20260815070000_openclaw_oauth_client.sql
@@ -1,0 +1,20 @@
+-- Add OpenClaw OAuth client to gymtrack-mcp.
+--
+-- Task: 30251df0-a8f2-4e28-9836-029edab8261d
+-- Tech design: docs/specs/gymtrack-mcp-openclaw-oauth-client-tech-design.md
+--
+-- Mirrors the insert-on-conflict pattern at the bottom of
+-- 20260804070000_mcp_oauth.sql: no schema change, no new table, no new RLS
+-- policy. The existing `gymtrack_oauth_clients_authenticated_read` policy
+-- covers the new row. AC4 ("no new client can bypass consent") is satisfied
+-- by construction: the existing `getConsent(...) revoked_at` check on
+-- /oauth/token still gates every token exchange, and the active-consent
+-- unique index on (user_id, client_id) where revoked_at is null still
+-- requires a user-approved consent row for client_id='openclaw'.
+
+insert into public.gymtrack_oauth_clients (client_id, client_name, redirect_uris)
+values
+  ('openclaw', 'OpenClaw', array['http://127.0.0.1:8789/callback'])
+on conflict (client_id) do update
+set client_name = excluded.client_name,
+    redirect_uris = excluded.redirect_uris;

--- a/docs/runbooks/gymtrack-agent-connect.md
+++ b/docs/runbooks/gymtrack-agent-connect.md
@@ -58,17 +58,20 @@ Migration `apps/gymtrack/supabase/migrations/20260804070000_mcp_oauth.sql` seeds
 | --- | --- | --- |
 | Claude | `claude-desktop` | `https://claude.ai/api/mcp/auth_callback` |
 | ChatGPT | `chatgpt` | `https://chatgpt.com/connector_platform_oauth_redirect` |
+| OpenClaw | `openclaw` | `http://127.0.0.1:8789/callback` |
+
+The third row is added by `apps/gymtrack/supabase/migrations/20260815070000_openclaw_oauth_client.sql` (task `30251df0`). `127.0.0.1:8789` is the loopback redirect OpenClaw binds for the duration of the OAuth dance (RFC 8252 §7.3 / OAuth 2.1 §10.2); it is one port above `local-dev`'s `8788` so no two seeded clients collide. If port `8789` is unavailable on a host, surface an actionable error to the user — do not silently bind a different port.
 
 Confirm the production rows have not drifted:
 
 ```sql
 select client_id, client_name, redirect_uris
 from public.gymtrack_oauth_clients
-where client_id in ('claude-desktop', 'chatgpt')
+where client_id in ('claude-desktop', 'chatgpt', 'openclaw')
 order by client_id;
 ```
 
-If either provider reports a redirect mismatch, capture the exact `redirect_uri` it sent, verify it against that provider's current documentation, and update only that client's allowlist. Do not add wildcard redirect URIs.
+If any provider reports a redirect mismatch, capture the exact `redirect_uri` it sent, verify it against that provider's current documentation, and update only that client's allowlist. Do not add wildcard redirect URIs.
 
 ### Claude end-to-end
 

--- a/docs/specs/gymtrack-mcp-openclaw-oauth-client-tech-design.md
+++ b/docs/specs/gymtrack-mcp-openclaw-oauth-client-tech-design.md
@@ -1,0 +1,131 @@
+---
+status: pending-review
+task_id: 30251df0-a8f4-4e28-9836-029edab8261d
+shipped_pr: null
+shipped_date: null
+---
+
+# Add OpenClaw OAuth client to gymtrack-mcp
+
+## Links
+
+- Tech design: `docs/specs/gymtrack-mcp-openclaw-oauth-client-tech-design.md`
+- Task: `30251df0-a8f4-4e28-9836-029edab8261d`
+- Tasks API record: `http://localhost:4001/api/v1/tasks/30251df0-a8f4-4e28-9836-029edab8261d`
+- Predecessor tech design (auth model + table layout): `docs/specs/gymtrack-mcp-server-oauth-auth-tech-design.md`
+- Runbook being extended: `docs/runbooks/gymtrack-agent-connect.md`
+
+## Problem
+
+`gymtrack-mcp`'s OAuth authorization server only recognizes two hardcoded public clients (`claude-desktop`, `chatgpt`), each with a redirect URI locked to a provider-controlled host. It does not implement Dynamic Client Registration (no `registration_endpoint` advertised in `/.well-known/oauth-authorization-server`) nor Client ID Metadata Documents (no `client_id_metadata_document_supported` flag).
+
+Confirmed 2026-08-15: `openclaw mcp login gymtrack` fails immediately with `Incompatible auth server: does not support dynamic client registration`. OpenClaw cannot complete the Authorization Code + PKCE flow against the deployed endpoint.
+
+This is now urgent: task `1eb6e48c` (Decommission legacy GymTrack agent keys and unify on OAuth) has already merged via PR #449 and is in `acceptance`. Once the legacy `gymtrack_agent_api_keys` path is fully decommissioned, OpenClaw / Quinn will have **zero** remaining path to GymTrack — no back-door key and no working OAuth client.
+
+## Approach: third static public PKCE client (not DCR or CIMD)
+
+Three options were on the table:
+
+1. **Static allowlist (chosen).** Add a third row to `gymtrack_oauth_clients`. The server already reads this table on every authorize and token request (`validateClientRedirect` → `repo.getOAuthClient`).
+2. **Dynamic Client Registration (RFC 7591).** Add `POST /oauth/register`, `client_secret` generation/storage/rotation, allowlisted redirect-URI pattern validation, rate limiting, and an admin revoke surface. New endpoints, new tables, new abuse-mitigation surface.
+3. **Client ID Metadata Documents (RFC 9470).** Add `client_id_metadata_document_supported: true` to the metadata document and a fetcher that resolves `client_id` URLs and validates the returned metadata against an allowlisted host set. Network egress, SSRF risk, document caching, allowlist maintenance.
+
+**Decision:** static allowlist. Reasoning:
+
+- The existing trust model is already a static allowlist of two known public clients. A third entry extends the same surface with zero new endpoints, zero new tables, zero new code paths in `app.js`.
+- DCR/CIMD solve "any first-party MCP client can self-register" — a problem we do not have. The only known first-party MCP clients we want to support are Claude, ChatGPT, and OpenClaw, all of which can ship a known `client_id` and redirect URI.
+- DCR/CIMD can be revisited later if/when we onboard fourth-party MCP clients. That is a separate tech design, not a precondition for OpenClaw.
+
+## Trust model impact (none — design constraint, not a checkbox)
+
+Adding `openclaw` to `gymtrack_oauth_clients` does **not** widen the public-client/PKCE trust model. Every check the server performs on a request using `client_id=openclaw` is identical to the check it performs on `client_id=claude-desktop`:
+
+| Check | Current behaviour | After this change |
+| --- | --- | --- |
+| `client_id` lookup | `repo.getOAuthClient(clientId)` reads `gymtrack_oauth_clients` | Identical — `openclaw` is a row in the same table. |
+| `redirect_uri` validation | Exact-string match against `gymtrack_oauth_clients.redirect_uris[]` | Identical — the registered URI for `openclaw` is the single string OpenClaw sends. No wildcards. |
+| PKCE | `code_challenge_method` must be `S256` (enforced in `validateAuthorizeRequest` and re-checked at `/oauth/token`) | Identical. |
+| Token endpoint auth | `token_endpoint_auth_methods_supported: ["none"]` — public client | Identical — `gymtrack_oauth_clients` has no `client_secret` column at all. |
+| Consent | `gymtrack_oauth_consents` row required, unique per `(user_id, client_id) where revoked_at is null`; `consumeAuthorizationCode` returns null when no active consent | Identical — `openclaw` is just another value for `client_id` in the unique index. The active-consent check (`getConsent(...) revoked_at` check in `/oauth/token`) still gates every token exchange. |
+| Refresh-token rotation | `gymtrack_rotate_oauth_refresh_token` checks `consent.revoked_at` and revokes the whole family on replay | Identical. |
+| Discovery surface | `/.well-known/oauth-authorization-server` advertises grants/methods/scopes | Identical — no new flags added. |
+
+AC4 ("no new client can access GymTrack data beyond what the user has consented to") is therefore satisfied by construction. The PR adds a regression test that asserts `client_id=openclaw` cannot obtain a token without an active consent row, matching the existing test for `claude-desktop`.
+
+## Redirect URI choice: loopback on `127.0.0.1:8789`
+
+OpenClaw is a CLI/agent runtime that runs on Tom's Mac mini. The OAuth dance needs a browser round-trip (user must approve at GymTrack's `/agent-consent` page) and a place for the authorization server to send the `code`. Three patterns are viable:
+
+- **(A) Loopback redirect (chosen).** OpenClaw binds `http://127.0.0.1:8789/callback` for the duration of the dance. Standard RFC 8252 §7.3 / OAuth 2.1 §10.2 pattern for public clients with no hosted callback. Matches the existing `local-dev` row pattern (`http://localhost:8788/callback`); picking port `8789` (one off from `local-dev`'s `8788`) avoids any port collision between the two clients.
+- **(B) `openclaw.ai`-hosted callback.** Deploy an `https://openclaw.ai/oauth/callback` endpoint that captures the `code` and forwards it back to the OpenClaw runtime via webhook or polling. Rejected: introduces a new production service, a state-forwarding protocol, and a second trust boundary outside GymTrack's existing model. No upside for a single-tenant agent runtime.
+- **(C) Dynamic port.** OpenClaw binds `127.0.0.1:<ephemeral>/callback` and tells the AS at auth-time. Rejected: `gymtrack_oauth_clients.redirect_uris` is a `text[]` with exact-string matching (no pattern / wildcard support). Dynamic-port support would need either DCR, CIMD, or a port-range allowlist — three separate design discussions, none of which are required to unblock OpenClaw.
+
+**Operational note for the OpenClaw runtime:** if port `8789` is unavailable, surface an actionable error suggesting the user free the port. If we later need dynamic ports, that is a follow-up task to redesign `redirect_uris` validation (likely to a small CIDR/port-range allowlist or to switch to DCR for the loopback case).
+
+## Implementation plan
+
+### `apps/gymtrack/supabase/migrations/20260815070000_openclaw_oauth_client.sql` (new)
+
+Mirrors the `insert ... on conflict do update` pattern at the bottom of `20260804070000_mcp_oauth.sql`:
+
+```sql
+insert into public.gymtrack_oauth_clients (client_id, client_name, redirect_uris)
+values
+  ('openclaw', 'OpenClaw', array['http://127.0.0.1:8789/callback'])
+on conflict (client_id) do update
+set client_name = excluded.client_name,
+    redirect_uris = excluded.redirect_uris;
+```
+
+No schema change. No new table. No new RLS policy (the existing `gymtrack_oauth_clients_authenticated_read` policy covers the new row).
+
+### `services/gymtrack-mcp/test/app.test.js` (extend)
+
+Add two test cases to lock AC4 against the new client:
+
+1. **Consent-required case.** Build a `/oauth/authorize` → `/oauth/authorize/decision` flow with `client_id=openclaw`, then assert `/oauth/token` returns `invalid_grant` when no `gymtrack_oauth_consents` row exists for `(user_id, 'openclaw')`. Mirror the existing `claude-desktop` test that asserts the same invariant.
+2. **Redirect-URI enforcement case.** Submit `client_id=openclaw` with `redirect_uri=https://attacker.example/callback` (or any URI not in the registered list) and assert `validateClientRedirect` returns `{ error: 'redirect_uri is not registered for this client.' }` and the authorize endpoint returns `400 invalid_client`. Mirror the equivalent `claude-desktop` redirect-mismatch test.
+
+Both tests reuse the existing `claude-desktop` test helpers — no new fixtures, no new test scaffolding.
+
+### `docs/runbooks/gymtrack-agent-connect.md` (extend)
+
+Add a row to the existing "Supabase OAuth clients" table:
+
+```
+| OpenClaw | `openclaw` | `http://127.0.0.1:8789/callback` |
+```
+
+And a confirmation query row:
+
+```sql
+select client_id, client_name, redirect_uris
+from public.gymtrack_oauth_clients
+where client_id in ('claude-desktop', 'chatgpt', 'openclaw')
+order by client_id;
+```
+
+No new operator checklist sections — the existing Fly MCP service smoke checks (`/health`, `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`, the unauthenticated `POST /mcp` `WWW-Authenticate` header) all apply unchanged.
+
+## OpenClaw-side MCP client config (out of scope for this PR, blocks AC2/AC3)
+
+Quinn / whoever owns the OpenClaw MCP client needs to register `gymtrack` as a configured MCP client with `client_id=openclaw` and `redirect_uri=http://127.0.0.1:8789/callback`, and have the client implement the loopback listener + PKCE dance. The OpenClaw MCP client already does DCR (which is why it currently fails the metadata discovery check); making it accept a configured static `client_id` instead is the unblock for AC2/AC3.
+
+This PR does not implement that change. Once OpenClaw-side config lands, AC2/AC3 can be verified end-to-end with the same manual smoke test the runbook already documents for Claude.
+
+## Risks and notes
+
+- **Port 8789 collision.** If a future seeded client also wants loopback on `8789`, this design needs to change (or that client picks a different port). Documented in the runbook addition.
+- **No client_secret column.** `gymtrack_oauth_clients` does not store a secret because all seeded clients are public PKCE. If OpenClaw ever needs confidential-client semantics (it does not, per OAuth 2.1 native-app guidance), that is a schema change and a separate task.
+- **No discovery surface change.** This task deliberately does not advertise `registration_endpoint` or `client_id_metadata_document_supported`. Adding either is a feature, not a bug fix; tracking it as a follow-up if/when a fourth-party MCP client needs it.
+- **Single-tenant assumption.** OpenClaw is currently a single-user runtime bound to Tom's GymTrack account. If multi-tenant OpenClaw support becomes a goal, the per-`client_id` consent model already handles it (each user gets their own consent row for `openclaw`), but the runbook should grow a "switch GymTrack account in OpenClaw" section.
+
+## Test plan (AC verification matrix)
+
+| AC | Verification |
+| --- | --- |
+| AC1 | This tech design (merged to `task-30251df0-openclaw-oauth-client` branch) + the `[tech-design-approved] true` comment from Quinn. |
+| AC2 | `openclaw mcp login gymtrack` succeeds end-to-end against the deployed `https://gymtrack-mcp.fly.dev`. Out of scope for this PR; depends on OpenClaw-side MCP client config (see "OpenClaw-side MCP client config" above). Verified after that work lands. |
+| AC3 | Same dependency as AC2: a successful OAuth dance followed by `POST /mcp` `tools/list` returns the three tools, and `tools/call plan_workout` returns expected content for Tom's account. |
+| AC4 | New test case in `services/gymtrack-mcp/test/app.test.js` asserting `client_id=openclaw` cannot obtain a token without an active consent row, plus a redirect-URI mismatch case. Both ship in this PR. |

--- a/services/gymtrack-mcp/test/app.test.js
+++ b/services/gymtrack-mcp/test/app.test.js
@@ -26,6 +26,11 @@ class FakeRepo {
         client_id: 'claude-desktop',
         client_name: 'Claude Desktop',
         redirect_uris: ['https://claude.example/callback']
+      },
+      {
+        client_id: 'openclaw',
+        client_name: 'OpenClaw',
+        redirect_uris: ['http://127.0.0.1:8789/callback']
       }
     ];
     this.users = new Map([['supabase-user-token', { id: 'user-1', email: 'rowan@example.com' }]]);
@@ -688,5 +693,65 @@ describe('GymTrack MCP OAuth server', () => {
     expect(description).toContain('…[redacted-supabase-url]…');
     // 80-char cap with one trailing ellipsis if truncation occurred
     expect(description.length).toBeLessThanOrEqual(81);
+  });
+
+  it('rejects openclaw token exchange when no consent row exists for (user_id, openclaw)', async () => {
+    const { app, repo } = makeApp();
+
+    // Build an authorization code that points at a consent_id that does not
+    // exist in the repo. This mirrors the "consent row never written" condition
+    // AC4 locks against: a fresh OpenClaw install attempting the PKCE dance
+    // against a user who has never approved the new client_id.
+    const code = 'openclaw-orphan-consent-code';
+    const verifier = 'openclaw-orphan-verifier';
+    await repo.createAuthorizationCode({
+      consentId: 'consent-does-not-exist',
+      userId: 'user-1',
+      clientId: 'openclaw',
+      codeHash: sha256Hex(code),
+      redirectUri: 'http://127.0.0.1:8789/callback',
+      scope: 'history:read progression:read workouts:write',
+      codeChallenge: pkceChallengeForVerifier(verifier),
+      codeChallengeMethod: 'S256',
+      expiresAt: new Date('2026-08-15T01:00:00.000Z')
+    });
+
+    const exchange = await request(app)
+      .post('/oauth/token')
+      .type('form')
+      .send({
+        grant_type: 'authorization_code',
+        client_id: 'openclaw',
+        redirect_uri: 'http://127.0.0.1:8789/callback',
+        code,
+        code_verifier: verifier
+      });
+
+    expect(exchange.status).toBe(400);
+    expect(exchange.body.error).toBe('invalid_grant');
+    expect(exchange.body.error_description).toMatch(/consent/i);
+    expect(repo.tokens).toHaveLength(0);
+  });
+
+  it('rejects openclaw authorize requests with a redirect_uri that is not registered for the client', async () => {
+    const { app } = makeApp();
+
+    const response = await request(app)
+      .get('/oauth/authorize')
+      .query({
+        response_type: 'code',
+        client_id: 'openclaw',
+        redirect_uri: 'https://attacker.example/callback',
+        scope: 'history:read',
+        state: 'opaque-state',
+        code_challenge: 'dmVyLWNoYWxsZW5nZQ',
+        code_challenge_method: 'S256'
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_client');
+    expect(response.body.error_description).toBe(
+      'redirect_uri is not registered for this client.'
+    );
   });
 });


### PR DESCRIPTION
## Summary

Seeds a third static public PKCE OAuth client (`openclaw`) into `gymtrack_oauth_clients` so the OpenClaw agent runtime can complete the OAuth 2.1 Authorization Code + PKCE flow against `gymtrack-mcp`. Without this, `openclaw mcp login gymtrack` fails immediately with `Incompatible auth server: does not support dynamic client registration` — and once task `1eb6e48c` (decommission legacy agent keys) reaches `done`, OpenClaw/Quinn will have zero remaining path to GymTrack.

Approach: third static public PKCE client (mirrors `claude-desktop`/`chatgpt`/`local-dev`), loopback redirect `http://127.0.0.1:8789/callback` (RFC 8252 §7.3 / OAuth 2.1 §10.2). No DCR, no CIMD, no schema change, no new RLS, no new endpoints. AC4 is satisfied by construction: the existing `getConsent(...) revoked_at` check on `/oauth/token` still gates every exchange, and the active-consent unique index on `(user_id, client_id) where revoked_at is null` still requires a user-approved consent row for `client_id='openclaw'`.

## Why now

Critical dependency: task `1eb6e48c` (decommission legacy `gymtrack_agent_api_keys`) merged via PR #449 and is in `acceptance`. Once the legacy path is fully decommissioned, OpenClaw / Quinn have **no** remaining path to GymTrack — no back-door key and no working OAuth client.

## Acceptance Criteria

- [x] AC1: A tech design documents the chosen approach (new static client vs DCR/CIMD), the redirect URI OpenClaw will use, and how it avoids widening the existing public-client/PKCE trust model. (📄 not code: docs/specs/gymtrack-mcp-openclaw-oauth-client-tech-design.md approved by Quinn 2026-08-15T06:47:46Z)
- [ ] AC2: `openclaw mcp login gymtrack` (or the equivalent OpenClaw MCP OAuth login flow) completes successfully against the deployed gymtrack-mcp endpoint and OpenClaw obtains a valid access token. (⚠️ not tested: depends on OpenClaw-side MCP client config — registering `client_id=openclaw` + `redirect_uri=http://127.0.0.1:8789/callback` and implementing the loopback listener + PKCE dance. Quinn-owned follow-up; verified after that work lands.)
- [ ] AC3: An authenticated OpenClaw MCP client can list and invoke the GymTrack MCP tools (`plan_workout`, `read_history`, `read_exercise_progression`). (⚠️ not tested: same OpenClaw-side dependency as AC2; verified after that work lands.)
- [x] AC4: No new client can access GymTrack data beyond what the user has consented to; the new client still goes through GymTrack's existing agent-consent approval screen. (🧪 testID: rejects openclaw token exchange when no consent row exists for (user_id, openclaw))

## Changes

- `apps/gymtrack/supabase/migrations/20260815070000_openclaw_oauth_client.sql` (new) — `insert ... on conflict do update` seeding the `openclaw` row into `gymtrack_oauth_clients`. Mirrors the pattern at the bottom of `20260804070000_mcp_oauth.sql`.
- `services/gymtrack-mcp/test/app.test.js` — adds `openclaw` to the `FakeRepo`'s seeded clients list (mirrors the production migration), plus two new tests that lock AC4 against the new client (`rejects openclaw token exchange when no consent row exists for (user_id, openclaw)` and `rejects openclaw authorize requests with a redirect_uri that is not registered for the client`).
- `docs/runbooks/gymtrack-agent-connect.md` — adds the OpenClaw row to the Supabase OAuth clients table, calls out the new migration, documents the `127.0.0.1:8789` port-choice rationale (one off `local-dev`'s `8788`), and updates the confirmation query to include `openclaw`.

## Risks / notes

- **Port 8789 collision.** If a future seeded client also wants loopback on `8789`, this design needs to change (or that client picks a different port). Documented in the runbook addition.
- **No client_secret column.** `gymtrack_oauth_clients` does not store a secret because all seeded clients are public PKCE. If OpenClaw ever needs confidential-client semantics, that is a schema change and a separate task.
- **No discovery surface change.** This PR deliberately does not advertise `registration_endpoint` or `client_id_metadata_document_supported`. Adding either is a feature, not a bug fix; tracking it as a follow-up if/when a fourth-party MCP client needs it.
- **Single-tenant assumption.** OpenClaw is currently a single-user runtime bound to Tom's GymTrack account. Per-`client_id` consent model already handles multi-tenant if it ever becomes a goal.

## Test plan

- `npx vitest run services/gymtrack-mcp/test/app.test.js` — 11 tests pass (9 existing + 2 new for AC4).
- AC1 verification: tech design doc + Quinn approval comment.
- AC2/AC3 verification: depends on OpenClaw-side MCP client config (out of scope for this PR).
- AC4 verification: covered by the two new tests in this PR.

## Task

- Task: `30251df0-a8f4-4e28-9836-029edab8261d`
- Tech design: `docs/specs/gymtrack-mcp-openclaw-oauth-client-tech-design.md`
- Predecessor task: `1eb6e48c` (Decommission legacy GymTrack agent keys and unify on OAuth, PR #449 merged)