### PR TITLE
fix(bookmarks): require Approved-by-Tom marker before offering spec for approval

### DIFF
--- a/agents/skills/product/spec-author/SKILL.md
+++ b/agents/skills/product/spec-author/SKILL.md
@@ -99,6 +99,8 @@ Bookmark pipeline specs go here:
 
 Use this only for bookmark/review pipeline items. Do not write direct/manual specs to `brain/bookmarks/specs/`.
 
+The unchecked `- [ ] **Approved by Tom**` marker (see Format below) is **required** on every bookmark-origin spec — `handle_approval_reply.py`'s `set_spec_approval_checkbox` toggles that exact line when Tom approves, and hard-fails if it is missing. Never omit it from a bookmark-origin spec.
+
 #### Completed specs
 
 Do not move specs to `done/` from this skill unless explicitly asked. Completion/archive movement belongs to task lifecycle cleanup.
@@ -131,6 +133,7 @@ For manual task specs in `brain/tasks/specs/open/`:
 - **Created:** <YYYY-MM-DD>
 
 **Status:** Draft
+- [ ] **Approved by Tom**
 
 ---
 

--- a/agents/workflows/bookmarks/scripts/validate_spec_output.py
+++ b/agents/workflows/bookmarks/scripts/validate_spec_output.py
@@ -14,6 +14,10 @@ Task proposals are read directly from the spec markdown at approval time
 
 Validations:
   - each `specDoc` must exist on disk before the state is updated
+  - each `specDoc` must contain the unchecked `- [ ] **Approved by Tom**`
+    marker `handle_approval_reply.py`'s `set_spec_approval_checkbox` toggles
+    on approval; specs missing it would otherwise pass this gate, reach
+    approval delivery, and only fail once Tom clicks Approve
 
 Idempotent:
   - rejects entries unless the existing bookmark is awaiting a spec
@@ -77,6 +81,11 @@ from classification_schema import Classification  # noqa: E402
 
 H1_RE = re.compile(r"^#\s+(?:Spec\s*[—–-]+\s*)?(.*\S)\s*$", re.MULTILINE)
 SECTION_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+# Mirrors handle_approval_reply.py's unchecked_re — kept in sync manually
+# since the two scripts don't share a module for this check.
+UNCHECKED_APPROVED_BY_TOM_RE = re.compile(
+    r"^\s*-\s*\[\s\]\s+\*\*Approved by Tom\*\*\s*$", re.MULTILINE
+)
 
 DEFAULT_OUTPUT = STATE_ROOT / "spec-output.json"
 REQUIRED_SPEC_KEYS = {"title", "specDoc"}
@@ -311,6 +320,21 @@ def main(argv: list[str] | None = None) -> int:
             invalid.append({
                 "bookmarkKey": bookmark_key,
                 "errors": [f"spec file(s) missing on disk: {missing_files}"],
+            })
+            continue
+
+        # Spec files must carry the unchecked approval marker before they can
+        # be offered to Tom — otherwise the toggle fails at approval time.
+        missing_marker = [
+            doc for doc in spec_docs
+            if not UNCHECKED_APPROVED_BY_TOM_RE.search((WORKSPACE / doc).read_text(encoding="utf-8"))
+        ]
+        if missing_marker:
+            invalid.append({
+                "bookmarkKey": bookmark_key,
+                "errors": [
+                    f"spec file(s) missing unchecked '- [ ] **Approved by Tom**' marker: {missing_marker}"
+                ],
             })
             continue
 

