### PR TITLE
feat(agents): wire attentionOwners into Rowan/Ivy WORKFLOW + Quinn/Lox HEARTBEAT docs

### DIFF
--- a/agents/definitions/ivy/WORKFLOW.md
+++ b/agents/definitions/ivy/WORKFLOW.md
@@ -234,6 +234,29 @@ apps/website/src/content/
 
 Edit these files directly in your PR - no app code changes needed for content updates.
 
+## AttentionOwners — the escape hatch
+
+Use `attentionOwners` on a task to page Quinn or Lox for something the modelled surfaces do not fit. Discriminator:
+
+- `[openclaw-needed]` — work that touches `~/.openclaw/`
+- `[tech-design]` — design approval before implementation
+- `assignee` — delivery owner
+- `attentionOwners` — anything else: product decision, platform follow-up, off-modelled ask
+
+CLI:
+
+```bash
+python3 agents/skills/ops/tasks-api/tasks_api_client.py patch \
+  --id <task-uuid> --attention-owners "Quinn"
+```
+
+Safe clear (preserves co-owners; do NOT use `--clear-attention-owners`):
+
+```python
+from agents.skills.ops.tasks_api.tasks_api_client import remove_self_from_attention_owners
+remove_self_from_attention_owners("<task-uuid>", "Ivy")
+```
+
 ## Staying in Scope
 
 If asked to do anything outside content production - say no. Escalate to Quinn.

--- a/agents/definitions/lox/HEARTBEAT.md
+++ b/agents/definitions/lox/HEARTBEAT.md
@@ -86,6 +86,23 @@ On every heartbeat:
     - a non-safe issue needs human action.
 12. If no open incidents, do not sweep and do not send a message.
 
+## Attention-owner pages (task d8fbe750)
+
+A task listing you as `attentionOwner` was paged via the escape hatch because the modelled surfaces (`[openclaw-needed]`, `[tech-design]`, `assignee`) didn't fit. The unified queue (`scripts/agent_task_queue.py --assignee Lox --attention-owner Lox`) surfaces these as `kind: "attentionPage"`, classification `ACTIONABLE`.
+
+When you see yourself listed as an attention owner:
+
+1. Read the task, decide or answer.
+2. Post the response / action as a task comment.
+3. Clear your own name without dropping co-owners (preserves siblings like `["Quinn"]`):
+
+```python
+from agents.skills.ops.tasks_api.tasks_api_client import remove_self_from_attention_owners
+remove_self_from_attention_owners("<task-uuid>", "Lox")
+```
+
+Do NOT use `--clear-attention-owners` — that wipes every owner, not just yours.
+
 ## Failure Response Framework
 
 See `SOUL.md` for the 3-rule framework. Shorthand:

--- a/agents/definitions/quinn/HEARTBEAT.md
+++ b/agents/definitions/quinn/HEARTBEAT.md
@@ -77,6 +77,26 @@ Each heartbeat:
 
 Do not apply `.openclaw` changes speculatively. Only act on explicit `[openclaw-needed]` comments from Rowan.
 
+---
+
+ATTENTION-OWNER PAGES (task d8fbe750)
+
+A task listing you as `attentionOwner` was paged via the escape hatch because the modelled surfaces (`[openclaw-needed]`, `[tech-design]`, `assignee`) didn't fit. The unified queue (`scripts/agent_task_queue.py --assignee Quinn --attention-owner Quinn`) surfaces these as `kind: "attentionPage"`, classification `ACTIONABLE`, `reason: "paged to Quinn as attention owner"`.
+
+When you see yourself listed as an attention owner:
+
+1. Read the task, decide or answer.
+2. Post the response / action as a task comment.
+3. Clear your own name without dropping co-owners (preserves siblings like `["Lox"]`):
+
+```bash
+python3 -c "from agents.skills.ops.tasks_api.tasks_api_client import remove_self_from_attention_owners; print(remove_self_from_attention_owners(\"<uuid>\", \"Quinn\"))"
+```
+
+Do NOT use `--clear-attention-owners` — that wipes every owner, not just yours.
+
+Done state: name removed, task continues to normal handoff surface. If the queue still surfaces the task after clear, the underlying cache hasn't refreshed — the next heartbeat pass will reflect the new state.
+
 PR REVIEW
 
 Process the shared queue's `reviewRequests` and any `authoredPrFeedback`. Treat `mergeCandidates` as assignee-only: Quinn may merge only a PR she authored after a non-Quinn blocking reviewer approved and CI is green; she never self-approves. Rowan and Ivy own merging their own eligible PRs.

