### PR TITLE
fix(bookmarks-lobster): use $step.json.field for stdin template refs

### DIFF
--- a/agents/workflows/bookmarks/bookmarks.lobster.yaml
+++ b/agents/workflows/bookmarks/bookmarks.lobster.yaml
@@ -70,7 +70,7 @@ steps:
       --base-url ${TASKS_API_BASE_URL}
       --json
     stdin: >-
-      {"directCreateItems": $request_spec_approval.directCreateItems}
+      {"directCreateItems": $request_spec_approval.json.directCreateItems}
 
   - id: create_tasks_from_proposals
     command: >-
@@ -78,7 +78,7 @@ steps:
       --base-url ${TASKS_API_BASE_URL}
       --json
     stdin: >-
-      {"readyPackages": $request_spec_approval.readyPackages, "blockedPackages": $request_spec_approval.blockedPackages}
+      {"readyPackages": $request_spec_approval.json.readyPackages, "blockedPackages": $request_spec_approval.json.blockedPackages}
     condition: $request_spec_approval.approved
 
   - id: resolve_spec_request


### PR DESCRIPTION
## Summary
- Every bookmark approval that reaches the WS3 direct-create step (`create_tasks_from_direct`) has been crashing on resume with `json.decoder.JSONDecodeError: Expecting value` — hit live today when Tom approved bookmark `fd71faa4cf029bf9`.
- Root cause: `bookmarks.lobster.yaml`'s `stdin` templates referenced `$request_spec_approval.directCreateItems` / `.readyPackages` / `.blockedPackages` directly. The `@clawdbot/lobster` engine stores every shell step's result as `{id, stdout, json}` — a script's own JSON output fields only exist under `.json.*`, never spread onto the top level (confirmed by reading `resolveStepRefs`/`getValueByPath` in the engine source). The only fields the engine promotes to top level are engine-owned ones like `.approved`/`.skipped` for approval steps. So these refs always resolved to `undefined` → the unresolved-ref fallback renders an empty string → `{"directCreateItems": }` — invalid JSON on stdin for `lobster_create_tasks_from_direct.py`.
- Both broken refs fixed to go through `.json.`: `create_tasks_from_direct`'s `directCreateItems` ref, and `create_tasks_from_proposals`'s `readyPackages`/`blockedPackages` refs (same bug, same step shape).

## Verification
- Copied the actual stuck resume state (Tom's 2026-08-18 approval of bookmark `fd71faa4cf029bf9`, resume token `workflow_resume_c3eac927-...`) to point at this fixed workflow file and re-ran `lobster resume --token <token> --approve yes`.
- It completed cleanly: created task `0a88859f-5d41-4811-801c-57442b4d03be` ("Inspectable Next-Step Decisions for Bookmark Spec Task-Type Classification"), moved the spec doc to `brain/tasks/specs/in-progress/`, and the bookmark's `reviewStatus` is now `tasked`. Confirmed via live Tasks API lookup.
- This means Tom's original approval already completed for real — no need to re-click approve.

## Test plan
- [x] Live resume against the exact stuck production token, verified via Tasks API that the task now exists
- [ ] Next bookmark run that reaches an approval gate with a non-empty `directCreateItems` or `readyPackages`/`blockedPackages` set should also be spot-checked once this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)