### PR TITLE
fix(crons): cd into cto-craft-tweet-drafts workflow dir before uv run (incident cto-craft-tweet-drafts-cron-runtime-2026-08-20)

### DIFF
--- a/agents/crons/prompts/cto-craft-tweet-drafts.md
+++ b/agents/crons/prompts/cto-craft-tweet-drafts.md
@@ -2,20 +2,32 @@ Run the CTO Craft recurring tweet-draft workflow and report the result.
 
 # Workflow
 
-1. Run the workflow CLI once from the canonical repo checkout:
+1. Run the workflow CLI once from its own uv-managed workspace so
+   that the workflow's `uv.lock` + `.venv` (which has
+   `cto-craft-workflow` installed) is used:
 
    ```bash
-   cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries
+   cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/cto-craft-tweet-drafts
    CTO_CRAFT_LANGGRAPH_DATABASE_URL="<from secrets>" \
    CONTENT_SCHEDULER_BASE_URL="https://api.sindustries.dev" \
    CONTENT_SCHEDULER_INGEST_SECRET="<from secrets>" \
-     uv run --frozen python agents/workflows/cto-craft-tweet-drafts/run.py run --json
+     uv run --frozen python run.py run --json
    ```
 
    The cron runtime provisions the three secrets above (the database URL
    for the LangGraph checkpointer, the Content Scheduler base URL, and
    the shared ingest secret). Local dev / CI may omit them for the
    `--dry-run` mode, which uses embedded fixtures and the FakeAngleModel.
+
+   **Why the `cd` lands inside the workflow directory, not the repo
+   root:** `cto-craft-workflow` is its own uv-managed workspace with a
+   separate `pyproject.toml` + `uv.lock` + `.venv`. Running `uv run`
+   from the parent repo root would resolve against the parent's
+   `uv.lock`, which does not include `cto-craft-workflow`, and the
+   `from cto_craft_workflow.cli import main` import in `run.py` would
+   fail with `ModuleNotFoundError`. The diff is reproducible:
+   `cd <workflow> && uv run --frozen python run.py --help` works,
+   `cd .. && uv run --frozen python <workflow>/run.py --help` fails.
 
 2. Parse the JSON envelope on stdout. It looks like:
 


### PR DESCRIPTION
## Root cause

The cto-craft-tweet-drafts cron prompt (`agents/crons/prompts/cto-craft-tweet-drafts.md`) was running `uv run --frozen python agents/workflows/cto-craft-tweet-drafts/run.py run --json` from the **parent sindustries directory**.

`cto-craft-workflow` is its own uv-managed workspace at `agents/workflows/cto-craft-tweet-drafts/` with a separate `pyproject.toml` + `uv.lock` + `.venv`. The parent's `uv.lock` does **not** include `cto-craft-workflow`, so the import `from cto_craft_workflow.cli import main` (at `run.py:13`) failed with `ModuleNotFoundError: No module named 'cto_craft_workflow'` on every Monday 08:00 AKL cron run.

Lox filed incident `cto-craft-tweet-drafts-cron-runtime-2026-08-20` (severity=medium, owner=rowan, coOwner=quinn) after reproducing the failure with two commands (see Verification below).

## Fix (Option A — surgical, smallest blast radius)

Change the cron prompt's `cd` target to land **inside** the workflow's own directory, so `uv run --frozen` resolves against the workflow's `uv.lock` + `.venv` (which has `cto-craft-workflow` installed).

```bash
cd /Users/quinnstoffer/.openclaw/workspace/codebases/sindustries/agents/workflows/cto-craft-tweet-drafts
CTO_CRAFT_LANGGRAPH_DATABASE_URL="<from secrets>" \
CONTENT_SCHEDULER_BASE_URL="https://api.sindustries.dev" \
CONTENT_SCHEDULER_INGEST_SECRET="<from secrets>" \
  uv run --frozen python run.py run --json
```

Also added a one-paragraph **Why the `cd` lands inside the workflow directory, not the repo root** note directly in the prompt so the next person doesn't re-introduce the regression.

## Other options considered (and rejected)

- **B:** Add cto-craft-workflow as a workspace member in parent's `pyproject.toml`. Bigger structural change; modifies the parent repo's workspace layout for a single-workflow fix.
- **C:** Install cto-craft-workflow in parent's venv via `uv pip install -e ...`. Creates duplicate state, brittle, and would re-break if parent ever rebuilds its venv from scratch.

Option A is the surgical fix.

## Verification (smoke-tested in worktree)

Reproduced Lox's two-command diff verbatim in this worktree (`fix-cto-craft-tweet-drafts-cron-prompt`):

1. `cd agents/workflows/cto-craft-tweet-drafts && uv run --frozen python run.py --help` → ✅ **SUCCESS**
   - Output: `usage: cto-craft-workflow [-h] {validate,run,replay} ...` (the workflow CLI loads)
   - `uv` created a fresh `.venv` in the worktree, installed 43 packages including `cto-craft-workflow`, no `ModuleNotFoundError`
2. `cd agents/workflows && uv run --frozen python cto-craft-tweet-drafts/run.py --help` → ❌ **FAILURE**
   - Same `ModuleNotFoundError: No module named 'cto_craft_workflow'` from `run.py:13`
   - Confirms the parent-dir `uv run` path is still broken (which is what the cron was hitting)

Post-fix: the cron will resolve against the workflow's own `.venv`, so the import succeeds and the workflow can run end-to-end. Next cron run is **Monday 2026-08-25 08:00 AKL** (5 days from now) — plenty of headroom.

## Followups (out of scope for this PR)

- Once the cron runs cleanly Monday, Tom can grant the `accepted` TaskApproval on `9dfe56e4` (CTO Craft pipeline task, currently `post_merge_blocked`), unblocking the pipeline.
- This is the third CTO Craft ops issue in Rowan's domain recently (after TMW-discovery URL pattern PR #487 and the `[accepted]` gate on `9dfe56e4`). All are now in flight.

## Risk

Lowest. One-line path change in a cron prompt; no code-path changes; no API changes; no DB changes. If the workflow's `.venv` is ever wiped, the next `uv run --frozen` will rebuild it (Lox's reproduction confirmed this in the worktree — fresh `.venv` was created and 43 packages installed cleanly).