### PR TITLE
fix(tasks): update approval labels for Ash's qa_agent/accepted gate split

### DIFF
--- a/apps/tasks/SPEC.md
+++ b/apps/tasks/SPEC.md
@@ -29,7 +29,7 @@ A focused task management surface for Tom and the agent team. Supports capturing
 4. Rendered markdown description content wraps within the task card instead of overflowing horizontally
 5. User can navigate to a full-screen detail view via explicit action
 6. Changes persist on save
-7. An **Approvals** sub-section renders one row per required approval type for the task's type (`spec`, `tech_design`, `qa`):
+7. An **Approvals** sub-section renders one row per required approval type for the task's type (`spec`, `tech_design`, `qa_agent`, `accepted`):
    - An unchecked checkbox approves through structured `POST /tasks/:id/approvals` with `{ type }`; a checked checkbox revokes through `DELETE /tasks/:id/approvals/:type`.
    - The browser includes an HttpOnly-cookie session and never supplies an approval owner; the API derives ownership from the authenticated principal.
    - Tasks remain readable while signed out. On load the UI checks `GET /auth/session`; changing an approval while signed out opens a minimal username/password login gate backed by `POST /auth/session`. The password is held only in the form state, cleared after submission/cancel, and never stored in JavaScript storage.
@@ -102,7 +102,7 @@ detail-view composer land in WS3.
    task field untouched. Removing one row only removes that row.
 5. No UI affordance should generate an attention request when an
    explicit workflow gate already represents the action. When a user
-   opens a structured approval (spec / tech_design / qa), the
+   opens a structured approval (spec / tech_design / qa_agent / accepted), the
    approval-row UX is the only path; the attention-editor UX never
    surfaces for the same action.
 
@@ -115,7 +115,7 @@ composer for the new planes land in WS3.
 1. The backlog exposes two ownership filter chips:
    * "My outstanding gates" — toggles `?workflowGateOwner=<self>` to
      surface tasks where the signed-in user owns an outstanding
-     structured gate (spec / tech_design / qa).
+     structured gate (spec / tech_design / qa_agent / accepted).
    * "Needs my attention" — toggles `?attentionOwner=<self>` to surface
      tasks with an exceptional / unmodelled attention request for the
      signed-in user, visually labelled as exceptional so it never

