### PR TITLE
fix(cto-craft): update archive HREF pattern to match TMW /tmw-NNN/ URL scheme

### DIFF
--- a/agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/issue_source.py
+++ b/agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/issue_source.py
@@ -46,7 +46,28 @@ class LatestIssue:
 # The selector patterns below are deliberately specific to the current
 # public TMW archive. Anything that returns no match on a known fixture
 # is treated as a parse error, not a silent no-op.
-_ARCHIVE_HREF_PATTERN = re.compile(r"^/issues?/[\w\-/]+/?$|^https?://[^/]+/issues?/[\w\-/]+/?$")
+#
+# TMW's URL scheme has drifted at least once (was ``/issue/<slug>`` before
+# the 2026 redesign; is now ``/tmw-<id>/``). When it drifts again the
+# pattern below is the only line that needs to change — see the
+# ``tests/fixtures/archive.html`` snapshot date in the test docstring for
+# the latest known-good scheme.
+#
+# The absolute alternative is scoped to TMW's own host on purpose: the
+# bare ``/tmw-`` prefix collides with cross-host URLs such as
+# ``https://ctocraft.com/tmw-sponsorship/`` that appear earlier in the
+# archive document than the real issue anchors and would otherwise be
+# picked as the "latest issue". Relative paths resolve against the
+# archive URL (which is always TMW's host), so the relative alternative
+# does not need the same scoping.
+_ARCHIVE_HREF_PATTERN = re.compile(
+    r"^/tmw-[\w\-/]+/?$"
+    r"|^https?://(?:[^/]+\.)?techmanagerweekly\.com/tmw-[\w\-/]+/?$"
+)
+# Article anchors inside an issue page are absolute third-party URLs
+# (e.g. staysaasy.com, lethain.com, substack.com) — those hosts are
+# unaffected by TMW's own URL-scheme drift, so this pattern doesn't need
+# the ``tmw-`` prefix and is intentionally broad.
 _ARTICLE_HREF_PATTERN = re.compile(r"^https?://[^/]+/[\w\-/]+/?$")
 
 

--- a/agents/workflows/cto-craft-tweet-drafts/tests/fixtures/archive.html
+++ b/agents/workflows/cto-craft-tweet-drafts/tests/fixtures/archive.html
@@ -1,4 +1,14 @@
 <!doctype html>
+<!--
+  TMW archive fixture. Snapshot taken 2026-08-19.
+
+  TMW's URL scheme changed during the 2026 redesign: post paths are now
+  ``/tmw-NNN/`` rather than the legacy ``/issue/<slug>``. The anchors in
+  this fixture reflect the live shape: ``class="u-permalink"`` and an
+  ``aria-label`` carrying the issue title — there is no inner anchor text
+  and no ``data-published-at`` attribute. Issue titles and numbers below
+  are real TMW posts (495→493) as of the snapshot date.
+-->
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -16,13 +26,13 @@
       <h2>Latest issues</h2>
       <ul>
         <li>
-          <a href="/issue/2026-08-04-slow-iteration" data-published-at="2026-08-04T09:00:00Z">Issue 412 — Slow iteration and the cost of delay</a>
+          <a class="u-permalink" href="/tmw-495/" aria-label="🐡 Unfocused Teams, Variation, Subtraction, Landing the Plane, Invisible Work, Stewardship, Energy Management: TMW #495"></a>
         </li>
         <li>
-          <a href="/issue/2026-07-28-boundaries" data-published-at="2026-07-28T09:00:00Z">Issue 411 — Boundaries, ownership, and the org chart</a>
+          <a class="u-permalink" href="/tmw-494/" aria-label="🍣 Good Judgment, Well-Rounded Leaders, Organisational Blindness, Agentic Quality, Finding Calm: TMW #494"></a>
         </li>
         <li>
