### PR TITLE
feat(tasks-api): rename qa → accepted, add qa_agent enum values for Ash gate

### DIFF
--- a/agents/skills/ops/tasks-api/scripts/test_pending_tech_design_approvals.py
+++ b/agents/skills/ops/tasks-api/scripts/test_pending_tech_design_approvals.py
@@ -62,7 +62,7 @@ class TechDesignApprovedTest(unittest.TestCase):
         self.assertFalse(p.tech_design_approved(task))
 
     def test_other_approval_type_is_not_approval(self):
-        task = {"approvals": [{"type": "qa", "state": "approved"}]}
+        task = {"approvals": [{"type": "accepted", "state": "approved"}]}
         self.assertFalse(p.tech_design_approved(task))
 
     def test_no_approvals_is_not_approval(self):

--- a/agents/skills/ops/tasks-api/tasks_api_client.py
+++ b/agents/skills/ops/tasks-api/tasks_api_client.py
@@ -423,13 +423,13 @@ def build_parser():
 
     approve = sub.add_parser("approve", help="Grant a structured task approval as the authenticated service actor")
     approve.add_argument("--id", required=True, help="Full task UUID")
-    approve.add_argument("--type", required=True, choices=["spec", "tech_design", "qa"])
+    approve.add_argument("--type", required=True, choices=["spec", "tech_design", "qa_agent", "accepted"])
     approve.add_argument("--note", help="Optional approval rationale")
     approve.set_defaults(func=cmd_approve)
 
     revoke = sub.add_parser("revoke-approval", help="Revoke a structured task approval as the authenticated service actor")
     revoke.add_argument("--id", required=True, help="Full task UUID")
-    revoke.add_argument("--type", required=True, choices=["spec", "tech_design", "qa"])
+    revoke.add_argument("--type", required=True, choices=["spec", "tech_design", "qa_agent", "accepted"])
     revoke.set_defaults(func=cmd_revoke_approval)
 
     a = sub.add_parser("archive", help="Archive (soft-delete) a task")

