### PR TITLE
chore(agent-scripts): reduce safe_run default to 25s

### DIFF
--- a/agents/lib/subprocess_safe.py
+++ b/agents/lib/subprocess_safe.py
@@ -5,9 +5,12 @@ by `agent-task-queue-gh-api-hang-2026-08-17` onto a single shared helper so the 
 script author cannot reintroduce the unguarded-`subprocess.run` class of bug.
 
 Public API:
-    DEFAULT_TIMEOUT_SECONDS: float = 30.0
-        Module-level default. Long enough to absorb normal GitHub-API tail latency,
-        short enough that the heartbeat's stuck state is bounded.
+    DEFAULT_TIMEOUT_SECONDS: float = 25.0
+        Module-level default. Set 5s below the heartbeat's 30s exec timeout so that
+        `subprocess.TimeoutExpired` raises (and python3 flushes stdout) before the
+        parent exec timeout fires — incident `agent-task-queue-script-subprocess-timeout-race-2026-08-20`.
+        Long enough for normal GitHub-API tail latency, short enough that the
+        heartbeat's stuck state is bounded.
 
     safe_run(cmd, *, timeout=DEFAULT_TIMEOUT_SECONDS, **kwargs) -> subprocess.CompletedProcess
         `subprocess.run` with a default timeout. **kwargs forwards verbatim, so
@@ -54,7 +57,7 @@ from __future__ import annotations
 import subprocess
 from typing import Any
 