--- a/apps/tasks/src/components/ApprovalsSection.jsx
+++ b/apps/tasks/src/components/ApprovalsSection.jsx
@@ -13,7 +13,8 @@ import { assigneeDisplayName, findAssigneeUser } from '../users/assignees.js';
 const APPROVAL_LABELS = {
   spec: 'Spec',
   tech_design: 'Tech Design',
-  qa: 'QA'
+  qa_agent: 'QA (Ash)',
+  accepted: 'Accepted'
 };
 
 function findApprovalForType(approvals, type) {

--- a/apps/tasks/src/components/ApprovalsSection.test.jsx
+++ b/apps/tasks/src/components/ApprovalsSection.test.jsx
@@ -24,7 +24,7 @@ vi.mock('../tasksApi.ts', async () => {
 
 const { ApprovalsSection } = await import('./ApprovalsSection.jsx');
 
-const required = (types = ['spec', 'tech_design', 'qa']) => ({
+const required = (types = ['spec', 'tech_design', 'qa_agent', 'accepted']) => ({
   taskType: 'feature', requiredApprovals: types, version: 1, source: 'builtin-default'
 });
 const approved = {
@@ -45,7 +45,7 @@ describe('ApprovalsSection', () => {
     fetchRequiredApprovalsMock.mockReset();
     createTaskApprovalMock.mockReset();
     deleteTaskApprovalMock.mockReset();
-    fetchAuthSessionMock.mockReset().mockResolvedValue({ actor: 'Tom', approvalTypes: ['spec', 'qa'] });
+    fetchAuthSessionMock.mockReset().mockResolvedValue({ actor: 'Tom', approvalTypes: ['spec', 'qa_agent'] });
     loginMock.mockReset();
     logoutMock.mockReset();
   });
@@ -65,7 +65,7 @@ describe('ApprovalsSection', () => {
   it('prompts anonymous users to sign in, keeps credentials ephemeral, then performs the requested approval', async () => {
     fetchAuthSessionMock.mockRejectedValue(new Error('Unauthenticated'));
     fetchRequiredApprovalsMock.mockResolvedValue(required(['spec']));
-    loginMock.mockResolvedValue({ actor: 'Tom', approvalTypes: ['spec', 'qa'] });
+    loginMock.mockResolvedValue({ actor: 'Tom', approvalTypes: ['spec', 'qa_agent'] });
     createTaskApprovalMock.mockResolvedValue(approved);
     render(<ApprovalsSection task={{ id: 'task-1', taskType: 'feature', approvals: [] }} />);
 
@@ -99,12 +99,12 @@ describe('ApprovalsSection', () => {
   it('optimistically approves one row, disables only that row, and refreshes the parent', async () => {
     const mutation = deferred();
     const onTaskRefresh = vi.fn().mockResolvedValue(undefined);
-    fetchRequiredApprovalsMock.mockResolvedValue(required(['spec', 'qa']));
+    fetchRequiredApprovalsMock.mockResolvedValue(required(['spec', 'qa_agent']));
     createTaskApprovalMock.mockReturnValue(mutation.promise);
     render(<ApprovalsSection task={{ id: 'task-1', taskType: 'feature', approvals: [] }} onTaskRefresh={onTaskRefresh} />);
 
     const spec = await screen.findByRole('checkbox', { name: 'Spec approval' });
-    const qa = screen.getByRole('checkbox', { name: 'QA approval' });
+    const qa = screen.getByRole('checkbox', { name: 'QA (Ash) approval' });
     await userEvent.click(spec);
 
     expect(spec).toBeChecked();

--- a/apps/tasks/src/tasksApi.ts
+++ b/apps/tasks/src/tasksApi.ts
@@ -85,7 +85,7 @@ export interface CreateCommentPayload {
   text: string;
 }
 
-export type ApprovalType = 'spec' | 'tech_design' | 'qa';
+export type ApprovalType = 'spec' | 'tech_design' | 'qa_agent' | 'accepted';
 export type ApprovalState = 'approved' | 'revoked';
 
 export interface TaskApproval {


### PR DESCRIPTION
## Summary
- Tom noticed every task card showed two blank approval circles. Root cause: PR #1 of Ash's onboarding (`a90f737`) renamed the backend's approval-type schema from `{spec, tech_design, qa}` to `{spec, tech_design, qa_agent, accepted}`, but the frontend `APPROVAL_LABELS` map, the `ApprovalType` TS union, and `apps/tasks/SPEC.md` were never updated — so the two new rows rendered with `undefined` label/tooltip/owner.
- Updated `ApprovalsSection.jsx`'s `APPROVAL_LABELS` to `qa_agent: 'QA (Ash)'` and `accepted: 'Accepted'`, updated the `ApprovalType` TS union in `tasksApi.ts` to match, and updated the stale approval-type examples in `apps/tasks/SPEC.md`.
- Updated `ApprovalsSection.test.jsx`, which was asserting against the old `qa` type and was the one test actually exercising this bug (it now fails without the fix, passes with it).
- Separately answered Tom's related question in chat: Ash's avatar showing on nearly every task in the attention stack is expected, not a bug — `qa_agent` is now a required approval on every `feature`/`code`/`content` task with a default gate owner of `Ash` (`services/tasks-api/src/config/requiredApprovals.ts`), so her avatar surfaces as the outstanding workflow-gate owner until she verifies.

## System Spec
No `docs/systems/*.md` change — this is a UI label/type fix, not a new system capability.

`apps/tasks/SPEC.md` updated (three references to the stale `spec / tech_design / qa` approval-type enumeration corrected to include `qa_agent` / `accepted`).

## Test plan
- [x] `npx vitest run src/components/ApprovalsSection.test.jsx src/components/StackedAvatarGroup.test.jsx src/tasksApi.test.ts` — 49/49 passing (was 48/49 before the fix; `ApprovalsSection.test.jsx` failed on the stale `qa` type)
- [x] `npx vitest run` (full `apps/tasks` suite) — 212/212 passing
- [ ] Tom to eyeball a task card in the app and confirm both new rows now show "QA (Ash)" and "Accepted" labels/avatars instead of blank circles

🤖 Generated with Claude Code