--- a/agents/workflows/feature-task/src/main.rs
+++ b/agents/workflows/feature-task/src/main.rs
@@ -966,14 +966,14 @@ fn task_approval_granted(task: &Task, approval_type: &str) -> bool {
 fn spec_check_should_skip_legacy_mutation(task: &Task) -> bool {
     task_approval_granted(task, "spec")
 }
-fn qa_ac_verified_structured(task: &Task) -> bool {
-    task_approval_granted(task, "qa")
+fn accepted_structured(task: &Task) -> bool {
+    task_approval_granted(task, "accepted")
 }
-fn qa_ac_verified_failures_structured(task: &Task) -> Vec<String> {
-    if qa_ac_verified_structured(task) {
+fn accepted_structured_failures(task: &Task) -> Vec<String> {
+    if accepted_structured(task) {
         vec![]
     } else {
-        vec!["Structured QA approval is missing or not approved; Tom must approve the `qa` TaskApproval before closing.".to_string()]
+        vec!["Structured accepted approval is missing or not approved; Tom must approve the `accepted` TaskApproval before closing.".to_string()]
     }
 }
 
@@ -1225,7 +1225,7 @@ fn post_merge(args: StageArgs) -> Result<Envelope> {
 
     // AC text check runs pre-merge at the doing → acceptance gate (verify_delivery).
     // Require Tom's explicit sign-off before closing.
-    let qa_failures = qa_ac_verified_failures_structured(&env.task);
+    let qa_failures = accepted_structured_failures(&env.task);
     if is_past(&env.task, "acceptance") {
         if !qa_failures.is_empty() {
             if !args.dry_run {
@@ -4777,13 +4777,13 @@ mod tests {
             approvals: vec![
                 approval_row("spec", "approved"),
                 approval_row("tech_design", "approved"),
-                approval_row("qa", "approved"),
+                approval_row("accepted", "approved"),
             ],
             ..Default::default()
         };
         assert!(spec_is_approved(&approved));
         assert!(tech_design_approved_structured(&approved));
-        assert!(qa_ac_verified_structured(&approved));
+        assert!(accepted_structured(&approved));
         let legacy = Task {
             description: Some("- [x] **Approved by Tom**".into()),
             comments: vec![TaskComment {
@@ -4794,18 +4794,18 @@ mod tests {
         };
         assert!(!spec_is_approved(&legacy));
         assert!(!tech_design_approved_structured(&legacy));
-        assert!(!qa_ac_verified_structured(&legacy));
+        assert!(!accepted_structured(&legacy));
         let revoked = Task {
             approvals: vec![
                 approval_row("spec", "revoked"),
                 approval_row("tech_design", "revoked"),
-                approval_row("qa", "revoked"),
+                approval_row("accepted", "revoked"),
             ],
             ..legacy
         };
         assert!(!spec_is_approved(&revoked));
         assert!(!tech_design_approved_structured(&revoked));
-        assert!(!qa_ac_verified_structured(&revoked));
+        assert!(!accepted_structured(&revoked));
     }
 
     #[test]

--- a/docs/specs/add-ash-qa-agent-verifier-gate-tech-design.md
+++ b/docs/specs/add-ash-qa-agent-verifier-gate-tech-design.md
@@ -1,0 +1,306 @@
+---
+status: draft
+task_id: f6a4d56a-fdd0-41fe-b5c0-6c042cb53f47
+product_spec: n/a (internal tooling)
+shipped_pr: null
+shipped_date: null
+---
+
+# Add Ash: QA-Agent Verifier Gate Tech Design
+
+## Links
+
+- Task: `f6a4d56a-fdd0-41fe-b5c0-6c042cb53f47` (`Add Ash: automated QA-verifier agent gate between doing and acceptance`)
+- Task API: `http://localhost:4001/api/v1/tasks/f6a4d56a-fdd0-41fe-b5c0-6c042cb53f47`
+- Today's failure log (motivation): 2026-08-18 manual QA pass 6/12 — every failure mechanically verifiable but the lobster never reads the diff
+
+## Scope
+
+- Repository: `Stoffer-Industries/sindustries`
+- Branch: `add-ash-qa-agent-gate` (from `origin/main`)
+- Worktree: `~/workspace/worktrees/add-ash-qa-agent-gate`
+- Primary code surfaces:
+  - `services/tasks-api/prisma/schema.prisma` (extend `ApprovalType` enum)
+  - `services/tasks-api/prisma/migrations/<ts>_extend_approval_types/` (one migration)
+  - `services/tasks-api/src/config/requiredApprovals.ts` (default mappings + owners)
+  - `services/tasks-api/src/routes/tasks/_mapper.ts` (derive `workflowGates` from all outstanding approvals, not just one handoff)
+  - `services/tasks-api/src/routes/tasks/_validation.ts` (validate new approval types at API boundary)
+  - `services/tasks-api/src/routes/tasks.ts` (revocation / drift handling for renamed types)
+  - `services/tasks-api/scripts/required-approvals-migrate.ts` (one-shot migration: rename `qa` → `accepted` for existing rows)
+  - `agents/skills/ops/tasks-api/tasks_api_client.py` (extend `--type` choices)
+  - `agents/workflows/feature-task/src/main.rs` (lobster gate transition logic)
+  - `agents/workflows/feature-task/src/ac_parsing.rs` (extract evidence tags for the verification script)
+  - `agents/workflows/feature-task/test/<...>.rs` (gate-transition tests, renamed-gate tests)
+  - `agents/ash/src/verify.ts` (Ash verification script — Quinn registers the agent, Rowan writes the script under `agents/ash/` only as a placeholder until Quinn provisions the agent; see `.openclaw` boundary below)
+  - `docs/systems/tasks-api.md` (update workflow-gates section to describe the two-gate model)
+
+## Product intent (one-paragraph)
+
+Today's lobster only checks PR-body shape (checkboxes ticked, evidence tag present, CI green). It never reads the codebase to confirm the claims are true. Today's manual QA pass (Tom) caught 6/12 — every failure was mechanically verifiable. We're introducing Ash, a Principal Quality Engineer agent, whose job is exactly that mechanical verification, and a new `qa_agent` workflow gate that the lobster requires satisfied before promoting a task from `doing → acceptance`. Tom's existing acceptance-stage sign-off becomes a separate `accepted` gate (renamed from today's `qa`), so the two checks (mechanical-by-agent vs human-by-Tom) are visibly distinct in the data model and the UI.
+
+## Ownership boundary check
+
+The natural source of truth for this change is **shared package / cross-app contract** — `services/tasks-api`'s `ApprovalType` enum + `TaskApproval` rows are already the structured-approval backbone (see `tasks-api-native-approvals-tech-design.md`), and the lobster already gates on `task_approval_granted(task, "qa")`. Adding a new gate by extending that same enum + wiring a new transition predicate is the durable boundary; introducing a separate "Ash gate" model would create a second source of truth for the same lifecycle concept.
+
+Concretely:
+
+- `ApprovalType` enum gets two new values (`qa_agent`, `accepted`) and the legacy `qa` value is removed via the same migration that renames existing rows.
+- The lobster's `qa_ac_verified_structured` predicate (used for `done`-closure audit) is renamed `accepted_structured` and checks `task_approval_granted(task, "accepted")`.
+- A new lobster predicate `qa_agent_verified` checks `task_approval_granted(task, "qa_agent")` and gates `doing → acceptance`.
+- A new lobster step `create_qa_agent_gate` creates an outstanding `qa_agent` TaskApproval row idempotently when a task enters `doing` (or when its PR merges while in `doing`).
+- `mapTask.workflowGates` is generalised from "one outstanding handoff" to "all outstanding approval-type rows for this task, joined with their configured owner" — this surfaces Ash's gate AND Tom's `accepted` gate simultaneously in the UI.
+
+No interim shims. The migration runs once at deploy and renames rows atomically (no period where `qa` and `accepted` coexist).
+
+## `.openclaw` boundary notes
+
+AC5 explicitly delegates Ash's agent identity to Quinn: Rowan must **not** attempt to register Ash inside `~/.openclaw/` directly. Instead Rowan:
+
+1. Writes a placeholder `agents/ash/` directory in the worktree containing only `verify.ts` (the verification script — pure code, no agent identity) and a `README.md` pointing at Quinn.
+2. Posts an `[openclaw-needed]` task comment listing exactly what Quinn must apply at the workspace level (session identity, model pin, GitHub identity, TASKS_API approval token, heartbeat/cron wiring, IDENTITY.md with `creature: wolf` and `title: Principal Quality Engineer`).
+3. The verification script is invoked by an external trigger (Quinn's heartbeat or a new cron) **after** the agent identity is provisioned. Rowan's PR can land without Ash running; the migration and lobster gate work without Ash; Ash's first satisfied gate happens on the next task that merges.
+
+Rowan does **not** create the `.openclaw/agents/ash/` directory, does **not** add Ash to any agents config, does **not** create a `ROWAN`-equivalent `~/.config/gh-ash` directory, and does **not** rotate any per-agent token. Anything touching `~/.openclaw/` stays outside this PR.
+
+## Implementation plan
+
+### 1. Tasks API schema (`services/tasks-api/prisma/schema.prisma`)
+
+Extend the existing `ApprovalType` enum:
+
+```prisma
+enum ApprovalType {
+  spec
+  tech_design
+  qa_agent    // NEW — Ash's mechanical verification gate
+  accepted    // RENAMED from qa — Tom's human sign-off at acceptance
+  // qa (legacy) — REMOVED via migration; no default value remains
+}
+```
+
+The legacy `qa` value is **removed** in the same migration that renames existing rows to `accepted`. No backwards-compatibility period (Postgres enum value drops are reversible via `ALTER TYPE ... ADD VALUE` if we ever need to roll back the migration — see Risks).
+
+### 2. Migration (`services/tasks-api/prisma/migrations/<ts>_extend_approval_types_qa_agent_accepted/`)
+
+Two-step migration in one `migration.sql`:
+
+```sql
+-- Step 1: extend the enum with the two new values BEFORE we rename rows
+ALTER TYPE "ApprovalType" ADD VALUE 'qa_agent';
+ALTER TYPE "ApprovalType" ADD VALUE 'accepted';
+
+-- Step 2: rename existing rows from qa -> accepted
+UPDATE "TaskApproval" SET type = 'accepted' WHERE type = 'qa';
+
+-- Step 3: drop the legacy enum value (Postgres requires dropping the default if any)
+ALTER TYPE "ApprovalType" DROP VALUE 'qa';
+```
+
+Preflight: `SELECT type, count(*) FROM "TaskApproval" GROUP BY type` before the migration; expect a non-empty `qa` bucket and empty `qa_agent` + `accepted` buckets. After: `qa_agent` empty, `accepted` equals old `qa` count, `qa` zero.
+
+Document the rollback path in the migration's comment block: re-adding `'qa'` to the enum (Postgres 12+ supports `ALTER TYPE ... ADD VALUE`) plus an UPDATE in the opposite direction is sufficient; no destructive column drops.
+
+### 3. Default config (`services/tasks-api/src/config/requiredApprovals.ts`)
+
+- Extend `DEFAULT_APPROVAL_OWNERS`:
+  ```ts
+  spec: 'Tom',
+  tech_design: 'Quinn',
+  qa_agent: 'Ash',
+  accepted: 'Tom',
+  // qa removed
+  ```
+- Extend `DEFAULT_REQUIRED_APPROVALS.mappings`:
+  ```ts
+  feature: ['spec', 'tech_design', 'qa_agent', 'accepted'],
+  code:    ['tech_design', 'qa_agent', 'accepted'],
+  content: ['spec', 'qa_agent', 'accepted'],
+  research: [],
+  ```
+- Update the `validApprovalTypes` set in `routes/tasks/_constants.ts` to match.
+
+### 4. Mapper (`services/tasks-api/src/routes/tasks/_mapper.ts`)
+
+Today `workflowGates` derives from the singular `task.workflowHandoffRoleId` field — only one outstanding gate is surfaced at a time. With two gates live per task, we generalise:
+
+```ts
+const workflowGates: Array<WorkflowGateSummary> = [];
+for (const approvalType of requiredApprovalTypes) {
+  const owner = gateOwnersByType[approvalType];
+  const approved = task.approvals?.some(
+    (a) => a.type === approvalType && a.state === 'approved' && !a.revokedAt
+  );
+  if (!approved) {
+    workflowGates.push({
+      roleId: `${approvalType}_gate`,       // e.g. qa_agent_gate, accepted_gate
+      owner,
+      gate: approvalType,                    // 'qa_agent' | 'accepted'
+      reason: reasonByType[approvalType],    // static per-type string
+      state: 'outstanding' as const,
+    });
+  }
+}
+```
+
+This replaces the `workflowHandoffRoleId`-derived gate entirely. The `Task.workflowHandoffRoleId` / `workflowHandoffGate` / `workflowHandoffReason` columns stay (used internally by the lobster for current-attention handoff) but no longer drive the API response surface.
+
+### 5. Tasks API route validation (`services/tasks-api/src/routes/tasks/_validation.ts`)
+
+Extend `validApprovalTypes` check to `['spec', 'tech_design', 'qa_agent', 'accepted']`. Reject `'qa'` with `400 INVALID_APPROVAL_TYPE` (defensive — external callers shouldn't be sending it after migration, but the migration runs at deploy time so a stale caller could race).
+
+### 6. Tasks API approval revocation drift handling (`services/tasks-api/src/routes/tasks.ts`)
+
+The current spec-approval revocation path (`description !== undefined` branch) needs a parallel branch for `qa_agent` and `accepted`: if `description` changes and either of those approvals is already `approved`, revoke it. Reuse the same `taskApproval.update` shape; add the two new types to the drift check. This keeps the existing promise that "approval state tracks the thing it approves" without growing the code surface significantly.
+
+### 7. Tasks API client (`agents/skills/ops/tasks-api/tasks_api_client.py`)
+
+Update the `approve --type` argparse choices from `['spec', 'tech_design', 'qa']` to `['spec', 'tech_design', 'qa_agent', 'accepted']`. No other change.
+
+### 8. Lobster changes (`agents/workflows/feature-task/src/main.rs`)
+
+- **New predicate** `qa_agent_verified(task) -> bool`: returns `task_approval_granted(task, "qa_agent")`. Distinct from the existing `qa_ac_verified_structured` (which becomes `accepted_structured`).
+- **Rename existing predicate** `qa_ac_verified_structured` → `accepted_structured` and have it check `task_approval_granted(task, "accepted")`. Update every call site. Three call sites confirmed by grep (lines 970, 1294, 4780/4802 in `main.rs`).
+- **New gate-creation step** `create_qa_agent_gate_if_missing(task)`: idempotent `POST /tasks/{id}/approvals` with `{type: "qa_agent", owner: "Ash", state: "outstanding"}` — but since the API only persists approved/revoked states, instead use the structured `POST /tasks/{id}/approvals` with `{type: "qa_agent", owner: "Ash"}` (default state = approved) and immediately revoke it: `DELETE /tasks/{id}/approvals/qa_agent`. This leaves a `TaskApproval` row with `state: "revoked"` and `revokedAt` set, which the audit trail treats as "created outstanding, not yet approved" — same pattern the spec-approval revocation path already uses.
+  - **Alternative (preferred):** extend the API to allow creating an `outstanding` `TaskApproval` row. The current enum only has `approved` and `revoked`; adding `outstanding` is one enum value + a one-line write path. This is cleaner — no revoked-as-proxy-for-outstanding hack. Surface this as a small extension to the tasks-api in the same PR. (If Quinn pushes back on the API surface change, fall back to the revoke-as-outstanding pattern; flag in PR description.)
+- **Trigger point** for `create_qa_agent_gate_if_missing`: when the lobster observes a state transition to `doing` for this task, OR when it observes a merged PR for a task still in `doing`. The lobster already detects both — wire the gate-creation into the existing transition handling for `open → doing` and into the merge-detection path.
+- **Transition gate**: `doing → acceptance` calls `transition_or_block(...)` already; add a precondition that `qa_agent_verified(task) == true`. If false, write a `[qa-agent-blocked]` comment (per AC3 — see step 9 for content) and return without transitioning. The existing fingerprint-dedup logic in `transition_or_block` is reused so we don't spam comments.
+- **`accepted` gate creation**: when the lobster promotes a task to `acceptance`, call `create_accepted_gate_if_missing(task)` — same shape as `create_qa_agent_gate_if_missing` but with `type: "accepted"`. The API's `mapTask` will then surface this as an outstanding gate owned by Tom, blocking `done` until Tom approves.
+
+### 9. Ash verification script (`agents/ash/src/verify.ts` + Ash agent runs it)
+
+This script is pure code and lives in the worktree at `agents/ash/src/verify.ts`. It is NOT invoked by the lobster (the lobster only creates them and gates on them); it is invoked by Ash's heartbeat / cron after Quinn provisions Ash's agent identity.
+
+Inputs (per task, supplied via CLI args):
+
+- `--task-id <uuid>`
+- `--tasks-api-base-url <url>` (defaults to `http://localhost:4001/api/v1`)
+- `--task-author <Ash>` (the per-agent TASKS_API_APPROVAL_TOKEN env var name)
+- `--pr-url <url>` (the merged PR for this task)
+
+Algorithm:
+
+1. Fetch the task via `GET /tasks/{id}` and the PR via GitHub REST `GET /repos/{owner}/{repo}/pulls/{n}`.
+2. Parse the PR body for AC evidence tags using the existing `parse_evidence` regex from `agents/workflows/feature-task/src/ac_parsing.rs:118-122` (or its equivalent if the lobster exposes one as a library — check at impl time). For each `- [x] AC<N>: ... (testID|not tested|not code|pr: <value>)` pair, capture the type + value.
+3. For each `(testID: <name>)`: spawn `pnpm test --filter <name>` (or equivalent `pnpm --filter <package> test -- <name>` based on `name` shape) inside the workspace and assert exit 0. Log the failure with the AC label, test name, and exit code.
+4. For each `(not tested: <file-path>)`: assert the file exists at `<repo-root>/<path>` relative to the workspace. For each `(pr: <file-path>)`: same existence check + extract the cited lines from the merged diff (`gh pr diff <url>`) and assert the cited lines exist in the diff.
+5. Cross-check: for each AC's evidence-text block, run a small LLM-style claim-vs-diff check (or a deterministic structural check — see Open Questions below).
+6. On all checks pass: POST `/tasks/{id}/approvals` with `{type: "qa_agent", owner: "Ash"}` to satisfy the gate. Log `[qa-agent-verified] task=<id> pr=<url>`.
+7. On any failure: POST `/tasks/{id}/comments` with `[qa-agent-blocked]\nAC<N>: <claim that failed>\n<reason>` and **do not** satisfy the gate. The lobster's transition gate will hold the task in `doing`.
+
+Edge cases:
+
+- No PR URL on the task → skip the verification, post `[qa-agent-blocked] No PR URL found in task.`, do not satisfy.
+- PR not merged → skip, post `[qa-agent-blocked] PR <url> is not merged.`, do not satisfy.
+- Auth failure on the API → post `[qa-agent-blocked] Tasks API auth failed: <err>` and exit non-zero. Do not satisfy.
+
+### 10. End-to-end tests (AC1, AC2, AC3, AC4 testIDs)
+
+- **AC1 testID (gate-transition test):** `agents/workflows/feature-task/test/qa_agent_gate.rs`
+  - Case A: task in `doing` with no `qa_agent` approval row → lobster does NOT promote to `acceptance`; posts `[qa-agent-blocked]` with reason "qa_agent gate is outstanding".
+  - Case B: task in `doing` with `qa_agent` approval `state: approved` → lobster promotes to `acceptance` and creates `accepted` approval row.
+- **AC2 testID (renamed-gate test):** `services/tasks-api/test/approval-types.test.ts`
+  - Migration test: pre-migration DB with `qa` rows; after migration runs, those rows are `accepted`, no `qa` rows exist, `qa_agent` enum value exists.
+  - Default-config test: `DEFAULT_REQUIRED_APPROVALS.mappings.code` includes both `qa_agent` and `accepted`.
+- **AC3 testID (verification script test):** `agents/ash/test/verify.test.ts`
+  - Missing-test case: PR body cites `testID: tests/foo.test.ts — "passes when foo"`, but `tests/foo.test.ts` doesn't exist → script posts `[qa-agent-blocked]` naming the missing test file; does NOT POST the approval.
+  - Missing-artifact case: PR body cites `pr: apps/tasks/src/newFeature.tsx — "introduces X"` but the file isn't in the diff → script posts `[qa-agent-blocked]` naming the missing artifact; does NOT POST the approval.
+  - Fabricated-evidence case: PR body claims AC4 has a test at line 50 but the diff only adds a doc file → script posts `[qa-agent-blocked]` naming the fabricated claim; does NOT POST the approval.
+- **AC4 testID (end-to-end test):** `agents/workflows/feature-task/test/end_to_end_qa_agent_gate.rs` or an integration test under `services/tasks-api/test/integration/`
+  - Setup: a `doing` task with a merged PR whose ACs are all honestly evidenced.
+  - Action: invoke the lobster's `doing → acceptance` transition once with no `qa_agent` approval (must hold), then invoke Ash's verify script (must POST the approval), then invoke the lobster's `doing → acceptance` transition again (must promote to `acceptance` and surface `accepted` as outstanding for Tom).
+  - Assert: task ends in `acceptance`, `workflowGates` contains exactly one entry — `{gate: "accepted", owner: "Tom", state: "outstanding"}`.
+
+### 11. `[openclaw-needed]` comment (AC5)
+
+Posted in the **same heartbeat** as the `[tech-design]` comment — a separate comment so the lobster and Quinn's discovery surface both see the ask independently. Content:
+
+```
+[openclaw-needed]
+Register Ash as a real OpenClaw agent. Same bootstrap pattern as Rowan (see `~/.openclaw/workspace/agents/rowan/`). Required:
+1. Workspace directory `~/.openclaw/workspace/agents/ash/` with AGENTS.md, SOUL.md, IDENTITY.md (creature: wolf, title: Principal Quality Engineer), USER.md, TOOLS.md, MEMORY.md, HEARTBEAT.md, WORKFLOW.md.
+2. GitHub identity: a fine-grained PAT for Ash with `repo` + `workflow` scopes, stored in `~/.openclaw/.env` as `ASH_GITHUB_TOKEN`. New `~/.config/gh-ash` directory.
+3. Tasks API per-agent token: `ASH_TASKS_API_APPROVAL_TOKEN` provisioned by Quinn and added to `services/tasks-api`'s `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` JSON list with `actor: "Ash"`.
+4. Heartbeat / cron wiring: an Ash heartbeat session bound to a cron that wakes every N minutes (recommend 15) and runs the verification script against any `doing` task with a merged PR whose `qa_agent` gate is outstanding. Pick the cadence after observing one full sweep.
+5. Telegram account `ash` registered under `channels.telegram.accounts.ash` so the agent can post task comments under its own identity.
+6. IDENTITY.md avatar: a wolf avatar (openclaw-wolf.png or similar).
+
+This PR does NOT register Ash — that's outside `codebases/sindustries`. The PR only adds the `agents/ash/src/verify.ts` script + tests; Ash's first satisfied gate happens after Quinn completes steps 1-6.
+```
+
+### 12. System docs (`docs/systems/tasks-api.md`)
+
+Update the workflow-gates section to document the two-gate model:
+
+- `qa_agent` gate: created when task enters `doing`, owned by Ash, satisfied by Ash's verification script.
+- `accepted` gate: created when task enters `acceptance`, owned by Tom, satisfied by Tom's `[qa-ac-verified] true` comment + structured approval.
+- Map `mapTask.workflowGates` to surface both gates simultaneously, not just one outstanding handoff.
+
+Also document the Ash agent at a high level (link to the worktree's `agents/ash/src/verify.ts` source); cross-reference the `[openclaw-needed]` bootstrap.
+
+## Data model changes
+
+| Change | Surface | Risk |
+|--------|---------|------|
+| `ApprovalType` enum: +2 values (`qa_agent`, `accepted`), -1 value (`qa`) | `services/tasks-api/prisma/schema.prisma` | Enum value drops are reversible via `ALTER TYPE ADD VALUE` (Postgres 12+) — see Risks |
+| `TaskApproval` rows with `type: 'qa'` → `type: 'accepted'` | Same migration as above | Data-only update, no row loss |
+| `Task.workflowHandoffRoleId` / `workflowHandoffGate` / `workflowHandoffReason` columns retained but no longer drive `mapTask.workflowGates` | `services/tasks-api/src/routes/tasks/_mapper.ts` | Internal lobster handoff signal preserved; external API surface changes |
+| New `ApprovalState.outstanding` (alternative approach to step 8) | `services/tasks-api/prisma/schema.prisma` | TBD — fallback if Quinn rejects the API change |
+| `agents/ash/src/verify.ts` new file | new directory in repo | None — pure code, isolated |
+
+## API contract changes
+
+- `POST /api/v1/tasks/{id}/approvals` now accepts `type ∈ {spec, tech_design, qa_agent, accepted}`. Existing clients sending `qa` get `400 INVALID_APPROVAL_TYPE` after migration.
+- `GET /api/v1/tasks/{id}` and `GET /api/v1/tasks` responses' `workflowGates[]` may contain **multiple entries** instead of at most one. Clients that assumed single-entry must handle the array shape (UI already iterates as a list per `apps/tasks/src/...` — verify at impl time, update if any code path assumes `workflowGates[0]`).
+- `DELETE /api/v1/tasks/{id}/approvals/{type}` works for `qa_agent` and `accepted` exactly like the existing three types.
+
+## Workflow / cron / skill changes
+
+- **Lobster cron:** unchanged — the existing sweep picks up the new predicates without config change.
+- **Ash cron (new, Quinn-owned):** a per-agent heartbeat for Ash that fires every ~15 minutes (TBD after observing one full sweep), invokes `agents/ash/src/verify.ts` against each `doing` task with a merged PR and outstanding `qa_agent` gate. **Quinn sets this up — Rowan only documents the required behaviour.**
+- **Tech-design skill:** unchanged.
+- **PR-process skill:** unchanged.
+
+## Test plan / AC verification matrix
+
+| AC | Test layer | Test file | Notes |
+|----|-----------|-----------|-------|
+| AC1 — `qa_agent` gate created on `doing`, gates `doing → acceptance` | unit (lobster) | `agents/workflows/feature-task/test/qa_agent_gate.rs` | Two cases: outstanding gate holds transition, approved gate allows it |
+| AC2 — `accepted` gate fires when task enters `acceptance` | integration (tasks-api) | `services/tasks-api/test/approval-types.test.ts` | Migration assertion + default-config assertion |
+| AC3 — Ash verification catches missing test, missing artifact, fabricated claim | unit (verify script) | `agents/ash/test/verify.test.ts` | Three cases, each asserts `[qa-agent-blocked]` comment posted and approval NOT posted |
+| AC4 — Passing PR reaches `acceptance` with `qa_agent` satisfied and `accepted` outstanding | e2e (lobster + tasks-api) | `agents/workflows/feature-task/test/end_to_end_qa_agent_gate.rs` or `services/tasks-api/test/integration/` | Full task lifecycle |
+| AC5 — `[openclaw-needed]` comment posted with Quinn's bootstrap steps | manual / heartbeat | verified at PR review time | One comment, exact format above |
+
+## Open questions / risks
+
+1. **Should `ApprovalState` grow an `outstanding` value, or use `revoked` as the proxy?** The revoke-as-outstanding pattern reuses existing code but is semantically odd (revoked implies someone approved-then-unapproved). Adding `outstanding` is one enum value + one write path. Recommendation: ask Quinn in the PR description which approach he prefers before merging. Default to the `outstanding` value approach unless Quinn objects in review.
+
+2. **Evidence-text claim-vs-diff check** — the structural checks in step 9 (test exists, file exists, line in diff) are deterministic and high-confidence. The "evidence text cross-checked against the real diff for overstated or fabricated claims" AC is fuzzier. Implementation options:
+   - (a) Deterministic structural check only — covers AC3(a) and AC3(b) reliably; AC3(c) is only checked if the cited line numbers / claims are testable structurally.
+   - (b) LLM call to a cheap model — covers AC3(c) but introduces a per-gate cost and async timing.
+   - (c) Hybrid — deterministic first, LLM fallback if structural checks pass but obvious gaps remain.
+   - Recommendation: start with (a). AC3(c) is already partially covered by (a) (fabricated test names won't exist; fabricated file paths won't exist). If Tom's 6/12 review showed failures that pure structural checks would miss, escalate before expanding scope. Flag in PR description.
+
+3. **Postgres enum value drop ordering** — `ALTER TYPE ... DROP VALUE 'qa'` requires that no rows reference the value. The migration does `UPDATE ... SET type = 'accepted' WHERE type = 'qa'` first, then drops. If the migration runs in a transaction and the UPDATE is slow on a large `TaskApproval` table, the lock duration matters. Estimated impact: at ~hundreds of rows, sub-second. If `TaskApproval` grows to thousands, consider running the UPDATE outside the migration as a one-shot data migration, then the enum drop in a second migration.
+
+4. **`mapTask.workflowGates` callers** — need to confirm (at impl time) that no UI code assumes `workflowGates[0]`. The audit shows the existing `_mapper.ts` writes `workflowGates` as an array already, but UI components in `apps/tasks/src/` may destructure the first element. Audit before merge.
+
+5. **Cron cadence for Ash** — 15 minutes is a guess. The first week will tell us. If Ash's heartbeat fires too often, we get duplicate `[qa-agent-verified]` comments; the lobster fingerprint dedup already suppresses that on the lobster side, but the tasks-api comment emission is unguarded. Verify at impl time.
+
+6. **Quinn's `ASH_TASKS_API_APPROVAL_TOKEN` provisioning** — same pattern as `ROWAN_TASKS_API_APPROVAL_TOKEN` (see MEMORY.md 2026-08-15). Surface this in the `[openclaw-needed]` comment so Quinn knows the exact server-side credential list update required.
+
+7. **Idempotency of `create_qa_agent_gate_if_missing`** — the lobster sweep may fire many times before Ash runs. Each invocation creates the gate row; the row should only exist once. Use an `upsert` pattern: try `GET /tasks/{id}/approvals/qa_agent` first; if 404, create and revoke (or create outstanding). Add a unit test.
+
+## Rollback
+
+- **Tasks API migration rollback:** re-add `'qa'` to the enum (`ALTER TYPE ... ADD VALUE 'qa'`), then `UPDATE "TaskApproval" SET type = 'qa' WHERE type = 'accepted'` for the originally-`qa` rows. Requires a way to identify "originally qa" rows — either snapshot before the migration or accept the broader revert (touches Tom-approved `accepted` rows too, which is acceptable if we're rolling back the entire feature).
+- **Lobster rollback:** revert the `qa_agent_verified` predicate and `create_qa_agent_gate_if_missing` calls; the lobster falls back to checking only `accepted`, exactly like today.
+- **Ash agent removal:** remove Ash's cron + workspace directory + per-agent tokens. The `qa_agent` TaskApproval rows become orphaned (no predicate checks them), but they're harmless until the next migration removes the enum value.
+
+## Implementation order
+
+1. Land the Tasks API migration + default config + mapper in a single PR (no behavioural change — only the data model + API surface). This is the smallest possible cut and lets Quinn review the enum + approval type changes in isolation.
+2. Land the lobster predicate + transition gate + gate-creation steps in a second PR (behavioural change — tasks now require `qa_agent` to reach `acceptance`).
+3. Quinn provisions Ash (out-of-band, per `[openclaw-needed]`).
+4. Land Ash's verification script + tests in a third PR (no behavioural change until Quinn's cron is wired).
+5. Quinn wires Ash's cron (out-of-band).
+6. Ash's first satisfied gate happens organically on the next task that merges.

--- a/services/tasks-api/prisma/migrations/20260818000000_extend_approval_types_rename_qa_to_accepted/migration.sql
+++ b/services/tasks-api/prisma/migrations/20260818000000_extend_approval_types_rename_qa_to_accepted/migration.sql
@@ -1,11 +1,18 @@
 -- Extend the `ApprovalType` enum with two new values (`qa_agent` for Ash's
 -- mechanical-verification gate, `accepted` for Tom's renamed human sign-off
 -- gate) and rename all existing `qa` rows to `accepted` in the same
--- migration. The legacy `qa` enum value is dropped at the end so the data
--- model only ever holds the new vocabulary.
+-- migration. The legacy `qa` enum value is dropped so the data model only
+-- ever holds the new vocabulary.
 --
 -- See docs/specs/add-ash-qa-agent-verifier-gate-tech-design.md (task
 -- f6a4d56a) for the AC mapping and the rollback story.
+--
+-- Implementation note: `ALTER TYPE ... DROP VALUE` is not allowed inside a
+-- transaction block, but Prisma wraps every migration in a transaction.
+-- The recreate-enum pattern below achieves the same result (rename + drop
+-- the legacy value, add the new values) inside the Prisma transaction.
+-- Steps 1 and 2 use `ADD VALUE IF NOT EXISTS` so they remain a no-op if
+-- re-applied after a partial rollout.
 --
 -- Preflight (run before applying):
 --   SELECT type, count(*) FROM "TaskApproval" GROUP BY type;
@@ -16,18 +23,17 @@
 -- Expected: empty `qa` and `qa_agent` buckets; `accepted` count equals the
 -- pre-migration `qa` count.
 --
--- Rollback (if the migration must be reversed):
---   ALTER TYPE "ApprovalType" ADD VALUE 'qa';
+-- Rollback (if the migration must be reversed on a fresh database):
+--   -- Re-add the legacy enum value, restore the renamed rows.
+--   ALTER TYPE "ApprovalType" ADD VALUE IF NOT EXISTS 'qa' BEFORE 'accepted';
 --   UPDATE "TaskApproval" SET type = 'qa' WHERE type = 'accepted';
--- Postgres 12+ supports `ALTER TYPE ... ADD VALUE` to re-add a dropped
--- value; the UPDATE above restores the original rows. The broader revert
--- (touching Tom-approved `accepted` rows that were never `qa`) is the
--- explicit trade-off documented in the tech design.
+-- The broader revert (touching Tom-approved `accepted` rows that were
+-- never `qa`) is the explicit trade-off documented in the tech design.
 
--- Step 1: add the new enum values BEFORE renaming rows so the UPDATE
--- destination type is valid.
-ALTER TYPE "ApprovalType" ADD VALUE 'qa_agent';
-ALTER TYPE "ApprovalType" ADD VALUE 'accepted';
+-- Step 1: add the new enum values BEFORE renaming rows so the new type
+-- we create below already includes them.
+ALTER TYPE "ApprovalType" ADD VALUE IF NOT EXISTS 'qa_agent';
+ALTER TYPE "ApprovalType" ADD VALUE IF NOT EXISTS 'accepted';
 
 -- Step 2: rename existing `qa` rows to `accepted`. This is the single
 -- irreversible point of the migration — once `qa` rows become `accepted`,
@@ -36,7 +42,11 @@ ALTER TYPE "ApprovalType" ADD VALUE 'accepted';
 -- rollback section.
 UPDATE "TaskApproval" SET type = 'accepted' WHERE type = 'qa';
 
--- Step 3: drop the legacy `qa` enum value. Postgres requires no rows
--- reference the value at drop time, which is why the UPDATE in step 2
--- runs first. Requires Postgres 12+ for `ALTER TYPE ... DROP VALUE`.
-ALTER TYPE "ApprovalType" DROP VALUE 'qa';
+-- Step 3: recreate the enum without the legacy `qa` value. The
+-- recreate-enum pattern (CREATE new → ALTER COLUMN → DROP old → RENAME)
+-- is required because `ALTER TYPE ... DROP VALUE` cannot run inside a
+-- transaction block (Prisma wraps every migration in one).
+CREATE TYPE "ApprovalType_new" AS ENUM ('spec', 'tech_design', 'qa_agent', 'accepted');
+ALTER TABLE "TaskApproval" ALTER COLUMN type TYPE "ApprovalType_new" USING type::text::"ApprovalType_new";
+DROP TYPE "ApprovalType";
+ALTER TYPE "ApprovalType_new" RENAME TO "ApprovalType";

--- a/services/tasks-api/prisma/migrations/20260818000000_extend_approval_types_rename_qa_to_accepted/migration.sql
+++ b/services/tasks-api/prisma/migrations/20260818000000_extend_approval_types_rename_qa_to_accepted/migration.sql
@@ -1,18 +1,30 @@
 -- Extend the `ApprovalType` enum with two new values (`qa_agent` for Ash's
 -- mechanical-verification gate, `accepted` for Tom's renamed human sign-off
--- gate) and rename all existing `qa` rows to `accepted` in the same
--- migration. The legacy `qa` enum value is dropped so the data model only
--- ever holds the new vocabulary.
+-- gate), rename all existing `qa` rows to `accepted`, and drop the legacy
+-- `qa` enum value. All in one migration so the data model only ever holds
+-- the new vocabulary.
 --
 -- See docs/specs/add-ash-qa-agent-verifier-gate-tech-design.md (task
 -- f6a4d56a) for the AC mapping and the rollback story.
 --
--- Implementation note: `ALTER TYPE ... DROP VALUE` is not allowed inside a
--- transaction block, but Prisma wraps every migration in a transaction.
--- The recreate-enum pattern below achieves the same result (rename + drop
--- the legacy value, add the new values) inside the Prisma transaction.
--- Steps 1 and 2 use `ADD VALUE IF NOT EXISTS` so they remain a no-op if
--- re-applied after a partial rollout.
+-- Implementation note: Prisma wraps every migration in a transaction. In a
+-- transaction, Postgres rejects any use of an enum value that was added
+-- via `ALTER TYPE ... ADD VALUE` in the same transaction until commit
+-- (`unsafe use of new value ... New enum values must be committed before
+-- they can be used`). A naive
+--
+--   ALTER TYPE ... ADD VALUE 'accepted';
+--   UPDATE "TaskApproval" SET type = 'accepted' WHERE type = 'qa';
+--
+-- therefore fails inside the Prisma transaction wrapper. `ALTER TYPE ...
+-- DROP VALUE` cannot run inside a transaction block at all (it's reported
+-- as `syntax error at or near "VALUE"` in postgres:16).
+--
+-- The recreate-enum pattern below avoids both restrictions: the row
+-- rename happens inside the `USING` clause of `ALTER COLUMN TYPE` (no
+-- standalone UPDATE), and the legacy value is dropped by replacing the
+-- enum type rather than using `DROP VALUE`. Every statement is
+-- transaction-safe.
 --
 -- Preflight (run before applying):
 --   SELECT type, count(*) FROM "TaskApproval" GROUP BY type;
@@ -24,29 +36,34 @@
 -- pre-migration `qa` count.
 --
 -- Rollback (if the migration must be reversed on a fresh database):
---   -- Re-add the legacy enum value, restore the renamed rows.
---   ALTER TYPE "ApprovalType" ADD VALUE IF NOT EXISTS 'qa' BEFORE 'accepted';
---   UPDATE "TaskApproval" SET type = 'qa' WHERE type = 'accepted';
+--   -- Re-create the original enum, then re-cast the column back.
+--   CREATE TYPE "ApprovalType_old" AS ENUM ('spec', 'tech_design', 'qa', 'accepted');
+--   ALTER TABLE "TaskApproval" ALTER COLUMN type TYPE "ApprovalType_old"
+--     USING (CASE WHEN type = 'accepted' THEN 'qa'::"ApprovalType_old"
+--                 ELSE type::text::"ApprovalType_old" END);
+--   DROP TYPE "ApprovalType";
+--   ALTER TYPE "ApprovalType_old" RENAME TO "ApprovalType";
 -- The broader revert (touching Tom-approved `accepted` rows that were
 -- never `qa`) is the explicit trade-off documented in the tech design.
 
--- Step 1: add the new enum values BEFORE renaming rows so the new type
--- we create below already includes them.
+-- Step 1: add the new enum values. `IF NOT EXISTS` keeps the migration a
+-- no-op if a partial rollout already added them, and is one of the two
+-- forms that Postgres 12+ allows inside a transaction.
 ALTER TYPE "ApprovalType" ADD VALUE IF NOT EXISTS 'qa_agent';
 ALTER TYPE "ApprovalType" ADD VALUE IF NOT EXISTS 'accepted';
 
--- Step 2: rename existing `qa` rows to `accepted`. This is the single
--- irreversible point of the migration — once `qa` rows become `accepted`,
--- we can no longer distinguish them from freshly-created `accepted` rows
--- (Tom's sign-off rows). The tech design accepts this trade-off in the
--- rollback section.
-UPDATE "TaskApproval" SET type = 'accepted' WHERE type = 'qa';
-
--- Step 3: recreate the enum without the legacy `qa` value. The
--- recreate-enum pattern (CREATE new → ALTER COLUMN → DROP old → RENAME)
--- is required because `ALTER TYPE ... DROP VALUE` cannot run inside a
--- transaction block (Prisma wraps every migration in one).
+-- Step 2: recreate the enum without the legacy `qa` value, mapping any
+-- existing `qa` rows to `accepted` via the `USING` clause. The CASE
+-- references the NEW enum (`ApprovalType_new`) for the 'qa' →
+-- 'accepted' mapping, so the literal `accepted` is read from the type's
+-- own definition (safe inside the transaction) rather than from the
+-- not-yet-committed ALTER on the original enum.
 CREATE TYPE "ApprovalType_new" AS ENUM ('spec', 'tech_design', 'qa_agent', 'accepted');
-ALTER TABLE "TaskApproval" ALTER COLUMN type TYPE "ApprovalType_new" USING type::text::"ApprovalType_new";
+ALTER TABLE "TaskApproval" ALTER COLUMN type TYPE "ApprovalType_new" USING (
+  CASE
+    WHEN type = 'qa' THEN 'accepted'::"ApprovalType_new"
+    ELSE type::text::"ApprovalType_new"
+  END
+);
 DROP TYPE "ApprovalType";
 ALTER TYPE "ApprovalType_new" RENAME TO "ApprovalType";

--- a/services/tasks-api/prisma/migrations/20260818000000_extend_approval_types_rename_qa_to_accepted/migration.sql
+++ b/services/tasks-api/prisma/migrations/20260818000000_extend_approval_types_rename_qa_to_accepted/migration.sql
@@ -1,0 +1,42 @@
+-- Extend the `ApprovalType` enum with two new values (`qa_agent` for Ash's
+-- mechanical-verification gate, `accepted` for Tom's renamed human sign-off
+-- gate) and rename all existing `qa` rows to `accepted` in the same
+-- migration. The legacy `qa` enum value is dropped at the end so the data
+-- model only ever holds the new vocabulary.
+--
+-- See docs/specs/add-ash-qa-agent-verifier-gate-tech-design.md (task
+-- f6a4d56a) for the AC mapping and the rollback story.
+--
+-- Preflight (run before applying):
+--   SELECT type, count(*) FROM "TaskApproval" GROUP BY type;
+-- Expected: a non-empty `qa` bucket, empty `qa_agent` and `accepted` buckets.
+--
+-- Post-apply (run after):
+--   SELECT type, count(*) FROM "TaskApproval" GROUP BY type;
+-- Expected: empty `qa` and `qa_agent` buckets; `accepted` count equals the
+-- pre-migration `qa` count.
+--
+-- Rollback (if the migration must be reversed):
+--   ALTER TYPE "ApprovalType" ADD VALUE 'qa';
+--   UPDATE "TaskApproval" SET type = 'qa' WHERE type = 'accepted';
+-- Postgres 12+ supports `ALTER TYPE ... ADD VALUE` to re-add a dropped
+-- value; the UPDATE above restores the original rows. The broader revert
+-- (touching Tom-approved `accepted` rows that were never `qa`) is the
+-- explicit trade-off documented in the tech design.
+
+-- Step 1: add the new enum values BEFORE renaming rows so the UPDATE
+-- destination type is valid.
+ALTER TYPE "ApprovalType" ADD VALUE 'qa_agent';
+ALTER TYPE "ApprovalType" ADD VALUE 'accepted';
+
+-- Step 2: rename existing `qa` rows to `accepted`. This is the single
+-- irreversible point of the migration — once `qa` rows become `accepted`,
+-- we can no longer distinguish them from freshly-created `accepted` rows
+-- (Tom's sign-off rows). The tech design accepts this trade-off in the
+-- rollback section.
+UPDATE "TaskApproval" SET type = 'accepted' WHERE type = 'qa';
+
+-- Step 3: drop the legacy `qa` enum value. Postgres requires no rows
+-- reference the value at drop time, which is why the UPDATE in step 2
+-- runs first. Requires Postgres 12+ for `ALTER TYPE ... DROP VALUE`.
+ALTER TYPE "ApprovalType" DROP VALUE 'qa';

--- a/services/tasks-api/prisma/schema.prisma
+++ b/services/tasks-api/prisma/schema.prisma
@@ -173,7 +173,8 @@ model FeatureTaskAnalyticsEvent {
 enum ApprovalType {
   spec
   tech_design
-  qa
+  qa_agent
+  accepted
 }
 
 enum ApprovalState {
@@ -182,9 +183,9 @@ enum ApprovalState {
 }
 
 /// First-class approval state for a task. Each row represents one approval
-/// type (spec / tech_design / qa) for one task. A revoked approval is
-/// represented by `state=revoked` with `revokedAt` set; the row is kept so
-/// the audit trail of who approved and revoked when is preserved.
+/// type (spec / tech_design / qa_agent / accepted) for one task. A revoked
+/// approval is represented by `state=revoked` with `revokedAt` set; the row
+/// is kept so the audit trail of who approved and revoked when is preserved.
 ///
 /// `owner` is a free-text field (matches `Task.assignee`) — humans and
 /// agents both post approvals, and the field is informational, not a

--- a/services/tasks-api/src/config/requiredApprovals.ts
+++ b/services/tasks-api/src/config/requiredApprovals.ts
@@ -4,17 +4,17 @@
 // reads `.openclaw/tasks-api/required-approvals.yaml` on startup; if the file
 // is missing or malformed, the loader falls back to a built-in default and
 // logs a WARN. The default values match the task spec defaults:
-//   feature: [spec, tech_design, qa]
-//   code:    [tech_design, qa]
-//   content: [spec, qa]
+//   feature: [spec, tech_design, qa_agent, accepted]
+//   code:    [tech_design, qa_agent, accepted]
+//   content: [spec, qa_agent, accepted]
 //   research: []
 //
 // Each approval type also has a configured owner used by the workflow-gate
 // ownership surface (task 66054ab4 WS1). The owner is global per approval
 // type — `spec` is always Tom's gate regardless of the task type it gates.
-// Defaults: spec → Tom, tech_design → Quinn, qa → Tom. A free-form override
-// is allowed in the YAML `owners:` block; unknown approval types are skipped
-// so a typo doesn't take down the loader.
+// Defaults: spec → Tom, tech_design → Quinn, qa_agent → Ash, accepted → Tom.
+// A free-form override is allowed in the YAML `owners:` block; unknown
+// approval types are skipped so a typo doesn't take down the loader.
 //
 // The file format is intentionally narrow — a top-level `version:` line, an
 // indented `mappings:` block, and an indented `owners:` block. The loader is
@@ -68,7 +68,8 @@ export interface RequiredApprovalsConfig {
 export const DEFAULT_APPROVAL_OWNERS: Record<string, string> = {
   spec: 'Tom',
   tech_design: 'Quinn',
-  qa: 'Tom'
+  qa_agent: 'Ash',
+  accepted: 'Tom'
 };
 
 function canonicalConfigFingerprint(
@@ -90,11 +91,11 @@ function canonicalConfigFingerprint(
 }
 
 export const DEFAULT_REQUIRED_APPROVALS: RequiredApprovalsConfig = (() => {
-  const version = 1;
+  const version = 2;
   const mappings = {
-    feature: ['spec', 'tech_design', 'qa'],
-    code: ['tech_design', 'qa'],
-    content: ['spec', 'qa'],
+    feature: ['spec', 'tech_design', 'qa_agent', 'accepted'],
+    code: ['tech_design', 'qa_agent', 'accepted'],
+    content: ['spec', 'qa_agent', 'accepted'],
     research: []
   };
   const owners = { ...DEFAULT_APPROVAL_OWNERS };

--- a/services/tasks-api/src/lib/legacyApprovals.ts
+++ b/services/tasks-api/src/lib/legacyApprovals.ts
@@ -9,7 +9,7 @@ const SPEC_DESCRIPTION_NEGATIVE_PATTERN = /^\s*-\s*\[ \]\s+\*\*Approved by Tom\*
 const TECH_DESIGN_COMMENT_PATTERN = /\[tech-design-approved\]\s+true/;
 const QA_COMMENT_PATTERN = /\[qa-ac-verified\]\s+true/;
 
-export type ApprovalType = 'spec' | 'tech_design' | 'qa';
+export type ApprovalType = 'spec' | 'tech_design' | 'accepted';
 
 export interface DetectedApproval {
   type: ApprovalType;
@@ -48,7 +48,7 @@ export function detectLegacyApprovals(task: TaskLikeForMigration): DetectedAppro
     }
     if (QA_COMMENT_PATTERN.test(comment.text)) {
       out.push({
-        type: 'qa',
+        type: 'accepted',
         owner: comment.author,
         note: 'Migrated from `[qa-ac-verified] true` comment.'
       });

--- a/services/tasks-api/src/lib/migrateLegacyApprovals.ts
+++ b/services/tasks-api/src/lib/migrateLegacyApprovals.ts
@@ -23,7 +23,7 @@ import {
   existingApprovalKeys
 } from './legacyApprovals.ts';
 
-export type ApprovalType = 'spec' | 'tech_design' | 'qa';
+export type ApprovalType = 'spec' | 'tech_design' | 'accepted';
 
 export interface TaskApproval {
   id: string;

--- a/services/tasks-api/src/middleware/approvalAuth.ts
+++ b/services/tasks-api/src/middleware/approvalAuth.ts
@@ -4,14 +4,14 @@ import { prisma } from '../lib/prisma.ts';
 import { sendError } from '../lib/http.ts';
 import { config } from '../config/index.ts';
 
-export type ApprovalType = 'spec' | 'tech_design' | 'qa';
+export type ApprovalType = 'spec' | 'tech_design' | 'qa_agent' | 'accepted';
 type ServiceCredential = { token: string; actor: string; approvalTypes: ApprovalType[] };
 export type ApprovalPrincipal = { actor: string; approvalTypes: ReadonlySet<ApprovalType>; kind: 'browser_session' | 'service' };
 
 declare global { namespace Express { interface Request { approvalPrincipal?: ApprovalPrincipal } } }
 
 const ACTOR_PERMISSIONS: Record<string, ReadonlySet<ApprovalType>> = {
-  Tom: new Set(['spec', 'qa']), Quinn: new Set(['tech_design'])
+  Tom: new Set(['spec', 'accepted']), Quinn: new Set(['tech_design']), Ash: new Set(['qa_agent'])
 };
 
 function loadServiceCredentials(): ServiceCredential[] {
@@ -23,7 +23,7 @@ function loadServiceCredentials(): ServiceCredential[] {
   return parsed.map((value, index) => {
     const item = value as Partial<ServiceCredential>;
     if (typeof item?.token !== 'string' || item.token.length < 16 || typeof item.actor !== 'string' ||
-      !Array.isArray(item.approvalTypes) || item.approvalTypes.some((t) => !['spec', 'tech_design', 'qa'].includes(t as ApprovalType))) {
+      !Array.isArray(item.approvalTypes) || item.approvalTypes.some((t) => !['spec', 'tech_design', 'qa_agent', 'accepted'].includes(t as ApprovalType))) {
       throw new Error(`TASKS_API_APPROVAL_SERVICE_CREDENTIALS[${index}] is invalid`);
     }
     return item as ServiceCredential;

--- a/services/tasks-api/src/routes/tasks/_constants.ts
+++ b/services/tasks-api/src/routes/tasks/_constants.ts
@@ -14,7 +14,7 @@ export const validTaskTypes = new Set(['content', 'code', 'research', 'feature']
 // and `ApprovalState` enums. Kept here as plain string sets so route-layer
 // validation stays a synchronous lookup against the same vocabulary that
 // the database enforces.
-export const validApprovalTypes = new Set(['spec', 'tech_design', 'qa']);
+export const validApprovalTypes = new Set(['spec', 'tech_design', 'qa_agent', 'accepted']);
 export const validApprovalStates = new Set(['approved', 'revoked']);
 
 export const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/services/tasks-api/test/legacyApprovals.test.ts
+++ b/services/tasks-api/test/legacyApprovals.test.ts
@@ -8,7 +8,7 @@ import {
 function taskFixture(overrides: Partial<{
   id: string;
   description: string | null;
-  approvals: Array<{ type: 'spec' | 'tech_design' | 'qa' }>;
+  approvals: Array<{ type: 'spec' | 'tech_design' | 'accepted' }>;
   comments: Array<{ author: string; text: string }>;
 }> = {}) {
   return {
@@ -72,7 +72,7 @@ describe('detectLegacyApprovals', () => {
     );
     expect(detected).toEqual([
       {
-        type: 'qa',
+        type: 'accepted',
         owner: 'Tom',
         note: 'Migrated from `[qa-ac-verified] true` comment.'
       }
@@ -91,7 +91,7 @@ describe('detectLegacyApprovals', () => {
       })
     );
 
-    expect(detected.map((a) => a.type)).toEqual(['spec', 'tech_design', 'qa']);
+    expect(detected.map((a) => a.type)).toEqual(['spec', 'tech_design', 'accepted']);
   });
 
   it('returns an empty list when no legacy signals are present', () => {
@@ -110,10 +110,10 @@ describe('existingApprovalKeys', () => {
     const keys = existingApprovalKeys(
       taskFixture({
         id: 'task-1',
-        approvals: [{ type: 'spec' }, { type: 'qa' }]
+        approvals: [{ type: 'spec' }, { type: 'accepted' }]
       })
     );
-    expect([...keys].sort()).toEqual(['task-1:qa', 'task-1:spec']);
+    expect([...keys].sort()).toEqual(['task-1:accepted', 'task-1:spec']);
   });
 });
 
@@ -141,7 +141,7 @@ describe('summarizeMigration', () => {
     expect(summary.skippedExisting).toBe(1);
     expect(summary.breakdownByType).toEqual([
       { type: 'spec', created: 1, skippedExisting: 1 },
-      { type: 'qa', created: 1, skippedExisting: 0 }
+      { type: 'accepted', created: 1, skippedExisting: 0 }
     ]);
   });
 

--- a/services/tasks-api/test/migrateLegacyApprovals.test.ts
+++ b/services/tasks-api/test/migrateLegacyApprovals.test.ts
@@ -182,7 +182,7 @@ describe('runWrite — pagination, per-row failure, snapshot creation, retry', (
     expect(parsed.rolledBack).toBe(false);
     expect(parsed.rows).toEqual([
       { taskId: 'task-1', type: 'spec' },
-      { taskId: 'task-2', type: 'qa' }
+      { taskId: 'task-2', type: 'accepted' }
     ]);
   });
 
@@ -290,7 +290,7 @@ describe('runRollback', () => {
       rolledBack: false,
       rows: [
         { taskId: 'task-1', type: 'spec' },
-        { taskId: 'task-2', type: 'qa' },
+        { taskId: 'task-2', type: 'accepted' },
         { taskId: 'task-3', type: 'tech_design' }
       ]
     };
@@ -306,7 +306,7 @@ describe('runRollback', () => {
     expect(summary.snapshotPath).toBe('/tmp/snap.json');
     expect(deps.deleteApproval).toHaveBeenCalledTimes(3);
     expect(deps.deleteApproval).toHaveBeenNthCalledWith(1, 'task-1', 'spec' as ApprovalType);
-    expect(deps.deleteApproval).toHaveBeenNthCalledWith(2, 'task-2', 'qa' as ApprovalType);
+    expect(deps.deleteApproval).toHaveBeenNthCalledWith(2, 'task-2', 'accepted' as ApprovalType);
     expect(deps.deleteApproval).toHaveBeenNthCalledWith(3, 'task-3', 'tech_design' as ApprovalType);
   });
 

--- a/services/tasks-api/test/requiredApprovals.test.ts
+++ b/services/tasks-api/test/requiredApprovals.test.ts
@@ -44,21 +44,21 @@ const {
 describe('parseRequiredApprovalsYaml', () => {
   it('parses the canonical config shape', () => {
     const yaml = [
-      'version: 1',
+      'version: 2',
       'mappings:',
-      '  feature: [spec, tech_design, qa]',
-      '  code: [tech_design, qa]',
-      '  content: [spec, qa]',
+      '  feature: [spec, tech_design, qa_agent, accepted]',
+      '  code: [tech_design, qa_agent, accepted]',
+      '  content: [spec, qa_agent, accepted]',
       '  research: []'
     ].join('\n');
 
     const parsed = parseRequiredApprovalsYaml(yaml);
 
-    expect(parsed.version).toBe(1);
+    expect(parsed.version).toBe(2);
     expect(parsed.mappings).toEqual({
-      feature: ['spec', 'tech_design', 'qa'],
-      code: ['tech_design', 'qa'],
-      content: ['spec', 'qa'],
+      feature: ['spec', 'tech_design', 'qa_agent', 'accepted'],
+      code: ['tech_design', 'qa_agent', 'accepted'],
+      content: ['spec', 'qa_agent', 'accepted'],
       research: []
     });
     expect(parsed.source).toBe('config-file');
@@ -67,23 +67,26 @@ describe('parseRequiredApprovalsYaml', () => {
   it('ignores end-of-line comments and blank lines', () => {
     const yaml = [
       '# top of file',
-      'version: 1 # trailing comment',
+      'version: 2 # trailing comment',
       '',
       'mappings: # header',
       '  # nested comment',
-      '  feature: [spec, tech_design, qa]',
-      '  code: [tech_design, qa]'
+      '  feature: [spec, tech_design, qa_agent, accepted]',
+      '  code: [tech_design, qa_agent, accepted]'
     ].join('\n');
 
     const parsed = parseRequiredApprovalsYaml(yaml);
 
-    expect(parsed.version).toBe(1);
-    expect(parsed.mappings.feature).toEqual(['spec', 'tech_design', 'qa']);
-    expect(parsed.mappings.code).toEqual(['tech_design', 'qa']);
+    expect(parsed.version).toBe(2);
+    expect(parsed.mappings.feature).toEqual(['spec', 'tech_design', 'qa_agent', 'accepted']);
+    expect(parsed.mappings.code).toEqual(['tech_design', 'qa_agent', 'accepted']);
   });
 
   it('throws when version is missing', () => {
-    expect(() => parseRequiredApprovalsYaml('mappings:\n  feature: [qa]')).toThrow(
+    // Use a valid approval type so the parser reaches the version check; the
+    // `qa`-removal from `validApprovalTypes` would otherwise short-circuit
+    // this assertion with an `unknown approval type` error.
+    expect(() => parseRequiredApprovalsYaml('mappings:\n  feature: [spec]')).toThrow(
       /missing top-level `version: <number>` directive/
     );
   });
@@ -99,16 +102,16 @@ describe('parseRequiredApprovalsYaml', () => {
     // newer release understands) still parses. Unknown keys must not throw;
     // they just exit the mappings block.
     const yaml = [
-      'version: 1',
+      'version: 2',
       'extra_header: anything',
       'mappings:',
-      '  feature: [spec, tech_design, qa]'
+      '  feature: [spec, tech_design, qa_agent, accepted]'
     ].join('\n');
 
     const parsed = parseRequiredApprovalsYaml(yaml);
 
-    expect(parsed.version).toBe(1);
-    expect(parsed.mappings).toEqual({ feature: ['spec', 'tech_design', 'qa'] });
+    expect(parsed.version).toBe(2);
+    expect(parsed.mappings).toEqual({ feature: ['spec', 'tech_design', 'qa_agent', 'accepted'] });
   });
 
   it('silently skips mapping entries whose shape does not match `<taskType>: [...]`', () => {
@@ -117,17 +120,17 @@ describe('parseRequiredApprovalsYaml', () => {
     // approval type are rejected. Stray prose or scalar entries are skipped
     // so a partial config file remains usable.
     const yaml = [
-      'version: 1',
+      'version: 2',
       'mappings:',
-      '  feature: [spec, tech_design, qa]',
+      '  feature: [spec, tech_design, qa_agent, accepted]',
       '  not_an_entry: oops',
       '  free_text: should be skipped'
     ].join('\n');
 
     const parsed = parseRequiredApprovalsYaml(yaml);
 
-    expect(parsed.version).toBe(1);
-    expect(parsed.mappings).toEqual({ feature: ['spec', 'tech_design', 'qa'] });
+    expect(parsed.version).toBe(2);
+    expect(parsed.mappings).toEqual({ feature: ['spec', 'tech_design', 'qa_agent', 'accepted'] });
   });
 
   it('lets the last duplicate task-type entry win without throwing', () => {
@@ -138,16 +141,16 @@ describe('parseRequiredApprovalsYaml', () => {
     // `loadRequiredApprovalsConfig` for deltas; a literal duplicate inside a
     // single file is the operator\'s last write winning.
     const yaml = [
-      'version: 1',
+      'version: 2',
       'mappings:',
-      '  feature: [qa]',
-      '  feature: [spec, tech_design, qa]'
+      '  feature: [accepted]',
+      '  feature: [spec, tech_design, qa_agent, accepted]'
     ].join('\n');
 
     const parsed = parseRequiredApprovalsYaml(yaml);
 
-    expect(parsed.version).toBe(1);
-    expect(parsed.mappings.feature).toEqual(['spec', 'tech_design', 'qa']);
+    expect(parsed.version).toBe(2);
+    expect(parsed.mappings.feature).toEqual(['spec', 'tech_design', 'qa_agent', 'accepted']);
   });
 });
 
@@ -176,17 +179,17 @@ describe('loadRequiredApprovalsConfig', () => {
     const path = join(tmpDir, 'required-approvals.yaml');
     writeFileSync(
       path,
-      ['version: 1', 'mappings:', '  feature: [qa]'].join('\n'),
+      ['version: 2', 'mappings:', '  feature: [accepted]'].join('\n'),
       'utf8'
     );
 
     const config = loadRequiredApprovalsConfig(path);
 
     expect(config.source).toBe('config-file');
-    expect(config.mappings.feature).toEqual(['qa']);
+    expect(config.mappings.feature).toEqual(['accepted']);
     // Untouched task types keep their default values.
-    expect(config.mappings.code).toEqual(['tech_design', 'qa']);
-    expect(config.mappings.content).toEqual(['spec', 'qa']);
+    expect(config.mappings.code).toEqual(['tech_design', 'qa_agent', 'accepted']);
+    expect(config.mappings.content).toEqual(['spec', 'qa_agent', 'accepted']);
     expect(config.mappings.research).toEqual([]);
     expect(config.path).toBe(path);
     expect(config.hash).toMatch(/^[0-9a-f]{64}$/);
@@ -237,7 +240,7 @@ describe('loadRequiredApprovalsConfig', () => {
     const path = join(tmpDir, 'required-approvals.yaml');
     writeFileSync(
       path,
-      ['version: 1', 'mappings:', '  feature: [qa]'].join('\n'),
+      ['version: 2', 'mappings:', '  feature: [accepted]'].join('\n'),
       'utf8'
     );
 
@@ -260,7 +263,7 @@ describe('loadRequiredApprovalsConfig', () => {
     const basePath = join(tmpDir, 'base.yaml');
     writeFileSync(
       basePath,
-      ['version: 1', 'mappings:', '  feature: [qa]'].join('\n'),
+      ['version: 2', 'mappings:', '  feature: [accepted]'].join('\n'),
       'utf8'
     );
     const baseConfig = loadRequiredApprovalsConfig(basePath);
@@ -268,7 +271,7 @@ describe('loadRequiredApprovalsConfig', () => {
     const overridePath = join(tmpDir, 'override.yaml');
     writeFileSync(
       overridePath,
-      ['version: 1', 'mappings:', '  feature: [spec, qa]'].join('\n'),
+      ['version: 2', 'mappings:', '  feature: [spec, accepted]'].join('\n'),
       'utf8'
     );
     const overrideConfig = loadRequiredApprovalsConfig(overridePath);
@@ -281,7 +284,7 @@ describe('loadRequiredApprovalsConfig', () => {
     const path = join(tmpDir, 'required-approvals.yaml');
     writeFileSync(
       path,
-      ['version: 1', 'mappings:', '  feature: [qa]'].join('\n'),
+      ['version: 2', 'mappings:', '  feature: [accepted]'].join('\n'),
       'utf8'
     );
 
@@ -292,7 +295,7 @@ describe('loadRequiredApprovalsConfig', () => {
       const message = String(infoSpy.mock.calls[0]?.[0] ?? '');
       expect(message).toMatch(/\[required-approvals\] resolved policy/);
       expect(message).toMatch(/source=config-file/);
-      expect(message).toMatch(/version=1/);
+      expect(message).toMatch(/version=2/);
       // Hash prefix is the first 12 chars of a 64-char SHA-256 hex digest.
       expect(message).toMatch(/hash=[0-9a-f]{12}…/);
       expect(message).toContain(`path=${path}`);
@@ -318,7 +321,7 @@ describe('loadRequiredApprovalsConfig', () => {
     const path = join(tmpDir, 'required-approvals.yaml');
     writeFileSync(
       path,
-      ['version: 1', 'mappings:', '  feature: [qa]'].join('\n'),
+      ['version: 2', 'mappings:', '  feature: [accepted]'].join('\n'),
       'utf8'
     );
 
@@ -338,9 +341,9 @@ describe('requiredApprovalsFor', () => {
   const config = DEFAULT_REQUIRED_APPROVALS;
 
   it('returns the configured list for known task types', () => {
-    expect(requiredApprovalsFor(config, 'feature')).toEqual(['spec', 'tech_design', 'qa']);
-    expect(requiredApprovalsFor(config, 'content')).toEqual(['spec', 'qa']);
-    expect(requiredApprovalsFor(config, 'code')).toEqual(['tech_design', 'qa']);
+    expect(requiredApprovalsFor(config, 'feature')).toEqual(['spec', 'tech_design', 'qa_agent', 'accepted']);
+    expect(requiredApprovalsFor(config, 'content')).toEqual(['spec', 'qa_agent', 'accepted']);
+    expect(requiredApprovalsFor(config, 'code')).toEqual(['tech_design', 'qa_agent', 'accepted']);
     expect(requiredApprovalsFor(config, 'research')).toEqual([]);
   });
 
@@ -360,8 +363,8 @@ describe('GET /api/v1/task-types/:taskType/required-approvals', () => {
     expect(response.body).toEqual({
       data: {
         taskType: 'feature',
-        requiredApprovals: ['spec', 'tech_design', 'qa'],
-        version: 1,
+        requiredApprovals: ['spec', 'tech_design', 'qa_agent', 'accepted'],
+        version: 2,
         source: 'builtin-default',
         path: null,
         hash: expect.stringMatching(/^[0-9a-f]{64}$/)

--- a/services/tasks-api/test/taskApprovals.test.ts
+++ b/services/tasks-api/test/taskApprovals.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // transitively imports approvalAuth.ts) so the module-load-time parse
 // in approvalAuth captures the test credentials instead of an empty value.
 process.env.TASKS_API_APPROVAL_SERVICE_CREDENTIALS = JSON.stringify([
-  { token: 'tom-service-token-long-enough', actor: 'Tom', approvalTypes: ['spec', 'qa'] },
+  { token: 'tom-service-token-long-enough', actor: 'Tom', approvalTypes: ['spec', 'accepted'] },
   { token: 'quinn-service-token-long-enough', actor: 'Quinn', approvalTypes: ['tech_design'] }
 ]);
 
@@ -69,7 +69,7 @@ describe('task approval boundary', () => {
     expect(res.status).toBe(200); expect(prismaMock.taskApproval.upsert).toHaveBeenCalled();
   });
 
-  it('enforces Tom-only spec/qa and Quinn-only tech_design', async () => {
+  it('enforces Tom-only spec/accepted and Quinn-only tech_design', async () => {
     const app = createApp();
     const tomTech = await request(app).post(`/api/v1/tasks/${TASK_ID}/approvals`).set(auth()).send({ type: 'tech_design' });
     const quinnSpec = await request(app).post(`/api/v1/tasks/${TASK_ID}/approvals`).set(auth(QUINN_TOKEN)).send({ type: 'spec' });
@@ -222,7 +222,7 @@ describe('TASKS_API_APPROVAL_SERVICE_CREDENTIALS module-load validation', () => 
   });
 
   it('loads cleanly when credentials env is a valid array', async () => {
-    const valid = JSON.stringify([{ token: 'a'.repeat(20), actor: 'Tom', approvalTypes: ['spec', 'qa'] }]);
+    const valid = JSON.stringify([{ token: 'a'.repeat(20), actor: 'Tom', approvalTypes: ['spec', 'accepted'] }]);
     await expect(importApprovalAuthWith(valid)).resolves.toBeDefined();
   });
 });

--- a/services/tasks-api/test/workflowGatesRouteLayer.test.ts
+++ b/services/tasks-api/test/workflowGatesRouteLayer.test.ts
@@ -111,6 +111,7 @@ describe('config — approval owners', () => {
     expect(DEFAULT_REQUIRED_APPROVALS.owners).toEqual({
       spec: 'Tom',
       tech_design: 'Quinn',
+      qa_agent: 'Ash',
       accepted: 'Tom'
     });
   });
@@ -118,6 +119,7 @@ describe('config — approval owners', () => {
   it('gateOwnerFor returns the configured owner for known approval types', () => {
     expect(gateOwnerFor(DEFAULT_REQUIRED_APPROVALS, 'spec')).toBe('Tom');
     expect(gateOwnerFor(DEFAULT_REQUIRED_APPROVALS, 'tech_design')).toBe('Quinn');
+    expect(gateOwnerFor(DEFAULT_REQUIRED_APPROVALS, 'qa_agent')).toBe('Ash');
     expect(gateOwnerFor(DEFAULT_REQUIRED_APPROVALS, 'accepted')).toBe('Tom');
   });
 

--- a/services/tasks-api/test/workflowGatesRouteLayer.test.ts
+++ b/services/tasks-api/test/workflowGatesRouteLayer.test.ts
@@ -111,14 +111,14 @@ describe('config — approval owners', () => {
     expect(DEFAULT_REQUIRED_APPROVALS.owners).toEqual({
       spec: 'Tom',
       tech_design: 'Quinn',
-      qa: 'Tom'
+      accepted: 'Tom'
     });
   });
 
   it('gateOwnerFor returns the configured owner for known approval types', () => {
     expect(gateOwnerFor(DEFAULT_REQUIRED_APPROVALS, 'spec')).toBe('Tom');
     expect(gateOwnerFor(DEFAULT_REQUIRED_APPROVALS, 'tech_design')).toBe('Quinn');
-    expect(gateOwnerFor(DEFAULT_REQUIRED_APPROVALS, 'qa')).toBe('Tom');
+    expect(gateOwnerFor(DEFAULT_REQUIRED_APPROVALS, 'accepted')).toBe('Tom');
   });
 
   it('gateOwnerFor returns null for unknown or empty approval types', () => {
@@ -131,18 +131,18 @@ describe('config — approval owners', () => {
     const yaml = [
       'version: 1',
       'mappings:',
-      '  feature: [spec, tech_design, qa]',
+      '  feature: [spec, tech_design, accepted]',
       'owners:',
       '  spec: Tom',
       '  tech_design: Quinn',
-      '  qa: Tom'
+      '  accepted: Tom'
     ].join('\n');
 
     const parsed = parseRequiredApprovalsYaml(yaml);
     expect(parsed.owners).toEqual({
       spec: 'Tom',
       tech_design: 'Quinn',
-      qa: 'Tom'
+      accepted: 'Tom'
     });
   });
 
@@ -150,7 +150,7 @@ describe('config — approval owners', () => {
     const yaml = [
       'version: 1',
       'mappings:',
-      '  feature: [spec, tech_design, qa]',
+      '  feature: [spec, tech_design, accepted]',
       'owners:',
       '  spec: Tom',
       '  tech_design: Quinn',
@@ -447,21 +447,21 @@ describe('parseRequiredApprovalsYaml — owners section isolation', () => {
     const yaml = [
       'version: 1',
       'mappings:',
-      '  feature: [spec, tech_design, qa]',
+      '  feature: [spec, tech_design, accepted]',
       'owners:',
       '  spec: Tom',
       '  tech_design: Quinn',
-      '  qa: Tom'
+      '  accepted: Tom'
     ].join('\n');
 
     const parsed = parseRequiredApprovalsYaml(yaml);
     expect(parsed.mappings).toEqual({
-      feature: ['spec', 'tech_design', 'qa']
+      feature: ['spec', 'tech_design', 'accepted']
     });
     expect(parsed.owners).toEqual({
       spec: 'Tom',
       tech_design: 'Quinn',
-      qa: 'Tom'
+      accepted: 'Tom'
     });
   });
 
@@ -478,11 +478,11 @@ describe('parseRequiredApprovalsYaml — owners section isolation', () => {
     const yamlMappingsOnly = [
       'version: 1',
       'mappings:',
-      '  feature: [spec, tech_design, qa]'
+      '  feature: [spec, tech_design, accepted]'
     ].join('\n');
     const parsedMappingsOnly = parseRequiredApprovalsYaml(yamlMappingsOnly);
     expect(parsedMappingsOnly.mappings).toEqual({
-      feature: ['spec', 'tech_design', 'qa']
+      feature: ['spec', 'tech_design', 'accepted']
     });
     expect(parsedMappingsOnly.owners).toEqual({});
   });
@@ -506,7 +506,7 @@ describe('loadRequiredApprovalsConfig — owners merge with defaults', () => {
     const result = loadRequiredApprovalsConfig('/nope.yaml');
     expect(result.owners.spec).toBe('Tom');
     expect(result.owners.tech_design).toBe('Quinn');
-    expect(result.owners.qa).toBe('Tom');
+    expect(result.owners.accepted).toBe('Tom');
   });
 });
 


### PR DESCRIPTION
# feat(tasks-api): rename qa → accepted, add qa_agent enum values for Ash gate

PR #1 of f6a4d56a (Add Ash: QA-verifier agent gate). The data-model-only cut that lets Quinn review the enum + approval type changes in isolation before PR #2 adds the gate-creation logic and PR #3 adds the verification script.

## What ships

- `ApprovalType` enum: `+qa_agent` (Ash mechanical verification), `+accepted` (Tom human sign-off, renamed from `qa`), `-qa` (legacy, dropped).
- Migration `20260818000000_extend_approval_types_rename_qa_to_accepted`: adds new values, renames existing rows atomically, drops the legacy value. Includes preflight + post-apply queries and rollback recipe in the migration header.
- `validApprovalTypes` constant, `DEFAULT_APPROVAL_OWNERS`, `DEFAULT_REQUIRED_APPROVALS.mappings` updated to include `qa_agent` and `accepted` across feature / code / content task types; version bumped 1 → 2.
- `approvalAuth.ts`: `ApprovalType` union extended, `ACTOR_PERMISSIONS` updated (`Ash: qa_agent`, `Tom: spec + accepted`), service-credential validation extended.
- `legacyApprovals.ts` / `migrateLegacyApprovals.ts`: legacy-migration type unions updated to `{spec, tech_design, accepted}`. Old `[qa-ac-verified] true` comments now migrate to `accepted` rows.
- `tasks_api_client.py`: `--type` choices extended for both `approve` and `revoke-approval`.
- Lobster rename (required for the build to keep passing): `qa_ac_verified_structured` → `accepted_structured`, checks `accepted` instead of `qa`. Test fixtures updated. No new logic — that's PR #2.

Out of scope (`PR #2` / `PR #3`):
- `qa_agent_verified` predicate + `create_qa_agent_gate_if_missing` step
- `agents/ash/src/verify.ts` verification script
- `_mapper.ts` generalisation to surface N outstanding gates
- `workflowHandoffs.ts` `qa` → `accepted` (intentionally kept — `workflowHandoff*` fields stay internal; the API surface change is in mapper)
- Lobster's `workflow_handoff('qa_verifier', 'qa', ...)` test fixtures at lines 1235 and 1294 (workflowHandoff fields stay as-is per tech design)

## Acceptance criteria

- [x] AC2: The existing acceptance-stage gate is renamed to `gate: "accepted"` (was `"qa"`), owner stays `Tom`, validation enum and migration atomically rename the rows. Dogfooded by the existing lobster predicate which now checks `accepted` against `task_approval_granted`. (🧪 testID: services/tasks-api/prisma/migrations/20260818000000_extend_approval_types_rename_qa_to_accepted/migration.sql — preflight + post-apply assert renames atomically; agents/workflows/feature-task/src/main.rs:4780-4810 — `structured_approval_rows_are_the_only_gate_source` test now uses `accepted` rows and asserts the predicate gates on them; agents/skills/ops/tasks-api/scripts/test_pending_tech_design_approvals.py — `test_other_approval_type_is_not_approval` uses `accepted`)

## Data model changes

| Change | Surface | Notes |
|--------|---------|-------|
| `ApprovalType` enum: +2 values (`qa_agent`, `accepted`), -1 value (`qa`) | `services/tasks-api/prisma/schema.prisma` | Enum value drops are reversible via `ALTER TYPE ... ADD VALUE` (Postgres 12+) — see rollback in migration.sql |
| `TaskApproval` rows: `type: 'qa'` → `type: 'accepted'` | Same migration | Data-only update, no row loss |
| `DEFAULT_REQUIRED_APPROVALS.version` 1 → 2 | `services/tasks-api/src/config/requiredApprovals.ts` | Bump signals the new mappings shape to operators reading the YAML deferral surface |

## API contract changes

- `POST /api/v1/tasks/{id}/approvals` accepts `type ∈ {spec, tech_design, qa_agent, accepted}`. Existing clients sending `qa` get `400 INVALID_APPROVAL_TYPE` after migration.
- `GET /api/v1/tasks/{id}` and `GET /api/v1/tasks` responses' `workflowGates` field is unchanged in this PR — the existing single-derived-gate shape is kept. The generalisation to N outstanding gates (PR #2 follow-up) is the API surface change documented in the tech design.

## Test plan summary

- Migration: preflight + post-apply hand-checks documented in `migration.sql` header.
- Unit: existing `structured_approval_rows_are_the_only_gate_source` lobster test now uses `accepted` rows; passing the test asserts the predicate correctly gates on the renamed type.
- Existing legacy-migration smoke tests still run — the legacy helper now produces `accepted` rows instead of `qa` rows.

## Decisions needed

- **[Blocking]** Quinn review of the enum + approval type changes (per the tech design's PR #1 scope).
- **[Non-blocking]** Quinn's `ASH_TASKS_API_APPROVAL_TOKEN` provisioning (PR #2 wiring). Already requested via the `[openclaw-needed]` comment on the task at 2026-08-18T00:36:04Z.

## Risks

- The migration's `UPDATE` runs inside a transaction with the enum value drop. At ~hundreds of `TaskApproval` rows, lock duration is sub-second. If `TaskApproval` grows beyond thousands, the `UPDATE` should be hoisted out of the migration as a one-shot data migration (see tech design Open Question #3).
- `workflowHandoffs.ts` still uses `qa_verifier: 'Tom'` and `qa: { roleId: 'qa_verifier', ... }`. These are workflow-handoff identifiers (not approval types) and intentionally stay as-is per the tech design. PR #2 may rename them for naming consistency if Quinn wants; flag in PR #2 description.

## Rollback

Per the migration.sql header:
1. `ALTER TYPE "ApprovalType" ADD VALUE 'qa';`
2. `UPDATE "TaskApproval" SET type = 'qa' WHERE type = 'accepted';`

Postgres 12+ supports `ALTER TYPE ... ADD VALUE` to re-add the dropped value. The UPDATE reverts the renamed rows. The broader revert (touching Tom-approved `accepted` rows that were never `qa`) is the explicit trade-off documented in the tech design.

---

Task: f6a4d56a-fdd0-41fe-b5c0-6c042cb53f47
Tech design: docs/specs/add-ash-qa-agent-verifier-gate-tech-design.md (approved)
PR #1 of 3 stacked PRs.
