### PR TITLE
fix(bookmarks): update spec test fixtures for Approved-by-Tom marker gate

### DIFF
--- a/tests/test_personal_wiki_hooks.py
+++ b/tests/test_personal_wiki_hooks.py
@@ -123,7 +123,7 @@ class PersonalWikiHookTests(unittest.TestCase):
         spec_path = self.root / spec_rel
         spec_path.parent.mkdir(parents=True, exist_ok=True)
         spec_path.write_text(
-            "# Spec — Example\n\n## Outcome\n\nShip the grounded recall path.\n\n## Acceptance Criteria\n\n- [ ] AC1\n",
+            "# Spec — Example\n\n- [ ] **Approved by Tom**\n\n## Outcome\n\nShip the grounded recall path.\n\n## Acceptance Criteria\n\n- [ ] AC1\n",
             encoding="utf-8",
         )
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -171,7 +171,10 @@ class PersonalWikiHookTests(unittest.TestCase):
         spec_rel = "brain/bookmarks/specs/example-k1.md"
         spec_path = self.root / spec_rel
         spec_path.parent.mkdir(parents=True, exist_ok=True)
-        spec_path.write_text("# Spec — Example\n\n## Outcome\n\nShip it.\n", encoding="utf-8")
+        spec_path.write_text(
+            "# Spec — Example\n\n- [ ] **Approved by Tom**\n\n## Outcome\n\nShip it.\n",
+            encoding="utf-8",
+        )
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
         self.output_path.write_text(
             json.dumps(

--- a/tests/test_validate_and_route.py
+++ b/tests/test_validate_and_route.py
@@ -565,7 +565,7 @@ class ValidateSpecOutputTests(unittest.TestCase):
     def _make_spec(self, rel_path: str) -> Path:
         spec = self.root / rel_path
         spec.parent.mkdir(parents=True, exist_ok=True)
-        spec.write_text("# Spec - test\n")
+        spec.write_text("# Spec - test\n\n- [ ] **Approved by Tom**\n")
         return spec
 
     def _run(self) -> dict:


### PR DESCRIPTION
## Summary
Follow-up to #476, which just merged to main and broke the "python workflow tests" CI job (Tom caught it post-merge). #476 added a hard gate in `validate_spec_output.py` requiring the unchecked `- [ ] **Approved by Tom**` marker before a bookmark spec can transition to `spec_created`. Three pre-existing test fixtures wrote spec bodies without that marker, so the new gate now correctly rejects them where the tests expect success.

## Fix
- `tests/test_personal_wiki_hooks.py`: added the marker to the two fixture spec bodies used by `test_validate_spec_output_indexes_specs_before_state_transition` and `test_validate_spec_output_fails_closed_when_wiki_update_fails`.
- `tests/test_validate_and_route.py`: added the marker to the shared `_make_spec()` helper (only used by tests that expect the happy-path apply to succeed; the missing-file/wrong-state/unknown-key tests short-circuit before the marker check, so they're unaffected).

## Test plan
- [x] Ran the exact CI invocation from `.github/workflows/ci.yml`'s `python-workflow-tests` job, all seven `unittest discover` commands — all green:
  - `tests/` (213 tests)
  - `agents/workflows/bookmarks/scripts/tests` (93 tests)
  - `agents/workflows/bookmarks/tests` (12 tests)
  - `agents/lib` (22 tests)
  - `agents/workflows/content-tasks/tests` (3 tests)
  - `agents/skills/ops/tasks-api/tests` (20 tests)
  - `agents/skills/ops/tasks-api/scripts` (52 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)