### PR TITLE
feat(x): resolve tweet author from status id for handle-less bookmark links

### DIFF
--- a/agents/workflows/bookmarks/scripts/tests/test_x_author_tweet.py
+++ b/agents/workflows/bookmarks/scripts/tests/test_x_author_tweet.py
@@ -30,6 +30,8 @@ from x_author_tweet import (  # noqa: E402  (import after sys.path tweak)
     call_x_tweets_route,
     compose_author_tweet,
     parse_x_link,
+    parse_x_status_id,
+    resolve_tweet_author,
     try_post_author_tweet,
 )
 
@@ -106,6 +108,71 @@ class ParseXLinkTests(unittest.TestCase):
     def test_malformed_handle_empty(self):
         # The regex requires a non-empty handle; this won't match.
         self.assertIsNone(parse_x_link("https://x.com//status/1234567890"))
+
+
+# --- parse_x_status_id ----------------------------------------------------
+
+class ParseXStatusIdTests(unittest.TestCase):
+    def test_web_intent_share_link(self):
+        # No author handle in the path at all — this is the format that
+        # made parse_x_link return None for a real bookmark (2026-08-18).
+        self.assertEqual(
+            parse_x_status_id("https://x.com/i/web/status/2087089133156208803"),
+            "2087089133156208803",
+        )
+
+    def test_still_matches_handle_form(self):
+        self.assertEqual(parse_x_status_id("https://x.com/somebody/status/1234567890"), "1234567890")
+
+    def test_statuses_alias(self):
+        self.assertEqual(parse_x_status_id("https://twitter.com/i/web/statuses/42"), "42")
+
+    def test_non_x_url_returns_none(self):
+        self.assertIsNone(parse_x_status_id("https://example.com/i/web/status/123"))
+
+    def test_no_status_segment_returns_none(self):
+        self.assertIsNone(parse_x_status_id("https://x.com/somebody"))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(parse_x_status_id(""))
+
+    def test_none_returns_none(self):
+        self.assertIsNone(parse_x_status_id(None))
+
+
+# --- resolve_tweet_author --------------------------------------------------
+
+class ResolveTweetAuthorTests(unittest.TestCase):
+    def test_happy_path_returns_handle(self):
+        fake_response = mock.MagicMock()
+        fake_response.read.return_value = json.dumps({"data": {"handle": "polydao"}}).encode("utf-8")
+        fake_response.__enter__ = lambda s: s
+        fake_response.__exit__ = lambda s, *a: None
+        with mock.patch("x_author_tweet.urllib.request.urlopen", return_value=fake_response):
+            self.assertEqual(resolve_tweet_author("999"), "polydao")
+
+    def test_404_returns_none(self):
+        http_err = urllib_error("HTTP Error 404", code=404)
+        with mock.patch("x_author_tweet.urllib.request.urlopen", side_effect=http_err):
+            self.assertIsNone(resolve_tweet_author("999"))
+
+    def test_missing_credentials_returns_none(self):
+        http_err = urllib_error("HTTP Error 503", code=503)
+        with mock.patch("x_author_tweet.urllib.request.urlopen", side_effect=http_err):
+            self.assertIsNone(resolve_tweet_author("999"))
+
+    def test_tasks_api_unreachable_returns_none(self):
+        with mock.patch("x_author_tweet.urllib.request.urlopen",
+                        side_effect=ConnectionRefusedError("refused")):
+            self.assertIsNone(resolve_tweet_author("999"))
+
+    def test_empty_handle_returns_none(self):
+        fake_response = mock.MagicMock()
+        fake_response.read.return_value = json.dumps({"data": {"handle": ""}}).encode("utf-8")
+        fake_response.__enter__ = lambda s: s
+        fake_response.__exit__ = lambda s, *a: None
+        with mock.patch("x_author_tweet.urllib.request.urlopen", return_value=fake_response):
+            self.assertIsNone(resolve_tweet_author("999"))
 
 
 # --- compose_author_tweet ------------------------------------------------
@@ -286,6 +353,38 @@ class TryPostAuthorTweetTests(unittest.TestCase):
             "link": "not-a-url",
             "title": "x",
         })
