### PR TITLE
fix(tasks-api consumers): send session cookie on mutations

### DIFF
--- a/apps/mission-control/src/contentSchedulerApi.js
+++ b/apps/mission-control/src/contentSchedulerApi.js
@@ -29,6 +29,7 @@ async function request(path, { method = 'GET', body, actor } = {}) {
       'content-type': 'application/json',
       ...(actor ? { 'x-actor': actor } : {})
     },
+    credentials: 'include',
     body: body !== undefined ? JSON.stringify(body) : undefined
   });
   let parsed = null;

--- a/apps/mission-control/src/contentSchedulerApi.test.js
+++ b/apps/mission-control/src/contentSchedulerApi.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createItem,
+  updateItem,
+  approveItem,
+  unapproveItem,
+  publishItem,
+  removeItem,
+  reorderItems
+} from './contentSchedulerApi.js';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const mockResponse = (data, ok = true) => ({
+  ok,
+  json: vi.fn().mockResolvedValue({ data })
+});
+
+// Regression: services/tasks-api/src/app.ts mounts requireAuthenticatedUser
+// on POST/PATCH/DELETE /api/v1/content-scheduler (task 0719a8e3), and the
+// Tasks API runs on a different port than mission-control — a cross-origin
+// request. Without credentials: 'include' the session cookie set by the
+// Tasks app's login() is never sent, so every mutation (including the
+// drag-to-reschedule "move tweet" flow) 401s.
+describe('contentSchedulerApi mutations send the browser session cookie', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('createItem', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ id: 1 }));
+    await createItem({ body: 'hi', source: 'manual', scheduledFor: '2026-08-20T00:00:00Z' });
+    expect(mockFetch.mock.calls[0][1].credentials).toBe('include');
+  });
+
+  it('updateItem (drag-to-reschedule)', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ id: 1 }));
+    await updateItem(1, { scheduledFor: '2026-08-21T00:00:00Z' });
+    expect(mockFetch.mock.calls[0][1].credentials).toBe('include');
+  });
+
+  it('approveItem', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ id: 1 }));
+    await approveItem(1, 'Tom');
+    expect(mockFetch.mock.calls[0][1].credentials).toBe('include');
+  });
+
+  it('unapproveItem', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ id: 1 }));
+    await unapproveItem(1, 'Tom');
+    expect(mockFetch.mock.calls[0][1].credentials).toBe('include');
+  });
+
+  it('publishItem', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ id: 1 }));
+    await publishItem(1, 'Tom');
+    expect(mockFetch.mock.calls[0][1].credentials).toBe('include');
+  });
+
+  it('removeItem', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ id: 1 }));
+    await removeItem(1, 'Tom');
+    expect(mockFetch.mock.calls[0][1].credentials).toBe('include');
+  });
+
+  it('reorderItems', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(null));
+    await reorderItems([1, 2, 3], 'Tom');
+    expect(mockFetch.mock.calls[0][1].credentials).toBe('include');
+  });
+});

--- a/apps/tasks/src/tasksApi.test.ts
+++ b/apps/tasks/src/tasksApi.test.ts
@@ -136,6 +136,7 @@ describe('tasksApi', () => {
         'http://localhost:4001/api/v1/tasks',
         expect.objectContaining({
           method: 'POST',
+          credentials: 'include',
           body: JSON.stringify({ title: 'New Task' })
         })
       );
@@ -179,10 +180,24 @@ describe('tasksApi', () => {
         'http://localhost:4001/api/v1/tasks/1',
         expect.objectContaining({
           method: 'PATCH',
+          credentials: 'include',
           body: JSON.stringify({ title: 'Updated', status: 'done', dependsOnIds: ['dep-1'] })
         })
       );
       expect(result).toEqual(task);
+    });
+
+    // Regression: the Tasks API and Tasks app run on different ports, so this
+    // is a cross-origin request. Without credentials: 'include' the browser
+    // session cookie set by login() is never sent, and requireAuthenticatedUser
+    // rejects the mutation with a 401 that the UI shows as "Failed to update task".
+    it('sends the browser session cookie so mutations survive requireAuthenticatedUser', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ id: 1 }));
+
+      await updateTask(1, { status: 'done' });
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.credentials).toBe('include');
     });
   });
 
