### PR TITLE
chore(agent-scripts): consolidate subprocess timeout handling via shared helper

### DIFF
--- a/agents/lib/__init__.py
+++ b/agents/lib/__init__.py
@@ -2,4 +2,9 @@
 
 Modules:
 - incident_state: Unified agent incident parser (Quinn + Lox) — task 75ec1c8c.
+- subprocess_safe: Bounded-time `subprocess.run` / `subprocess.Popen` wrappers — task 8a2df49c.
 """
+
+from .subprocess_safe import DEFAULT_TIMEOUT_SECONDS, safe_popen, safe_run
+
+__all__ = ["safe_run", "safe_popen", "DEFAULT_TIMEOUT_SECONDS"]

--- a/agents/lib/subprocess_safe.py
+++ b/agents/lib/subprocess_safe.py
@@ -1,0 +1,130 @@
+"""Bounded-time `subprocess` wrappers for agent scripts.
+
+Task 8a2df49c-791b-4f09-a37a-446fa8c6fd5d: consolidate the systemic pattern surfaced
+by `agent-task-queue-gh-api-hang-2026-08-17` onto a single shared helper so the next
+script author cannot reintroduce the unguarded-`subprocess.run` class of bug.
+
+Public API:
+    DEFAULT_TIMEOUT_SECONDS: float = 30.0
+        Module-level default. Long enough to absorb normal GitHub-API tail latency,
+        short enough that the heartbeat's stuck state is bounded.
+
+    safe_run(cmd, *, timeout=DEFAULT_TIMEOUT_SECONDS, **kwargs) -> subprocess.CompletedProcess
+        `subprocess.run` with a default timeout. **kwargs forwards verbatim, so
+        `check=`, `capture_output=`, `text=`, `env=`, `cwd=`, `input=`, `shell=`,
+        and other `subprocess.run` kwargs work as before. **kwargs cannot include
+        `timeout=` — that's the only named kwarg captured by `safe_run`.
+
+        Raises:
+            subprocess.TimeoutExpired — after `timeout` seconds if the child has not
+                exited. Callers own the policy (raise, retry, or record-and-skip).
+            subprocess.CalledProcessError — only when `check=True` and the child
+                exits non-zero.
+
+    safe_popen(cmd, *, timeout=DEFAULT_TIMEOUT_SECONDS, **kwargs) -> _TimeoutAwarePopen
+        `subprocess.Popen` whose `.wait()` is bounded by a default timeout. The
+        returned object proxies the underlying Popen so attributes like `.stdout`,
+        `.stdin`, `.stderr`, `.pid`, `.terminate()`, and `.kill()` work as before.
+        Only `.wait()` is intercepted to apply the default timeout when called
+        without an explicit value. **kwargs forwards verbatim (the constructor
+        itself accepts no `timeout=`).
+
+        Notes:
+            * `subprocess.Popen` does not accept `timeout=` at construction. The
+              bound is enforced on `.wait()`, which is the only blocking call.
+            * On timeout, the proc is not auto-killed — `safe_run`'s posture of
+              "no swallowing" applies. Callers that want cleanup on timeout wrap
+              the call site themselves (kill + re-wait, then raise).
+            * Streaming reads on `.stdout` / `.stderr` continue to work. Pair with
+              `.wait()` and you'll be bounded at `timeout` seconds for the lifetime
+              of the parent read.
+
+        Deliberate non-features (mirror `safe_run`):
+            * No entry-print log on every call (would require call-site context the
+              helper does not have; the runbook recommends this as a separate chore).
+            * No `TimeoutExpired` swallowing (callers own the policy).
+            * No default for `timeout` other than `DEFAULT_TIMEOUT_SECONDS`. Pass
+              `timeout=None` explicitly to opt out (legacy `subprocess.run` semantics).
+
+See `agents/lib/test_subprocess_safe.py` for the executable contract.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+DEFAULT_TIMEOUT_SECONDS: float = 30.0
+
+
+def safe_run(
+    cmd: list[str],
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess:
+    """subprocess.run with a default timeout. **kwargs forwards verbatim.
+
+    Raises:
+        subprocess.TimeoutExpired — after `timeout` seconds if the child has not exited.
+            Callers own the policy (raise, retry, or record-and-skip).
+        subprocess.CalledProcessError — only when `check=True` and the child exits non-zero.
+
+    No swallowing. No entry-print log. No default for `timeout` other than the module constant.
+    """
+    return subprocess.run(cmd, timeout=timeout, **kwargs)
+
+
+class _TimeoutAwarePopen:
+    """subprocess.Popen proxy that bounds the default `wait()` timeout.
+
+    Attribute access is delegated to the underlying Popen so call sites that use
+    `.stdout`, `.stdin`, `.stderr`, `.pid`, `.terminate()`, `.kill()`, etc. work
+    transparently. Only `.wait()` is intercepted to apply the default timeout when
+    no explicit timeout is given.
+    """
+
+    __slots__ = ("_popen", "_default_timeout")
+
+    def __init__(self, popen: subprocess.Popen, default_timeout: float) -> None:
+        self._popen = popen
+        self._default_timeout = default_timeout
+
+    def wait(self, timeout: float | None = None) -> int:
+        bound = self._default_timeout if timeout is None else timeout
+        return self._popen.wait(timeout=bound)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._popen, name)
+
+    def __repr__(self) -> str:
+        return (
+            f"_TimeoutAwarePopen({self._popen!r}, "
+            f"default_timeout={self._default_timeout})"
+        )
+
+
+def safe_popen(
+    cmd: list[str],
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    **kwargs: Any,
+) -> _TimeoutAwarePopen:
+    """subprocess.Popen whose `.wait()` defaults to a bounded timeout.
+
+    The returned object proxies the underlying subprocess.Popen so all attributes
+    (`.stdout`, `.stdin`, `.stderr`, `.pid`, `.terminate()`, `.kill()`, etc.) work
+    as before. Only `.wait()` is intercepted to apply `timeout` (default
+    `DEFAULT_TIMEOUT_SECONDS`) when no explicit timeout is given. Pass an explicit
+    `timeout=` to `.wait()` to override.
+
+    Raises:
+        subprocess.TimeoutExpired — propagated from the underlying `.wait(timeout=...)`
+            after the bound elapses. No cleanup is performed; callers that want to reap
+            a stuck child wrap the call site (kill + brief re-wait, then re-raise).
+    """
+    proc = subprocess.Popen(cmd, **kwargs)
+    return _TimeoutAwarePopen(proc, default_timeout=timeout)
+
+
+__all__ = ["safe_run", "safe_popen", "DEFAULT_TIMEOUT_SECONDS"]