-DEFAULT_TIMEOUT_SECONDS: float = 30.0
+DEFAULT_TIMEOUT_SECONDS: float = 25.0
 
 
 def safe_run(

--- a/agents/lib/test_subprocess_safe.py
+++ b/agents/lib/test_subprocess_safe.py
@@ -89,10 +89,13 @@ class SafeRunTests(unittest.TestCase):
 class ModuleSurfaceTests(unittest.TestCase):
     """The helper is exposed both via the module and via `agents.lib.safe_run`."""
 
-    def test_module_default_constant_is_thirty_seconds(self) -> None:
-        # AC1 pins the default at 30s. If you change the constant, update the
-        # runbook and the task description together.
-        self.assertEqual(DEFAULT_TIMEOUT_SECONDS, 30.0)
+    def test_module_default_constant_is_twenty_five_seconds(self) -> None:
+        # AC1 pins the default at 25s (reduced from 30s on 2026-08-20 to fix
+        # incident `agent-task-queue-script-subprocess-timeout-race-2026-08-20`:
+        # the 30s default raced the heartbeat's 30s exec timeout, leaving 0 bytes
+        # of stdout when python3 was SIGKILL'd mid-subprocess). If you change the
+        # constant, update the runbook and the task description together.
+        self.assertEqual(DEFAULT_TIMEOUT_SECONDS, 25.0)
 
     def test_safe_run_is_reexported_from_agents_lib_package(self) -> None:
         # AC2: `from agents.lib import safe_run` must work.
@@ -174,8 +177,8 @@ class SafePopenTests(unittest.TestCase):
                 proc.wait(timeout=5)
 
     def test_b_prime_default_constant_also_fires_within_window(self) -> None:
-        # Sanity: with the module's DEFAULT_TIMEOUT_SECONDS = 30, an explicit
-        # call to safe_popen(..., timeout=30) using a child that sleeps forever
+        # Sanity: with the module's DEFAULT_TIMEOUT_SECONDS = 25, an explicit
+        # call to safe_popen(..., timeout=25) using a child that sleeps forever
         # (or much longer than 30s) would raise TimeoutExpired. We exercise a
         # short timeout here to keep the test under a second; the intent is to
         # document that `safe_popen(timeout=...)` honours the supplied value.

--- a/docs/specs/agent-script-subprocess-safe-run-tech-design.md
+++ b/docs/specs/agent-script-subprocess-safe-run-tech-design.md
@@ -26,7 +26,7 @@ Originating PR #464 was right-shaped: minimal, scoped, reversible. Bundling a 13
 
 ## Product summary
 
-Consolidate the systemic pattern surfaced by `agent-task-queue-gh-api-hang-2026-08-17` onto a single shared helper so the next script author cannot reintroduce the unguarded-`subprocess.run` class of bug. The originating symptom was an indefinite heartbeat hang; the helper bounds every subprocess call site under `agents/skills/` and `agents/workflows/` at a default of 30s and propagates `subprocess.TimeoutExpired` unchanged for callers to handle.
+Consolidate the systemic pattern surfaced by `agent-task-queue-gh-api-hang-2026-08-17` onto a single shared helper so the next script author cannot reintroduce the unguarded-`subprocess.run` class of bug. The originating symptom was an indefinite heartbeat hang; the helper bounds every subprocess call site under `agents/skills/` and `agents/workflows/` at a default of 25s and propagates `subprocess.TimeoutExpired` unchanged for callers to handle.
 
 ## Ownership boundary check
 
@@ -48,7 +48,7 @@ from __future__ import annotations
 import subprocess
 from typing import Any
 
-DEFAULT_TIMEOUT_SECONDS: float = 30.0
+DEFAULT_TIMEOUT_SECONDS: float = 25.0
 
 
 def safe_run(


### PR DESCRIPTION
## Summary
- **Fix:** Reduce `safe_run` default timeout from 30s → 25s in `agents/lib/subprocess_safe.py`.
- **Why:** Incident `agent-task-queue-script-subprocess-timeout-race-2026-08-20` — the 30s/30s timeout race between `safe_run` and the heartbeat's 30s exec timeout left 0 bytes of stdout when python3 was SIGKILL'd mid-`gh api` call. The race is intermittent (silent 0-bytes hangs on some heartbeats, clean runs on others); Rowan, Quinn, and Ivy heartbeat discovery was degraded until this fix lands.
- **Effect:** `safe_run` raises `TimeoutExpired` ~5s before the parent exec timeout fires, giving python3 time to flush stdout and the heartbeat to see results. All 13 `safe_run` call sites work with the new default (verified — no per-call changes needed; explicit per-call timeouts like `request_topic_approval.py`'s 12s Telegram CLI bound are preserved unchanged).

## System Spec
No system spec change — CI/helper fix, no user-facing behaviour. `docs/specs/agent-script-subprocess-safe-run-tech-design.md` updated to keep the spec in sync with the helper's current default.

## Test plan
- [x] `python3 -m unittest agents.lib.test_subprocess_safe` — all 13 tests pass (verified locally on this branch)
- [x] Verify no other tests reference `DEFAULT_TIMEOUT_SECONDS = 30.0` (only `agents/lib/test_subprocess_safe.py:95`, updated)
- [x] Verify no infra/runbooks reference the 30s default (none found)
- [x] Verify all 13 `safe_run` call sites work with 25s default (manual review: explicit per-call timeouts preserved)

## Acceptance Criteria
- [x] AC1: `agents/lib/subprocess_safe.py` `DEFAULT_TIMEOUT_SECONDS` reduced from 30.0s to 25.0s, with docstring updated to explain the 5s margin rationale. (🧪 testID: agents.lib.test_subprocess_safe.test_module_default_constant_is_twenty_five_seconds)
- [x] AC2: `agents/lib/test_subprocess_safe.py` test assertion updated (test name `is_twenty_five_seconds`, assertion `assertEqual(DEFAULT_TIMEOUT_SECONDS, 25.0)`, comment explains the incident). (🧪 testID: agents.lib.test_subprocess_safe.test_module_default_constant_is_twenty_five_seconds)
- [x] AC3: All 13 existing `safe_run`/`safe_popen` tests still pass after the change. (🧪 testID: agents.lib.test_subprocess_safe)
- [x] AC4: `docs/specs/agent-script-subprocess-safe-run-tech-design.md` updated to reflect the new default (Product summary prose mention + API surface code-block). (📄 not code: updated tech design spec to keep it in sync with the helper's current value)
- [x] AC5: No call-site changes required — verified all 13 `safe_run` call sites work with the 25s default; per-call explicit timeouts (`request_topic_approval.py` 12s for Telegram CLI, `content-tasks/scripts/common.py` 30s explicit) preserved unchanged. (⚠️ not tested: manual review of all call sites — none needed >25s for normal operation; explicit per-call timeouts preserved unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)