### PR TITLE
cod—audit: sindustries weekly review 2026-W34

### DIFF
--- a/docs/repo-audits/2026-W34.md
+++ b/docs/repo-audits/2026-W34.md
@@ -54,7 +54,7 @@
 
 ### Code quality
 
-**[Low] `workflow_lock` always attempts `pg_advisory_unlock` even when the lock was not acquired, and `_stable_namespace_key` is dead code.** ✅ [PR #462](https://github.com/Stoffer-Industries/sindustries/pull/462)
+<<<<**[Low] `workflow_lock` always attempts `pg_advisory_unlock` even when the lock was not acquired, and `_stable_namespace_key` is dead code.** ✅ [PR #462](https://github.com/Stoffer-Industries/sindustries/pull/462)
 
 - **Where:** `agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/locking.py:118-133`. When `pg_try_advisory_lock` returns false (a concurrent run holds it), the `finally` block still runs `SELECT pg_advisory_unlock(...)`, which returns false and emits a PostgreSQL `WARNING: you don't own a lock of type ExclusiveLock` — a log-noise/correctness smell (releasing a lock you never held). Separately, `_stable_namespace_key` (`:64-78`) is exported and documented but the lock path uses the hardcoded `LOCK_NAMESPACE`/`LOCK_KEY` constants, so the helper is unused.
 - **Why it matters:** Low. The advisory-lock behavior is functionally correct (the `already_running` no-op still fires), but the unconditional unlock produces misleading warnings under normal contention, and the dead helper invites confusion about which keying scheme is authoritative.


### PR DESCRIPTION
## Executive Summary

**Health grade: B.** Sindustries is a well-structured early-production monorepo, and this week's authorization work resolved the two standing W33 findings: GymTrack's `/api/agent/*` endpoints now authenticate through the OAuth path (`apps/gymtrack/api/agent/history.js:47,68` imports `oauthAuth.js`; the legacy `gymtrack_agent_api_keys` reader is gone), gymtrack-mcp has a real CI job (`.github/workflows/ci.yml:375`), and tasks-api mutations are gated by a shared session/Bearer principal (`services/tasks-api/src/app.ts:122-133`, `middleware/requireAuth.ts`). The most important new risk is a direct consequence of that last change: the newly-added general mutation gate is mounted on the whole `/api/v1/content-scheduler` prefix and now intercepts `POST .../imports/cto-craft` before the route's own `x-content-ingest-secret` check — but the CTO Craft workflow client (and its cron) send only the ingest secret and no session/Bearer, so the entire CTO-Craft → Content Scheduler import path returns `401 AUTH_REQUIRED` in production. The endpoint's own test suite passes only because a test helper injects a Bearer the real client never sends, so CI is green while the feature is broken. Secondary risks: the CTO Craft workflow's SSRF-safe fetcher is bypassable via DNS rebinding (validate-then-refetch by hostname), and the whole `cto-craft-tweet-drafts` test suite — including the SSRF tests — is not wired into CI, repeating the W33 "security-critical new code is under-covered by CI" theme. No Critical issue was verified. Top opportunities: reconcile the two auth mechanisms colliding on the import route, pin the validated IP in `safe_fetch`, and add a CI job for the new workflow.

Full audit: [`docs/repo-audits/2026-W34.md`](https://github.com/Stoffer-Industries/sindustries/blob/code-garden/sindustries/2026-W34/docs/repo-audits/2026-W34.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)