--- a/agents/workflows/bookmarks/tests/test_validate_spec_output.py
+++ b/agents/workflows/bookmarks/tests/test_validate_spec_output.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+SCRIPTS = REPO / 'agents' / 'workflows' / 'bookmarks' / 'scripts'
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+BOOKMARKS_ROOT = REPO / 'agents' / 'workflows' / 'bookmarks'
+if str(BOOKMARKS_ROOT) not in sys.path:
+    sys.path.insert(0, str(BOOKMARKS_ROOT))
+WIKI_ROOT = REPO / 'agents' / 'workflows' / 'wiki'
+if str(WIKI_ROOT) not in sys.path:
+    sys.path.insert(0, str(WIKI_ROOT))
+
+
+def load_module(name: str, file_name: str, workspace: Path):
+    os.environ['OPENCLAW_WORKSPACE'] = str(workspace)
+    for stale in ('common', 'wiki_catalog', 'bookmark_state_machine', 'classification_schema'):
+        sys.modules.pop(stale, None)
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / file_name)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ValidateSpecOutputMarkerTests(unittest.TestCase):
+    def _seed_state(self, workspace: Path, bookmark_key: str) -> None:
+        state_path = workspace / 'brain' / 'state' / 'bookmark-review-state.json'
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps({
+            'version': 1,
+            'items': {
+                bookmark_key: {
+                    'bookmarkKey': bookmark_key,
+                    'reviewStatus': 'spec_requested',
+                },
+            },
+            'approvalLocks': {},
+        }), encoding='utf-8')
+
+    def _artifact(self, bookmark_key: str, spec_doc: str) -> dict:
+        return {
+            'entries': [
+                {
+                    'bookmarkKey': bookmark_key,
+                    'requestType': 'new',
+                    'specs': [
+                        {
+                            'title': 'Example',
+                            'specDoc': spec_doc,
+                            'classification': 'feature',
+                            'classification_rationale': 'because',
+                        },
+                    ],
+                },
+            ],
+        }
+
+    def test_spec_missing_marker_is_rejected_and_state_not_advanced(self):
+        with tempfile.TemporaryDirectory() as td:
+            workspace = Path(td)
+            self._seed_state(workspace, 'abcd1234')
+            spec_rel = 'brain/bookmarks/specs/example-abcd1234.md'
+            spec = workspace / spec_rel
+            spec.parent.mkdir(parents=True)
+            spec.write_text('# Spec — Example\n\n**Status:** Draft\n\n## Outcome\nShip it.\n', encoding='utf-8')
+
+            artifact_path = workspace / 'brain' / 'state' / 'spec-output.json'
+            artifact_path.write_text(json.dumps(self._artifact('abcd1234', spec_rel)), encoding='utf-8')
+
+            mod = load_module('validate_spec_output_missing_marker_test', 'validate_spec_output.py', workspace)
+            exit_code = mod.main(['--input', str(artifact_path), '--json'])
+
+            self.assertEqual(exit_code, 0)
+            state = mod.load_state(Path(mod.STATE_PATH))
+            self.assertEqual(state['items']['abcd1234']['reviewStatus'], 'spec_requested')
+            # Artifact must remain for a fixed re-run, not be silently consumed.
+            self.assertTrue(artifact_path.exists())
+
+    def test_spec_with_unchecked_marker_is_applied(self):
+        with tempfile.TemporaryDirectory() as td:
+            workspace = Path(td)
+            self._seed_state(workspace, 'abcd1234')
+            spec_rel = 'brain/bookmarks/specs/example-abcd1234.md'
+            spec = workspace / spec_rel
+            spec.parent.mkdir(parents=True)
+            spec.write_text(
+                '# Spec — Example\n\n**Status:** Draft\n- [ ] **Approved by Tom**\n\n## Outcome\nShip it.\n',
+                encoding='utf-8',
+            )
+
+            artifact_path = workspace / 'brain' / 'state' / 'spec-output.json'
+            artifact_path.write_text(json.dumps(self._artifact('abcd1234', spec_rel)), encoding='utf-8')
+
+            mod = load_module('validate_spec_output_with_marker_test', 'validate_spec_output.py', workspace)
+            exit_code = mod.main(['--input', str(artifact_path), '--json'])
+
+            self.assertEqual(exit_code, 0)
+            state = mod.load_state(Path(mod.STATE_PATH))
+            self.assertEqual(state['items']['abcd1234']['reviewStatus'], 'spec_created')
+            self.assertFalse(artifact_path.exists())
+            self.assertTrue((artifact_path.with_name(artifact_path.name + '.processed')).exists())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Bookmark approval was failing with `approval checkbox toggle failed: missing unchecked Approved by Tom marker` — hit live today on bookmark `cd6e2932d0be53d9` / approval `ap26753367`. Tom asked whether #473 fixed this; it didn't, #473 fixed an unrelated stdin JSON-ref bug in the same workflow file.
- Root cause: `handle_approval_reply.py`'s `set_spec_approval_checkbox` requires an unchecked `- [ ] **Approved by Tom**` line to toggle on approval, but the `spec-author` skill's shared template never wrote that line. About half of existing `brain/bookmarks/specs/*.md` files are missing it (39/78) — the gap is old and widespread, not a one-off.
- Nothing upstream of approval ever checked for the marker, so a spec missing it sails through generation and gets delivered to Tom for approval, only to fail the moment he clicks Approve.

## Fix
- `agents/skills/product/spec-author/SKILL.md`: add the marker to the shared spec template (right after `**Status:** Draft`, matching the existing convention) and call out that it's required for bookmark-origin specs.
- `agents/workflows/bookmarks/scripts/validate_spec_output.py`: reject spec-output entries whose spec doc lacks the unchecked marker before transitioning the bookmark to `spec_created`, so the failure surfaces (and the artifact is retained for a fixed re-run) at generation time instead of at Tom's approval click.

## Immediate unblock (already applied outside this PR)
- Manually added the missing marker to `brain/bookmarks/specs/vault-frontmatter-graph-edges-cd6e2932d0be53d9.md` directly (it's a brain/ doc, not code). The lobster resume token for approval `ap26753367` was never consumed (the toggle fails *before* resume is called), so no state reset was needed — Tom can just reply Approve again.
- The other 38 pre-existing specs missing the marker are untouched; most are old/superseded revisions. Flagging as a possible follow-up if Tom wants a bulk backfill, but out of scope here.

## Test plan
- [x] New `agents/workflows/bookmarks/tests/test_validate_spec_output.py`: spec missing the marker is rejected and bookmark stays at `spec_requested` with the artifact retained; spec with the marker is applied and transitions to `spec_created`.
- [x] `python3 -m unittest discover -s agents/workflows/bookmarks/tests -p "test_*.py"` — full existing suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)