+        self.assertEqual(result, {"status": SKIPPED, "error": "missing_x_link"})
+
+    def test_web_intent_link_resolves_author_and_posts(self):
+        # x.com/i/web/status/<id> has no handle in the path; try_post_author_tweet
+        # must fall back to resolve_tweet_author instead of skipping outright.
+        with mock.patch(
+            "x_author_tweet.resolve_tweet_author",
+            return_value="polydao",
+        ) as resolve_mock, mock.patch(
+            "x_author_tweet.compose_author_tweet",
+            return_value="@polydao nice thread",
+        ) as compose_mock, mock.patch(
+            "x_author_tweet.call_x_tweets_route",
+            return_value={"url": "https://x.com/sindustries/status/1", "postedAt": "now"},
+        ):
+            result = try_post_author_tweet({
+                "source": "x",
+                "link": "https://x.com/i/web/status/2087089133156208803",
+                "title": "x",
+            })
+        resolve_mock.assert_called_once_with("2087089133156208803", base_url=None)
+        # compose_author_tweet must see the resolved handle via authorHandle.
+        self.assertEqual(compose_mock.call_args[0][0]["authorHandle"], "polydao")
+        self.assertEqual(result["status"], POSTED)
+
+    def test_web_intent_link_skipped_when_author_unresolvable(self):
+        with mock.patch("x_author_tweet.resolve_tweet_author", return_value=None):
+            result = try_post_author_tweet({
+                "source": "x",
+                "link": "https://x.com/i/web/status/2087089133156208803",
+                "title": "x",
+            })
         self.assertEqual(result, {"status": SKIPPED, "error": "missing_x_link"})
 
     def test_llm_failure_records_error(self):

--- a/agents/workflows/bookmarks/scripts/x_author_tweet.py
+++ b/agents/workflows/bookmarks/scripts/x_author_tweet.py
@@ -9,6 +9,10 @@ underlying approval transition (AC3 best-effort contract).
 
 Module surface:
     - parse_x_link(url)                       -> (handle, status_id) | None
+    - parse_x_status_id(url)                  -> status_id | None (no handle required;
+                                                 also matches `x.com/i/web/status/<id>`)
+    - resolve_tweet_author(status_id, ...)    -> handle | None (best-effort GET via
+                                                 tasks-api `/x/tweets/:id/author`)
     - compose_author_tweet(state_item)        -> str   (≤280 chars; raises TweetComposeError)
     - call_x_tweets_route(text, status_id)    -> {"url", "postedAt"} | raises XApiError
                                                  | CredentialsMissingError
@@ -93,6 +97,32 @@ def parse_x_link(url: str | None) -> tuple[str, str] | None:
     if not handle or not status_id:
         return None
     return (handle, status_id)
+
+
+# x.com host + any /status/<id> segment, regardless of what comes before it.
+# Superset of _X_STATUS_RE: also matches X's generic web-intent share links
+# like `x.com/i/web/status/<id>`, which don't carry the author's handle in
+# the path at all (parse_x_link returns None for those).
+_X_HOST_RE = re.compile(r"^https?://(?:www\.|mobile\.)?(?:twitter|x)\.com/", re.IGNORECASE)
+_X_STATUS_ID_ONLY_RE = re.compile(r"/status(?:es)?/(?P<status_id>\d+)(?:/|\?|#|$)", re.IGNORECASE)
+
+
+def parse_x_status_id(url: str | None) -> str | None:
+    """Extract just the numeric status id from any x.com/twitter.com URL.
+
+    Unlike ``parse_x_link``, this does not require a handle segment before
+    ``/status/`` — it also matches generic share-link formats such as
+    ``x.com/i/web/status/<id>`` where the author isn't in the URL at all.
+    Callers that need the author must resolve it separately (see
+    ``resolve_tweet_author``).
+    """
+    if not isinstance(url, str):
+        return None
+    cleaned = url.strip()
+    if not cleaned or not _X_HOST_RE.match(cleaned):
+        return None
+    match = _X_STATUS_ID_ONLY_RE.search(cleaned)
+    return match.group("status_id") if match else None
 
 
 # --- Tweet composition ---------------------------------------------------