@@ -220,7 +235,7 @@ describe('tasksApi', () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:4001/api/v1/tasks/1',
-        expect.objectContaining({ method: 'DELETE' })
+        expect.objectContaining({ method: 'DELETE', credentials: 'include' })
       );
       expect(result).toBeNull();
     });
@@ -301,6 +316,7 @@ describe('tasksApi', () => {
         'http://localhost:4001/api/v1/tasks/1/comments',
         expect.objectContaining({
           method: 'POST',
+          credentials: 'include',
           body: JSON.stringify({ author: 'John', text: 'Comment' })
         })
       );

--- a/apps/tasks/src/tasksApi.ts
+++ b/apps/tasks/src/tasksApi.ts
@@ -146,6 +146,7 @@ const API_BASE =
 async function api<T>(path: string, options?: RequestInit): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`, {
     headers: { 'content-type': 'application/json', ...(options?.headers ?? {}) },
+    credentials: 'include',
     ...options
   });
 


### PR DESCRIPTION
## Summary

Tom reported two symptoms: "Failed to update task" when checking AC checkboxes in the Tasks app, and being unable to drag/reschedule ("move") a tweet in the Content Scheduler tab of mission-control. Both trace to the same root cause: `db967e2` (task `0719a8e3`) added `requireAuthenticatedUser` middleware gating every `POST/PATCH/DELETE` on `/api/v1/tasks`, `/api/v1/tags`, and `/api/v1/content-scheduler` behind the `tasks_api_session` cookie. Both browser clients are cross-origin from the Tasks API (different dev ports), and both had `fetch()` calls that never set `credentials: 'include'`, so the session cookie was never sent and every mutation 401'd — surfaced to users as a generic "Failed to update task" toast (Tasks app) or a silently-failing drag (Content Scheduler).

## Fix

- `apps/tasks/src/tasksApi.ts` — default `credentials: 'include'` in the shared `api()` helper, covering `createTask`/`updateTask`/`archiveTask`/`createTaskComment`.
- `apps/mission-control/src/contentSchedulerApi.js` — same fix in its shared `request()` helper, covering `createItem`/`updateItem`/`approveItem`/`unapproveItem`/`publishItem`/`removeItem`/`reorderItems`.

## Acceptance Criteria

- [x] AC1: `updateTask` (AC-checkbox toggles, all task PATCH calls) sends the browser session cookie cross-origin. (🧪 testID: apps/tasks/src/tasksApi.test.ts — "sends the browser session cookie so mutations survive requireAuthenticatedUser")
- [x] AC2: `createTask`, `archiveTask`, `createTaskComment` — same fix. (🧪 testID: apps/tasks/src/tasksApi.test.ts — updated specs assert `credentials: 'include'`)
- [x] AC3: Content Scheduler mutations, including drag-to-reschedule ("move tweet"), send the session cookie. (🧪 testID: apps/mission-control/src/contentSchedulerApi.test.js — new file, 7 tests covering all mutating calls)

## Test plan

- `apps/tasks`: `npm run test` — 212/212 passing; `npm run build` — clean
- `apps/mission-control`: `npm run test` — 223/223 passing (7 new); `npm run build` — clean
- Confirmed CORS for the live dev environment (`services/tasks-api/.env.prodlike`, port 4001) already allows both `localhost:5174` (Tasks app) and `localhost:5175` (mission-control) with credentials, so no server-side CORS change needed — cookies are host-scoped (not port-scoped per RFC 6265), so a session established via the Tasks app's login is honoured cross-port once `credentials: 'include'` is set client-side.
- Confirmed locally that an unauthenticated `PATCH /api/v1/tasks/:id` against the running Tasks API returns 401, matching the reported symptom
- Checked for other browser consumers of the now-gated `/api/v1/tags` and `/api/v1/feature-task-analytics/events` mutation routes — none found (server/agent-side callers use Bearer tokens, unaffected). `apps/mission-control/src/tasksApi.js` is GET-only, unaffected. `apps/budget-mobile` and `apps/gymtrack`'s connected-agents panel hit entirely separate backends, unaffected.

Not a feature task — small, well-diagnosed bug fix, ticketless per Tom's direction in Telegram (topic app-tasks, 2026-08-18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)