### PR TITLE
chore(code-garden): mark W33 audit T3.1 done [PR #407]

### DIFF
--- a/docs/repo-audits/2026-W33.md
+++ b/docs/repo-audits/2026-W33.md
@@ -104,7 +104,7 @@
 
 **Milestone 3 — Quality & polish**
 
-- **T3.1 — Validate approval service credentials at boot and memoize.** Parse/validate `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` once at startup; fail fast on malformed config. *Files:* `services/tasks-api/src/middleware/approvalAuth.ts`. *AC:* malformed credentials env fails process boot with a clear error; no per-request re-parse. *Effort:* S. *Risk:* Low. *Deps:* none. (`garden-safe`.)
+- **T3.1 — Validate approval service credentials at boot and memoize.** Parse/validate `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` once at startup; fail fast on malformed config. *Files:* `services/tasks-api/src/middleware/approvalAuth.ts`. *AC:* malformed credentials env fails process boot with a clear error; no per-request re-parse. *Effort:* S. *Risk:* Low. *Deps:* none. (`garden-safe`.) ✅ [PR #407](https://github.com/Stoffer-Industries/sindustries/pull/407)
 
 **Top-3 implementation sketches:**
 


### PR DESCRIPTION
## Summary
- **Audit:** docs/repo-audits/2026-W33.md
- **Finding:** [Low] T3.1 — Validate approval service credentials at boot and memoize
- Adds the missing `✅ [PR #407]` marker to the W33 audit's Task Plan T3.1 line. PR #407 (merged 2026-08-10) implemented the boot-time memoization and fail-fast parse; the W34 audit confirms the fix landed, but the W33 file's Task Plan line was never annotated.

## Test plan
- [ ] No logic changes — diff is a single-line audit marker addition
- [ ] Markdown renders correctly on GitHub (link + emoji)

🌱 Code garden — non-functional cleanup only