### PR TITLE
feat(bookmarks): WS3 contract — classification routing in bookmark pipeline (task 536e04fc)

### DIFF
--- a/agents/skills/product/spec-author/SKILL.md
+++ b/agents/skills/product/spec-author/SKILL.md
@@ -177,13 +177,25 @@ If the caller expects pipeline-consumable output, print JSON after writing:
     {
       "title": "Spec title",
       "specDoc": "brain/tasks/specs/open/<slug>.md",
-      "specType": "infra workflow"
+      "specType": "infra workflow",
+      "classification": "feature",
+      "classification_rationale": "One sentence: why this is feature-typed and not code/research."
     }
   ]
 }
 ```
 
 For bookmark-origin specs, `specDoc` should point at `brain/bookmarks/specs/...`.
+
+### Classification (required per spec, task 536e04fc WS3)
+
+Every spec in the returned bundle MUST carry a `classification` of `feature`, `code`, or `research` plus a one-sentence `classification_rationale`. The bookmark pipeline uses this to decide whether Tom's spec approval is required:
+
+- `feature` — work that needs Tom's spec approval before tasks are created. Default for product/feature work touching the Sindustries stack or product surface.
+- `code` — engineering work that has no product surface (tooling, infra, refactors, internal-only). Skips Tom's approval; tasks are created directly with `type: code`.
+- `research` — investigation/spike work. Skips Tom's approval; tasks are created directly with `type: research`.
+
+Do NOT return `ambiguous` — that value is reserved for the validator when LLM output is malformed (malformed JSON, missing field, wrong enum). If you genuinely cannot classify a spec, return the value you most lean toward plus a rationale that names the alternative; the pipeline will surface it for manual triage if the rationale reads as hedging. The four-value enum is enforced downstream by `agents/workflows/bookmarks/classification_schema.py::parse_classification_payload` — invalid output maps to `ambiguous` and routes to the bookmark-triage queue.
 
 ## Quality Bar
 

--- a/agents/workflows/bookmarks/bookmarks.lobster.yaml
+++ b/agents/workflows/bookmarks/bookmarks.lobster.yaml
@@ -59,12 +59,26 @@ steps:
     stdin: $generate_specs.stdout
     approval: required
 
+  # WS3 direct-create route (task 536e04fc) — runs unconditionally because
+  # code/research specs do not require Tom's approval. Splits the
+  # request_spec_approval payload by direct vs. approval buckets so the
+  # approval flow above can still gate on $request_spec_approval.approved
+  # without dragging direct items in with it.
+  - id: create_tasks_from_direct
+    command: >-
+      python3 codebases/sindustries/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_direct.py
+      --base-url ${TASKS_API_BASE_URL}
+      --json
+    stdin: >-
+      {"directCreateItems": $request_spec_approval.directCreateItems}
+
   - id: create_tasks_from_proposals
     command: >-
       python3 codebases/sindustries/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py
       --base-url ${TASKS_API_BASE_URL}
       --json
-    stdin: $request_spec_approval.stdout
+    stdin: >-
+      {"readyPackages": $request_spec_approval.readyPackages, "blockedPackages": $request_spec_approval.blockedPackages}
     condition: $request_spec_approval.approved
 
   - id: resolve_spec_request

--- a/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_direct.py
+++ b/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_direct.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Create Tasks API tasks from `/directCreateItems` in the bookmark pipeline.
+
+Task 536e04fc WS3 — direct-create route.
+
+This script is the consumer for the `directCreateItems` slice emitted by
+`lobster_request_spec_approval.py` when its classification routing
+determines that none of an item's specs require Tom's approval (all specs
+are `code` or `research`). It runs unconditionally in the pipeline (no
+approval gate), bypassing the approval flow so a code/research spec
+becomes a task in one cron tick instead of waiting for human review.
+
+Output payload shape (per `lobster_request_spec_approval.py`):
+
+  directCreateItems: [
+    {
+      "bookmarkKey": "...",
+      "topic": "...",
+      "title": "...",
+      "specDocs": [...],
+      "tasks": [
+        {
+          "title": "...",
+          "type": "code" | "research",
+          "specDoc": "brain/bookmarks/specs/foo.md",
+          "bookmarkKey": "...",
+          "classification_rationale": "...",
+        },
+      ],
+    },
+  ]
+
+For each task, we POST to the Tasks API with `taskType` matching the
+classification (so the sort `taskType=code` or `taskType=research` filter
+hits it from the dashboard). The description points at the spec doc so
+the implementer can find the source of truth.
+
+Dedup: we keep the same per-spec-tags scheme the approval flow uses
+(`spec-task:<sha1>`) so re-running the pipeline does not duplicate
+existing tasks.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from common import WORKSPACE, dump_json, now_iso
+
+SCRIPT_ROOT = WORKSPACE / "codebases" / "sindustries" / "agents" / "skills" / "ops" / "tasks-api"
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+from tasks_api_client import api_request, list_tasks, service_token_env  # noqa: E402
+
+# Per-agent service credential for the tasks-api mutation surface
+# (task 0719a8e3). Same BOOKMARK_LOBSTER_TOKEN the approval-flow consumer
+# uses. Falls back to TASKS_API_APPROVAL_TOKEN when unset.
+BOOKMARK_LOBSTER_TOKEN = service_token_env('BOOKMARK_LOBSTER_TOKEN')
+
+TASK_SPECS_IN_PROGRESS = 'brain/tasks/specs/in-progress'
+BOOKMARK_SPECS_PREFIX = 'brain/bookmarks/specs/'
+
+
+def spec_marker(spec_doc: str) -> str:
+    """Stable dedup marker based on spec doc path.
+
+    Mirrors `lobster_create_tasks_from_proposals.spec_marker` so the
+    direct-route and approval-route share dedup keys; an item that flips
+    from feature to code (or vice versa) keeps the same taskId.
+    """
+    digest = hashlib.sha1(spec_doc.encode('utf-8')).hexdigest()[:16]
+    return f'spec-task:{digest}'
+
+
+def task_spec_destination(spec_doc: str) -> str:
+    rel = str(spec_doc).strip()
+    if rel.startswith(f'{TASK_SPECS_IN_PROGRESS}/'):
+        return rel
+    if not rel.startswith(BOOKMARK_SPECS_PREFIX):
+        return rel
+    return f'{TASK_SPECS_IN_PROGRESS}/{Path(rel).name}'
+
+
+def move_bookmark_spec_to_task_in_progress(spec_doc: str) -> tuple[str, bool]:
+    dest_doc = task_spec_destination(spec_doc)
+    if dest_doc == spec_doc:
+        return dest_doc, False
+    source = WORKSPACE / spec_doc
+    dest = WORKSPACE / dest_doc
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        if source.exists() and source.read_bytes() != dest.read_bytes():
+            raise RuntimeError(f'destination already exists with different content: {dest_doc}')
+        return dest_doc, False
+    if not source.exists():
+        raise FileNotFoundError(f'spec file not found: {spec_doc}')
+    source.rename(dest)
+    return dest_doc, True
+
+
+def _extract_section(text: str, heading: str) -> str:
+    pattern = re.compile(rf'^## {re.escape(heading)}\s*\n', re.MULTILINE)
+    match = pattern.search(text)
+    if not match:
+        return ''
+    section = text[match.end():]
+    next_h = re.search(r'^## ', section, re.MULTILINE)
+    return (section[:next_h.start()] if next_h else section).strip()
+
+
+def build_task_from_spec(spec_doc: str, task_spec_doc: str, bookmark_key: str, topic: str) -> dict | None:
+    """Read a spec markdown file and build a task dict (title + description)."""
+    spec_path = WORKSPACE / spec_doc
+    if not spec_path.exists():
+        return None
+
+    text = spec_path.read_text(encoding='utf-8')
+
+    title_match = re.search(r'^#\s+Spec\s*[—–-]+\s*(.+)$', text, re.MULTILINE)
+    title = title_match.group(1).strip() if title_match else spec_path.stem.replace('-', ' ').title()
+
+    acs = _extract_section(text, 'Acceptance Criteria')
+    notes = _extract_section(text, 'Notes')
+    outcome = _extract_section(text, 'Outcome')
+
+    parts = [
+        f'**Spec:** {task_spec_doc}',
+        f'**Topic:** {topic}',
+        f'**Bookmark:** {bookmark_key}',
+    ]
+    if outcome:
+        parts += ['', '---', '', outcome]
+    if acs:
+        parts += ['', '## Acceptance Criteria', '', acs]
+    if notes:
+        parts += ['', '## Notes', '', notes]
+
+    return {
+        'title': title,
+        'description': '\n'.join(parts),
+        'priority': 'high',
+    }
+
+
+def task_tags(topic: str, bookmark_key: str, spec_docs: list[str], marker: str) -> list[str]:
+    tags = [
+        'source:bookmark-review-pipeline',
+        f'topic:{topic}',
+        f'bookmark:{bookmark_key}',
+        marker,
+    ]
+    for spec_doc in spec_docs:
+        tags.append(f'spec:{spec_doc}')
+    return tags
+
+
+def task_reusable(task: dict) -> bool:
+    status = str(task.get('status') or '').strip().lower()
+    if task.get('completedAt') or task.get('archivedAt'):
+        return False
+    if status == 'done':
+        return False
+    return True
+
+
+def existing_tasks_by_marker(base_url: str, limit: int = 500) -> dict[str, dict]:
+    indexed = {}
+    for task in list_tasks(limit=limit, base_url=base_url):
+        if not task_reusable(task):
+            continue
+        tags = task.get('tags')
+        if not isinstance(tags, list):
+            continue
+        for tag in tags:
+            if isinstance(tag, str) and tag.startswith('spec-task:'):
+                indexed[tag] = task
+    return indexed
+
+
+def create_task_for_direct(
+    base_url: str,
+    topic: str,
+    bookmark_key: str,
+    spec_doc: str,
+    spec_docs: list[str],
+    task_type: str,
+    classification_rationale: str | None,
+    existing_by_marker: dict[str, dict],
+) -> tuple[dict | None, dict | None]:
+    """Create (or reuse) a task for a single direct-routed spec.
+
+    Returns (created, error). When the marker exists, returns
+    `reused: True` and moves the spec to in-progress if needed.
+    """
+    task_spec_doc = task_spec_destination(spec_doc)
+    marker = spec_marker(task_spec_doc)
+    legacy_marker = spec_marker(spec_doc)
+    existing = existing_by_marker.get(marker) or existing_by_marker.get(legacy_marker)
+    if existing and existing.get('id'):
+        try:
+            moved_doc, moved = move_bookmark_spec_to_task_in_progress(spec_doc)
+        except FileNotFoundError:
+            # Backward-compatible reuse path; the source spec is gone but the
+            # task already exists. The next pipeline run will still see the
+            # marker, so this branch is safe.
+            moved_doc, moved = spec_doc, False
+        except Exception as exc:  # noqa: BLE001
+            return None, {
+                'bookmarkKey': bookmark_key,
+                'topic': topic,
+                'specDoc': spec_doc,
+                'marker': marker,
+                'error': str(exc),
+            }
+        return {
+            'bookmarkKey': bookmark_key,
+            'topic': topic,
+            'specDoc': moved_doc,
+            'sourceSpecDoc': spec_doc,
+            'taskId': str(existing['id']),
+            'reused': True,
+            'moved': moved,
+            'marker': marker,
+            'taskType': task_type,
+        }, None
+
+    spec_def = build_task_from_spec(spec_doc, task_spec_doc, bookmark_key, topic)
+    if spec_def is None:
+        return None, {
+            'bookmarkKey': bookmark_key,
+            'topic': topic,
+            'specDoc': spec_doc,
+            'marker': marker,
+            'error': f'spec file not found: {spec_doc}',
+        }
+
+    payload = {
+        'title': spec_def['title'],
+        'description': spec_def['description'],
+        'priority': spec_def['priority'],
+        'status': 'open',
+        'taskType': task_type,
+        'tags': task_tags(topic, bookmark_key, [task_spec_destination(d) for d in spec_docs], marker),
+    }
+    if classification_rationale:
+        # Carry the WS3 rationale through to the task as a tag so reviewers
+        # can audit *why* the classifier routed this spec to direct-create.
+        payload['tags'].append(f'classification-rationale:{classification_rationale[:120]}')
+
+    response = api_request('POST', base_url, '/tasks', payload, token=BOOKMARK_LOBSTER_TOKEN)
+    task = response.get('data') if isinstance(response, dict) else None
+    task_id = task.get('id') if isinstance(task, dict) else None
+    if task_id is None:
+        return None, {
+            'bookmarkKey': bookmark_key,
+            'topic': topic,
+            'specDoc': spec_doc,
+            'marker': marker,
+            'error': 'Tasks API response did not include data.id',
+            'response': response,
+        }
+
+    try:
+        moved_doc, moved = move_bookmark_spec_to_task_in_progress(spec_doc)
+    except Exception as exc:  # noqa: BLE001
+        return None, {
+            'bookmarkKey': bookmark_key,
+            'topic': topic,
+            'specDoc': spec_doc,
+            'marker': marker,
+            'taskId': str(task_id),
+            'error': str(exc),
+        }
+
+    created = {
+        'bookmarkKey': bookmark_key,
+        'topic': topic,
+        'specDoc': moved_doc,
+        'sourceSpecDoc': spec_doc,
+        'title': spec_def['title'],
+        'taskId': str(task_id),
+        'taskType': task_type,
+        'reused': False,
+        'moved': moved,
+        'marker': marker,
+    }
+    existing_by_marker[marker] = task if isinstance(task, dict) else {'id': task_id, 'tags': payload['tags']}
+    return created, None
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description='Create Tasks API tasks from direct-routed bookmark specs')
+    p.add_argument('--base-url', default='')
+    p.add_argument('--json', action='store_true')
+    args = p.parse_args()
+
+    data = json.load(sys.stdin)
+    base_url = args.base_url.strip() or (os.getenv('TASKS_API_BASE_URL') or '').strip()
+    if not base_url:
+        raise SystemExit('--base-url or TASKS_API_BASE_URL is required')
+
+    direct_items = data.get('directCreateItems') or []
+    existing_by_marker = existing_tasks_by_marker(base_url)
+
+    created: list[dict] = []
+    errors: list[dict] = []
+    for item in direct_items:
+        bookmark_key = item.get('bookmarkKey') or ''
+        topic = item.get('topic') or 'general'
+        spec_docs = item.get('specDocs') or []
+        for task in item.get('tasks') or []:
+            spec_doc = task.get('specDoc')
+            task_type = task.get('type')
+            if task_type not in ('code', 'research'):
+                # Defensive: routing layer should never emit anything else,
+                # but if a corrupt spec_payload ever reaches us, fail
+                # closed instead of silently demoting to feature.
+                errors.append({
+                    'bookmarkKey': bookmark_key,
+                    'topic': topic,
+                    'specDoc': spec_doc,
+                    'error': f'direct-create task type must be code or research, got {task_type!r}',
+                })
+                continue
+            if not spec_doc:
+                errors.append({
+                    'bookmarkKey': bookmark_key,
+                    'topic': topic,
+                    'error': 'direct-create task missing specDoc',
+                })
+                continue
+            result, error = create_task_for_direct(
+                base_url,
+                topic,
+                bookmark_key,
+                spec_doc,
+                spec_docs,
+                task_type,
+                task.get('classification_rationale'),
+                existing_by_marker,
+            )
+            if result:
+                created.append(result)
+            if error:
+                errors.append(error)
+
+    dump_json({
+        'ok': len(errors) == 0,
+        'generatedAt': now_iso(),
+        'created': created,
+        'errors': errors,
+        'directCreateItems': direct_items,
+    })
+    return 0 if not errors else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/agents/workflows/bookmarks/scripts/lobster_request_spec_approval.py
+++ b/agents/workflows/bookmarks/scripts/lobster_request_spec_approval.py
@@ -5,9 +5,11 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 from common import (
     STATE_PATH,
+    STATE_ROOT,
     WORKSPACE,
     dump_json,
     load_state,
@@ -22,6 +24,17 @@ from bookmark_state_machine import (
     is_task_linked,
     reconcile_tasked_item,
 )
+
+# Triage queue for ambiguous-classified bookmarks (task 536e04fc WS3).
+# Appended to on every run that emits ambiguous events. Consumed by the
+# WS4 recurring cron (Quinn-owned registration) that surfaces them as a
+# Telegram report when older than 7 days.
+TRIAGE_QUEUE_PATH = STATE_ROOT / "bookmark-triage-queue.json"
+
+# Routing decision values for the WS3 classification contract.
+ROUTE_FEATURE = "feature"
+ROUTE_DIRECT = "direct"
+ROUTE_AMBIGUOUS = "ambiguous"
 
 # Compact preview helpers — keeps payload under lobster's 2000-char preview cap.
 _ITEM_KEEP = {"bookmarkKey", "specDocs", "topic", "approvalTopic", "title"}
@@ -62,6 +75,123 @@ def _build_item_summary(item: dict) -> dict:
     }
 
 
+def _resolve_route(state_item: dict, item_input: dict) -> tuple[str, list[dict]]:
+    """Return (route, per_spec_data) for the implement item.
+
+    route is one of:
+    - ROUTE_FEATURE: keep today's flow (Tom reviews + approval)
+    - ROUTE_DIRECT: skip approval, downstream calls Tasks API create with
+      type=classification
+    - ROUTE_AMBIGUOUS: no approval, no task; emit bookmark-triage-needed
+      event so WS4 cron can surface it for manual triage
+
+    per_spec_data is a list of classification records keyed by specDoc.
+
+    The routing priority is: ambiguous > feature > direct. If no
+    classifications are present (state pre-dates WS3 contract), the item
+    falls back to feature to preserve today's flow.
+    """
+    classifications = (
+        list(state_item.get("classifications") or [])
+        or list(item_input.get("classifications") or [])
+    )
+
+    if not classifications:
+        return ROUTE_FEATURE, []
+
+    per_spec: list[dict] = []
+    has_ambiguous = False
+    has_feature = False
+    has_direct = False
+    for c in classifications:
+        cls = c.get("classification")
+        per_spec.append({
+            "specDoc": c.get("specDoc"),
+            "classification": cls,
+            "classification_rationale": c.get("classification_rationale"),
+            "classificationError": c.get("classificationError"),
+        })
+        if cls == "ambiguous" or cls is None or c.get("classificationError"):
+            has_ambiguous = True
+        elif cls == "feature":
+            has_feature = True
+        elif cls in ("code", "research"):
+            has_direct = True
+        else:
+            # Unknown enum value — treat as ambiguous so the pipeline never
+            # silently coerces to a wrong route.
+            has_ambiguous = True
+
+    if has_ambiguous:
+        return ROUTE_AMBIGUOUS, per_spec
+    if has_feature:
+        return ROUTE_FEATURE, per_spec
+    if has_direct:
+        return ROUTE_DIRECT, per_spec
+    return ROUTE_FEATURE, per_spec  # unreachable in practice
+
+
+def _append_triage_events(events: list[dict], path: Path | None = None) -> int:
+    """Append triage events to bookmark-triage-queue.json. Returns the new size.
+
+    Queue file is a JSON list. Malformed or missing files are treated as
+    empty. Parent directories are created on first write.
+
+    The default path is read from the module-level `TRIAGE_QUEUE_PATH` at
+    call time (not import time) so tests can monkey-patch the target.
+    """
+    target = path if path is not None else TRIAGE_QUEUE_PATH
+    if target.exists():
+        try:
+            existing = json.loads(target.read_text(encoding="utf-8"))
+            if not isinstance(existing, list):
+                existing = []
+        except (json.JSONDecodeError, OSError):
+            existing = []
+    else:
+        existing = []
+    existing.extend(events)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    return len(existing)
+
+
+def _build_direct_create_item(
+    item: dict, per_spec: list[dict]
+) -> dict:
+    """Build a directCreateItems entry from an implement item + per-spec data.
+
+    Each spec becomes a proposed task with type=classification. The downstream
+    caller (lobster or tasks-api client) reads this and creates one task per
+    entry. The proposedTasks field carries the actual task list so the
+    downstream doesn't need to re-parse the spec docs.
+    """
+    spec_titles = {
+        s.get("specDoc"): s.get("title")
+        for s in (item.get("specProposals") or [])
+    }
+    tasks = []
+    for spec in per_spec:
+        cls = spec.get("classification")
+        spec_doc = spec.get("specDoc")
+        if cls not in ("code", "research"):
+            continue  # direct route only emits code/research tasks
+        tasks.append({
+            "title": spec_titles.get(spec_doc) or Path(spec_doc or "").stem,
+            "type": cls,
+            "specDoc": spec_doc,
+            "bookmarkKey": item.get("bookmarkKey"),
+            "classification_rationale": spec.get("classification_rationale"),
+        })
+    return {
+        "bookmarkKey": item.get("bookmarkKey"),
+        "topic": item.get("topic"),
+        "title": item.get("title"),
+        "specDocs": [s.get("specDoc") for s in per_spec if s.get("specDoc")],
+        "tasks": tasks,
+    }
+
+
 def _update_item(state_items: dict, bookmark_key: str, reason: str, state_path: Path, **fields: object) -> bool:
     item = state_items.get(bookmark_key)
     if not item:
@@ -91,6 +221,45 @@ def main() -> int:
     state_items = state.get("items", {})
     state_path = Path(STATE_PATH)
 
+    # --- Phase 0: WS3 classification routing (task 536e04fc) ---
+    # Divert items before the approval flow so ambiguous and direct-create
+    # items never appear in readyPackages. The implement bucket is split
+    # into three sub-buckets:
+    #   - ambiguous: emit bookmark-triage-needed event, skip approval
+    #   - direct: skip approval, output for downstream Tasks API create
+    #   - feature: continue to the existing approval flow (Phase 1)
+    routed_implement: list[dict] = []
+    direct_create_items: list[dict] = []
+    triage_events: list[dict] = []
+    for item in data.get("implement", []):
+        bookmark_key = item.get("bookmarkKey")
+        state_item = state_items.get(bookmark_key, {})
+        route, per_spec = _resolve_route(state_item, item)
+        if route == ROUTE_AMBIGUOUS:
+            triage_events.append({
+                "bookmarkKey": bookmark_key,
+                "title": item.get("title"),
+                "topic": item.get("topic"),
+                "specDocs": [s.get("specDoc") for s in per_spec],
+                "classificationRationales": [
+                    s.get("classification_rationale") for s in per_spec
+                ],
+                "classificationErrors": [
+                    s.get("classificationError") for s in per_spec
+                ],
+                "emittedAt": now_iso(),
+            })
+            continue
+        if route == ROUTE_DIRECT:
+            direct_create_items.append(_build_direct_create_item(item, per_spec))
+            continue
+        # ROUTE_FEATURE: fall through to the existing approval flow
+        routed_implement.append({**item, "_classifications": per_spec})
+
+    # Persist triage events. WS4 cron (Quinn-owned) reads this queue.
+    if triage_events:
+        _append_triage_events(triage_events)
+
     # --- Phase 1: prepare packages (was lobster_prepare_topic_approval) ---
     pending_topics = {
         get_approval_topic(item)
@@ -101,7 +270,7 @@ def main() -> int:
     candidate_packages: list[dict] = []
     blocked_packages: list[dict] = []
 
-    for item in data.get("implement", []):
+    for item in routed_implement:
         bookmark_key = item.get("bookmarkKey")
         state_item = state_items.get(bookmark_key, {})
         # get_approval_topic reads curation.topic first — the authoritative source.
@@ -234,7 +403,12 @@ def main() -> int:
             base = {k: v for k, v in package.items() if k in _PACKAGE_KEEP}
             compact_ready.append({**base, "items": items_with_specs})
 
-    json.dump({"readyPackages": compact_ready, "blockedPackages": compact_blocked}, sys.stdout)
+    json.dump({
+        "readyPackages": compact_ready,
+        "blockedPackages": compact_blocked,
+        "directCreateItems": direct_create_items,
+        "triageEvents": triage_events,
+    }, sys.stdout)
     sys.stdout.write("\n")
     return 0
 

--- a/agents/workflows/bookmarks/scripts/validate_spec_output.py
+++ b/agents/workflows/bookmarks/scripts/validate_spec_output.py
@@ -61,6 +61,20 @@ from wiki_catalog import (
     upsert_entry as wiki_upsert_entry,
 )
 
+# Task 536e04fc WS3 — pipeline routing on LLM-driven classification.
+# validate_entry_shape below uses Classification as the single source of
+# truth for the four-value enum (`feature | code | research | ambiguous`).
+# WS2's parse_classification_payload validates raw LLM output and is not
+# re-applied here — by the time validate_spec_output runs, the spec
+# markdown is on disk and the per-spec classification metadata has
+# already passed the enum check, so passing the values through is the
+# correct shape.
+CLASSIFICATION_SCRIPT_ROOT = Path(__file__).resolve().parents[1]
+if str(CLASSIFICATION_SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(CLASSIFICATION_SCRIPT_ROOT))
+
+from classification_schema import Classification  # noqa: E402
+
 H1_RE = re.compile(r"^#\s+(?:Spec\s*[—–-]+\s*)?(.*\S)\s*$", re.MULTILINE)
 SECTION_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
 
@@ -79,15 +93,33 @@ def validate_entry_shape(entry: dict[str, Any]) -> list[str]:
         errors.append("specs must be a non-empty list")
         return errors
     for i, spec in enumerate(specs):
+        if not isinstance(spec, dict):
+            errors.append(f"specs[{i}] must be an object")
+            continue
         missing = REQUIRED_SPEC_KEYS - set(spec.keys())
         if missing:
             errors.append(f"specs[{i}] missing keys: {sorted(missing)}")
+        classification = spec.get("classification")
+        if classification not in {c.value for c in Classification}:
+            errors.append(
+                f"specs[{i}].classification must be one of "
+                f"{{feature, code, research, ambiguous}}, got {classification!r}"
+            )
+        rationale = spec.get("classification_rationale")
+        if classification != Classification.AMBIGUOUS.value and (
+            not isinstance(rationale, str) or not rationale.strip()
+        ):
+            errors.append(
+                f"specs[{i}].classification_rationale must be a non-empty string "
+                f"when classification is {classification!r}"
+            )
     return errors
 
 
-def build_proposals(entry: dict[str, Any]) -> tuple[list[str], list[dict[str, Any]]]:
+def build_proposals(entry: dict[str, Any]) -> tuple[list[str], list[dict[str, Any]], list[dict[str, Any]]]:
     spec_docs: list[str] = []
     spec_proposals: list[dict[str, Any]] = []
+    classifications: list[dict[str, Any]] = []
     for spec in entry["specs"]:
         spec_doc = spec["specDoc"]
         spec_docs.append(spec_doc)
@@ -95,7 +127,20 @@ def build_proposals(entry: dict[str, Any]) -> tuple[list[str], list[dict[str, An
             "title": spec["title"],
             "specDoc": spec_doc,
         })
-    return spec_docs, spec_proposals
+        # validate_entry_shape has already enforced the four-value enum
+        # and the non-empty rationale for non-ambiguous values, so we
+        # pass the values through as-authoritative. We do NOT re-run
+        # parse_classification_payload here: that validator is for raw
+        # LLM output and refuses empty spec_markdown, which we do not
+        # have on this code path — the spec markdown is already on disk
+        # by the time validate_spec_output runs.
+        classifications.append({
+            "specDoc": spec_doc,
+            "classification": spec.get("classification"),
+            "classification_rationale": spec.get("classification_rationale", ""),
+            "classificationError": None,
+        })
+    return spec_docs, spec_proposals, classifications
 
 
 
@@ -256,7 +301,7 @@ def main(argv: list[str] | None = None) -> int:
             })
             continue
 
-        spec_docs, spec_proposals = build_proposals(entry)
+        spec_docs, spec_proposals, classifications = build_proposals(entry)
 
         # Spec files must exist on disk before we mark spec_created.
         missing_files = [
@@ -291,6 +336,7 @@ def main(argv: list[str] | None = None) -> int:
             "reviewStatus": "spec_created",
             "specDocs": spec_docs,
             "specProposals": spec_proposals,
+            "classifications": classifications,
             "lastUpdatedAt": now_iso(),
         })
         items[bookmark_key] = item
@@ -305,6 +351,7 @@ def main(argv: list[str] | None = None) -> int:
             "bookmarkKey": bookmark_key,
             "previousStatus": previous_status,
             "specDocs": spec_docs,
+            "classifications": classifications,
             "requestType": entry.get("requestType", "new"),
         })
 

--- a/tests/test_personal_wiki_hooks.py
+++ b/tests/test_personal_wiki_hooks.py
@@ -134,7 +134,12 @@ class PersonalWikiHookTests(unittest.TestCase):
                         {
                             "bookmarkKey": "k1",
                             "requestType": "new",
-                            "specs": [{"title": "Example", "specDoc": spec_rel}],
+                            "specs": [{
+                                "title": "Example",
+                                "specDoc": spec_rel,
+                                "classification": "feature",
+                                "classification_rationale": "Example spec for grounded recall path — product-facing feature work.",
+                            }],
                         }
                     ]
                 }
@@ -175,7 +180,12 @@ class PersonalWikiHookTests(unittest.TestCase):
                         {
                             "bookmarkKey": "k1",
                             "requestType": "new",
-                            "specs": [{"title": "Example", "specDoc": spec_rel}],
+                            "specs": [{
+                                "title": "Example",
+                                "specDoc": spec_rel,
+                                "classification": "feature",
+                                "classification_rationale": "Example spec — needs Tom approval before any task exists.",
+                            }],
                         }
                     ]
                 }

--- a/tests/test_validate_and_route.py
+++ b/tests/test_validate_and_route.py
@@ -591,6 +591,8 @@ class ValidateSpecOutputTests(unittest.TestCase):
             "specs": [{
                 "title": "Spec",
                 "specDoc": "brain/spec.md",
+                "classification": "feature",
+                "classification_rationale": "Happy-path fixture: spec shape is valid and feature-typed.",
             }],
         }])
         out = self._run()
@@ -610,6 +612,8 @@ class ValidateSpecOutputTests(unittest.TestCase):
             "specs": [{
                 "title": "Spec",
                 "specDoc": "brain/specs/does/not/exist.md",
+                "classification": "feature",
+                "classification_rationale": "Fixture focuses on missing-file path; shape is otherwise valid.",
             }],
         }])
         out = self._run()
@@ -628,6 +632,8 @@ class ValidateSpecOutputTests(unittest.TestCase):
             "specs": [{
                 "title": "Spec",
                 "specDoc": "brain/spec.md",
+                "classification": "feature",
+                "classification_rationale": "Fixture focuses on unknown-key path; shape is otherwise valid.",
             }],
         }])
 
@@ -650,6 +656,8 @@ class ValidateSpecOutputTests(unittest.TestCase):
             "specs": [{
                 "title": "Spec",
                 "specDoc": "brain/spec.md",
+                "classification": "feature",
+                "classification_rationale": "Fixture focuses on wrong-state path; shape is otherwise valid.",
             }],
         }])
 

--- a/tests/test_validate_spec_output_classification.py
+++ b/tests/test_validate_spec_output_classification.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Task 536e04fc WS3 — classification capture in validate_spec_output.
+
+The WS3 pipeline routing depends on `validate_spec_output.py` recording
+each spec's LLM-driven classification into bookmark state so the next
+pipeline stage (lobster_request_spec_approval) can branch on it.
+
+These tests pin the shape contract:
+- validate_entry_shape rejects missing/empty classifications
+- validate_entry_shape rejects unknown classification values
+- validate_entry_shape rejects empty classification_rationale
+- build_proposals emits one classification record per spec
+- build_proposals runs every value through parse_classification_payload
+  (the WS2 single-source-of-truth validator) — invalid enum values map
+  to Classification.AMBIGUOUS, not a free-form string
+- Classification records carry specDoc so request_spec_approval can
+  look them up by document path
+
+Run with the rest of the sindustries test suite:
+    python3 -m pytest tests/test_validate_spec_output_classification.py -v
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# Make sure the scripts + classification_schema are importable.
+SCRIPTS_ROOT = Path(__file__).resolve().parents[1] / "agents" / "workflows" / "bookmarks" / "scripts"
+CLASSIFICATION_ROOT = Path(__file__).resolve().parents[1] / "agents" / "workflows" / "bookmarks"
+for _p in (SCRIPTS_ROOT, CLASSIFICATION_ROOT):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+
+@pytest.fixture(scope="module")
+def validate_spec_output():
+    """Import the script as a module. Skips if not present in this worktree."""
+    try:
+        return importlib.import_module("validate_spec_output")
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"validate_spec_output not importable in this checkout: {exc}")
+
+
+def _entry(specs):
+    return {"bookmarkKey": "abc123", "specs": specs}
+
+
+def _spec(title="Spec", spec_doc="brain/bookmarks/specs/x-abc123.md", **overrides):
+    base = {
+        "title": title,
+        "specDoc": spec_doc,
+        "classification": "feature",
+        "classification_rationale": "Touches product surface.",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestValidateEntryShapeRejectsBadClassification:
+    def test_missing_classification_field_rejected(self, validate_spec_output):
+        spec = _spec()
+        del spec["classification"]
+        errors = validate_spec_output.validate_entry_shape(_entry([spec]))
+        assert any("classification" in e for e in errors), errors
+
+    def test_unknown_classification_enum_rejected(self, validate_spec_output):
+        spec = _spec(classification="bugfix")
+        errors = validate_spec_output.validate_entry_shape(_entry([spec]))
+        assert any("classification" in e for e in errors), errors
+
+    def test_empty_classification_rationale_rejected_for_feature(self, validate_spec_output):
+        spec = _spec(classification="feature", classification_rationale="   ")
+        errors = validate_spec_output.validate_entry_shape(_entry([spec]))
+        assert any("classification_rationale" in e for e in errors), errors
+
+    def test_empty_classification_rationale_rejected_for_code(self, validate_spec_output):
+        spec = _spec(classification="code", classification_rationale="")
+        errors = validate_spec_output.validate_entry_shape(_entry([spec]))
+        assert any("classification_rationale" in e for e in errors), errors
+
+    def test_ambiguous_rationale_may_be_empty(self, validate_spec_output):
+        # Ambiguous is reserved for malformed-LLM-output. Rationale is
+        # optional in that case because the parse error key carries the
+        # diagnostic. Pipeline behaviour: the bookmark is surfaced for
+        # manual triage via the WS3 triage queue, so we should not block
+        # the validator on rationale here.
+        spec = _spec(classification="ambiguous", classification_rationale="")
+        errors = validate_spec_output.validate_entry_shape(_entry([spec]))
+        assert not any("classification_rationale" in e for e in errors), errors
+
+
+class TestBuildProposalsCapturesClassifications:
+    def test_emits_one_classification_record_per_spec(self, validate_spec_output):
+        specs = [
+            _spec(title="S1", spec_doc="brain/bookmarks/specs/x-abc123.md", classification="feature"),
+            _spec(title="S2", spec_doc="brain/bookmarks/specs/y-abc123.md", classification="code"),
+            _spec(title="S3", spec_doc="brain/bookmarks/specs/z-abc123.md", classification="research"),
+        ]
+        spec_docs, spec_proposals, classifications = validate_spec_output.build_proposals(_entry(specs))
+        assert spec_docs == [s["specDoc"] for s in specs]
+        assert len(spec_proposals) == 3
+        assert [c["specDoc"] for c in classifications] == spec_docs
+        assert [c["classification"] for c in classifications] == ["feature", "code", "research"]
+
+    def test_unknown_enum_value_rejected_before_build_proposals(self, validate_spec_output):
+        """validate_entry_shape is the single gate for the four-value enum;
+        build_proposals trusts that gate and passes values through. This test
+        pins the contract: build_proposals does NOT re-validate and would
+        propagate an unknown enum verbatim if it ever slipped through, so the
+        only safe behaviour is to refuse unknown values upstream."""
+        # Confirm validate_entry_shape rejects the unknown value:
+        spec = _spec(classification="bugfix", classification_rationale="Stale pipeline")
+        errors = validate_spec_output.validate_entry_shape(_entry([spec]))
+        assert any("classification" in e for e in errors), errors
+
+    def test_classification_records_carry_specDoc_for_routing_lookup(self, validate_spec_output):
+        """lobster_request_spec_approval reads `item.classifications` keyed by
+        specDoc so it can decide per-item whether all specs are
+        code/research (→ direct create), any are feature (→ approval),
+        or any are ambiguous (→ triage)."""
+        spec = _spec(spec_doc="brain/bookmarks/specs/specific-abc123.md")
+        _docs, _proposals, classifications = validate_spec_output.build_proposals(_entry([spec]))
+        assert classifications[0]["specDoc"] == "brain/bookmarks/specs/specific-abc123.md"
+        assert classifications[0]["classificationError"] is None

--- a/tests/test_validate_spec_output_classification.py
+++ b/tests/test_validate_spec_output_classification.py
@@ -10,22 +10,19 @@ These tests pin the shape contract:
 - validate_entry_shape rejects unknown classification values
 - validate_entry_shape rejects empty classification_rationale
 - build_proposals emits one classification record per spec
-- build_proposals runs every value through parse_classification_payload
-  (the WS2 single-source-of-truth validator) — invalid enum values map
-  to Classification.AMBIGUOUS, not a free-form string
 - Classification records carry specDoc so request_spec_approval can
   look them up by document path
 
-Run with the rest of the sindustries test suite:
-    python3 -m pytest tests/test_validate_spec_output_classification.py -v
+Runs under the same discover command as the rest of the sindustries
+test suite (which uses `unittest discover`, not pytest):
+    python3 -m unittest tests.test_validate_spec_output_classification
 """
 from __future__ import annotations
 
 import importlib
 import sys
+import unittest
 from pathlib import Path
-
-import pytest
 
 
 # Make sure the scripts + classification_schema are importable.
@@ -36,13 +33,14 @@ for _p in (SCRIPTS_ROOT, CLASSIFICATION_ROOT):
         sys.path.insert(0, str(_p))
 
 
-@pytest.fixture(scope="module")
-def validate_spec_output():
-    """Import the script as a module. Skips if not present in this worktree."""
+def _load_validate_spec_output():
+    """Import the script as a module. Skip the whole class if absent."""
     try:
         return importlib.import_module("validate_spec_output")
     except Exception as exc:  # noqa: BLE001
-        pytest.skip(f"validate_spec_output not importable in this checkout: {exc}")
+        raise unittest.SkipTest(
+            f"validate_spec_output not importable in this checkout: {exc}"
+        )
 
 
 def _entry(specs):
@@ -60,69 +58,76 @@ def _spec(title="Spec", spec_doc="brain/bookmarks/specs/x-abc123.md", **override
     return base
 
 
-class TestValidateEntryShapeRejectsBadClassification:
-    def test_missing_classification_field_rejected(self, validate_spec_output):
+class TestValidateEntryShapeRejectsBadClassification(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.vso = _load_validate_spec_output()
+
+    def test_missing_classification_field_rejected(self):
         spec = _spec()
         del spec["classification"]
-        errors = validate_spec_output.validate_entry_shape(_entry([spec]))
-        assert any("classification" in e for e in errors), errors
+        errors = self.vso.validate_entry_shape(_entry([spec]))
+        self.assertTrue(any("classification" in e for e in errors), errors)
 
-    def test_unknown_classification_enum_rejected(self, validate_spec_output):
+    def test_unknown_classification_enum_rejected(self):
         spec = _spec(classification="bugfix")
-        errors = validate_spec_output.validate_entry_shape(_entry([spec]))
-        assert any("classification" in e for e in errors), errors
+        errors = self.vso.validate_entry_shape(_entry([spec]))
+        self.assertTrue(any("classification" in e for e in errors), errors)
 
-    def test_empty_classification_rationale_rejected_for_feature(self, validate_spec_output):
+    def test_empty_classification_rationale_rejected_for_feature(self):
         spec = _spec(classification="feature", classification_rationale="   ")
-        errors = validate_spec_output.validate_entry_shape(_entry([spec]))
-        assert any("classification_rationale" in e for e in errors), errors
+        errors = self.vso.validate_entry_shape(_entry([spec]))
+        self.assertTrue(any("classification_rationale" in e for e in errors), errors)
 
-    def test_empty_classification_rationale_rejected_for_code(self, validate_spec_output):
+    def test_empty_classification_rationale_rejected_for_code(self):
         spec = _spec(classification="code", classification_rationale="")
-        errors = validate_spec_output.validate_entry_shape(_entry([spec]))
-        assert any("classification_rationale" in e for e in errors), errors
+        errors = self.vso.validate_entry_shape(_entry([spec]))
+        self.assertTrue(any("classification_rationale" in e for e in errors), errors)
 
-    def test_ambiguous_rationale_may_be_empty(self, validate_spec_output):
+    def test_ambiguous_rationale_may_be_empty(self):
         # Ambiguous is reserved for malformed-LLM-output. Rationale is
         # optional in that case because the parse error key carries the
         # diagnostic. Pipeline behaviour: the bookmark is surfaced for
         # manual triage via the WS3 triage queue, so we should not block
         # the validator on rationale here.
         spec = _spec(classification="ambiguous", classification_rationale="")
-        errors = validate_spec_output.validate_entry_shape(_entry([spec]))
-        assert not any("classification_rationale" in e for e in errors), errors
+        errors = self.vso.validate_entry_shape(_entry([spec]))
+        self.assertFalse(any("classification_rationale" in e for e in errors), errors)
 
 
-class TestBuildProposalsCapturesClassifications:
-    def test_emits_one_classification_record_per_spec(self, validate_spec_output):
+class TestBuildProposalsCapturesClassifications(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.vso = _load_validate_spec_output()
+
+    def test_emits_one_classification_record_per_spec(self):
         specs = [
             _spec(title="S1", spec_doc="brain/bookmarks/specs/x-abc123.md", classification="feature"),
             _spec(title="S2", spec_doc="brain/bookmarks/specs/y-abc123.md", classification="code"),
             _spec(title="S3", spec_doc="brain/bookmarks/specs/z-abc123.md", classification="research"),
         ]
-        spec_docs, spec_proposals, classifications = validate_spec_output.build_proposals(_entry(specs))
-        assert spec_docs == [s["specDoc"] for s in specs]
-        assert len(spec_proposals) == 3
-        assert [c["specDoc"] for c in classifications] == spec_docs
-        assert [c["classification"] for c in classifications] == ["feature", "code", "research"]
+        spec_docs, spec_proposals, classifications = self.vso.build_proposals(_entry(specs))
+        self.assertEqual(spec_docs, [s["specDoc"] for s in specs])
+        self.assertEqual(len(spec_proposals), 3)
+        self.assertEqual([c["specDoc"] for c in classifications], spec_docs)
+        self.assertEqual([c["classification"] for c in classifications], ["feature", "code", "research"])
 
-    def test_unknown_enum_value_rejected_before_build_proposals(self, validate_spec_output):
+    def test_unknown_enum_value_rejected_before_build_proposals(self):
         """validate_entry_shape is the single gate for the four-value enum;
         build_proposals trusts that gate and passes values through. This test
         pins the contract: build_proposals does NOT re-validate and would
         propagate an unknown enum verbatim if it ever slipped through, so the
         only safe behaviour is to refuse unknown values upstream."""
-        # Confirm validate_entry_shape rejects the unknown value:
         spec = _spec(classification="bugfix", classification_rationale="Stale pipeline")
-        errors = validate_spec_output.validate_entry_shape(_entry([spec]))
-        assert any("classification" in e for e in errors), errors
+        errors = self.vso.validate_entry_shape(_entry([spec]))
+        self.assertTrue(any("classification" in e for e in errors), errors)
 
-    def test_classification_records_carry_specDoc_for_routing_lookup(self, validate_spec_output):
+    def test_classification_records_carry_specDoc_for_routing_lookup(self):
         """lobster_request_spec_approval reads `item.classifications` keyed by
         specDoc so it can decide per-item whether all specs are
         code/research (→ direct create), any are feature (→ approval),
         or any are ambiguous (→ triage)."""
         spec = _spec(spec_doc="brain/bookmarks/specs/specific-abc123.md")
-        _docs, _proposals, classifications = validate_spec_output.build_proposals(_entry([spec]))
-        assert classifications[0]["specDoc"] == "brain/bookmarks/specs/specific-abc123.md"
-        assert classifications[0]["classificationError"] is None
+        _docs, _proposals, classifications = self.vso.build_proposals(_entry([spec]))
+        self.assertEqual(classifications[0]["specDoc"], "brain/bookmarks/specs/specific-abc123.md")
+        self.assertIsNone(classifications[0]["classificationError"])

--- a/tests/test_wsj_routing.py
+++ b/tests/test_wsj_routing.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Task 536e04fc WS3 — classification routing in `lobster_request_spec_approval`.
+
+The WS3 routing layer decides whether an `implement` item needs Tom's
+approval (any spec is `feature`), can go straight to a `code`/`research`
+task (every spec is code or research), or should be surfaced for manual
+triage (any spec is `ambiguous` or its classification is missing/unknown).
+
+Tests pin the routing contract:
+- `_resolve_route` returns ROUTE_FEATURE when any spec is feature
+- `_resolve_route` returns ROUTE_DIRECT only when every spec is code/research
+- `_resolve_route` returns ROUTE_AMBIGUOUS when any spec is ambiguous OR
+  missing OR has a classificationError OR carries an unknown enum
+- `_resolve_route` falls back to ROUTE_FEATURE when no classifications
+  exist (preserves the pre-WS3 flow)
+- State shape `classifications` takes precedence over input shape
+  `classifications`; passing both is undefined — state wins
+- `_build_direct_create_item` only emits `code`/`research` tasks
+- `_append_triage_events` appends to the queue and creates the file on
+  first write
+
+Runs under the same discover command as the rest of the sindustries
+test suite (which uses `unittest discover`, not pytest):
+    python3 -m unittest tests.test_wsj_routing
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+# Make sure the scripts root is importable for the lobster_request_spec_approval
+# module under test.
+SCRIPTS_ROOT = Path(__file__).resolve().parents[1] / "agents" / "workflows" / "bookmarks" / "scripts"
+WORKFLOW_DIR = Path(__file__).resolve().parents[1] / "agents" / "workflows" / "bookmarks"
+for _p in (SCRIPTS_ROOT, WORKFLOW_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+
+def _load_routing():
+    """Import the script as a module. Skip the whole class if absent."""
+    try:
+        return importlib.import_module("lobster_request_spec_approval")
+    except Exception as exc:  # noqa: BLE001
+        raise unittest.SkipTest(
+            f"lobster_request_spec_approval not importable in this checkout: {exc}"
+        )
+
+
+def _spec(spec_doc, classification, *, rationale=None, error=None):
+    return {
+        "specDoc": spec_doc,
+        "classification": classification,
+        "classification_rationale": rationale or "",
+        "classificationError": error,
+    }
+
+
+class TestRoutePriority(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.routing = _load_routing()
+
+    def test_ambiguous_wins_over_feature(self):
+        classify = [
+            _spec("brain/bookmarks/specs/a.md", "feature", rationale="r"),
+            _spec("brain/bookmarks/specs/b.md", "ambiguous"),
+        ]
+        state = {"items": {"abc": {"classifications": classify}}}
+        route, per_spec = self.routing._resolve_route(state["items"]["abc"], {})
+        self.assertEqual(route, self.routing.ROUTE_AMBIGUOUS)
+        self.assertEqual(len(per_spec), 2)
+
+    def test_feature_wins_over_direct(self):
+        """If any spec is feature, the item must go through approval even
+        when other specs are code/research. Mixed items are feature, full
+        stop."""
+        classify = [
+            _spec("brain/bookmarks/specs/a.md", "code", rationale="r"),
+            _spec("brain/bookmarks/specs/b.md", "feature", rationale="r"),
+            _spec("brain/bookmarks/specs/c.md", "research", rationale="r"),
+        ]
+        state = {"items": {"abc": {"classifications": classify}}}
+        route, _per_spec = self.routing._resolve_route(state["items"]["abc"], {})
+        self.assertEqual(route, self.routing.ROUTE_FEATURE)
+
+    def test_all_code_research_is_direct(self):
+        classify = [
+            _spec("brain/bookmarks/specs/a.md", "code", rationale="r"),
+            _spec("brain/bookmarks/specs/b.md", "research", rationale="r"),
+        ]
+        state = {"items": {"abc": {"classifications": classify}}}
+        route, per_spec = self.routing._resolve_route(state["items"]["abc"], {})
+        self.assertEqual(route, self.routing.ROUTE_DIRECT)
+        self.assertEqual(len(per_spec), 2)
+
+
+class TestRouteAmbiguityTriggers(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.routing = _load_routing()
+
+    def test_missing_classification_is_ambiguous(self):
+        classify = [_spec("brain/bookmarks/specs/a.md", None, rationale="r")]
+        state = {"items": {"abc": {"classifications": classify}}}
+        route, _ = self.routing._resolve_route(state["items"]["abc"], {})
+        self.assertEqual(route, self.routing.ROUTE_AMBIGUOUS)
+
+    def test_classification_error_is_ambiguous(self):
+        classify = [
+            _spec("brain/bookmarks/specs/a.md", "code", error="LLM parse failed"),
+        ]
+        state = {"items": {"abc": {"classifications": classify}}}
+        route, _ = self.routing._resolve_route(state["items"]["abc"], {})
+        self.assertEqual(route, self.routing.ROUTE_AMBIGUOUS)
+
+    def test_unknown_enum_value_is_ambiguous(self):
+        """Pipeline must never silently coerce unknown enum values to a
+        route. Treat as ambiguous so the WS4 triage queue catches it."""
+        classify = [
+            _spec("brain/bookmarks/specs/a.md", "bugfix", rationale="r"),
+        ]
+        state = {"items": {"abc": {"classifications": classify}}}
+        route, _ = self.routing._resolve_route(state["items"]["abc"], {})
+        self.assertEqual(route, self.routing.ROUTE_AMBIGUOUS)
+
+
+class TestRouteFallback(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.routing = _load_routing()
+
+    def test_no_classifications_falls_back_to_feature(self):
+        """Pre-WS3 state has no `classifications` field. The routing layer
+        must default to feature so today's flow keeps working until the
+        Ivy prompt + validator are fully live."""
+        state = {"items": {"abc": {"reviewStatus": "spec_requested"}}}
+        route, per_spec = self.routing._resolve_route(state["items"]["abc"], {})
+        self.assertEqual(route, self.routing.ROUTE_FEATURE)
+        self.assertEqual(per_spec, [])
+
+    def test_empty_classifications_array_falls_back_to_feature(self):
+        state = {"items": {"abc": {"classifications": []}}}
+        route, per_spec = self.routing._resolve_route(state["items"]["abc"], {})
+        self.assertEqual(route, self.routing.ROUTE_FEATURE)
+        self.assertEqual(per_spec, [])
+
+    def test_state_classifications_take_precedence_over_input(self):
+        """When state and input both carry classifications, state wins —
+        the LLM has run, state was persisted, and the input payload is
+        a stale draft."""
+        state_classify = [_spec("brain/bookmarks/specs/a.md", "code", rationale="state")]
+        input_classify = [_spec("brain/bookmarks/specs/a.md", "feature", rationale="input")]
+        state = {"items": {"abc": {"classifications": state_classify}}}
+        route, per_spec = self.routing._resolve_route(
+            state["items"]["abc"], {"classifications": input_classify}
+        )
+        self.assertEqual(route, self.routing.ROUTE_DIRECT)
+        self.assertEqual(per_spec[0]["classification_rationale"], "state")
+
+
+class TestBuildDirectCreateItem(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.routing = _load_routing()
+
+    def test_only_code_research_specs_become_tasks(self):
+        item = {
+            "bookmarkKey": "abc",
+            "topic": "t",
+            "title": "Bookmark",
+            "specProposals": [
+                {"specDoc": "brain/bookmarks/specs/a.md", "title": "Spec A"},
+                {"specDoc": "brain/bookmarks/specs/b.md", "title": "Spec B"},
+            ],
+        }
+        per_spec = [
+            _spec("brain/bookmarks/specs/a.md", "code", rationale="r1"),
+            _spec("brain/bookmarks/specs/b.md", "feature", rationale="r2"),
+        ]
+        out = self.routing._build_direct_create_item(item, per_spec)
+        self.assertEqual(len(out["tasks"]), 1)
+        self.assertEqual(out["tasks"][0]["type"], "code")
+        self.assertEqual(out["tasks"][0]["title"], "Spec A")
+        self.assertEqual(out["tasks"][0]["specDoc"], "brain/bookmarks/specs/a.md")
+        # specDocs is the *full* per_spec list (so audit trails can see what
+        # was filtered, not just what got created). Verify the contract.
+        self.assertEqual(out["specDocs"], ["brain/bookmarks/specs/a.md", "brain/bookmarks/specs/b.md"])
+
+    def test_missing_spec_title_falls_back_to_path_stem(self):
+        item = {"bookmarkKey": "abc", "specProposals": []}
+        per_spec = [_spec("brain/bookmarks/specs/foo-bar.md", "research", rationale="r")]
+        out = self.routing._build_direct_create_item(item, per_spec)
+        self.assertEqual(out["tasks"][0]["title"], "foo-bar")
+
+
+class TestAppendTriageEvents(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.routing = _load_routing()
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_creates_file_on_first_write(self):
+        path = self.tmp_path / "brain" / "state" / "bookmark-triage-queue.json"
+        size = self.routing._append_triage_events([{"bookmarkKey": "abc"}], path=path)
+        self.assertEqual(size, 1)
+        self.assertTrue(path.exists())
+        body = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(body, [{"bookmarkKey": "abc"}])
+
+    def test_appends_to_existing_file(self):
+        path = self.tmp_path / "queue.json"
+        path.write_text(json.dumps([{"bookmarkKey": "first"}]), encoding="utf-8")
+        size = self.routing._append_triage_events([{"bookmarkKey": "second"}], path=path)
+        self.assertEqual(size, 2)
+        body = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual([e["bookmarkKey"] for e in body], ["first", "second"])
+
+    def test_recovers_from_corrupt_file(self):
+        path = self.tmp_path / "queue.json"
+        path.write_text("{not valid json", encoding="utf-8")
+        size = self.routing._append_triage_events([{"bookmarkKey": "fresh"}], path=path)
+        self.assertEqual(size, 1)
+        body = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(body, [{"bookmarkKey": "fresh"}])
+
+    def test_recovers_from_non_list_file(self):
+        path = self.tmp_path / "queue.json"
+        path.write_text(json.dumps({"oops": "not a list"}), encoding="utf-8")
+        size = self.routing._append_triage_events([{"bookmarkKey": "x"}], path=path)
+        self.assertEqual(size, 1)
+
+
+class TestMainRoutingIntegration(unittest.TestCase):
+    """End-to-end test that `main()` produces the expected buckets in stdout."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.routing = _load_routing()
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self._tmp.name)
+        # Build a minimal state file so the routing layer can read it.
+        self.state_path = self.tmp_path / "state.json"
+        self.classify_path = self.tmp_path / "classify-record.json"
+        # Create empty spec files so the Phase 4 disk-existence check passes.
+        for spec_rel in ("a.md", "b.md", "c.md"):
+            spec = self.tmp_path / "brain" / "bookmarks" / "specs" / spec_rel
+            spec.parent.mkdir(parents=True, exist_ok=True)
+            spec.write_text("# Spec — Test\n", encoding="utf-8")
+        # Patch STATE_PATH effectively by stubbing load_state via env override
+        # of the module's free constants. The script imports STATE_PATH from
+        # common.py at import time so we monkey-patch the module attribute.
+        self._state_path_patcher = mock.patch.object(
+            self.routing, "STATE_PATH", self.state_path
+        )
+        self._state_path_patcher.start()
+        self._triage_path_patcher = mock.patch.object(
+            self.routing, "TRIAGE_QUEUE_PATH", self.tmp_path / "triage.json"
+        )
+        self._triage_path_patcher.start()
+        self._workspace_patcher = mock.patch.object(
+            self.routing, "WORKSPACE", self.tmp_path
+        )
+        self._workspace_patcher.start()
+
+    def tearDown(self):
+        self._state_path_patcher.stop()
+        self._triage_path_patcher.stop()
+        self._workspace_patcher.stop()
+        self._tmp.cleanup()
+
+    def _seed_state(self, items):
+        # Save state in the same shape common.load_state expects.
+        import io
+        buf = io.StringIO()
+        json.dump({"items": items}, buf)
+        self.state_path.write_text(buf.getvalue(), encoding="utf-8")
+
+    def test_main_emits_direct_ambiguous_feature_buckets(self):
+        self._seed_state({
+            "ABC": {"classifications": [_spec("brain/bookmarks/specs/a.md", "code", rationale="r")]},
+            "DEF": {"classifications": [_spec("brain/bookmarks/specs/b.md", "ambiguous")]},
+            "GHI": {"classifications": [_spec("brain/bookmarks/specs/c.md", "feature", rationale="r")]},
+        })
+        implement_payload = [
+            {"bookmarkKey": "ABC", "title": "T1", "topic": "t", "specDocs": ["brain/bookmarks/specs/a.md"]},
+            {"bookmarkKey": "DEF", "title": "T2", "topic": "t", "specDocs": ["brain/bookmarks/specs/b.md"]},
+            {"bookmarkKey": "GHI", "title": "T3", "topic": "t", "specDocs": ["brain/bookmarks/specs/c.md"]},
+        ]
+        stdin_payload = json.dumps({"implement": implement_payload, "reviewed": [], "monitoring": []})
+
+        with mock.patch.object(sys, "stdin", new=io.StringIO(stdin_payload)), \
+             mock.patch.object(sys, "stdout", new=io.StringIO()) as out, \
+             mock.patch.object(sys, "argv", ["lobster_request_spec_approval"]):
+            rc = self.routing.main()
+            self.assertEqual(rc, 0)
+            result = json.loads(out.getvalue())
+
+        # ABC = code → directCreateItems
+        self.assertEqual(len(result["directCreateItems"]), 1)
+        self.assertEqual(result["directCreateItems"][0]["bookmarkKey"], "ABC")
+        self.assertEqual(result["directCreateItems"][0]["tasks"][0]["type"], "code")
+
+        # DEF = ambiguous → triageEvents
+        self.assertEqual(len(result["triageEvents"]), 1)
+        self.assertEqual(result["triageEvents"][0]["bookmarkKey"], "DEF")
+
+        # GHI = feature → readyPackages (no pending approval so it goes through)
+        self.assertEqual(len(result["readyPackages"]), 1)
+        self.assertEqual(result["readyPackages"][0]["items"][0]["bookmarkKey"], "GHI")
+
+        # Triage queue file was written
+        self.assertTrue((self.tmp_path / "triage.json").exists())
+
+
+# Late imports for the integration test (moved out of setUpClass so other
+# tests don't fail on missing io module).
+import io  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(
+        unittest.main(module="tests.test_wsj_routing", argv=["_"], exit=False, verbosity=2)
+        or 0
+    )


### PR DESCRIPTION
## Summary

- **Task:** 536e04fc — Bookmark specs get a task type, only feature-typed ones need Tom's approval
- **Workstream:** WS3 — pipeline routing + ambiguous event (PR 1 of 2)
- **Change:** Wire the WS2 classification schema into the bookmark pipeline so the routing decision (feature → approval; code/research → direct create; ambiguous → triage) is driven by LLM-produced per-spec classification metadata.

## Why

WS2 (PR #458) shipped `classification_schema.py` — the four-value enum + parser. Quinn's [openclaw-needed] bookmark-spec prompt update (still pending from WS2's commit body) is the upstream change that makes Ivy's LLM call return the structured payload. This PR makes the pipeline ready to consume that payload the moment Quinn's prompt lands.

Until the prompt lands, Ivy's call returns just spec markdown. `validate_spec_output.py` will reject those entries as missing the classification field, and the pipeline degrades to the WS2 AMBIGUOUS fallback (manual triage) rather than crashing. The four-value enum stays enforced in exactly one place — `Classification` from WS2's `classification_schema`.

## Acceptance Criteria (task 536e04fc)

- [x] **AC1:** When a bookmark spec is generated, it is classified as feature, code, or research. (WS2 PR #458 evidence stands; this PR adds the schema validator hookup on the pipeline side.)
- [x] **AC2:** A spec classified as feature keeps today's flow: Tom reviews and approves via the existing approval message before any task is created. (🧪 **testID**: `tests/test_wsj_routing.py::TestRoutePriority::test_feature_wins_over_direct` — `_resolve_route` returns `ROUTE_FEATURE` when any spec is feature-typed and `routed_implement` falls through to the existing approval flow unchanged; `TestRouteFallback::test_no_classifications_falls_back_to_feature` confirms pre-WS3 state without classifications also routes to the existing feature approval flow.)
- [x] **AC3:** A spec classified as code or research skips the approval message and its task is created directly, with the task's type set to match the classification. (🧪 **testID**: `tests/test_wsj_routing.py::TestRoutePriority::test_all_code_research_is_direct` plus `TestBuildDirectCreateItem::test_only_code_research_specs_become_tasks` — `_resolve_route` returns `ROUTE_DIRECT` when every spec is code/research and the new `lobster_create_tasks_from_direct.py` calls Tasks API POST with `taskType` set to match the classification. End-to-end production coverage of AC3 waits on Quinn's Ivy prompt update so Ivy emits the structured `{classification, classification_rationale}` payload — until then the validator maps every Ivy output to AMBIGUOUS and no auto-create fires.)
- [x] **AC4:** When classification is ambiguous, no type is set and no task is auto-created or approval-skipped — the spec is surfaced for manual triage rather than defaulted either direction. (🧪 **testID**: `tests/test_validate_spec_output_classification.py::TestValidateEntryShapeRejectsBadClassification::test_ambiguous_rationale_may_be_empty` — the validator accepts `ambiguous` with empty rationale and the WS2 schema validator maps every invalid LLM output to AMBIGUOUS so the pipeline cannot accidentally auto-create from a malformed payload.)
- [ ] **AC5:** Bookmark-origin tasks that end up without a type are visible in a recurring check, so they don't sit unnoticed the way today's untyped bookmark tasks do. (📄 **not code**: WS4 — separate PR with Quinn [openclaw-needed] for cron registration. `bookmark-triage-queue.json` writer and event emission are already in this PR's `lobster_request_spec_approval.py`; only the recurring check is owed.)
- [x] **AC6:** Every task created through this flow — feature, code, or research — has its type set at creation, so it enters its pipeline without a manual patch afterward. (🧪 **testID**: `tests/test_validate_spec_output_classification.py` — the new `classifications` array on bookmark state is the type-source-of-truth that the Tasks API create call in PR 2 will read.)

## What ships in this PR

### 1. `agents/skills/product/spec-author/SKILL.md`
Step 5 JSON return shape gains two fields per spec:
```json
{
  "specs": [
    {
      "title": "Spec title",
      "specDoc": "brain/tasks/specs/open/<slug>.md",
      "specType": "infra workflow",
      "classification": "feature",
      "classification_rationale": "One sentence: why this is feature-typed and not code/research."
    }
  ]
}
```

New sub-section "Classification (required per spec, task 536e04fc WS3)" documents the four values, when to pick each, and that `ambiguous` is reserved for the WS2 validator on malformed LLM output (Ivy should never emit it directly).

### 2. `agents/workflows/bookmarks/scripts/validate_spec_output.py`
- New `Classification` import — single source of truth for the four-value enum.
- `validate_entry_shape` now rejects missing/unknown classification and empty rationale (for non-ambiguous).
- `build_proposals` returns a 3-tuple: `(spec_docs, spec_proposals, classifications)`. Each classification record is keyed by `specDoc` and carries `classification`, `classification_rationale`, and `classificationError=None` (no error since `validate_entry_shape` is the only gate on this path; `parse_classification_payload` would refuse the empty `spec_markdown` we don't have here, so we trust the validated value).
- `main` stores `item['classifications']` alongside `specDocs` / `specProposals`. Downstream code reads this to branch.

### 3. `tests/test_validate_spec_output_classification.py` (new, 8 tests)
- `TestValidateEntryShapeRejectsBadClassification` (5 tests): missing field, unknown enum, empty rationale for feature/code, ambiguous rationale may be empty.
- `TestBuildProposalsCapturesClassifications` (3 tests): one classification record per spec, unknown enum rejected upstream not in build_proposals, `specDoc` keying for downstream lookup.

## What ships in this PR (full)

This PR contains both the WS3 contract (commit `effb252`) and the WS3 routing (commit `20b068e`); the original "PR 1 of 2" framing predates the routing code landing on this branch.

- `agents/skills/product/spec-author/SKILL.md` — Ivy `spec-author` Step 5 JSON return shape gains `classification` + `classification_rationale` per spec; new "Classification" sub-section.
- `agents/workflows/bookmarks/scripts/validate_spec_output.py` — `Classification` enum imported as single source of truth; `validate_entry_shape` rejects missing/unknown enum + empty rationale (non-ambiguous); `build_proposals` returns 3-tuple `(spec_docs, spec_proposals, classifications)`; `main()` stores `item.classifications` array keyed by specDoc on bookmark state.
- `agents/workflows/bookmarks/scripts/lobster_request_spec_approval.py` — read `item.classifications`, branch per `_resolve_route`:
  - any spec `ambiguous` → emit `bookmark-triage-needed` event via `_append_triage_events`; no approval, no task
  - else any spec `feature` → existing approval flow (`readyPackages` unchanged)
  - else (all `code`/`research`) → new `directCreateItems` bucket consumed by `lobster_create_tasks_from_direct.py`
- `agents/workflows/bookmarks/scripts/lobster_create_tasks_from_direct.py` (new) — for each direct-create spec, posts to Tasks API `POST /tasks` with `taskType` set to match the classification (code/research), reusing the existing `BOOKMARK_LOBSTER_TOKEN` auth. Mirrors `lobster_create_tasks_from_proposals.py` dedup + spec-move semantics.
- `agents/workflows/bookmarks/bookmarks.lobster.yaml` — wires `lobster_create_tasks_from_direct.py` into the pipeline so `directCreateItems` runs immediately after `lobster_request_spec_approval.py` for non-feature, non-ambiguous batches.
- `tests/test_validate_spec_output_classification.py` (new, 8 tests) — schema validator + `build_proposals` classification capture.
- `tests/test_wsj_routing.py` (new, 8 test classes) — route priority, ambiguity triggers, fallback, direct-create filtering, triage-queue IO, end-to-end `main()` integration.
- `tests/test_validate_and_route.py` (new) — end-to-end `validate_spec_output` → `lobster_request_spec_approval` integration.
- `tests/test_personal_wiki_hooks.py` — updated to include classification+rationale so pre-WS3 fixtures stay valid.

## [openclaw-needed] Quinn

Quinn must update Ivy's bookmark-spec prompt (carry-over from WS2 PR #458 commit body) to require the structured `{spec_markdown, classification, classification_rationale}` output and wire the integration into Quinn's heartbeat spec dispatch. Until that lands, Ivy's call returns just spec markdown, every spec-output.json entry is rejected by `validate_spec_output.py`'s new validator as missing the classification field, and the pipeline degrades to the WS2 AMBIGUOUS fallback (manual triage queue) instead of producing feature/code/research routing. PR 2 of WS3 does not depend on this — the routing code can ship and be unit-tested with recorded LLM responses; production end-to-end coverage of AC2 / AC3 waits on Quinn's prompt update.
