### PR TITLE
fix(bookmarks): don't hard-fail task creation for wiki-unindexed legacy specs

### DIFF
--- a/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py
+++ b/agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py
@@ -16,9 +16,11 @@ if str(WIKI_SCRIPT_ROOT) not in sys.path:
     sys.path.insert(0, str(WIKI_SCRIPT_ROOT))
 
 from wiki_catalog import (
+    CatalogError,
     configure_workspace as configure_wiki_workspace,
     event_key_for_payload,
     retarget_entry as wiki_retarget_entry,
+    upsert_entry as wiki_upsert_entry,
 )
 
 SCRIPT_ROOT = WORKSPACE / "codebases" / "sindustries" / "agents" / "skills" / "ops" / "tasks-api"
@@ -151,6 +153,37 @@ def _extract_section(text: str, heading: str) -> str:
     return (section[:next_h.start()] if next_h else section).strip()
 
 
+def _wiki_seed_fields(doc_path: str) -> tuple[str, str]:
+    """Derive a title + short summary from a spec file for a fresh wiki entry."""
+    text = (WORKSPACE / doc_path).read_text(encoding='utf-8')
+    title_match = re.search(r'^#\s+Spec\s*[—–-]+\s*(.+)$', text, re.MULTILINE)
+    title = title_match.group(1).strip() if title_match else Path(doc_path).stem.replace('-', ' ').title()
+    excerpt_source = _extract_section(text, 'Outcome') or text
+    lines = [line.strip() for line in excerpt_source.splitlines() if line.strip() and not line.strip().startswith('#')]
+    summary = re.sub(r'\s+', ' ', ' '.join(lines)).strip()
+    if len(summary) > 220:
+        summary = summary[:219].rstrip() + '…'
+    return title, summary or 'Spec catalog entry'
+
+
+def retarget_or_seed_wiki_entry(old_source: str, new_source: str, event_key: str) -> None:
+    """Retarget the wiki entry from old_source to new_source.
+
+    Specs created before the wiki catalog was wired into
+    validate_spec_output.py (2026-08-14) were never indexed under
+    old_source, so a strict retarget hard-fails even though the task and
+    file move have already succeeded by the time this runs. Fall back to
+    seeding a fresh entry for new_source instead of losing that work.
+    """
+    try:
+        wiki_retarget_entry(old_source, new_source, event_key=event_key)
+    except CatalogError as exc:
+        if not str(exc).startswith('source is not indexed:'):
+            raise
+        title, summary = _wiki_seed_fields(new_source)
+        wiki_upsert_entry('spec', new_source, title, summary, event_key=event_key)
+
+
 def build_task_from_spec(spec_doc: str, task_spec_doc: str, bookmark_key: str, topic: str) -> dict | None:
     """Read a spec markdown file and build a task dict (title + description)."""
     spec_path = WORKSPACE / spec_doc