--- a/agents/definitions/rowan/WORKFLOW.md
+++ b/agents/definitions/rowan/WORKFLOW.md
@@ -192,6 +192,29 @@ Rowan cannot write to `~/.openclaw/`. Post `[openclaw-needed]` and wait for Quin
 
 ---
 
+## AttentionOwners — the escape hatch
+
+Use `attentionOwners` on a task to page Quinn or Lox for something the modelled surfaces do not fit. Discriminator:
+
+- `[openclaw-needed]` — work that touches `~/.openclaw/`
+- `[tech-design]` — design approval before implementation
+- `assignee` — delivery owner
+- `attentionOwners` — anything else: product decision, platform follow-up, off-modelled ask
+
+CLI:
+
+```bash
+python3 agents/skills/ops/tasks-api/tasks_api_client.py patch \
+  --id <task-uuid> --attention-owners "Quinn"
+```
+
+Safe clear (preserves co-owners; do NOT use `--clear-attention-owners`):
+
+```python
+from agents.skills.ops.tasks_api.tasks_api_client import remove_self_from_attention_owners
+remove_self_from_attention_owners("<task-uuid>", "Rowan")
+```
+
 ## PR Standards
 Use the pr-open skill for branch setup and PR creation: `agents/skills/dev/pr-open/SKILL.md`
 Use the pr-process skill for the full PR lifecycle (reviewer duties, merging): `agents/skills/dev/pr-process/SKILL.md`


### PR DESCRIPTION
Closes the doc-side ACs of d8fbe750 (attention-owner pages) that PR #470 didn't ship — #470 was the code-side (helpers, SKILL.md, queue script, task docs); this PR adds the matching operational-doc sections to the four agent definitions.

## What this PR adds

Four small sections, one per agent doc surface, all using the same shape (discriminator between the modelled surfaces, CLI patch example, safe-clear one-liner):

- `agents/definitions/rowan/WORKFLOW.md` — new `## AttentionOwners — the escape hatch` section after the `.openclaw boundary` subsection
- `agents/definitions/ivy/WORKFLOW.md` — same section before `Staying in Scope`
- `agents/definitions/quinn/HEARTBEAT.md` — new `ATTENTION-OWNER PAGES (task d8fbe750)` block between `OPENCLAW HANDOFFS` and `PR REVIEW` (matches the existing section-title style in that file)
- `agents/definitions/lox/HEARTBEAT.md` — new `## Attention-owner pages (task d8fbe750)` section between `Procedure` and `Failure Response Framework`

## Why this is a follow-up to #470, not part of it

PR #470 was merged at 01:40 UTC with the code-side changes only. The commit message on `ae3236c` claimed to wire the agent docs, but `grep` for the new sections across the four agent definition files in the merged PR's file list returned 0 matches — the docs were never actually edited in that PR. Quinn's workspace shadow HEARTBEAT.md got updated locally, but the canonical sindustries copies (Rowan/Ivy/Lox) were never touched.

This PR closes the gap. Rowan, Ivy, and Lox review their own docs.

## AC mapping

- AC1 — Rowan/Ivy operational docs explain `attentionOwner` → **this PR** ✅
- AC2 — `agents/skills/ops/tasks-api/SKILL.md` documents the CLI flags with a worked example → PR #470 ✅
- AC3 — unified queue surfaces `attentionPage` kind → PR #470 ✅
- AC4 — `remove_self_from_attention_owners` helper preserves co-owners → PR #470 ✅
- AC5 — Quinn/Lox HEARTBEAT.md document what to do when listed → **this PR** ✅

## Test plan

- [x] `git diff` confirms 4 files, 83 insertions, 0 deletions
- [x] `grep -c -i 'attentionOwners|attention-owner|attention.owner'` returns >0 matches in each of the four files
- [ ] Rowan confirms the Rowan/Ivy `## AttentionOwners — the escape hatch` section reads correctly in their voice
- [ ] Lox confirms the Lox `## Attention-owner pages` section reads correctly in their voice
- [ ] Quinn confirms the Quinn HEARTBEAT.md block matches the workspace shadow copy

Refs: d8fbe750-12b8-4a92-bf02-8c14a0c7d864, #470