@@ -223,6 +253,26 @@ def call_x_tweets_route(
         raise TasksApiUnreachableError(f"tasks_api_unreachable:{reason}") from exc
 
 
+def resolve_tweet_author(status_id: str, *, base_url: str | None = None) -> str | None:
+    """Best-effort GET of a tweet's author handle via tasks-api.
+
+    Returns ``None`` on any failure (missing credentials, tweet not found,
+    X API error, tasks-api unreachable) rather than raising — callers use
+    this to fill in a handle for links like `x.com/i/web/status/<id>` that
+    don't carry one, and fall back to the existing `missing_x_link` skip
+    when resolution doesn't produce a usable handle.
+    """
+    url = f"{_tasks_api_base_url(base_url)}/x/tweets/{status_id}/author"
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+            handle = (payload.get("data") or {}).get("handle")
+            return handle if isinstance(handle, str) and handle else None
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, ConnectionError, OSError):
+        return None
+
+
 # --- Integration entry point ---------------------------------------------
 
 def _skipped(reason: str) -> dict[str, Any]:
@@ -263,9 +313,19 @@ def try_post_author_tweet(
         return _skipped("non_x_source")
 
     parsed = parse_x_link(state_item.get("link"))
-    if parsed is None:
-        return _skipped("missing_x_link")
-    _handle, status_id = parsed
+    if parsed is not None:
+        _handle, status_id = parsed
+    else:
+        # Handle-less share links (e.g. `x.com/i/web/status/<id>`) still
+        # carry a resolvable status id — look up the author instead of
+        # skipping outright.
+        status_id = parse_x_status_id(state_item.get("link"))
+        if status_id is None:
+            return _skipped("missing_x_link")
+        resolved_handle = resolve_tweet_author(status_id, base_url=tasks_api_base_url)
+        if not resolved_handle:
+            return _skipped("missing_x_link")
+        state_item = {**state_item, "authorHandle": resolved_handle}
 
     try:
         text = compose_author_tweet(state_item)
@@ -308,7 +368,9 @@ __all__ = [
     "XApiError",
     "TasksApiUnreachableError",
     "parse_x_link",
+    "parse_x_status_id",
     "compose_author_tweet",
     "call_x_tweets_route",
+    "resolve_tweet_author",
     "try_post_author_tweet",
 ]

--- a/services/tasks-api/src/routes/contentSchedulerPublish.ts
+++ b/services/tasks-api/src/routes/contentSchedulerPublish.ts
@@ -77,6 +77,14 @@ export function guardPublish(
  */
 export interface XClient {
   createTweet(input: { text: string; in_reply_to_tweet_id?: string }): Promise<{ url: string; postedAt: Date }>;
+  /**
+   * Resolve the @handle of a tweet's author from its numeric status id.
+   * Returns null when the tweet doesn't exist / isn't visible (e.g. deleted,
+   * protected). Used to reply to bookmarks whose saved link is a generic
+   * `x.com/i/web/status/<id>` share URL that doesn't carry the author's
+   * handle in the path.
+   */
+  getTweetAuthor(tweetId: string): Promise<{ handle: string } | null>;
 }
 
 /**
@@ -98,6 +106,13 @@ export class FakeXClient implements XClient {
       postedAt: new Date()
     };
   }
+
+  async getTweetAuthor(tweetId: string): Promise<{ handle: string } | null> {
+    const { createHash } = await import('node:crypto');
+    // Deterministic fake handle so dev/test flows have stable assertions.
+    const digest = createHash('sha256').update(tweetId).digest('hex').slice(0, 8);
+    return { handle: `fake_author_${digest}` };
+  }
 }
 
 /**
@@ -115,7 +130,15 @@ export class RealXClient implements XClient {
     private readonly timeoutMs: number = 10_000
   ) {}
 
-  private async oauthHeader(method: string, url: string, bodyParams: Record<string, string>): Promise<string> {
+  // `signedParams` are the OAuth1.0a "request parameters" that get folded
+  // into the signature base string alongside the oauth_* params — i.e.
+  // the URL query string (GET) or an application/x-www-form-urlencoded
+  // body (POST). Per the OAuth1.0a spec, parameters from a *non*
+  // form-urlencoded body (our POSTs are JSON) are NOT request parameters
+  // and must NOT be signed. Callers with a JSON body must pass {} here;
+  // passing the JSON payload's fields breaks the signature and X returns
+  // a generic 401 Unauthorized with no indication the body caused it.
+  private async oauthHeader(method: string, url: string, signedParams: Record<string, string>): Promise<string> {
     const { createHmac } = await import('node:crypto');
 
     const nonce = Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
@@ -130,7 +153,7 @@ export class RealXClient implements XClient {
       oauth_version: '1.0'
     };
 
-    const allParams = { ...oauthParams, ...bodyParams };
+    const allParams = { ...oauthParams, ...signedParams };
     const paramString = Object.keys(allParams)
       .sort()
       .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(allParams[k])}`)
@@ -151,15 +174,12 @@ export class RealXClient implements XClient {
 
   async createTweet(input: { text: string; in_reply_to_tweet_id?: string }): Promise<{ url: string; postedAt: Date }> {
     const url = 'https://api.twitter.com/2/tweets';
-    const body: Record<string, string> = { text: input.text };
+    const body: { text: string; reply?: { in_reply_to_tweet_id: string } } = { text: input.text };
     if (input.in_reply_to_tweet_id) {
-      body.reply = JSON.stringify({ in_reply_to_tweet_id: input.in_reply_to_tweet_id });
+      body.reply = { in_reply_to_tweet_id: input.in_reply_to_tweet_id };
     }
-    const bodyParams: Record<string, string> = {};
-    if (input.in_reply_to_tweet_id) {
-      bodyParams.reply = body.reply;
-    }
-    const authorization = await this.oauthHeader('POST', url, bodyParams);
+    // JSON body — no signed params (see oauthHeader comment above).
+    const authorization = await this.oauthHeader('POST', url, {});
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -185,6 +205,43 @@ export class RealXClient implements XClient {
         url: `https://x.com/${this.handle}/status/${id}`,
         postedAt: new Date()
       };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async getTweetAuthor(tweetId: string): Promise<{ handle: string } | null> {
+    const url = `https://api.twitter.com/2/tweets/${encodeURIComponent(tweetId)}`;
+    // GET query-string params are OAuth1.0a "request parameters" and must
+    // be signed, unlike a JSON POST body (see oauthHeader comment above).
+    const queryParams: Record<string, string> = {
+      expansions: 'author_id',
+      'user.fields': 'username'
+    };
+    const authorization = await this.oauthHeader('GET', url, queryParams);
+    const query = Object.entries(queryParams)
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+      .join('&');
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await fetch(`${url}?${query}`, {
+        method: 'GET',
+        signal: controller.signal,
+        headers: { authorization }
+      });
+      if (res.status === 404) {
+        return null;
+      }
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`X API ${res.status}: ${body.slice(0, 200)}`);
+      }
+      const json = (await res.json()) as {
+        includes?: { users?: Array<{ username?: string }> };
+      };
+      const username = json?.includes?.users?.[0]?.username;
+      return username ? { handle: username } : null;
     } finally {
       clearTimeout(timer);
     }

--- a/services/tasks-api/src/routes/xTweet.ts
+++ b/services/tasks-api/src/routes/xTweet.ts
@@ -7,11 +7,22 @@
 // task 55ac9240-d54a-4b2c-88c4-8bb8af85d2b2 (Bookmark approval — author
 // tweet notification).
 //
-// Endpoint:
+// Endpoints:
 //   POST /api/v1/x/tweets
 //     body: { text: string, in_reply_to_tweet_id?: string }
 //     200:  { data: { url: string, postedAt: ISO-8601 } }
 //     400:  TWEET_TOO_LONG | INVALID_BODY
+//     502:  X_API_ERROR
+//     503:  MISSING_CREDENTIALS
+//
+//   GET /api/v1/x/tweets/:id/author
+//     Resolves the @handle of a tweet's author from its numeric id. Added
+//     so the bookmark approval flow can reply to bookmarks whose saved
+//     link is a generic `x.com/i/web/status/<id>` share URL (no handle in
+//     the path) instead of silently skipping the author-reply step.
+//     200:  { data: { handle: string } }
+//     400:  INVALID_TWEET_ID
+//     404:  TWEET_NOT_FOUND
 //     502:  X_API_ERROR
 //     503:  MISSING_CREDENTIALS
 //
@@ -92,6 +103,42 @@ export function xTweetRouter(): Router {
       // a useful error reason in tweetLog.error, but never leak secrets.
       const safeMessage = message.slice(0, 200);
       console.error('[xTweet] client.createTweet failed:', safeMessage);
+      res.status(502).json({
+        error: { code: 'X_API_ERROR', message: safeMessage }
+      });
+    }
+  });
+
+  router.get('/x/tweets/:id/author', async (req, res) => {
+    const id = req.params.id;
+    if (!/^\d+$/.test(id)) {
+      res.status(400).json({
+        error: { code: 'INVALID_TWEET_ID', message: '`id` must be a numeric tweet id' }
+      });
+      return;
+    }
+
+    const client = getXClient();
+    if (client === null) {
+      res.status(503).json({
+        error: { code: 'MISSING_CREDENTIALS', message: 'X credentials are not configured' }
+      });
+      return;
+    }
+
+    try {
+      const author = await client.getTweetAuthor(id);
+      if (author === null) {
+        res.status(404).json({
+          error: { code: 'TWEET_NOT_FOUND', message: `no author found for tweet ${id}` }
+        });
+        return;
+      }
+      res.status(200).json({ data: { handle: author.handle } });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'unknown X client error';
+      const safeMessage = message.slice(0, 200);
+      console.error('[xTweet] client.getTweetAuthor failed:', safeMessage);
       res.status(502).json({
         error: { code: 'X_API_ERROR', message: safeMessage }
       });

--- a/services/tasks-api/test/contentScheduler.test.ts
+++ b/services/tasks-api/test/contentScheduler.test.ts
@@ -139,6 +139,134 @@ describe('FakeXClient', () => {
     expect(a.url).not.toBe(c.url);
     expect(a.postedAt).toBeInstanceOf(Date);
   });
+
+  it('getTweetAuthor returns a deterministic fake handle', async () => {
+    const client = new FakeXClient();
+    const a = await client.getTweetAuthor('123');
+    const b = await client.getTweetAuthor('123');
+    const c = await client.getTweetAuthor('456');
+    expect(a).toEqual(b);
+    expect(a?.handle).not.toEqual(c?.handle);
+    expect(a?.handle).toMatch(/^fake_author_[0-9a-f]{8}$/);
+  });
+});
+
+// --- RealXClient ------------------------------------------------------------
+//
+// createTweet's JSON body previously double-stringified the `reply` field
+// (`{reply: JSON.stringify({...})}` sent inside a JSON.stringify'd outer
+// body, producing `"reply": "{\"in_reply_to_tweet_id\":...}"` — an escaped
+// string, not the nested object X's API expects) and signed that same
+// stringified value as an OAuth1.0a request parameter even though the
+// request body is JSON, not form-urlencoded. Per the OAuth1.0a spec, only
+// oauth_* params and (for GET) the query string belong in the signature
+// base string for a non-form body — including body content there produces
+// a signature X rejects with a generic 401. Both bugs were confirmed live
+// against api.twitter.com on 2026-08-18 (a real reply attempt 401'd, and a
+// corrected request with the same credentials succeeded through to X's own
+// business-rule check). These tests guard the request *shape*; the
+// signature math itself isn't independently re-derived here.
+describe('RealXClient', () => {
+  const client = new RealXClient('key', 'secret', 'token', 'tokenSecret', 'sindustries');
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('createTweet sends a properly-nested JSON body for a reply', async () => {
+    let capturedBody: string | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return {
+          ok: true,
+          json: async () => ({ data: { id: '999' } })
+        } as Response;
+      })
+    );
+
+    await client.createTweet({ text: 'hello', in_reply_to_tweet_id: '2087089133156208803' });
+
+    expect(capturedBody).toBeDefined();
+    const parsed = JSON.parse(capturedBody as string);
+    // The bug produced `reply` as an escaped JSON *string*; it must be a
+    // nested object per X API v2's documented shape.
+    expect(parsed).toEqual({
+      text: 'hello',
+      reply: { in_reply_to_tweet_id: '2087089133156208803' }
+    });
+  });
+
+  it('createTweet omits reply entirely for a non-reply tweet', async () => {
+    let capturedBody: string | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return { ok: true, json: async () => ({ data: { id: '1' } }) } as Response;
+      })
+    );
+
+    await client.createTweet({ text: 'no reply' });
+
+    expect(JSON.parse(capturedBody as string)).toEqual({ text: 'no reply' });
+  });
+
+  it('getTweetAuthor resolves the handle from a v2 tweets-lookup response', async () => {
+    let capturedUrl: string | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        capturedUrl = url;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: { id: '2087089133156208803', text: '...' },
+            includes: { users: [{ username: 'polydao' }] }
+          })
+        } as Response;
+      })
+    );
+
+    const result = await client.getTweetAuthor('2087089133156208803');
+
+    expect(result).toEqual({ handle: 'polydao' });
+    expect(capturedUrl).toContain('/2/tweets/2087089133156208803');
+    expect(capturedUrl).toContain('expansions=author_id');
+    expect(capturedUrl).toContain('user.fields=username');
+  });
+
+  it('getTweetAuthor returns null on a 404 (deleted / not found)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 404, text: async () => '' }) as unknown as Response)
+    );
+    const result = await client.getTweetAuthor('999');
+    expect(result).toBeNull();
+  });
+
+  it('getTweetAuthor returns null when the response has no users', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { id: '999' }, includes: {} })
+      }) as unknown as Response)
+    );
+    const result = await client.getTweetAuthor('999');
+    expect(result).toBeNull();
+  });
+
+  it('getTweetAuthor throws on a non-404 error status', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 500, text: async () => 'server error' }) as unknown as Response)
+    );
+    await expect(client.getTweetAuthor('999')).rejects.toThrow(/X API 500/);
+  });
 });
 
 // --- getXClient selection -------------------------------------------------

--- a/services/tasks-api/test/xTweet.test.ts
+++ b/services/tasks-api/test/xTweet.test.ts
@@ -4,9 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // `vi.hoisted` runs before `vi.mock` factories, which Vitest also hoists.
 // We need the spy/mock fn handles available when the factory for
 // contentSchedulerPublish.ts runs.
-const { createTweetSpy, getXClientMock } = vi.hoisted(() => {
+const { createTweetSpy, getTweetAuthorSpy, getXClientMock } = vi.hoisted(() => {
   return {
     createTweetSpy: vi.fn(),
+    getTweetAuthorSpy: vi.fn(),
     getXClientMock: vi.fn()
   };
 });
@@ -54,8 +55,10 @@ beforeEach(() => {
     url: 'https://x.com/sindustries/status/abc123',
     postedAt: new Date('2026-07-19T00:00:00.000Z')
   });
+  getTweetAuthorSpy.mockResolvedValue({ handle: 'polydao' });
   getXClientMock.mockReturnValue({
-    createTweet: createTweetSpy
+    createTweet: createTweetSpy,
+    getTweetAuthor: getTweetAuthorSpy
   });
 });
 
@@ -170,5 +173,51 @@ describe('POST /api/v1/x/tweets', () => {
     expect(res.status).toBe(502);
     expect(res.body.error.code).toBe('X_API_ERROR');
     expect(typeof res.body.error.message).toBe('string');
+  });
+});
+
+// --- GET /api/v1/x/tweets/:id/author --------------------------------------
+
+describe('GET /api/v1/x/tweets/:id/author', () => {
+  it('returns 200 with the resolved handle', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/x/tweets/2087089133156208803/author');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ handle: 'polydao' });
+    expect(getTweetAuthorSpy).toHaveBeenCalledWith('2087089133156208803');
+  });
+
+  it('returns 400 INVALID_TWEET_ID for a non-numeric id', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/x/tweets/not-a-number/author');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_TWEET_ID');
+    expect(getTweetAuthorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 TWEET_NOT_FOUND when the client resolves null', async () => {
+    getTweetAuthorSpy.mockResolvedValue(null);
+    const app = createApp();
+    const res = await request(app).get('/api/v1/x/tweets/999/author');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('TWEET_NOT_FOUND');
+  });
+
+  it('returns 503 MISSING_CREDENTIALS when getXClient() returns null', async () => {
+    getXClientMock.mockReturnValue(null);
+    const app = createApp();
+    const res = await request(app).get('/api/v1/x/tweets/999/author');
+    expect(res.status).toBe(503);
+    expect(res.body.error.code).toBe('MISSING_CREDENTIALS');
+    expect(getTweetAuthorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 502 X_API_ERROR when client.getTweetAuthor throws', async () => {
+    getTweetAuthorSpy.mockRejectedValue(new Error('X API 500: boom'));
+    const app = createApp();
+    const res = await request(app).get('/api/v1/x/tweets/999/author');
+    expect(res.status).toBe(502);
+    expect(res.body.error.code).toBe('X_API_ERROR');
+    expect(res.body.error.message).toMatch(/X API 500/);
   });
 });


### PR DESCRIPTION
## Summary
Tonight's live incident (bookmark `cd6e2932d0be53d9`) exposed two things:

1. The author-reply step silently skips every bookmark whose saved link is X's generic web-intent format (`x.com/i/web/status/<id>`) instead of the canonical `x.com/<handle>/status/<id>` — `parse_x_link` requires the handle to already be in the URL, and there was no fallback.
2. `RealXClient.createTweet` has two real bugs that broke the first live reply attempt with a generic `401 Unauthorized`:
   - The `reply` field was double-JSON-encoded (`JSON.stringify({...})` nested inside the outer `JSON.stringify(body)`), so X received an escaped *string* where its API expects a nested object.
   - `oauthHeader` was signing that same body content as an OAuth1.0a request parameter, which is only correct for form-urlencoded bodies — ours is JSON. Per the OAuth1.0a spec, a JSON body's fields must NOT be part of the signature base string; only `oauth_*` params (and, for GET, the query string) belong there. Signing extra content there breaks the signature and X returns a bare 401 with no hint the body was the cause.

Both were found and fixed by hand tonight while manually resolving a real bookmark's author handle and posting a real reply against tasks-api's live X credentials (`X_CLIENT=real`) — confirmed: the old code 401'd, the corrected signing got past auth to a legitimate 403 from X itself.

## Fix
- **`XClient.getTweetAuthor(tweetId)`** — new interface method. `FakeXClient` returns a deterministic fake handle; `RealXClient` does a real `GET https://api.twitter.com/2/tweets/:id?expansions=author_id&user.fields=username`, signed correctly (query params ARE part of the OAuth1.0a signature for a GET).
- **`GET /api/v1/x/tweets/:id/author`** — new tasks-api route exposing it, mirroring the existing `POST /x/tweets` pattern (503 missing creds, 404 not found, 502 API error).
- **`x_author_tweet.py`**: `parse_x_status_id()` extracts a bare status id from any `x.com/status/<id>` path regardless of what's before it (handle or not); `resolve_tweet_author()` calls the new route (best-effort, returns `None` on any failure); `try_post_author_tweet()` now tries this fallback before giving up with `missing_x_link`.
- **`RealXClient.createTweet`**: fixed the nested-body shape and the signature bug (always pass `{}` for the JSON-body POST; only real signed params — like `getTweetAuthor`'s query string — go through `oauthHeader`'s `signedParams` arg now).

## Known follow-up (not in scope here)
Once the signature bug was fixed, the live reply attempt got past `401` to a clean `403` from X itself: *"You can only reply to or quote posts where you are mentioned or are the author."* That's a platform/app-tier restriction, not something this PR (or any code) can route around — it means the author-reply feature likely can't post for any bookmark where `@sindustries` isn't already mentioned in the source tweet. Flagging to Tom separately; this PR only fixes the signature bug and the discoverability half (finding the handle at all).

## Test plan
- [x] `agents/workflows/bookmarks/scripts/tests/test_x_author_tweet.py` — 56/56 passing, including new `ParseXStatusIdTests`, `ResolveTweetAuthorTests`, and two `try_post_author_tweet` fallback-path tests (web-intent link resolves + posts; web-intent link with unresolvable author still skips cleanly).
- [x] `services/tasks-api/test/xTweet.test.ts` + `test/contentScheduler.test.ts` — 60/60 passing, including new `GET /x/tweets/:id/author` route tests and `RealXClient` request-shape tests (createTweet body nesting, getTweetAuthor URL/response parsing, 404/500 handling).
- [x] Full `tasks-api` suite (`npx vitest run --exclude test/db-integration.test.ts`, with `prisma generate` run first): 364/365 passing — the one failure (`contentSchedulerImport.test.ts`, an unrelated missing local ingest-secret env var) is pre-existing and untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)