@@ -203,7 +236,7 @@ def create_task_for_spec(
             moved_doc, moved = move_bookmark_spec_to_task_in_progress(spec_doc)
             patch_task_spec_line(base_url, str(existing['id']), spec_doc, moved_doc, existing)
             if spec_doc != moved_doc:
-                wiki_retarget_entry(
+                retarget_or_seed_wiki_entry(
                     spec_doc,
                     moved_doc,
                     event_key=event_key_for_payload(
@@ -270,7 +303,7 @@ def create_task_for_spec(
         if moved_doc != task_spec_doc:
             patch_task_spec_line(base_url, str(task_id), task_spec_doc, moved_doc, task if isinstance(task, dict) else None)
         if spec_doc != moved_doc:
-            wiki_retarget_entry(
+            retarget_or_seed_wiki_entry(
                 spec_doc,
                 moved_doc,
                 event_key=event_key_for_payload(

--- a/agents/workflows/bookmarks/tests/test_spec_lifecycle.py
+++ b/agents/workflows/bookmarks/tests/test_spec_lifecycle.py
@@ -94,6 +94,45 @@ class BookmarkSpecLifecycleTests(unittest.TestCase):
             self.assertNotIn(f'`{source_rel}`', index_text)
             self.assertIn(f'`{dest_rel}`', index_text)
 
+    def test_bookmark_task_creation_seeds_wiki_entry_for_unindexed_legacy_spec(self):
+        with tempfile.TemporaryDirectory() as td:
+            workspace = Path(td)
+            mod = load_module('lobster_create_tasks_legacy_wiki_test', 'lobster_create_tasks_from_proposals.py', workspace)
+            source_rel = 'brain/bookmarks/specs/example-abcd1234.md'
+            source = workspace / source_rel
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                '# Spec — Example\n\n- [x] **Approved by Tom**\n\n## Outcome\nShip it.\n\n## Acceptance Criteria\n- [ ] AC1: Build it\n',
+                encoding='utf-8',
+            )
+            # Deliberately do NOT seed the wiki index for source_rel — this
+            # reproduces a spec created before validate_spec_output.py wired
+            # in wiki_upsert_entry (2026-08-14), so old_source was never
+            # indexed. retarget_entry alone would hard-fail here even though
+            # the task and file move below succeed.
+            load_module('wiki_catalog_legacy_wiki_test', '../../wiki/wiki_catalog.py', workspace)
+
+            def fake_api(method, base_url, path, payload=None, *, token=None):
+                if method == 'POST':
+                    return {'data': {'id': 'task-1', 'description': payload['description'], 'tags': payload['tags']}}
+                if method == 'PATCH':
+                    return {'data': {'id': 'task-1'}}
+                return {'data': {'id': 'task-1', 'description': ''}}
+
+            with mock.patch.object(mod, 'api_request', side_effect=fake_api):
+                result, error = mod.create_task_for_spec('http://tasks', 'agent-tools', 'abcd1234', source_rel, [source_rel], {})
+
+            self.assertIsNone(error)
+            self.assertIsNotNone(result)
+            dest_rel = 'brain/tasks/specs/in-progress/example-abcd1234.md'
+            self.assertEqual(result['specDoc'], dest_rel)
+            self.assertFalse(source.exists())
+            self.assertTrue((workspace / dest_rel).exists())
+            index_text = (workspace / 'brain/wiki/index.md').read_text(encoding='utf-8')
+            self.assertIn(f'`{dest_rel}`', index_text)
+            self.assertIn('Example', index_text)
+            self.assertIn('Ship it.', index_text)
+
     def test_bookmark_move_is_idempotent_and_repairs_stale_spec_line_for_existing_task(self):
         with tempfile.TemporaryDirectory() as td:
             workspace = Path(td)


### PR DESCRIPTION
## Summary
Live incident from tonight: Tom clicked Approve on bookmark `cd6e2932d0be53d9` (after #476 unblocked the checkbox), and the resume failed with `source is not indexed: brain/bookmarks/specs/vault-frontmatter-graph-edges-cd6e2932d0be53d9.md`.

What actually happened inside `create_task_for_spec` (`lobster_create_tasks_from_proposals.py`):
1. POST created task `28cd257a` ✅
2. Moved the spec file to `brain/tasks/specs/in-progress/` ✅
3. `wiki_retarget_entry(old, new)` raised `CatalogError("source is not indexed: ...")` ❌ — because this spec was created 2026-08-13, **before** `validate_spec_output.py` was wired up to call `wiki_upsert_entry` (2026-08-14), so it was never catalogued under its old path.

Steps 1–2 aren't rolled back on a later exception, so the task and file move landed for real, but the function returned an error instead of a success, which made the whole step exit 1. That aborted the lobster workflow before its next step (`resolve_spec_request.py`) could run — the one script that would have set `reviewStatus: tasked`, recorded `taskIds`, and released the `brain` topic's approval lock. Net effect: the bookmark was stuck at `approval_pending` with an already-consumed resume token, and the `brain` topic lock stayed held, blocking every other brain-topic item queued behind it (e.g. `a06ef76555a20233`).

I hand-reconciled that one item's state directly (matching exactly what `resolve_spec_request.py` would have done, minus its X-reply-tweet side effect, which I did not want to trigger without checking with Tom first) so nothing stayed stuck. This PR is the actual code fix.

## Fix
`agents/workflows/bookmarks/scripts/lobster_create_tasks_from_proposals.py`:
- Added `retarget_or_seed_wiki_entry()`: try the normal `retarget_entry` first; only on the specific `"source is not indexed:"` failure, fall back to seeding a fresh wiki entry at the new (already-moved) path instead of discarding the task+move that already succeeded. Any other `CatalogError` (duplicate index rows, wrong source kind, etc.) still raises normally — this only widens the one failure mode that's provably safe to recover from.
- Both call sites in `create_task_for_spec` (the "reuse existing task" path and the "create new task" path) now go through the wrapper.

## Test plan
- [x] New test `test_bookmark_task_creation_seeds_wiki_entry_for_unindexed_legacy_spec` — simulates a legacy spec that was never wiki-indexed, verifies task creation still succeeds and the wiki index ends up with a seeded entry at the destination path.
- [x] `agents/workflows/bookmarks/tests` (13 tests) and `agents/workflows/bookmarks/scripts/tests` (93 tests) — green.
- Note: `python3 -m unittest discover -s tests` currently shows 3 pre-existing failures on this branch — those are the same fixture gaps already fixed in #477 (unmerged as of this PR), unrelated to this change. Confirmed by diffing failure output against #477's description. Once #477 merges, rebasing this branch will show it green too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)