### PR TITLE
fix(tasks-api): scope workflow gates to current status

### DIFF
--- a/services/tasks-api/src/routes/tasks/_mapper.ts
+++ b/services/tasks-api/src/routes/tasks/_mapper.ts
@@ -61,13 +61,11 @@ export function mapTaskAttentionOwner(attentionOwners) {
  *
  * Generalisation rationale (PR #2 f6a4d56a): the legacy single-source
  * shape derived `workflowGates` from the singular `task.workflowHandoffRoleId`
- * column — only one outstanding gate could be surfaced at a time, which
- * forces the lobster and the UI to model two distinct gates (Ash's
- * mechanical verification + Tom's human sign-off) as a single attention
- * queue. PR #2 derives `workflowGates` from ALL required approval types for
- * the task's `taskType`, so the UI can show both `qa_agent` (Ash) and
- * `accepted` (Tom) as simultaneous outstanding gates on a task in
- * `acceptance`.
+ * column — only one outstanding gate could be surfaced at a time. The mapper
+ * now derives gates from the required approval types for the task's
+ * `taskType`, but scopes them to the current workflow transition so the UI
+ * shows only the owner whose approval is actionable at the task's current
+ * status.
  *
  * The `task.workflowHandoffRoleId` / `workflowHandoffGate` /
  * `workflowHandoffReason` columns remain populated (they still drive the
@@ -99,6 +97,13 @@ export function buildMapTaskOptions(
   return { requiredApprovalTypes: required, gateOwnersByType };
 }
 
+const ACTIONABLE_STATUS_BY_APPROVAL_TYPE: Readonly<Record<string, string>> = {
+  spec: 'open',
+  tech_design: 'ready',
+  qa_agent: 'doing',
+  accepted: 'acceptance'
+};
+
 export function mapTask(task, options) {
 
   const dependsOn = task.dependencies
@@ -118,13 +123,16 @@ export function mapTask(task, options) {
   const attentionOwners = attentionOwnerRows.map((row) => row.owner);
 
   const workflowHandoffOwner = workflowHandoffOwnerFor(task.workflowHandoffRoleId);
-  // PR #2 (f6a4d56a) generalisation: derive `workflowGates` from the
-  // required approval types configured for this task's `taskType`, joined
-  // with the configured owner per type and the task's structured approval
-  // rows. Any required approval type whose row is not in `state: approved`
-  // (including missing rows and `revoked` rows) is surfaced as an
-  // outstanding gate. This is what makes Ash's `qa_agent` gate and Tom's
-  // `accepted` gate simultaneously visible on a task in `acceptance`.
+  // Derive `workflowGates` from required approval types, configured owners,
+  // structured approval rows, and the task's current workflow stage. A gate
+  // is actionable only on the transition it controls:
+  // open → spec, ready → tech_design, doing → qa_agent,
+  // acceptance → accepted. `done` has no actionable approval gate.
+  //
+  // This status scoping prevents future requirements (for example Tom's
+  // `accepted` sign-off) from appearing in the avatar stack while a task is
+  // still in `doing`, and prevents already-passed gates from reappearing when
+  // their approval row is missing or revoked on an inconsistent task record.
   const requiredApprovalTypes = options?.requiredApprovalTypes ?? [];
   const gateOwnersByType = options?.gateOwnersByType ?? {};
   const approvedTypes = new Set(
@@ -133,6 +141,7 @@ export function mapTask(task, options) {
       .map((a) => a.type)
   );
   const derivedGates = requiredApprovalTypes
+    .filter((approvalType) => ACTIONABLE_STATUS_BY_APPROVAL_TYPE[approvalType] === task.status)
     .filter((approvalType) => !approvedTypes.has(approvalType))
     .map((approvalType) => ({
       roleId: `${approvalType}_gate`,

--- a/services/tasks-api/test/workflowGatesRouteLayer.test.ts
+++ b/services/tasks-api/test/workflowGatesRouteLayer.test.ts
@@ -512,6 +512,47 @@ describe('loadRequiredApprovalsConfig — owners merge with defaults', () => {
   });
 });
 
+describe('mapTask — status-scoped workflow gates', () => {
+  const options = {
+    requiredApprovalTypes: ['spec', 'tech_design', 'qa_agent', 'accepted'],
+    gateOwnersByType: {
+      spec: 'Tom',
+      tech_design: 'Quinn',
+      qa_agent: 'Ash',
+      accepted: 'Tom'
+    }
+  };
+
+  it.each([
+    ['open', 'spec', 'Tom'],
+    ['ready', 'tech_design', 'Quinn'],
+    ['doing', 'qa_agent', 'Ash'],
+    ['acceptance', 'accepted', 'Tom']
+  ])('shows only the gate actionable at status %s', (status, gate, owner) => {
+    expect(mapTask(baseTaskFixture({ status }), options).workflowGates).toEqual([{
+      roleId: `${gate}_gate`,
+      owner,
+      gate,
+      reason: null,
+      state: 'outstanding'
+    }]);
+  });
+
+  it('shows no workflow gate once the task is done', () => {
+    expect(mapTask(baseTaskFixture({ status: 'done' }), options).workflowGates).toEqual([]);
+  });
+
+  it('omits the current stage gate when its structured approval is active', () => {
+    expect(mapTask(baseTaskFixture({
+      status: 'doing',
+      approvals: [{
+        id: 'qa', type: 'qa_agent', owner: 'Ash', state: 'approved',
+        approvedAt: new Date(), revokedAt: null, createdAt: new Date(), updatedAt: new Date()
+      }]
+    }), options).workflowGates).toEqual([]);
+  });
+});
+
 describe('explicit workflow handoffs', () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -579,16 +620,13 @@ describe('explicit workflow handoffs', () => {
         workflowHandoffGate: 'qa'
       })
     }));
-    // The response derives workflowGates from the required-approvals
-    // config for this task's `taskType`; with no approvals set, the four
-    // feature gates (spec / tech_design / qa_agent / accepted) are all
-    // outstanding, each owned by the type's configured owner.
-    expect(response.body.data.workflowGates).toEqual(expect.arrayContaining([
-      expect.objectContaining({ gate: 'spec', owner: 'Tom', state: 'outstanding' }),
-      expect.objectContaining({ gate: 'tech_design', owner: 'Quinn', state: 'outstanding' }),
-      expect.objectContaining({ gate: 'qa_agent', owner: 'Ash', state: 'outstanding' }),
-      expect.objectContaining({ gate: 'accepted', owner: 'Tom', state: 'outstanding' })
-    ]));
+    // The response derives workflowGates from the required-approvals config
+    // and scopes it to the task's current status. `baseTaskFixture` is in
+    // `doing`, so Ash's qa_agent gate is the only actionable approval; Tom's
+    // accepted gate remains hidden until the task reaches `acceptance`.
+    expect(response.body.data.workflowGates).toEqual([
+      expect.objectContaining({ gate: 'qa_agent', owner: 'Ash', state: 'outstanding' })
+    ]);
   });
 
   it('rejects unknown role ids before writing', async () => {


### PR DESCRIPTION
## Summary

- Scope derived `workflowGates` to the task's current workflow transition instead of surfacing every unapproved requirement for the task type.
- Map approval ownership to the status where it is actionable: `spec → open`, `tech_design → ready`, `qa_agent → doing`, `accepted → acceptance`; `done` exposes no approval gate.
- Keep structured approval state authoritative: an already-approved current-stage gate remains omitted.
- Update the stale mapper comment that described Ash and Tom as simultaneously visible in `acceptance`; the avatar stack now represents the next actionable owner only.

## Why

`mapTask` previously calculated `requiredApprovalTypes - approvedTypes` without considering `task.status`. As a result, `doing` tasks displayed both Ash's `qa_agent_gate` and Tom's future `accepted_gate`, and could also display already-passed spec/design owners when rows were missing or revoked. The UI should show who owns the current transition, not every eventual requirement.

## System Spec

No system spec change — this corrects the existing Tasks API `workflowGates` response semantics to match the lobster workflow status order and current-transition ownership model.

## Test plan

- [x] Focused mapper/route suite: `npm test --workspace @sindustries/tasks-api -- --run test/workflowGatesRouteLayer.test.ts` → **44 passed**.
- [x] Added table-driven coverage for `open`, `ready`, `doing`, `acceptance`, and `done`, plus an approved-current-gate case.
- [x] Updated route-layer assertion: a `doing` feature task exposes only Ash's `qa_agent` gate, not spec, tech design, or accepted.
- [x] `git diff --check` passes.
- [ ] Full Tasks API suite currently has one unrelated origin/main failure: `contentSchedulerImport.test.ts` expects 201 but receives 401. Reproduced the same failure after stashing this PR's changes; focused workflow-gate coverage is green.

## Review routing

Tom is the blocking reviewer for this direct ask. Quinn is included for normal code review/visibility.

🤖 Generated with Claude Code