### PR TITLE
fix(agent-scripts): add 30s timeout to agent_task_queue._gh_api subprocess.run

### DIFF
--- a/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
@@ -362,6 +362,7 @@ def _gh_api(config_dir: str, token_env: str, endpoint: str) -> Any:
         capture_output=True,
         text=True,
         env=env,
+        timeout=30,
     )
     return json.loads(result.stdout)
 


### PR DESCRIPTION
## What

Adds `timeout=30` to the lone `subprocess.run` in `agents/skills/ops/tasks-api/scripts/agent_task_queue.py:_gh_api`. One line, no other changes.

## Why

Originating incident: `agent-task-queue-gh-api-hang-2026-08-17`. A hung `gh api` call would block Rowan's heartbeat queue indefinitely because the script had no `timeout=` and no caller-side deadline. Symptoms: heartbeat step 1 (queue classification) never returned, `[implementer-prs]` comments lagged, no PR surfaced for review. See `infra/runbooks/agent-script-subprocess-no-timeout-hang.md` for the pattern.

## Scope decisions

- **Minimal, not shared helper.** This PR adds the timeout to the one call site that produced the actual hang. The systemic scope (13 agent-owned scripts / 18 unguarded call sites across `agents/skills` and `agents/workflows` — see runbook inventory) is real but is a different class of change. Bundling it here would inflate the diff and blur the PR description. Helper consolidation is a follow-up chore, not part of this PR.
- **No entry-print / no `sys` import.** Diagnostic logging on entry is a separate concern (PR standards say no churn outside the smallest viable fix). Bundling entry-prints would have made the diff 4 lines instead of 1, with a different review surface.

## Validation

- [x] `python3 -m py_compile agents/skills/ops/tasks-api/scripts/agent_task_queue.py` succeeds.
- [x] `git diff` shows exactly +1 line (`timeout=30,` after `env=env,`).
- [x] All call sites of `_gh_api` are read-only fetches via `gh api`; none catch `subprocess.CalledProcessError` without re-raising, so a new `TimeoutExpired` propagates cleanly to the heartbeat and is logged as a useful failure fingerprint.
- [x] No data-plane impact — the change is local to the script and only adds a bound on a subprocess the script invokes.

## Risk / reversibility

- 30s is generous for `gh api` against a single endpoint (normal 1–3s, worst-case retries on transient 5xx stay well under 30s). If a future endpoint legitimately needs more, bump the kwarg in place; do not remove the timeout.
- Reversible via `git revert`.

## Acceptance criteria

- [ ] Quinn approval
- [ ] CI green
- [ ] Lox independent verification (Acceptance checklist in the runbook): `timeout=` present, heartbeat completes in bounded time, `/api/v1/health` still 200, incident state `resolved`.
- [ ] Tom-confirmation via Telegram CLI (Lox will post).

## Out of scope (follow-up)

`chore(agent-scripts): consolidate subprocess timeout handling via shared helper`. Spec draft is in the incident notes; lands in its own PR with its own review.
