### PR TITLE
chore(code-garden): only unlock advisory lock when acquired; drop dead helper [2026-W34]

### DIFF
--- a/agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/locking.py
+++ b/agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/locking.py
@@ -18,7 +18,6 @@ and the workflow's own stable key.
 
 from __future__ import annotations
 
-import hashlib
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Iterator
@@ -43,22 +42,6 @@ class LockHandle:
 
     connection: object
     acquired: bool
-
-
-def _stable_namespace_key(component: str) -> int:
-    """Map a stable component string into a 63-bit signed integer.
-
-    PostgreSQL's ``pg_try_advisory_lock(key bigint)`` takes a single
-    signed 64-bit integer. We hash the component into a positive 64-bit
-    value and then collapse it into a signed 63-bit range to be safe
-    across platforms.
-    """
-
-    digest = hashlib.sha256(component.encode("utf-8")).digest()
-    value = int.from_bytes(digest[:8], byteorder="big", signed=False)
-    # Mask to signed 63-bit range (PostgreSQL's ``bigint`` is signed 64-bit
-    # but we want a positive, safe key).
-    return value & 0x7FFF_FFFF_FFFF_FFFF
 
 
 def _check_connection(conn) -> None:
@@ -91,23 +74,22 @@ def workflow_lock(
         sql = "SELECT pg_try_advisory_lock(%s, %s)"
 
     cursor = connection.cursor()
+    acquired = False
     try:
         cursor.execute(sql, (LOCK_NAMESPACE, LOCK_KEY))
-        row = cursor.fetchone()
         if wait:
             acquired = True
         else:
+            row = cursor.fetchone()
             acquired = bool(row and row[0])
         yield LockHandle(connection=connection, acquired=acquired)
     finally:
-        try:
-            if wait:
+        if acquired:
+            try:
                 cursor.execute("SELECT pg_advisory_unlock(%s, %s)", (LOCK_NAMESPACE, LOCK_KEY))
-            else:
-                cursor.execute("SELECT pg_advisory_unlock(%s, %s)", (LOCK_NAMESPACE, LOCK_KEY))
-        except Exception:
-            # Best-effort release; the connection will close on exit.
-            pass
+            except Exception:
+                # Best-effort release; the connection will close on exit.
+                pass
         try:
             cursor.close()
         except Exception:
@@ -120,5 +102,4 @@ __all__ = [
     "LOCK_NAMESPACE",
     "LOCK_KEY",
     "workflow_lock",
-    "_stable_namespace_key",
 ]

--- a/agents/workflows/cto-craft-tweet-drafts/tests/test_locking.py
+++ b/agents/workflows/cto-craft-tweet-drafts/tests/test_locking.py
@@ -1,0 +1,126 @@
+"""Tests for the CTO Craft workflow lock context manager.
+
+The non-obvious contract under test: when ``pg_try_advisory_lock`` reports
+the lock is already held (a concurrent run), the ``finally`` block must
+NOT call ``pg_advisory_unlock``. Releasing a lock you never held emits a
+PostgreSQL ``WARNING: you don't own a lock of type ExclusiveLock`` and
+hides the real contended-run log line.
+"""
+
+from __future__ import annotations
+
+from cto_craft_workflow.locking import LOCK_KEY, LOCK_NAMESPACE, workflow_lock
+
+
+class _RecordingCursor:
+    """Cursor stub that records every executed SQL statement.
+
+    ``lock_returned`` controls the row returned for ``pg_try_advisory_lock``:
+    - True → row with `[True]` so the caller treats the lock as acquired.
+    - False → row with `[False]` so the caller treats the lock as already held.
+    """
+
+    def __init__(self, lock_returned: bool) -> None:
+        self._lock_returned = lock_returned
+        self.executed: list[tuple[str, tuple]] = []
+        self.closed = False
+
+    def execute(self, sql: str, params: tuple = ()) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> tuple:
+        return (self._lock_returned,)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeConnection:
+    def __init__(self, cursor: _RecordingCursor) -> None:
+        self._cursor = cursor
+
+    def cursor(self) -> _RecordingCursor:
+        return self._cursor
+
+
+def test_contended_run_does_not_call_unlock() -> None:
+    """A contended run (lock already held) must skip ``pg_advisory_unlock``.
+
+    This is the W34 T3.1 audit scenario: ``pg_try_advisory_lock`` returns
+    False, the handle is yielded with ``acquired=False``, and the finally
+    block must not attempt to release a lock the caller never held.
+    """
+
+    cursor = _RecordingCursor(lock_returned=False)
+    conn = _FakeConnection(cursor)
+
+    with workflow_lock(conn, wait=False) as handle:
+        assert handle.acquired is False
+
+    executed_sqls = [sql for sql, _ in cursor.executed]
+    assert "SELECT pg_try_advisory_lock(%s, %s)" in executed_sqls
+    assert "SELECT pg_advisory_unlock(%s, %s)" not in executed_sqls
+    assert cursor.closed is True
+
+
+def test_acquired_run_releases_lock() -> None:
+    """When the lock is acquired, the finally block must release it."""
+
+    cursor = _RecordingCursor(lock_returned=True)
+    conn = _FakeConnection(cursor)
+
+    with workflow_lock(conn, wait=False) as handle:
+        assert handle.acquired is True
+
+    executed_sqls = [sql for sql, _ in cursor.executed]
+    assert "SELECT pg_try_advisory_lock(%s, %s)" in executed_sqls
+    assert "SELECT pg_advisory_unlock(%s, %s)" in executed_sqls
+    assert cursor.closed is True
+
+
+def test_wait_mode_presumes_acquired_and_releases() -> None:
+    """``wait=True`` calls blocking ``pg_advisory_lock`` and treats the lock
+    as acquired; the finally block must always release it."""
+
+    cursor = _RecordingCursor(lock_returned=False)  # value irrelevant for wait mode
+    conn = _FakeConnection(cursor)
+
+    with workflow_lock(conn, wait=True) as handle:
+        assert handle.acquired is True
+
+    executed_sqls = [sql for sql, _ in cursor.executed]
+    assert "SELECT pg_advisory_lock(%s, %s)" in executed_sqls
+    assert "SELECT pg_advisory_unlock(%s, %s)" in executed_sqls
+
+
+def test_lock_uses_constants_namespace_and_key() -> None:
+    """Lock acquisition must use the module-level LOCK_NAMESPACE/LOCK_KEY."""
+
+    cursor = _RecordingCursor(lock_returned=True)
+    conn = _FakeConnection(cursor)
+
+    with workflow_lock(conn, wait=False):
+        pass
+
+    acquire_calls = [
+        params for sql, params in cursor.executed if "pg_try_advisory_lock" in sql
+    ]
+    assert acquire_calls == [(LOCK_NAMESPACE, LOCK_KEY)]
+    unlock_calls = [
+        params for sql, params in cursor.executed if "pg_advisory_unlock" in sql
+    ]
+    assert unlock_calls == [(LOCK_NAMESPACE, LOCK_KEY)]
+
+
+def test_none_connection_raises_lock_error() -> None:
+    """``None`` connection is rejected before any SQL is executed."""
+
+    raised = False
+    try:
+        with workflow_lock(None, wait=False):
+            pass
+    except Exception as exc:  # noqa: BLE001
+        raised = True
+        assert exc.code == "LOCK_DB_UNAVAILABLE"  # type: ignore[attr-defined]
+
+    assert raised

--- a/docs/repo-audits/2026-W34.md
+++ b/docs/repo-audits/2026-W34.md
@@ -1,0 +1,114 @@
+# Sindustries Repository Audit — 2026-W34
+
+## Executive Summary
+
+**Health grade: B.** Sindustries is a well-structured early-production monorepo, and this week's authorization work resolved the two standing W33 findings: GymTrack's `/api/agent/*` endpoints now authenticate through the OAuth path (`apps/gymtrack/api/agent/history.js:47,68` imports `oauthAuth.js`; the legacy `gymtrack_agent_api_keys` reader is gone), gymtrack-mcp has a real CI job (`.github/workflows/ci.yml:375`), and tasks-api mutations are gated by a shared session/Bearer principal (`services/tasks-api/src/app.ts:122-133`, `middleware/requireAuth.ts`). The most important new risk is a direct consequence of that last change: the newly-added general mutation gate is mounted on the whole `/api/v1/content-scheduler` prefix and now intercepts `POST .../imports/cto-craft` before the route's own `x-content-ingest-secret` check — but the CTO Craft workflow client (and its cron) send only the ingest secret and no session/Bearer, so the entire CTO-Craft → Content Scheduler import path returns `401 AUTH_REQUIRED` in production. The endpoint's own test suite passes only because a test helper injects a Bearer the real client never sends, so CI is green while the feature is broken. Secondary risks: the CTO Craft workflow's SSRF-safe fetcher is bypassable via DNS rebinding (validate-then-refetch by hostname), and the whole `cto-craft-tweet-drafts` test suite — including the SSRF tests — is not wired into CI, repeating the W33 "security-critical new code is under-covered by CI" theme. No Critical issue was verified. Top opportunities: reconcile the two auth mechanisms colliding on the import route, pin the validated IP in `safe_fetch`, and add a CI job for the new workflow.
+
+## Repo Map
+
+**Purpose:** Monorepo for Sindustries product surfaces and agent-operated workflows: Tasks, Mission Control, GymTrack, Budget, Website, shared UI/design tokens, backend APIs, and Rust/Python automation.
+
+**Stack:** Node.js 22; npm workspaces; React/Vite web apps; Expo mobile app; Express + Prisma + PostgreSQL services (`services/tasks-api`, `services/budget-api`); Supabase for GymTrack; a standalone MCP OAuth server (`services/gymtrack-mcp`); a Rust feature-task workflow; Python/LangGraph operational workflows; GitHub Actions CI.
+
+**Architecture:** `apps/*` clients call domain services and Supabase; `packages/*` holds shared UI, tokens, telemetry, domain code; `services/gymtrack-mcp` is an OAuth-authenticated MCP server; `agents/workflows/*` owns automation (Rust Lobster, Python bookmark pipeline, and the new LangGraph CTO-Craft pipeline); `infra/*` owns runtime wiring.
+
+**Key directories:** `apps/` user-facing products; `services/` backend domains; `packages/` shared libraries; `agents/workflows/cto-craft-tweet-drafts/` new weekly LangGraph tweet-draft pipeline; `agents/workflows/feature-task/` Rust Lobster; `agents/workflows/bookmarks/` Python bookmark pipeline; `docs/` architecture, specs, runbooks, audits; `.github/workflows/` CI/deploy.
+
+**Surprise:** tasks-api now has **two authentication schemes that both claim the `/api/v1/content-scheduler` prefix**: the general session/Bearer mutation gate (`app.ts:122`) and the route-local `x-content-ingest-secret` check inside `POST /content-scheduler/imports/cto-craft` (`contentScheduler.ts:564-576`). The gate runs first and wins, so the ingest-secret path is unreachable for its intended caller.
+
+## Audit Report
+
+### Strengths
+
+- **W33 findings resolved.** GymTrack agent endpoints now authenticate via OAuth (`apps/gymtrack/api/agent/history.js:47,68`, `server/oauthAuth.js`), and the legacy `gymtrack_agent_api_keys` reader in `server/agentAuth.js` is gone (`7b5a54a`). gymtrack-mcp has a CI job (`.github/workflows/ci.yml:375-399`). tasks-api mutations require a principal (`services/tasks-api/src/middleware/requireAuth.ts`, mounted at `app.ts:122-133`), and comment author is now server-derived — closing the W33 forgeable-author finding.
+- **`safe_fetch` is a genuinely careful SSRF implementation** (`agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/safe_fetch.py`): scheme allow-list, embedded-credential rejection, per-hop IP validation against private/loopback/link-local/multicast/reserved/unspecified ranges, redirect/size/time caps, content-type allow-list, tracking-param stripping, and query-redacted logging. The residual weakness below is the one classic gap it doesn't close.
+- **Import client redacts secrets and bodies** (`content_scheduler.py`): errors carry only a status code and a short classification; the request body, response body, and secret are never logged.
+- **Module-load credential validation.** `requireAuth.ts:44-79` parses `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` once at module load and fails process boot on malformed config (resolves the W33 Low re-parse finding).
+- **Broad CI matrix** across apps, services, packages, Python workflows, and Rust.
+
+### Security & correctness
+
+**[High] The CTO-Craft → Content Scheduler import path is unreachable in production: the general mutation gate intercepts it before the route's own ingest-secret check, and the real client sends no session/Bearer.**
+
+- **Where:** `services/tasks-api/src/app.ts:130` mounts `app.use('/api/v1/content-scheduler', gateMutations)`, where `gateMutations` runs `requireAuthenticatedUser` on every `POST/PATCH/DELETE` (`app.ts:122-133`). The import route `POST /content-scheduler/imports/cto-craft` (`services/tasks-api/src/routes/contentScheduler.ts:564-576`) matches that prefix, so the gate runs first. `requireAuthenticatedUser` (`middleware/requireAuth.ts:110-152`) requires a `tasks_api_session` cookie or an `Authorization: Bearer <service credential>` and returns `401 AUTH_REQUIRED` otherwise. The workflow client sends neither: `ImportClient.import_drafts` sets only `Content-Type` and `x-content-ingest-secret` (`agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/content_scheduler.py:104-108`), and the cron prompt provisions only `CONTENT_SCHEDULER_INGEST_SECRET` against `https://api.sindustries.dev` (`agents/crons/prompts/cto-craft-tweet-drafts.md:6-16`).
+- **Why it matters:** In any environment where `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` is configured (i.e. production), every weekly CTO-Craft run receives `401` at the gate, before the ingest-secret is ever evaluated; the client maps `401` to `AUTH_REJECTED` (`content_scheduler.py:52-53`) and the run reports `outcome: "failed"` with zero drafts created. The feature cannot function. This is the exact "authorization added surface-by-surface breaks a sibling caller" pattern flagged as a W33 theme — the mutation gate (task 0719a8e3) silently superseded the pre-existing ingest-secret contract.
+- **Why CI stays green:** the endpoint's suite passes only because `authedRequest` injects `Authorization: Bearer integration-test-token-long-enough` on every call (`services/tasks-api/test/helpers/auth.ts:14-25`, used throughout `test/contentSchedulerImport.test.ts`). That Bearer satisfies the gate; the real client has no equivalent. The tests validate the ingest-secret logic in isolation but never reproduce the production caller's headers, so the collision is invisible.
+- **Fact vs judgment:** *Fact* — the gate is mounted on the prefix and runs before the route; the client sends only the ingest header; the tests add a Bearer the client lacks. *Judgment* — exploit-free but a hard functional break the moment the gate is deployed to an environment with service credentials configured; severity assumes the cron is (or is about to be) live against `api.sindustries.dev`.
+- **Severity:** High. → Classification: `tracked-code-task` (auth-boundary reconciliation; small tech design recommended — see Open Questions OQ1).
+
+**[Medium] `safe_fetch` SSRF guard is bypassable via DNS rebinding (validate-then-refetch by hostname; the validated IP is never pinned to the connection).**
+
+- **Where:** `agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/safe_fetch.py:255-270`. `_validate_url_and_resolve(current_url)` resolves the host with `socket.getaddrinfo` and rejects private/loopback/etc. addresses (`:112-160`), then `self._client.get(current_url, ...)` performs a **second, independent** DNS resolution inside httpx using the same hostname. Nothing carries the validated IP into the actual connection.
+- **Why it matters:** An attacker who controls a linked article URL (the article set is untrusted per the module's own docstring) and runs an authoritative DNS server can return a public IP for the validation lookup and a private/loopback IP (e.g. `169.254.169.254`, `127.0.0.1`) for the httpx request microseconds later — the classic TOCTOU DNS-rebinding bypass. Because the module is explicitly the workflow's SSRF boundary, this is the one gap that defeats the rest of its (good) checks. The per-hop re-validation on redirects has the same shape and does not help, since each hop still validates one hostname and then reconnects by hostname.
+- **Why it isn't caught by tests:** every `safe_fetch` test injects an `httpx.MockTransport`/client (`test/test_safe_fetch.py:11-25`), so real DNS never runs; the guard's real-world resolution behavior is untested.
+- **Fact vs judgment:** *Fact* — two independent resolutions with no IP pinning. *Judgment* — exploitability requires attacker-controlled linked-article DNS; real-world likelihood is low-to-moderate given the trusted TMW seed, but the consequence (reading cloud metadata / internal services) is high.
+- **Severity:** Medium. → Classification: `tracked-code-task` (pin the validated IP: resolve once, connect to the IP with `Host`/SNI preserved, or use an httpx transport with a pinned resolver).
+
+### Testing
+
+**[Medium] The entire `cto-craft-tweet-drafts` test suite — including the SSRF and durability tests — does not run in CI.**
+
+- **Where:** `.github/workflows/ci.yml:52-63` (`python-workflow-tests`) discovers `tests/`, `agents/workflows/bookmarks/**`, `agents/lib`, `agents/workflows/content-tasks/tests`, and `agents/skills/ops/tasks-api/**`, but **never** `agents/workflows/cto-craft-tweet-drafts/tests`. Compounding this, that suite is pytest-based (`test_safe_fetch.py:6`, fixture-injected `conftest.py`, `pytest.raises`, `respx`, `pytest-asyncio` per `pyproject.toml:24-30`), so even if the directory were added to the existing `python -m unittest discover` step, the fixture-parametrized tests would error rather than run.
+- **Why it matters:** The workflow's most safety-relevant code — the SSRF fetcher, the advisory-lock durability path (`test_durability.py`), and the graph wiring (`test_graph.py`) — never executes in CI. Regressions in the SSRF guard or the Content Scheduler import contract ship undetected. This is a direct recurrence of the W33 gymtrack-mcp CI-gap theme: a new security-sensitive subsystem shipped with tests that don't run in CI.
+- **Severity:** Medium. → Classification: `garden-safe` / quick win — add a pytest step for `agents/workflows/cto-craft-tweet-drafts` mirroring how W33 added the gymtrack-mcp job (behavior-preserving CI addition).
+
+### Code quality
+
+**[Low] `workflow_lock` always attempts `pg_advisory_unlock` even when the lock was not acquired, and `_stable_namespace_key` is dead code.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+
+- **Where:** `agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/locking.py:118-133`. When `pg_try_advisory_lock` returns false (a concurrent run holds it), the `finally` block still runs `SELECT pg_advisory_unlock(...)`, which returns false and emits a PostgreSQL `WARNING: you don't own a lock of type ExclusiveLock` — a log-noise/correctness smell (releasing a lock you never held). Separately, `_stable_namespace_key` (`:64-78`) is exported and documented but the lock path uses the hardcoded `LOCK_NAMESPACE`/`LOCK_KEY` constants, so the helper is unused.
+- **Why it matters:** Low. The advisory-lock behavior is functionally correct (the `already_running` no-op still fires), but the unconditional unlock produces misleading warnings under normal contention, and the dead helper invites confusion about which keying scheme is authoritative.
+- **Severity:** Low. → Classification: `garden-safe` (only unlock when `handle.acquired`; drop or wire up `_stable_namespace_key`).
+
+### Dimensions rated healthy (one line each)
+
+- **Architecture & design:** The CTO-Craft pipeline has clean seams (single network module for fetch, single module for the import HTTP call, graph stays HTTP-free) — the only architectural issue is the auth-prefix collision above, not the module boundaries.
+- **Performance:** No new N+1 or unbounded-growth patterns; fetch is bounded by size/time/redirect caps and the import posts a single bounded batch.
+- **Dependencies:** New workflow pins bounded version ranges (`pyproject.toml`); no unmaintained or unusually heavy additions spotted.
+- **Documentation:** README, tech designs, and the cron prompt for CTO-Craft are accurate and specific; the one stale contract is the ingest-secret auth story, which the mutation gate has silently overtaken (see High finding).
+
+## Improvement Strategy
+
+**Themes explaining most findings:**
+
+1. **Prefix-scoped auth middleware overtakes route-local auth.** Mounting `requireAuthenticatedUser` on the whole `/api/v1/content-scheduler` prefix silently superseded a route that authenticated differently. *Target state:* one authentication decision per route, explicitly chosen; where a route needs a distinct scheme (ingest secret), it is either excluded from the prefix gate or the gate recognizes that scheme. *Principle:* two auth schemes on one path is a bug, not a defense-in-depth.
+2. **Security-critical new code is under-covered by CI (recurring).** The CTO-Craft suite — SSRF, locking, graph — doesn't run in CI, exactly as gymtrack-mcp didn't at W33. *Target state:* every workspace/workflow with a test suite has a CI job that actually discovers and runs it, in the suite's native runner. *Principle:* untested safety code is unshipped safety.
+3. **Tests that add auth the real caller lacks give false green.** `authedRequest` masked the import break. *Target state:* endpoint tests reproduce the production caller's headers for at least one path, or an integration test exercises the real client contract. *Principle:* a test that authenticates differently than the caller tests a different system.
+
+**Explicit non-goals (recommend NOT fixing now):**
+
+- Do not remove the general mutation gate to fix the import route — the gate is the correct W33 fix; instead reconcile the one colliding route.
+- Do not rewrite `safe_fetch` — it is close to correct; add IP pinning rather than replacing it.
+
+**"Done" signals:** a live CTO-Craft run creates drafts against `api.sindustries.dev` (not `401`); `safe_fetch` connects to a pre-validated IP; CI runs the `cto-craft-tweet-drafts` pytest suite on changes to that path.
+
+## Task Plan
+
+**Quick wins (high impact, S effort):**
+
+- **QW1 — Add a CI job for `cto-craft-tweet-drafts`.** Add a pytest step (its own job or a step in `python-workflow-tests`) that installs the workflow's dev extras and runs `pytest agents/workflows/cto-craft-tweet-drafts/tests`. *Files:* `.github/workflows/ci.yml`. *AC:* CI runs and passes the CTO-Craft suite on PRs touching `agents/workflows/cto-craft-tweet-drafts/**`. *Effort:* S. *Risk:* Low. *Deps:* none. → `garden-safe`.
+
+**Milestone 1 — Critical fixes (correctness/security)**
+
+- **T1.1 — Reconcile the import-route auth collision.** Make `POST /content-scheduler/imports/cto-craft` reachable with only the ingest secret: either exclude that exact path from the `/api/v1/content-scheduler` mutation gate and rely on its route-local `x-content-ingest-secret` check, or teach `requireAuthenticatedUser` to accept a valid ingest secret as a service principal for that route, or make the client also send a Bearer service credential. Add a test that posts with **only** `x-content-ingest-secret` (no Bearer) and asserts success. *Files:* `services/tasks-api/src/app.ts`, `services/tasks-api/src/routes/contentScheduler.ts`, `services/tasks-api/test/contentSchedulerImport.test.ts`. *AC:* a request with only the ingest secret succeeds; a request with a wrong/absent ingest secret is rejected; CI reproduces the real client's header set. *Effort:* M. *Risk:* Med (auth boundary). *Deps:* OQ1 decision; small tech design recommended.
+- **T1.2 — Pin the validated IP in `safe_fetch`.** Resolve the host once, validate, then connect to that IP (preserving `Host`/SNI), or use an httpx transport with a pinned resolver, so the connection cannot re-resolve to a private address. Add a test that simulates rebinding (validation IP public, connection IP private) and asserts `SSRF_BLOCKED`. *Files:* `agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/safe_fetch.py`, `test/test_safe_fetch.py`. *AC:* a rebinding scenario is rejected; existing fetch behavior for legitimate hosts is unchanged. *Effort:* M. *Risk:* Low. *Deps:* QW1 (so the new test runs in CI).
+
+**Milestone 3 — Quality & polish**
+
+- **T3.1 — Fix the advisory-lock unlock and dead helper.** Only call `pg_advisory_unlock` when `handle.acquired`; remove or wire up `_stable_namespace_key`. *Files:* `agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/locking.py`. *AC:* a contended run produces no `you don't own a lock` warning; no unused exported helper. *Effort:* S. *Risk:* Low. *Deps:* none. → `garden-safe`.
+
+**Top-3 implementation sketches:**
+
+- **QW1:** Add a step to `python-workflow-tests` (or a sibling job) that runs `uv run --frozen --extra dev pytest` in `agents/workflows/cto-craft-tweet-drafts`, gated on `paths: agents/workflows/cto-craft-tweet-drafts/**`.
+- **T1.1:** In `app.ts`, change the content-scheduler gate to skip `req.path === '/content-scheduler/imports/cto-craft'` (leaving that route's own secret check as the sole auth), and add a `contentSchedulerImport.test.ts` case using plain `request(app)` + only the ingest header.
+- **T1.2:** Replace `self._client.get(current_url, ...)` with a request whose connection target is the already-validated IP (e.g. httpx `transport` with a resolver returning the pinned address, `Host` header set to the original hostname), keeping the redirect loop's per-hop validation.
+
+## Open Questions
+
+1. **OQ1 (blocks T1.1):** For `POST /content-scheduler/imports/cto-craft`, which auth is authoritative — the shared session/Bearer mutation gate, or the route-local `x-content-ingest-secret`? Options: (a) exclude the path from the gate and keep the ingest secret; (b) fold the ingest secret into `requireAuthenticatedUser` as a service principal; (c) issue the CTO-Craft workflow a Bearer service credential and drop the ingest secret. *Needs Tom/Quinn — determines the auth model for machine-to-machine ingest routes generally.*
+2. **OQ2:** Is the CTO-Craft cron already scheduled/live against `api.sindustries.dev`? If yes, T1.1 is a production incident (weekly runs are 401-ing now); if it's still a dormant POC, T1.1 is a pre-launch blocker. *Needs Tom/Quinn.*
+3. **OQ3:** Should adding a prefix-scoped auth middleware require an inventory of route-local auth on that prefix (a checklist item), to prevent a gate from silently overtaking a sibling route again? *Process decision.*
+
+---
+
+_Follow-up note: the High (T1.1) and Medium (T1.2) items are `tracked-code-task` classifications and should be created as `code` tasks (T1.1 with a linked tech design) so this audit's finding lines can be updated with `➡️ Tracked by task …`. QW1 and T3.1 are `garden-safe` and can be picked up by normal code-garden selection._

--- a/docs/repo-audits/2026-W34.md
+++ b/docs/repo-audits/2026-W34.md
@@ -54,7 +54,7 @@
 
 ### Code quality
 
-**[Low] `workflow_lock` always attempts `pg_advisory_unlock` even when the lock was not acquired, and `_stable_namespace_key` is dead code.** ✅ [PR #TBD](https://github.com/Stoffer-Industries/sindustries/pull/TBD)
+**[Low] `workflow_lock` always attempts `pg_advisory_unlock` even when the lock was not acquired, and `_stable_namespace_key` is dead code.** ✅ [PR #462](https://github.com/Stoffer-Industries/sindustries/pull/462)
 
 - **Where:** `agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/locking.py:118-133`. When `pg_try_advisory_lock` returns false (a concurrent run holds it), the `finally` block still runs `SELECT pg_advisory_unlock(...)`, which returns false and emits a PostgreSQL `WARNING: you don't own a lock of type ExclusiveLock` — a log-noise/correctness smell (releasing a lock you never held). Separately, `_stable_namespace_key` (`:64-78`) is exported and documented but the lock path uses the hardcoded `LOCK_NAMESPACE`/`LOCK_KEY` constants, so the helper is unused.
 - **Why it matters:** Low. The advisory-lock behavior is functionally correct (the `already_running` no-op still fires), but the unconditional unlock produces misleading warnings under normal contention, and the dead helper invites confusion about which keying scheme is authoritative.


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W34.md
- **Finding:** [Low] `workflow_lock` always attempts `pg_advisory_unlock` even when the lock was not acquired, and `_stable_namespace_key` is dead code.
- Track `acquired` outside the try/finally so the contended-run finally block skips `pg_advisory_unlock` (removes the PostgreSQL `WARNING: you don't own a lock` on every concurrent run), and drop the unused `_stable_namespace_key` helper that the lock path never called. Adds `tests/test_locking.py` with five focused tests pinning the unlock-on-acquired invariant.

## Test plan
- [x] `pytest agents/workflows/cto-craft-tweet-drafts/tests/test_locking.py` passes (5 tests cover contended-run, acquired-run, wait-mode, constant-keying, none-conn)
- [x] No logic changes — lock-acquired and lock-already-held outcomes unchanged; the only observable delta is the removal of the spurious PostgreSQL warning on contended runs

🌱 Code garden — non-functional cleanup only