--- a/agents/lib/test_subprocess_safe.py
+++ b/agents/lib/test_subprocess_safe.py
@@ -1,0 +1,223 @@
+"""Tests for `agents.lib.subprocess_safe.safe_run`.
+
+Task 8a2df49c-791b-4f09-a37a-446fa8c6fd5d, AC3. Five sub-cases:
+(a) happy-path rc=0
+(b) timeout raises subprocess.TimeoutExpired after `timeout` seconds
+(c) check=True propagates CalledProcessError on rc!=0
+(d) capture_output + text returns decoded stdout
+(e) parameterized: explicit `timeout=` is honored (verifies the helper does not
+    override the caller's value with the module default).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+import unittest
+
+from agents.lib.subprocess_safe import DEFAULT_TIMEOUT_SECONDS, safe_popen, safe_run
+
+
+class SafeRunTests(unittest.TestCase):
+    def test_a_happy_path_returns_completed_process_with_zero_returncode(self) -> None:
+        # (a) `safe_run(["true"])` returns CompletedProcess rc=0
+        result = safe_run(["true"])
+        self.assertIsInstance(result, subprocess.CompletedProcess)
+        self.assertEqual(result.returncode, 0)
+
+    def test_b_timeout_raises_timeout_expired_after_configured_timeout(self) -> None:
+        # (b) `safe_run(["sleep", "5"], timeout=0.5)` raises TimeoutExpired after ~0.5s
+        start = time.monotonic()
+        with self.assertRaises(subprocess.TimeoutExpired) as cm:
+            safe_run(["sleep", "5"], timeout=0.5)
+        elapsed = time.monotonic() - start
+        # Subprocess.TimeoutExpired fires a bit after the configured timeout — accept
+        # a generous upper bound so a slow CI runner does not flake this test.
+        self.assertGreaterEqual(elapsed, 0.5)
+        self.assertLess(elapsed, 5.0)
+        # The exception's `cmd` attribute echoes the argv we passed.
+        self.assertEqual(cm.exception.cmd[:2], ["sleep", "5"])
+
+    def test_c_check_true_propagates_called_process_error_on_nonzero_exit(self) -> None:
+        # (c) `safe_run(["false"], check=True)` raises CalledProcessError
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            safe_run(["false"], check=True)
+        self.assertEqual(cm.exception.returncode, 1)
+
+    def test_d_capture_output_text_returns_decoded_stdout(self) -> None:
+        # (d) `safe_run(["sh", "-c", "echo hi"], capture_output=True, text=True)`
+        #     returns stdout="hi\n"
+        result = safe_run(
+            ["sh", "-c", "echo hi"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.stdout, "hi\n")
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(result.returncode, 0)
+
+    def test_e_explicit_timeout_is_honored_for_nondefault_values(self) -> None:
+        # (e) parameterized: an explicit timeout other than the module default
+        #     is honored. We pick values across the spectrum PR uses:
+        #       - 0.5s (sleep 5 -> timeout fires)
+        #       - 5.0s (sleep 1 -> returns before timeout)
+        #       - default (returns)
+        cases = [
+            # (timeout, argv, should_timeout, label)
+            (0.5, ["sleep", "5"], True, "tight-tight timeout fires"),
+            (5.0, ["sleep", "0.1"], False, "loose timeout is not hit"),
+            (DEFAULT_TIMEOUT_SECONDS, ["true"], False, "default-equivalent returns"),
+        ]
+        for timeout_s, argv, should_timeout, label in cases:
+            with self.subTest(label=label, timeout=timeout_s):
+                if should_timeout:
+                    with self.assertRaises(
+                        subprocess.TimeoutExpired,
+                        msg=f"timeout={timeout_s} should have fired ({label})",
+                    ):
+                        safe_run(argv, timeout=timeout_s)
+                else:
+                    result = safe_run(argv, timeout=timeout_s)
+                    self.assertEqual(
+                        result.returncode,
+                        0,
+                        msg=f"timeout={timeout_s} should have completed ({label})",
+                    )
+
+
+class ModuleSurfaceTests(unittest.TestCase):
+    """The helper is exposed both via the module and via `agents.lib.safe_run`."""
+
+    def test_module_default_constant_is_thirty_seconds(self) -> None:
+        # AC1 pins the default at 30s. If you change the constant, update the
+        # runbook and the task description together.
+        self.assertEqual(DEFAULT_TIMEOUT_SECONDS, 30.0)
+
+    def test_safe_run_is_reexported_from_agents_lib_package(self) -> None:
+        # AC2: `from agents.lib import safe_run` must work.
+        from agents.lib import safe_run as reexported
+        from agents.lib.subprocess_safe import safe_run as from_module
+
+        self.assertIs(reexported, from_module)
+
+    def test_safe_popen_is_reexported_from_agents_lib_package(self) -> None:
+        # Companion helper for streaming subprocesses; same re-export contract.
+        from agents.lib import safe_popen as reexported
+        from agents.lib.subprocess_safe import safe_popen as from_module
+
+        self.assertIs(reexported, from_module)
+
+
+class SafePopenTests(unittest.TestCase):
+    """`safe_popen` is the streaming-subprocess sibling of `safe_run`."""
+
+    def test_a_returns_proxy_with_default_completion(self) -> None:
+        # happy path: child exits quickly, .wait() with no kwargs honors the
+        # default bound but does not actually trigger it (child finished first).
+        proc = safe_popen(
+            [sys.executable, "-c", "import sys; sys.stdout.write('ok')"],
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            stdout, _ = proc.communicate()
+            self.assertEqual(stdout, "ok")
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    def test_proxy_passes_through_attribute_access(self) -> None:
+        # `.pid`, `.returncode`, `.stdout`, `.terminate()`, `.kill()` are all on
+        # the underlying Popen and must work via the proxy without surprises.
+        proc = safe_popen([sys.executable, "-c", "pass"])
+        try:
+            self.assertIsInstance(proc.pid, int)
+            self.assertGreater(proc.pid, 0)
+            self.assertIsNone(proc.returncode)  # not exited yet
+            proc.kill()
+            proc.wait(timeout=5)
+            self.assertIsNotNone(proc.returncode)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    def test_b_wait_raises_timeout_expired_after_default(self) -> None:
+        # `proc.wait()` with no explicit timeout uses the helper-supplied default
+        # and propagates subprocess.TimeoutExpired after that many seconds. We
+        # pass `safe_popen(..., timeout=0.5)` to keep the test fast — the contract
+        # we exercise is "default timeout is honored when no explicit one is passed
+        # to wait()", not "the default is exactly 30s".
+        proc = safe_popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            timeout=0.5,
+        )
+        try:
+            start = time.monotonic()
+            with self.assertRaises(subprocess.TimeoutExpired):
+                proc.wait()  # no explicit timeout -> uses safe_popen default 0.5
+            elapsed = time.monotonic() - start
+            self.assertGreaterEqual(elapsed, 0.5)
+            self.assertLess(
+                elapsed,
+                5.0,
+                msg=(
+                    "safe_popen default wait() must fire within the configured "
+                    f"timeout=0.5s; observed {elapsed:.2f}s"
+                ),
+            )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    def test_b_prime_default_constant_also_fires_within_window(self) -> None:
+        # Sanity: with the module's DEFAULT_TIMEOUT_SECONDS = 30, an explicit
+        # call to safe_popen(..., timeout=30) using a child that sleeps forever
+        # (or much longer than 30s) would raise TimeoutExpired. We exercise a
+        # short timeout here to keep the test under a second; the intent is to
+        # document that `safe_popen(timeout=...)` honours the supplied value.
+        proc = safe_popen(
+            [sys.executable, "-c", "import time; time.sleep(10)"],
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
+        # Override via explicit wait() so the test finishes quickly without
+        # waiting the full 30s default.
+        try:
+            with self.assertRaises(subprocess.TimeoutExpired):
+                proc.wait(timeout=0.25)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    def test_c_wait_with_explicit_timeout_short_circuits_the_default(self) -> None:
+        # Passing an explicit small timeout overrides the helper default. This
+        # mirrors safe_run's contract: explicit timeout wins.
+        proc = safe_popen(
+            [sys.executable, "-c", "import time; time.sleep(10)"],
+        )
+        try:
+            start = time.monotonic()
+            with self.assertRaises(subprocess.TimeoutExpired):
+                proc.wait(timeout=0.5)
+            elapsed = time.monotonic() - start
+            self.assertGreaterEqual(elapsed, 0.5)
+            self.assertLess(
+                elapsed,
+                5.0,
+                msg=(
+                    "explicit timeout=0.5 must fire within ~0.5s; "
+                    f"observed {elapsed:.2f}s"
+                ),
+            )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/skills/bookmarks/x-ingest/scripts/run_x_ingest.py
+++ b/agents/skills/bookmarks/x-ingest/scripts/run_x_ingest.py
@@ -9,6 +9,20 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_run
+
 _env_ws = os.environ.get("OPENCLAW_WORKSPACE", "").strip()
 WORKSPACE = Path(_env_ws).resolve() if _env_ws else Path.home() / ".openclaw" / "workspace"
 SCRIPT = Path(__file__).resolve().parent / "x" / "run.cjs"
@@ -64,7 +78,7 @@ def main() -> int:
     env.setdefault("OPENCLAW_WORKSPACE", str(WORKSPACE))
 
     before = _md_snapshot()
-    result = subprocess.run(cmd, cwd=str(WORKSPACE), env=env)
+    result = safe_run(cmd, cwd=str(WORKSPACE), env=env)
 
     if result.returncode == 0:
         after = _md_snapshot()

--- a/agents/skills/bookmarks/x-ingest/tests/test_linked_articles.py
+++ b/agents/skills/bookmarks/x-ingest/tests/test_linked_articles.py
@@ -7,6 +7,20 @@ from pathlib import Path
 
 import pytest
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_run
+
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
 PROCESS_SCRIPT = REPO_ROOT / "agents/skills/bookmarks/x-ingest/scripts/x/process.cjs"
@@ -64,7 +78,7 @@ def article_server():
 
 
 def run_node(source, *, env=None):
-    result = subprocess.run(
+    result = safe_run(
         ["node", "-e", source],
         cwd=REPO_ROOT,
         env={**os.environ, **(env or {})},

--- a/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
@@ -20,6 +20,20 @@ import subprocess
 import time
 from typing import Any
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_run
+
 CLIENT_PATH = pathlib.Path(__file__).parents[1] / "tasks_api_client.py"
 SPEC = importlib.util.spec_from_file_location("tasks_api_client", CLIENT_PATH)
 tasks_api_client = importlib.util.module_from_spec(SPEC)
@@ -356,13 +370,12 @@ def _gh_api(config_dir: str, token_env: str, endpoint: str) -> Any:
     token = env.get(token_env)
     if token:
         env["GH_TOKEN"] = token
-    result = subprocess.run(
+    result = safe_run(
         ["gh", "api", endpoint],
         check=True,
         capture_output=True,
         text=True,
         env=env,
-        timeout=30,
     )
     return json.loads(result.stdout)
 

--- a/agents/workflows/bookmarks/run.py
+++ b/agents/workflows/bookmarks/run.py
@@ -8,6 +8,20 @@ import sys
 import threading
 from pathlib import Path
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_popen
+
 _env_ws = os.environ.get("OPENCLAW_WORKSPACE", "").strip()
 WORKSPACE = Path(_env_ws).resolve() if _env_ws else Path(__file__).resolve().parents[5]
 PIPELINE = WORKSPACE / "codebases" / "sindustries" / "agents" / "workflows" / "bookmarks" / "bookmarks.lobster.yaml"
@@ -66,7 +80,7 @@ def _stream_reader(pipe, prefix: str, sink: list[str]) -> None:
 def run(cmd: list[str], stdin_text: str | None = None, env: dict[str, str] | None = None, label: str | None = None) -> dict:
     label = label or Path(cmd[0]).name
     log_progress(f"starting {label}: {' '.join(cmd)}")
-    proc = subprocess.Popen(
+    proc = safe_popen(
         cmd,
         cwd=str(WORKSPACE),
         text=True,

--- a/agents/workflows/bookmarks/scripts/common.py
+++ b/agents/workflows/bookmarks/scripts/common.py
@@ -15,6 +15,20 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_run
+
 _env_ws = os.environ.get("OPENCLAW_WORKSPACE", "").strip()
 WORKSPACE = Path(_env_ws).resolve() if _env_ws else Path(__file__).resolve().parents[6]
 # brain is a symlink to iCloud - don't resolve it to avoid cross-device paths
@@ -580,7 +594,7 @@ def invoke_llm_json(prompt: str, input_payload: dict[str, Any], schema: dict[str
         "-",
     ])
     try:
-        completed = subprocess.run(
+        completed = safe_run(
             args,
             check=True,
             capture_output=True,
@@ -684,7 +698,7 @@ def invoke_llm_json_via_agent(prompt: str, input_payload: dict[str, Any], schema
         "--json",
     ]
     try:
-        completed = subprocess.run(
+        completed = safe_run(
             args,
             check=True,
             capture_output=True,

--- a/agents/workflows/bookmarks/scripts/debug/request_single_spec_approval.py
+++ b/agents/workflows/bookmarks/scripts/debug/request_single_spec_approval.py
@@ -7,6 +7,20 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_run
+
 WORKSPACE = Path(__file__).resolve().parents[7]
 BOOKMARKS_DIR = Path(__file__).resolve().parent.parent
 if str(BOOKMARKS_DIR) not in sys.path:
@@ -19,7 +33,7 @@ GENERATE_SPECS = BOOKMARKS_DIR / "lobster_generate_specs.py"
 
 
 def run_json(args: list[str], stdin_payload: dict | None = None) -> dict:
-    completed = subprocess.run(
+    completed = safe_run(
         args,
         input=(json.dumps(stdin_payload) if stdin_payload is not None else None),
         text=True,

--- a/agents/workflows/bookmarks/scripts/handle_approval_reply.py
+++ b/agents/workflows/bookmarks/scripts/handle_approval_reply.py
@@ -16,6 +16,20 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_run
+
 # Resolve the bookmark workflow dir so `common` can be imported from here.
 _env_ws = os.environ.get("OPENCLAW_WORKSPACE", "").strip()
 _ws = Path(_env_ws).resolve() if _env_ws else Path(__file__).resolve().parents[6]
@@ -59,7 +73,7 @@ def fetch_messages(channel: str, limit: int, trigger_text: str = "", trigger_sen
         return [msg]
     args = ["openclaw", "messages", "list", "--channel", channel, "--limit", str(limit), "--json"]
     try:
-        result = subprocess.run(args, check=True, capture_output=True, text=True, cwd=str(WORKSPACE))
+        result = safe_run(args, check=True, capture_output=True, text=True, cwd=str(WORKSPACE))
     except (FileNotFoundError, subprocess.CalledProcessError):
         return []
     raw = (result.stdout or "").strip()
@@ -144,7 +158,7 @@ def run_lobster_resume(token: str, approve: bool) -> tuple[dict | None, str | No
     env["PYTHONPATH"] = f"{tasks_api_path}:{existing}" if existing else tasks_api_path
     env.setdefault("TASKS_API_BASE_URL", "http://localhost:4000/api/v1")
     try:
-        result = subprocess.run(args, check=True, capture_output=True, text=True, cwd=str(WORKSPACE), env=env)
+        result = safe_run(args, check=True, capture_output=True, text=True, cwd=str(WORKSPACE), env=env)
     except FileNotFoundError:
         return None, "lobster CLI not found"
     except subprocess.CalledProcessError as exc:
@@ -232,7 +246,7 @@ def force_clear_approval_lock(state: dict, approval_id: str, approved: bool) -> 
 
 def rebuild_revised_approval(bookmark_key: str) -> dict | None:
     script = WORKSPACE / "codebases" / "sindustries" / "agents" / "workflows" / "bookmarks" / "scripts" / "rebuild_revised_approval.py"
-    proc = subprocess.run(
+    proc = safe_run(
         [sys.executable, str(script), "--bookmark-key", bookmark_key, "--json"],
         text=True,
         capture_output=True,

--- a/agents/workflows/bookmarks/scripts/rebuild_revised_approval.py
+++ b/agents/workflows/bookmarks/scripts/rebuild_revised_approval.py
@@ -9,6 +9,20 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_run
+
 _env_ws = os.environ.get("OPENCLAW_WORKSPACE", "").strip()
 WORKSPACE = Path(_env_ws).resolve() if _env_ws else Path(__file__).resolve().parents[6]
 _BOOKMARK_WF = WORKSPACE / 'codebases' / 'sindustries' / 'agents' / 'workflows' / 'bookmarks' / 'scripts'
@@ -19,7 +33,7 @@ REQUEST_TOPIC_APPROVAL = _BOOKMARK_WF / 'request_topic_approval.py'
 
 
 def run_json(cmd: list[str], stdin_data: dict | None = None, env: dict[str, str] | None = None) -> dict:
-    proc = subprocess.run(
+    proc = safe_run(
         cmd,
         cwd=str(WORKSPACE),
         input=(json.dumps(stdin_data) if stdin_data is not None else None),

--- a/agents/workflows/bookmarks/scripts/request_topic_approval.py
+++ b/agents/workflows/bookmarks/scripts/request_topic_approval.py
@@ -10,6 +10,20 @@ import fcntl
 from pathlib import Path
 from typing import Any
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_run
+
 from common import STATE_PATH, WORKSPACE, dump_json, get_approval_topic, load_state, log_transition, now_iso, save_state, transition_log_path
 
 
@@ -329,7 +343,7 @@ def deliver_approval_message(message: str, delivery: dict) -> dict:
 
     cli_failed = False
     try:
-        completed = subprocess.run(
+        completed = safe_run(
             args,
             capture_output=True,
             text=True,

--- a/agents/workflows/content-tasks/run.py
+++ b/agents/workflows/content-tasks/run.py
@@ -9,6 +9,20 @@ import sys
 import threading
 from pathlib import Path
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_popen, safe_run
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 SCRIPTS_DIR = SCRIPT_DIR / "scripts"
 PIPELINE = SCRIPT_DIR / "content-task.lobster.yaml"
@@ -50,7 +64,7 @@ def run_workflow(task_id: str, capacity_limit: int) -> dict:
                     break
         except Exception:
             pass
-    proc = subprocess.Popen(
+    proc = safe_popen(
         cmd,
         text=True,
         stdout=subprocess.PIPE,

--- a/agents/workflows/content-tasks/scripts/common.py
+++ b/agents/workflows/content-tasks/scripts/common.py
@@ -13,6 +13,20 @@ import sys
 from pathlib import Path
 from typing import Any
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_run
+
 # Compute repo-owned paths relative to this file so cron runs do not depend on
 # OPENCLAW_WORKSPACE_ROOT being set. Keep WORKSPACE as the OpenClaw workspace root for
 # consumers such as format_transition.py that resolve brain/ source paths against it.
@@ -372,12 +386,12 @@ def parse_pr_url(url: str) -> tuple[str, str, str] | None:
 
 
 def _run_gh_json(cmd: list[str]) -> Any:
-    proc = subprocess.run(cmd, text=True, capture_output=True, timeout=30)
+    proc = safe_run(cmd, text=True, capture_output=True)
     error = (proc.stderr or proc.stdout or "").strip()
     if proc.returncode != 0 and os.environ.get("GITHUB_TOKEN") and ("HTTP 401" in error or "Bad credentials" in error):
         env = dict(os.environ)
         env.pop("GITHUB_TOKEN", None)
-        proc = subprocess.run(cmd, text=True, capture_output=True, timeout=30, env=env)
+        proc = safe_run(cmd, text=True, capture_output=True, env=env)
         error = (proc.stderr or proc.stdout or "").strip()
     if proc.returncode != 0:
         raise RuntimeError(error or "gh command failed")

--- a/agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/angle_model.py
+++ b/agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/angle_model.py
@@ -21,6 +21,20 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Protocol, runtime_checkable
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_run
+
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 
@@ -226,7 +240,7 @@ def _run_openclaw(
     cwd: str,
 ) -> subprocess.CompletedProcess[str]:
     command = [message if part == "__PROMPT__" else part for part in args]
-    return subprocess.run(
+    return safe_run(
         command,
         check=True,
         capture_output=True,

--- a/agents/workflows/feature-task/run.py
+++ b/agents/workflows/feature-task/run.py
@@ -12,6 +12,20 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+# Bootstrap `agents.lib` so `from agents.lib import safe_run` works under plain
+# `python3 <this>.py` invocations. Walks up from `__file__` looking for a
+# directory containing `agents/lib/`.
+import sys as _sys
+from pathlib import Path as _p
+_w = next(
+    (a for a in [_p(__file__).resolve().parent, *_p(__file__).resolve().parents]
+     if (a / "agents" / "lib").is_dir()), None)
+if _w is not None and str(_w) not in _sys.path:
+    _sys.path.insert(0, str(_w))
+del _sys, _p, _w
+
+from agents.lib import safe_popen, safe_run
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 FEATURE_TASK_PIPELINE = SCRIPT_DIR / "feature-task.lobster.yaml"
 CODE_TASK_PIPELINE = SCRIPT_DIR / "code-task.lobster.yaml"
@@ -135,7 +149,7 @@ def run_workflow(task_id: str, base_url: str, dry_run: bool, pipeline: Path) -> 
         }
     )
     cmd = ["lobster", "run", "--mode", "tool", str(pipeline), "--args-json", args_json]
-    proc = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=workflow_env())
+    proc = safe_popen(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=workflow_env())
     stdout_lines: list[str] = []
     stderr_lines: list[str] = []
     threads = [
@@ -175,7 +189,7 @@ def run_brain_spec_approval_reconciliation(base_url: str, dry_run: bool) -> dict
         "--workspace-root",
         str(WORKSPACE_ROOT),
     ]
-    proc = subprocess.run(cmd, text=True, capture_output=True, env=workflow_env())
+    proc = safe_run(cmd, text=True, capture_output=True, env=workflow_env())
     result: dict[str, Any] = {
         "returncode": proc.returncode,
         "stdout": proc.stdout,

--- a/docs/specs/agent-script-subprocess-safe-run-tech-design.md
+++ b/docs/specs/agent-script-subprocess-safe-run-tech-design.md
@@ -1,0 +1,206 @@
+---
+status: draft
+task_id: 8a2df49c-791b-4f09-a37a-446fa8c6fd5d
+product_spec: n/a
+shipped_pr: null
+shipped_date: null
+---
+
+# Tech Design — Consolidate subprocess timeout handling via shared `safe_run` helper
+
+## Links and scope
+
+- Task: `8a2df49c-791b-4f09-a37a-446fa8c6fd5d` — chore(agent-scripts): consolidate subprocess timeout handling via shared helper
+- Originating incident: `agent-task-queue-gh-api-hang-2026-08-17`
+- Originating PR (predecessor, minimal fix): PR #464 (merged 2026-08-17T00:57:42Z, merge commit `3981c94b`) — added `timeout=30` to the lone `_gh_api` call site
+- Runbook: `infra/runbooks/agent-script-subprocess-no-timeout-hang.md`
+- Incident state: `brain/state/lox-incident-state.json` key `agent-task-queue-gh-api-hang-2026-08-17` (already `resolved` from PR #464; this task does not change that unless a regression surfaces)
+- Repository: `Stoffer-Industries/sindustries`
+- Branch: `task-8a2df49c-agent-script-subprocess-safe-run`
+- Worktree: `/Users/quinnstoffer/.openclaw/workspace/worktrees/task-8a2df49c-agent-script-subprocess-safe-run`
+- Primary surfaces: `agents/lib/` (new `subprocess_safe.py` + tests), `agents/skills/`, `agents/workflows/` (13 files migrated), `infra/RUNBOOKS.md` (runbook entry status update)
+
+## Why this exists (not bundled with PR #464)
+
+Originating PR #464 was right-shaped: minimal, scoped, reversible. Bundling a 13-file migration into "fix the hang" would have inflated the diff and blurred the review. Helper consolidation is a different class of change — it introduces a shared module and changes the import surface of every consumer — so it deserves its own branch, its own review, and its own merge.
+
+## Product summary
+
+Consolidate the systemic pattern surfaced by `agent-task-queue-gh-api-hang-2026-08-17` onto a single shared helper so the next script author cannot reintroduce the unguarded-`subprocess.run` class of bug. The originating symptom was an indefinite heartbeat hang; the helper bounds every subprocess call site under `agents/skills/` and `agents/workflows/` at a default of 30s and propagates `subprocess.TimeoutExpired` unchanged for callers to handle.
+
+## Ownership boundary check
+
+**Natural source of truth:** a shared Python module at `agents/lib/subprocess_safe.py`. This is a cross-script contract, not a single-call-site concern, so it belongs in the shared infra library (`agents/lib/`) — the same location that already houses `agents/lib/incident_state.py` and is re-exported via `agents/lib/__init__.py`. A per-script timeout kwarg would re-introduce the very pattern the task is closing out, so the boundary is "shared module + explicit import path" rather than "inline timeout per call".
+
+**Rowan posture:** this is a chore, not a feature, but it is the kind of small-increment consolidation that pays off across every future call site. Per `SOUL.md`, when the durable solution (a shared helper) is about as easy as an interim shim (leaving inline `timeout=` calls in place), build the durable boundary now. The interim shape would be 13 call sites still owning their own `timeout=` kwarg — same review surface as the helper pass, but leaves the bug class open.
+
+**No service boundary change.** No API routes, database tables, queues, cron entries, or external integrations are touched. The change is local to Python agent scripts.
+
+## `.openclaw` boundary
+
+None. No secrets, no OpenClaw runtime config, no cron changes. The shared module is checked into `agents/lib/` alongside `incident_state.py`.
+
+## API surface — `agents/lib/subprocess_safe.py`
+
+```python
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+DEFAULT_TIMEOUT_SECONDS: float = 30.0
+
+
+def safe_run(
+    cmd: list[str],
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess:
+    """subprocess.run with a default timeout. **kwargs forwards verbatim.
+
+    Raises:
+        subprocess.TimeoutExpired — after `timeout` seconds if the child has not exited.
+            Callers own the policy (raise, retry, or record-and-skip).
+        subprocess.CalledProcessError — only when `check=True` and the child exits non-zero.
+
+    No swallowing. No entry-print log. No default for `timeout` other than the module constant.
+    """
+    return subprocess.run(cmd, timeout=timeout, **kwargs)
+
+
+__all__ = ["safe_run", "DEFAULT_TIMEOUT_SECONDS"]
+```
+
+### Re-export
+
+`agents/lib/__init__.py` adds `from .subprocess_safe import safe_run, DEFAULT_TIMEOUT_SECONDS` so callers can do `from agents.lib import safe_run`. Existing `from .incident_state import ...` line stays; the new line goes alongside it.
+
+### Deliberate non-features
+
+- **No entry-print on every `safe_run` call.** The runbook recommends `print(f"[<script>] {cmd}", file=sys.stderr, flush=True)` before each subprocess call for future hang diagnosability. AC1 of the task description explicitly omits this from `safe_run`'s contract; it is a separate follow-up chore that can land independently. Mentioned in `## Out of scope` below.
+- **No `TimeoutExpired` swallowing.** Callers that want graceful degradation wrap the call site themselves. Existing `request_topic_approval.py` and `angle_model.py` already have explicit `try/except subprocess.TimeoutExpired` handlers — those are preserved across the call-site rewrites.
+- **No JS-side equivalent.** Only `subprocess.run` / `Popen` / etc. in Python. `node:child_process.exec` / `Bun.spawn` are out of scope per AC4's "Python only here" boundary.
+
+## Test plan — `agents/lib/test_subprocess_safe.py`
+
+Per AC3, covers (b)–(e) plus a smoke test:
+
+| # | Test | What it asserts |
+|---|---|---|
+| (a) | `safe_run(["true"])` | returns `CompletedProcess` with `returncode == 0` |
+| (b) | `safe_run(["sleep", "5"], timeout=0.5)` | raises `subprocess.TimeoutExpired` after ~0.5s |
+| (c) | `safe_run(["false"], check=True)` | raises `subprocess.CalledProcessError` |
+| (d) | `safe_run(["sh", "-c", "echo hi"], capture_output=True, text=True)` | returns stdout `"hi\n"` |
+| (e) | parameterized per existing inline `timeout=` in the 13-file scope | migration preserves observable behaviour (timeout duration honoured, stdout/stderr preserved, exception types unchanged) |
+
+Tests are pure stdlib (`unittest` style to match `agents/lib/test_incident_state.py` precedent — or `pytest` if that's the convention elsewhere under `agents/lib/`; verify before committing). No new dependencies.
+
+## AC-by-AC verification matrix
+
+| AC | What it claims | How it verifies | Failure mode |
+|---|---|---|---|
+| AC1 | Helper API + default timeout + kwargs forwarding + no TimeoutExpired swallowing | tests (a)–(d) above; static read of `subprocess_safe.py` shows `**kwargs` passthrough and zero `try/except` wrapping | n/a (lint) |
+| AC2 | `from agents.lib import safe_run` works | Add an import smoke to test file (e) | Module-load failure |
+| AC3 | Five-test coverage of the helper | The test file itself exists and `python3 -m pytest agents/lib/test_subprocess_safe.py` exits 0 | Test failure |
+| AC4 | 13 files migrated to `safe_run`; no unguarded `subprocess.*` calls remain in listed scope | Per-file `git diff --stat` shows the call-site rewrite; re-grep below returns zero hits | Missed call site |
+| AC5 | Re-grep returns zero unguarded call sites in `agents/skills/` + `agents/workflows/` (excluding `.venv/`, `node_modules/`, `site-packages/`, `__pycache__/`) | Run the awk from the runbook; expect empty stdout | Any line returned = missed site |
+| AC6 | `python3 -m py_compile` passes for all 13 migrated files | Iterate over the file list, run `python3 -m py_compile <path>` for each; expect exit 0 | Syntax error / import cycle |
+| AC7 | `infra/RUNBOOKS.md` entry updated to "closed via chore PR — see <PR link>" | `git diff infra/RUNBOOKS.md` shows the update | n/a (text-only) |
+
+### Re-grep verification (from the runbook)
+
+```sh
+for f in $(grep -rln --include='*.py' \
+    'subprocess\.\(run\|Popen\|call\|check_output\|check_call\)' \
+    codebases/sindustries/agents/{skills,workflows} \
+    | grep -v '\.venv/' | grep -v 'node_modules/'); do
+  awk -v f="$f" '
+    /subprocess\.(run|Popen|call|check_output|check_call)\(/ {
+      start=NR; depth=gsub(/\(/, "(", $0)-gsub(/\)/, ")", $0); buf=$0; next
+    }
+    start && NR>start {
+      buf=buf"\n"$0
+      depth+=gsub(/\(/, "(", $0)-gsub(/\)/, ")", $0)
+      if (depth<=0) {
+        if (buf !~ /timeout[ =]/) print f":"start
+        start=0; buf=""
+      }
+    }
+    ' "$f"
+done | sort
+```
+
+Expected (post-migration): empty stdout. The four "already guarded but migrated for consistency" files (`request_topic_approval.py`, `content-tasks/scripts/common.py`, `angle_model.py`, `agent_task_queue.py`) become `safe_run(...)` calls without an inline `timeout=` because the helper default takes over — but the awk regex `/timeout[ =]/` would still match the `timeout=` keyword in `safe_run(timeout=...)` IF a caller passed it explicitly. To preserve a true zero-return shape, callers that previously used a non-default timeout pass it through: e.g. `request_topic_approval.py`'s 12s Telegram-CLI call becomes `safe_run(args, capture_output=True, text=True, timeout=12)` — the `timeout=12` keeps the awk happy AND preserves the tighter bound the script needs.
+
+## Implementation plan — file/module scope
+
+### Sequence
+
+1. Add `agents/lib/subprocess_safe.py` with `safe_run` and `DEFAULT_TIMEOUT_SECONDS`.
+2. Update `agents/lib/__init__.py` to re-export them.
+3. Add `agents/lib/test_subprocess_safe.py` covering AC3 (a)–(e). Run locally; confirm green.
+4. Migrate the 13 files in two sub-passes:
+   - **Pass A — non-test, non-bookmark files first** (smaller blast radius, easier review):
+     - `agents/workflows/feature-task/run.py` (2 sites)
+     - `agents/workflows/content-tasks/run.py` (1)
+     - `agents/workflows/content-tasks/scripts/common.py` (2 — already guarded, swap to `safe_run(args, ..., timeout=30)` to preserve the 30s existing bound)
+     - `agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/angle_model.py` (1 — already guarded with `try/except subprocess.TimeoutExpired`; preserve the except)
+     - `agents/skills/ops/tasks-api/scripts/agent_task_queue.py` (1 — PR #464 added `timeout=30,`; this PR replaces `subprocess.run([...], timeout=30, **kwargs)` with `safe_run([...], **kwargs)` so the helper default takes over. **Reviewer note:** this is the intended shape, NOT a revert of PR #464. The 30s default is identical to PR #464's explicit value; the only difference is whether the timeout is declared at the call site or inherited from the helper.)
+     - `agents/skills/bookmarks/x-ingest/scripts/run_x_ingest.py` (1)
+   - **Pass B — bookmark files** (largest group, batched for review):
+     - `agents/workflows/bookmarks/run.py` (1)
+     - `agents/workflows/bookmarks/scripts/handle_approval_reply.py` (3)
+     - `agents/workflows/bookmarks/scripts/common.py` (2)
+     - `agents/workflows/bookmarks/scripts/rebuild_revised_approval.py` (1)
+     - `agents/workflows/bookmarks/scripts/request_topic_approval.py` (1 — already guarded at 12s; becomes `safe_run(args, ..., timeout=12)` to preserve the tighter bound)
+     - `agents/workflows/bookmarks/scripts/debug/request_single_spec_approval.py` (1)
+5. Migrate `agents/skills/bookmarks/x-ingest/tests/test_linked_articles.py` (1, test, lower priority — per AC4's "lower priority" annotation). Land with Pass B or as a final follow-up commit in the same PR.
+6. Update `infra/RUNBOOKS.md` to reflect "closed via chore PR — see <PR link>" (AC7).
+7. Re-run the awk re-grep (AC5); expect zero.
+8. `python3 -m py_compile` each migrated file (AC6).
+9. Smoke-run the bookmark workflow script that was the originating class of failure (`python3 agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Rowan --json` — should now finish in <2s, not hang).
+10. Open PR; include the AC checklist in the PR body per WORKFLOW.md PR standards.
+
+### Files NOT touched
+
+- `services/` — no service changes
+- `apps/` — no app changes
+- `infra/runbooks/agent-script-subprocess-no-timeout-hang.md` — the runbook itself stays as the durable reference; only `infra/RUNBOOKS.md` (the index) gets the closed-via-chore note
+- `agents/lib/incident_state.py` and its tests — unrelated surface
+
+## Data model / API contract
+
+No data model changes. The only "API" is the helper signature above — a private intra-repo Python contract. No HTTP endpoints, no DB schema, no JSON shapes.
+
+## Workflow / cron / skill changes
+
+None. Existing skills (`agents/skills/...`) that own the migrated scripts keep their contract unchanged from the outside. The migration is internal — same behaviour, same callers, same outputs, with the only difference being a default timeout floor where one didn't exist before.
+
+## Open questions and risks
+
+1. **Default timeout at 30s vs per-call-site tuning.** Two call sites currently use non-30s defaults (`request_topic_approval.py` uses 12s for Telegram CLI; `agents/workflows/content-tasks/scripts/common.py` uses 30s which matches). The migration preserves the tighter 12s by passing `timeout=12` explicitly; this is the only place the helper's default is overridden. **Risk:** if a future script's correct timeout is much smaller (e.g. <5s), the author must remember to pass it. **Mitigation:** this is exactly the same as the pre-helper world, and the helper's default is documented in its docstring. Acceptable.
+
+2. **PR #464 sequencing risk.** The agent_task_queue.py change removes the inline `timeout=30,` kwarg that PR #464 added. A reviewer skimming the diff could read this as a revert. **Mitigation:** the AC4 reviewer note is in the PR description, and the 30s default is identical — observable behaviour is unchanged. Verified pre-write by reading PR #464 body and the current line 359 of `agent_task_queue.py`.
+
+3. **Existing `try/except TimeoutExpired` handlers.** `request_topic_approval.py` (around line 348) and `angle_model.py` (around line 114) wrap their subprocess calls in `try/except subprocess.TimeoutExpired`. The migration must preserve these handlers — the helper does not swallow, so the exception still propagates. **Mitigation:** migration is mechanical `subprocess.run(...)` → `safe_run(...)`, leaving the surrounding `try/except` block intact.
+
+4. **Inventory drift between PR #464 merge and this PR.** The runbook's "13 files / 18 call sites" inventory was captured 2026-08-17. If anyone has touched any of those files between then and the implementation commit, the count may have changed. **Mitigation:** the awk re-grep at AC5 verification time will surface any new call site or removed one; if the inventory has drifted, either update the implementation to match the new shape, or call out the drift in the PR description.
+
+5. **What if a future script wants `timeout=None`?** Python's `subprocess.run` accepts `timeout=None` as "no timeout" (legacy behaviour). `safe_run` enforces a default of 30s; a caller passing `timeout=None` gets the same behaviour as before. **Mitigation:** this is documented in the docstring. No risk for the current 13-file scope.
+
+## Out of scope (separate chores if wanted; do NOT bundle into this PR)
+
+Per the task description's explicit out-of-scope list:
+
+- **Entry-print on every `safe_run` call** — `print(f"[<script>] {cmd}", file=sys.stderr, flush=True)` immediately before each subprocess call. The runbook recommends this for future hang diagnosability, but it is a separate change from helper consolidation (it touches every call site again, and the helper cannot add it without owning call-site context). File as a follow-up chore if wanted.
+- **`TimeoutExpired` swallowing policy at the helper layer** — graceful skip-the-task behaviour. The helper deliberately does not swallow; callers own the policy. File as a separate chore if a wrapper is wanted.
+- **Migrating `node:child_process.exec` / `Bun.spawn` JS-side equivalents** — Python only here. Out of scope per AC4.
+
+## References
+
+- Originating PR: <https://github.com/Stoffer-Industries/sindustries/pull/464>
+- Runbook: `infra/runbooks/agent-script-subprocess-no-timeout-hang.md`
+- Precedent for `agents/lib/` as shared infra location: `agents/lib/incident_state.py` + `agents/lib/test_incident_state.py`
+- Tech-design skill: `agents/skills/dev/tech-design/SKILL.md`
+- Doc conventions: `docs/CONVENTIONS.md`


### PR DESCRIPTION
## Summary

Consolidates the systemic `subprocess.run` / `Popen` no-timeout pattern surfaced by `agent-task-queue-gh-api-hang-2026-08-17` onto a single shared helper. Originating PR #464 patched the one call site that hung; this PR is the follow-up chore that lands the helper pass across all 13 agent-owned files / 18 unguarded call sites.

## Approach

- New module `agents/lib/subprocess_safe.py` exposes `safe_run` and `safe_popen` (the streaming-subprocess sibling), each with a default 30s timeout floor.
- `**kwargs` forwards verbatim — `check=`, `capture_output=`, `text=`, `env=`, `cwd=`, `input=`, `shell=`, etc. — so existing call-site shape is preserved.
- No `TimeoutExpired` swallowing — call sites own the policy.
- `agents/lib/__init__.py` re-exports both helpers for `from agents.lib import safe_run`.
- 13-file migration swaps every previously-unguarded `subprocess.run` / `Popen` for `safe_run` / `safe_popen`. Per-call `timeout=` values smaller than 30s are preserved as explicit kwargs — e.g. `request_topic_approval.py`'s 12s Telegram-CLI bound stays explicit; `angle_model.py` keeps its surrounding `try / except subprocess.TimeoutExpired` block intact.
- Re-grep at AC5 returns zero unguarded call sites in scope.
- Helper-loaded path: each migrated file imports via `from agents.lib import safe_run` (or `safe_popen`). A short bootstrap block at the top of every migrated file walks parents looking for `agents/lib/` so plain `python3 <file>.py` invocations resolve the import without requiring the script to be on `sys.path` already.

## Reviewer note on `agent_task_queue.py`

This migration removes the inline `timeout=30,` kwarg that PR #464 added at line 359 and lets the helper default take over. **This is the intended shape, NOT a revert of PR #464.** The 30s bound is identical — `DEFAULT_TIMEOUT_SECONDS = 30.0` in `agents/lib/subprocess_safe.py` — and the call still passes the same `**kwargs` to `subprocess.run` via `safe_run`. The only difference is whether the timeout is declared at the call site or inherited from the helper module.

If a reviewer flags the diff as a revert, point them at the `timeout=timeout` line in `safe_run` itself and `DEFAULT_TIMEOUT_SECONDS` — observable behaviour is unchanged.

## Acceptance Criteria

- [x] AC1: `agents/lib/subprocess_safe.py` introduces `safe_run(cmd, *, timeout=30.0, **kwargs) -> subprocess.CompletedProcess` with default 30s timeout, forwards **kwargs to `subprocess.run` (preserving `check=`, `capture_output=`, `text=`, `env=`, `cwd=`, `input=`, `shell=`, etc.), and propagates `subprocess.TimeoutExpired` unchanged. No `TimeoutExpired` swallowing — call sites own the policy. (📄 not code: agents/lib/subprocess_safe.py defines safe_run cmd kwargs with timeout=30.0 default DEFAULT_TIMEOUT_SECONDS, forwards kwargs to subprocess.run preserving check, capture_output, text, env, cwd, input, shell. Propagates TimeoutExpired unchanged. No swallowing — call sites own policy.)
- [x] AC2: `agents/lib/__init__.py` re-exports `safe_run` so callers can `from agents.lib import safe_run`. (📄 not code: agents/lib/__init__.py adds from subprocess_safe import DEFAULT_TIMEOUT_SECONDS, safe_popen, safe_run plus matching __all__.)
- [x] AC3: `agents/lib/test_subprocess_safe.py` covers: (a) `safe_run(["true"])` returns CompletedProcess rc=0; (b) `safe_run(["sleep", "5"], timeout=0.5)` raises `TimeoutExpired` after ~0.5s; (c) `safe_run(["false"], check=True)` raises `CalledProcessError`; (d) `safe_run(["sh", "-c", "echo hi"], capture_output=True, text=True)` returns stdout=`"hi\n"`; (e) parameterized test per existing inline `timeout=` to confirm migration preserves behavior. (🧪 testID: python3 -m unittest agents.lib.test_subprocess_safe — Ran 13 tests in 2.516s — OK. Cases a, b, c, d, e for safe_run plus proxy and wait/timeout behaviour for safe_popen.)
- [x] AC4: All 13 files migrated to use `safe_run` (no `subprocess.run`/`Popen`/`call`/`check_output`/`check_call` calls remain unguarded in the listed scope). The 13 files (verified inventory 2026-08-17, full table in runbook's Systemic scope section): `agents/workflows/bookmarks/scripts/handle_approval_reply.py` (3 sites), `agents/workflows/feature-task/run.py` (2), `agents/workflows/bookmarks/scripts/common.py` (2), `agents/workflows/content-tasks/scripts/common.py` (2), `agents/skills/ops/tasks-api/scripts/agent_task_queue.py` (1, sequencing note: PR #464 already added `timeout=30,`; the helper-pass migration changes that to `safe_run([...])` *without* an explicit `timeout=` kwarg because the helper default takes over — reviewer note: this is intentional, not a revert), `agents/skills/bookmarks/x-ingest/scripts/run_x_ingest.py` (1), `agents/skills/bookmarks/x-ingest/tests/test_linked_articles.py` (1, test, lower priority), `agents/workflows/bookmarks/run.py` (1), `agents/workflows/bookmarks/scripts/rebuild_revised_approval.py` (1), `agents/workflows/bookmarks/scripts/request_topic_approval.py` (1), `agents/workflows/bookmarks/scripts/debug/request_single_spec_approval.py` (1), `agents/workflows/content-tasks/run.py` (1), `agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/angle_model.py` (1). (📄 not code: awk re-grep over agents/skills + agents/workflows excluding agents/lib helper + test files + .venv + node_modules + site-packages + __pycache__ returns zero unguarded subprocess calls. 13 listed files migrated — handle_approval_reply 3 sites — feature-task/run.py 2 — bookmarks/scripts/common.py 2 — content-tasks/scripts/common.py 2 — agent_task_queue.py 1 — run_x_ingest.py 1 — test_linked_articles.py 1 — bookmarks/run.py 1 — rebuild_revised_approval.py 1 — request_topic_approval.py 1 — request_single_spec_approval.py 1 — content-tasks/run.py 1 — angle_model.py 1.)
- [x] AC5: Re-grep after migration returns zero unguarded call sites. Re-grep scope: `agents/skills/` + `agents/workflows/` only, **excluding** `**/.venv/**`, `**/node_modules/**`, `**/site-packages/**`, `**/__pycache__/**` (third-party vendored code is out of scope; without this exclusion the migration would attempt to rewrite compiled vendored copies). Use the awk from the runbook's Systemic scope section. (📄 not code: awk re-grep against agents/skills + agents/workflows excluding agents/lib helper + test files plus .venv + node_modules + site-packages + __pycache__ returns zero matches.)
- [x] AC6: `python3 -m py_compile` passes for all 13 migrated files; smoke runs (where applicable) complete without hanging. (🧪 testID: python3 -m py_compile passes for all 13 migrated files plus new helper and test files — no SyntaxError — no import resolution failure. Smoke run of agent_task_queue.py completed without hanging.)
- [x] AC7: Runbook entry in `infra/RUNBOOKS.md` for `agent-script-subprocess-no-timeout-hang` updated to reflect "closed via chore PR — see <PR link>" (or removed if the systemic class is no longer relevant). Incident state `brain/state/lox-incident-state.json` key `agent-task-queue-gh-api-hang-2026-08-17` already resolved at PR #464 merge; no additional state change needed unless helper-pass PR uncovers a regression. (📄 not code: row 39 of workspace-root /Users/quinnstoffer/.openclaw/workspace/infra/RUNBOOKS.md annotated with closure marker — task description explicitly allows alternative clause "or removed if systemic class no longer relevant" — workspace-level edit outside sindustries tree.)

## Test plan

- `python3 -m unittest agents.lib.test_subprocess_safe` — 13 tests pass.
- `python3 -m py_compile` against each migrated file — OK.
- Re-grep — zero remaining unguarded `subprocess.*` calls in `agents/skills/` + `agents/workflows/`.
- Smoke: `python3 agents/skills/ops/tasks-api/scripts/agent_task_queue.py --assignee Rowan --json` should finish in <2s rather than hang.

## Risks / notes

- **Default timeout at 30s.** Two call sites use non-30s timeouts. `request_topic_approval.py` keeps `timeout=12` explicit for the Telegram-CLI bound; `_run_gh_json` in `agents/workflows/content-tasks/scripts/common.py` used `timeout=30` which matches the helper default and is preserved by removing the inline kwarg. No silent loosening anywhere.
- **Existing `try / except subprocess.TimeoutExpired` handlers preserved.** Both `request_topic_approval.py` and `angle_model.py` had pre-existing timeout-error handling; the migration replaces only the inner `subprocess.run` call, leaving the surrounding `try / except` block intact. Helper does not swallow, so the exception still propagates.
- **PR #464 sequencing.** As called out in the Reviewer note above, `agent_task_queue.py`'s line shape deliberately drops the explicit `timeout=30,`. The 30s is now coming from the helper. Verify `DEFAULT_TIMEOUT_SECONDS == 30.0` and that the call still forwards `check=`, `capture_output=`, `text=`, `env=` to `subprocess.run`.
- **Bootstrap block in each migrated file.** 12 files add a 14-line bootstrap block that walks parents to find `agents/lib/`. This is mechanical and verifiable; an alternative would be to add the helpers to the runtime `PYTHONPATH`, but that would couple every script that calls Python to an env-var contract that isn't in scope for this chore.

## Out of scope (separate chores if wanted; do NOT bundle)

- - Entry-print `print(f"[<script>] {cmd}", file=sys.stderr, flush=True)` on every `safe_run` call. The runbook recommends this for future hang diagnosability, but it is a separate change from helper consolidation — the helper cannot add it without owning call-site context.
- `TimeoutExpired` swallowing policy at the helper layer. The helper deliberately does not swallow; callers own the policy.
- Migrating `node:child_process.exec` / `Bun.spawn` JS-side equivalents. Python only here.

## Refs

- Task: 8a2df49c-791b-4f09-a37a-446fa8c6fd5d
- Tech design: `docs/specs/agent-script-subprocess-safe-run-tech-design.md` (Quinn approved 2026-08-17)
- Originating PR: #464
- Runbook: `/Users/quinnstoffer/.openclaw/workspace/infra/runbooks/agent-script-subprocess-no-timeout-hang.md` (Lox-owned, workspace-root level, not in sindustries)
