### PR TITLE
fix(repo): gitignore tasks-api .bak files blocking canonical checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ services/tasks-api/.env.dev
 services/tasks-api/.env.dev.local
 services/tasks-api/.env.prodlike
 services/tasks-api/.env.prodlike.local
+services/tasks-api/*.bak*
 services/tasks-api/src/generated/
 services/tasks-api/generated/
 services/budget-api/.env.dev


### PR DESCRIPTION
## Summary

Lox raised `shared-worktree-behind-origin-main-2026-08-18`: the canonical `codebases/sindustries` checkout kept falling behind `origin/main` because OpenClaw Edge's fast-forward refresh requires a clean `git status`, and `services/tasks-api/.env.prodlike.bak2-20260816T010930Z` is an untracked file sitting in that checkout. Every time new commits land on `origin/main`, the refresh silently fails until someone manually cleans it up — 3rd occurrence of the same root cause in 6 days per Lox's tracking, 20+ dirty-state errors logged.

## Fix

Add `services/tasks-api/*.bak*` to `.gitignore`. Verified with `git check-ignore -v` that it matches the exact offending filename. Scoped to `services/tasks-api/` (not repo-wide) since that's the only place this backup-file pattern has occurred.

This is option (a) of the three Lox offered Tom in the incident (merge a `.gitignore` fix / manually `rm` the file / loosen Edge's dirty-check policy) — the permanent fix, since the file itself is harmless and doesn't need deleting, just excluding from the dirty-check.

## Test plan

- `git status --short` in the canonical checkout showed only the one untracked file before this change
- `git check-ignore -v services/tasks-api/.env.prodlike.bak2-20260816T010930Z` confirms the new pattern matches it
- No code changes — `.gitignore` only, nothing to build/test

Not a feature task — ticketless per Tom's direction in Telegram (topic app-tasks, 2026-08-18), same session as PR #467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)