-          <a href="/issue/2026-07-21-fluff" data-published-at="2026-07-21T09:00:00Z">Issue 410 — When 'communicate better' is the wrong prescription</a>
+          <a class="u-permalink" href="/tmw-493/" aria-label="🍓 Restless Teams, Two-Way Doors, AI and Team Tensions, Healthy Conflict, Open Weights, Bad Prioritisation, Token Pricing: TMW #493"></a>
         </li>
       </ul>
     </main>

--- a/agents/workflows/cto-craft-tweet-drafts/tests/test_graph.py
+++ b/agents/workflows/cto-craft-tweet-drafts/tests/test_graph.py
@@ -30,7 +30,7 @@ from cto_craft_workflow.state import make_initial_state
 
 
 ARCHIVE_URL = "https://www.techmanagerweekly.com/"
-ISSUE_URL = "https://www.techmanagerweekly.com/issue/2026-08-04-slow-iteration"
+ISSUE_URL = "https://www.techmanagerweekly.com/tmw-495/"
 STRONG_URL = "https://staysaasy.com/p/slow-iteration"
 GENERIC_URL = "https://lethain.com/fluff-receipts/"
 BOUNDARY_URL = "https://lethain.com/boundaries/"

--- a/agents/workflows/cto-craft-tweet-drafts/tests/test_issue_source.py
+++ b/agents/workflows/cto-craft-tweet-drafts/tests/test_issue_source.py
@@ -13,10 +13,42 @@ from cto_craft_workflow.issue_source import (
 
 def test_parse_archive_returns_latest_issue(archive_html: bytes) -> None:
     latest = parse_archive("https://www.techmanagerweekly.com/", archive_html)
-    assert latest.issue_url.endswith("/issue/2026-08-04-slow-iteration")
-    assert latest.issue_published_at == "2026-08-04T09:00:00Z"
+    # TMW's URL scheme changed during the 2026 redesign: post paths are
+    # now ``/tmw-NNN/`` rather than the legacy ``/issue/<slug>``. The
+    # archive fixture (snapshot 2026-08-19) reflects the live shape:
+    # anchors carry the slug only via href + aria-label; there is no
+    # inner anchor text and no ``data-published-at`` attribute.
+    assert latest.issue_url == "https://www.techmanagerweekly.com/tmw-495/"
+    # The current public archive does not expose metadata on the permalink
+    # anchor; both optional fields are None today. Coverage for the
+    # metadata propagation path is in ``test_parse_archive_propagates_metadata_when_present``.
+    assert latest.issue_published_at is None
+    assert latest.issue_title is None
+
+
+def test_parse_archive_propagates_metadata_when_present() -> None:
+    """Guards the optional title + ``data-published-at`` propagation path.
+
+    The live TMW archive does not currently set either attribute on the
+    permalink anchor, but the parser contract still allows for them
+    (``LatestIssue`` declares both fields as Optional). If a future TMW
+    redesign re-introduces either attribute, the parser must surface it
+    verbatim.
+    """
+
+    body = (
+        b'<html><body><main>'
+        b'<a class="u-permalink" href="/tmw-495/" '
+        b'data-published-at="2026-08-17T09:00:00Z">'
+        b'Issue 495 \xe2\x80\x94 Slow iteration and the cost of delay'
+        b'</a>'
+        b"</main></body></html>"
+    )
+    latest = parse_archive("https://www.techmanagerweekly.com/", body)
+    assert latest.issue_url == "https://www.techmanagerweekly.com/tmw-495/"
+    assert latest.issue_published_at == "2026-08-17T09:00:00Z"
     assert latest.issue_title is not None
-    assert "412" in latest.issue_title
+    assert "Slow iteration" in latest.issue_title
 
 
 def test_parse_archive_skips_social_and_nav_links(archive_html: bytes) -> None:
@@ -27,6 +59,25 @@ def test_parse_archive_skips_social_and_nav_links(archive_html: bytes) -> None:
     assert "linkedin.com" not in latest.issue_url
 
 
+def test_parse_archive_ignores_cross_host_tmw_prefix() -> None:
+    """TMW's bare ``/tmw-`` prefix collides with cross-host URLs like
+    ``https://ctocraft.com/tmw-sponsorship/`` that appear earlier in
+    the archive document than the real issue permalinks. The absolute
+    alternative of the regex must be scoped to TMW's own host so a
+    cross-host ``/tmw-*`` URL never shadows a real ``/tmw-<id>/`` issue
+    anchor.
+    """
+
+    body = (
+        b"<html><body>"
+        b'<a href="https://ctocraft.com/tmw-sponsorship/">Sponsor</a>'
+        b'<a class="u-permalink" href="/tmw-495/">Issue 495</a>'
+        b"</body></html>"
+    )
+    latest = parse_archive("https://www.techmanagerweekly.com/", body)
+    assert latest.issue_url == "https://www.techmanagerweekly.com/tmw-495/"
+
+
 def test_parse_archive_raises_on_unknown_layout() -> None:
     body = b"<html><body><p>no anchors here</p></body></html>"
     with pytest.raises(ParseError) as exc_info:
@@ -34,9 +85,27 @@ def test_parse_archive_raises_on_unknown_layout() -> None:
     assert exc_info.value.code == "ARCHIVE_NO_ISSUE"
 
 
+def test_parse_archive_raises_when_legacy_scheme_returns() -> None:
+    """If TMW ever moves off ``/tmw-*`` URLs again, the parser must fail
+    loudly with ``ARCHIVE_NO_ISSUE`` rather than silently no-op. This is
+    the same drift-detection signal that surfaced the 2026 redesign bug.
+    """
+
+    body = (
+        b'<html><body><main>'
+        b'<a href="/issue/2026-08-04-slow-iteration">'
+        b"Issue 412 \xe2\x80\x94 Slow iteration and the cost of delay"
+        b"</a>"
+        b"</main></body></html>"
+    )
+    with pytest.raises(ParseError) as exc_info:
+        parse_archive("https://www.techmanagerweekly.com/", body)
+    assert exc_info.value.code == "ARCHIVE_NO_ISSUE"
+
+
 def test_parse_issue_links_returns_deduped_articles(issue_html: bytes) -> None:
     links = parse_issue_links(
-        "https://www.techmanagerweekly.com/issue/2026-08-04-slow-iteration",
+        "https://www.techmanagerweekly.com/tmw-495/",
         issue_html,
         max_links=30,
     )
@@ -51,7 +120,7 @@ def test_parse_issue_links_returns_deduped_articles(issue_html: bytes) -> None:
 
 def test_parse_issue_links_strips_tracking_query(issue_html: bytes) -> None:
     links = parse_issue_links(
-        "https://www.techmanagerweekly.com/issue/2026-08-04-slow-iteration",
+        "https://www.techmanagerweekly.com/tmw-495/",
         issue_html,
         max_links=30,
     )
@@ -62,7 +131,7 @@ def test_parse_issue_links_strips_tracking_query(issue_html: bytes) -> None:
 
 def test_parse_issue_links_respects_max_links(issue_html: bytes) -> None:
     links = parse_issue_links(
-        "https://www.techmanagerweekly.com/issue/2026-08-04-slow-iteration",
+        "https://www.techmanagerweekly.com/tmw-495/",
         issue_html,
         max_links=2,
     )
@@ -73,7 +142,7 @@ def test_parse_issue_links_raises_when_no_articles() -> None:
     body = b"<html><body><a href='/about'>About</a></body></html>"
     with pytest.raises(ParseError) as exc_info:
         parse_issue_links(
-            "https://www.techmanagerweekly.com/issue/2026-08-04-slow-iteration",
+            "https://www.techmanagerweekly.com/tmw-495/",
             body,
             max_links=30,
         )


### PR DESCRIPTION
## Summary

- TMW's URL scheme changed from `/issue/<slug>` to `/tmw-<id>/` during their 2026 redesign. The previous regex `_ARCHIVE_HREF_PATTERN = re.compile(r"^/issues?/[\w\-/]+/?$|...")` in `agents/workflows/cto-craft-tweet-drafts/src/cto_craft_workflow/issue_source.py` only matched the legacy `/issue/` shape, so `parse_archive` raised `ParseError("ARCHIVE_NO_ISSUE", ...)` on every real fetch and `discover_latest_issue` returned `outcome="failed"` — including the Monday 08:00 AKL cron run.
- Update `_ARCHIVE_HREF_PATTERN` to match `/tmw-*` paths and scope the absolute alternative to `techmanagerweekly.com`. The bare `/tmw-` prefix collides with cross-host URLs such as `https://ctocraft.com/tmw-sponsorship/` (the sponsor nav link on the live archive) which would otherwise be picked as the "latest issue" since it appears earlier in the document than the real permalink anchors. Relative paths are safe without scoping because `_http_or_relative` resolves them against the archive URL (always TMW's host).
- Refresh `tests/fixtures/archive.html` to mirror the live shape: anchors carry `class="u-permalink"` and `aria-label="..."` with no inner anchor text and no `data-published-at` attribute (the live page doesn't expose either today).
- Add three regression tests:
  - `test_parse_archive_propagates_metadata_when_present` — covers the metadata propagation path if a future TMW redesign re-introduces `data-published-at` or anchor text.
  - `test_parse_archive_ignores_cross_host_tmw_prefix` — guards the sponsor-URL shadow-pick hazard (live regression from this bug).
  - `test_parse_archive_raises_when_legacy_scheme_returns` — ensures the parser fails loudly (`ParseError` rather than silent no-op) the next time TMW drifts.
- Update `ISSUE_URL` constant in `tests/test_graph.py` to point at `/tmw-495/` to match the new fixture.

`_ARTICLE_HREF_PATTERN` was checked against the live issue page and is unchanged: article anchors inside an issue page are absolute third-party URLs (e.g. `https://staysaasy.com/...`) that the new TMW URL scheme does not affect.

## System Spec

No system spec change — this is an isolated parser bugfix unblocking the already-merged task `9dfe56e4-13c4-4bb4-b53f-de7c77afd0d2` (PR #434). No `docs/systems/*.md` or `apps/<app>/SPEC.md` was modified.

## Test plan

- [x] `cd agents/workflows/cto-craft-tweet-draft s && uv sync --frozen --extra dev && uv run --frozen pytest tests/` → **45 passed** (was 6 failing on the original code against the live URL scheme). Includes the 3 new regression tests.
- [x] Live smoke test against `https://www.techmanagerweekly.com/` at 2026-08-19 ~20:57 UTC — `parse_archive` returns `https://www.techmanagerweekly.com/tmw-495/` (latest issue, dated 2026-08-17) as expected.
- [x] Verified `discover_latest_issue` no longer raises `ARCHIVE_NO_ISSUE` ParseError against the live archive.

## Caveats (out of scope, surfaced for follow-up)

Pre-existing observations from the live smoke test, not regressions introduced by this fix. Surfacing them so a future PR can decide:

1. **Substack article blocklist.** `_NEVER_LINK_HOST_HINTS` includes `"substack.com"` and the live issue pages link to ~7 substack articles per issue (e.g. `mikefisher.substack.com/p/the-subtraction-instinct`). All are filtered out by `_is_probably_article`. This means a meaningful share of TMW's recommended reads never reach the angle model. TMW appears to have shifted toward substack-hosted content; the blocklist may need rethinking.
2. **CTO Craft promo links pass `is_probably_article`.** `https://ctocraft.com/community`, `https://ctocraft.com/tmw-sponsorship/`, `https://conference.ctocraft.com/...` all parse as articles (host not in blocklist, non-empty path). They get fanned out and the angle model scores them low. Not blocking, but adds noise to the weekly run.

Neither of these blocks Monday's cron — the parser bug was the blocker. Happy to follow up as a separate task if Tom wants either of them tightened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)