### PR TITLE
fix(tasks): surface Ash current gate queue

### DIFF
--- a/agents/definitions/ash/HEARTBEAT.md
+++ b/agents/definitions/ash/HEARTBEAT.md
@@ -3,22 +3,26 @@
 **Scope of this file:** when Ash discovers work and what triggers action. See
 `WORKFLOW.md` for execution and routing.
 
-1. Query active tasks where Ash is the **top** attention owner:
+1. Build Ash's unified queue:
 
    ```bash
-   python3 agents/skills/ops/tasks-api/tasks_api_client.py list \
-     --attention-owner Ash \
-     --status ready --status doing --status acceptance
+   python3 agents/skills/ops/tasks-api/scripts/agent_task_queue.py \
+     --assignee Ash --json
    ```
 
-   The API filter is position-0-only. Do not act merely because Ash owns an
-   outstanding `qa_agent` gate; that gate is eligibility/context, not routing.
+   The queue fetches both `attentionOwner=Ash` and
+   `workflowGateOwner=Ash`. Routing precedence is strict:
 
-2. Hydrate each result and confirm `attentionOwners[0] == "Ash"`
-   case-insensitively. Later Ash slots are dormant. Preserve duplicate slots.
-3. Take one concrete action on the highest-priority actionable task through
-   `WORKFLOW.md`. Future-stage gates remain dormant; only the exact gate for the
-   task's current status may be evaluated.
+   - when `attentionOwners` is populated, only position 0 acts; every gate-owner
+     fallback and later attention slot is dormant;
+   - when `attentionOwners` is empty, Ash may act on an outstanding gate only if
+     it is the exact gate for the current stage (`doing → qa_agent` for Ash);
+   - stale, approved, and future-stage gates are never actionable.
+
+2. Hydrate the top candidate and re-confirm its attention stack, current status,
+   gate type, state, and owner before acting. Preserve duplicate role slots.
+3. Take one concrete action through `WORKFLOW.md`.
 4. Do not scan comments for routing tags. Comments may supply evidence/history,
-   but the attention stack is authoritative.
-5. If no task has Ash at position 0, return `HEARTBEAT_OK`.
+   but attention position 0 and the empty-attention current-gate fallback are
+   the control state.
+5. If neither rule yields an actionable task, return `HEARTBEAT_OK`.

--- a/agents/definitions/ash/TOOLS.md
+++ b/agents/definitions/ash/TOOLS.md
@@ -16,7 +16,9 @@ never write or rotate them from an ordinary QA pass.
 Use `agents/skills/ops/tasks-api/tasks_api_client.py` for task reads/writes.
 `attentionOwners` is a full ordered replacement, not a set:
 
-- index 0 acts now;
+- index 0 acts now whenever the stack is populated;
+- when the stack is empty, the exact current outstanding workflow-gate owner is
+  the fallback actor;
 - later slots are dormant escalation targets;
 - repeated names are intentional role slots and must not be deduplicated;
 - comments are audit/evidence only and never route work.

--- a/agents/definitions/ash/WORKFLOW.md
+++ b/agents/definitions/ash/WORKFLOW.md
@@ -8,16 +8,20 @@ belongs in `HEARTBEAT.md`.
 Keep these ordered role slots separate:
 
 - `assignee`: delivery owner;
-- `workflowGates`: eligibility/context owner for the current lifecycle gate;
-- `attentionOwners[0]`: the only current actor;
+- `workflowGates`: eligibility/context owner and, only when the attention stack
+  is empty, fallback actor for the exact current lifecycle gate;
+- `attentionOwners[0]`: authoritative current actor whenever the stack exists;
 - later `attentionOwners`: dormant escalation targets.
 
-Ash owning `qa_agent` never automatically makes Ash the attention owner. The
-Tasks API mapper is stage-aware: `open → spec`, `ready → tech_design`, `doing →
-qa_agent`, `acceptance → accepted`. Ignore stale and future gate owners. Repeated
-people across or within planes are meaningful and must remain visible.
+Ash owning `qa_agent` never creates or replaces an attention-owner row. It does
+make Ash actionable as the gate-owner fallback when `attentionOwners` is empty,
+the gate is outstanding, and the task is in `doing`. The Tasks API mapper is
+stage-aware: `open → spec`, `ready → tech_design`, `doing → qa_agent`,
+`acceptance → accepted`. Ignore stale, approved, and future gates. If any
+attention owner exists, position 0 acts and Ash's gate fallback is dormant.
+Repeated people across or within planes are meaningful and must remain visible.
 
-## When Ash is position 0
+## When Ash is actionable
 
 1. Fetch the full task and current delivery PR.
 2. For a `doing` task with the current `qa_agent` gate, run the verifier in

--- a/agents/definitions/test_definitions.py
+++ b/agents/definitions/test_definitions.py
@@ -38,6 +38,8 @@ class AshDefinitionContractTest(unittest.TestCase):
         self.assertIn("appearing later in a tail remains dormant", workflow)
         self.assertIn("ordinary delivery evidence fails", workflow)
         self.assertIn("route by capability", workflow)
+        self.assertIn("gate-owner fallback when `attentionOwners` is empty", workflow)
+        self.assertIn("position 0 acts and Ash's gate fallback is dormant", workflow)
 
 
 if __name__ == "__main__":

--- a/agents/skills/ops/tasks-api/SKILL.md
+++ b/agents/skills/ops/tasks-api/SKILL.md
@@ -50,8 +50,9 @@ This read-only adapter retrieves full active tasks and classifies them as
 `ACTIONABLE`, `WAITING_EXTERNAL`, `DEPENDENCY_BLOCKED`, or `BLOCKED`. Lobster
 remains the sole owner of capacity and state admission. When `attentionOwners` is populated, position 0 overrides comment-derived
 classification: only that owner sees actionable task work. Legacy delivery and
-checklist comments remain evidence. Without an attention stack, existing
-assignee/PR classification remains the fallback.
+checklist comments remain evidence. Without an attention stack, the exact
+current outstanding workflow-gate owner is actionable; assignee/PR
+classification remains the fallback when no current gate is outstanding.
 
 ### Attention owners: ordered action and escalation stack
 
@@ -77,9 +78,11 @@ python3 tasks_api_client.py patch --id <task-uuid> \
 
 OpenClaw/runtime blockers route to Quinn by putting Quinn first. Legacy
 `[openclaw-needed]`, checklist, and other bracketed comments are audit history;
-they are not routing state. The heartbeat queue automatically fetches the
-invoking agent's attention-owned tasks and only treats a task as actionable when
-that agent is position 0. Lower escalation slots remain dormant until advanced.
+they are not routing state. The heartbeat queue automatically fetches the invoking agent's attention-owned
+and current gate-owned tasks. A populated attention stack is authoritative and
+only position 0 acts. With an empty stack, the exact current outstanding gate
+owner is the fallback actor. Lower escalation slots and stale/future gates remain
+dormant.
 
 Safe helpers perform a fetch → mutate → PATCH round trip. Because duplicate
 slots are valid, callers must intentionally remove/advance the resolved slot,

--- a/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/agent_task_queue.py
@@ -59,18 +59,26 @@ GITHUB_IDENTITIES = {
     "rowan": ("rowanstoffer", "~/.config/gh-rowan", "ROWAN_GITHUB_TOKEN"),
     "ivy": ("ivystoffer", "~/.config/gh-ivy", "IVY_GITHUB_TOKEN"),
     "quinn": ("quinnstoffer", "~/.config/gh-quinn", "QUINN_GITHUB_TOKEN"),
+    "ash": ("ashstoffer", "~/.config/gh-ash", "ASH_GITHUB_TOKEN"),
     # Tom is the terminal human attention owner. His queue remains read-only;
     # the default gh config is used only to hydrate PR context.
     "tom": ("stoff81", "~/.config/gh", "GITHUB_TOKEN"),
 }
 GREEN_CHECK_CONCLUSIONS = {"success", "skipped", "neutral"}
+CURRENT_GATE_BY_STATUS = {
+    "open": "spec",
+    "ready": "tech_design",
+    "doing": "qa_agent",
+    "acceptance": "accepted",
+}
 QUEUE_KIND_ORDER = {
     "authoredPrFeedback": 0,
     "mergeCandidate": 1,
     "reviewRequest": 2,
     "techDesignApproval": 3,
     "task": 4,
-    "attentionPage": 5,
+    "workflowGate": 5,
+    "attentionPage": 6,
 }
 TASK_PRIORITY_ORDER = {"urgent": 0, "high": 1, "medium": 2, "low": 3}
 URL_RE = re.compile(r"https?://[^\s)>]+")
@@ -389,6 +397,75 @@ def fetch_agent_tasks(assignee: str, base_url: str | None = None) -> list[dict[s
     return [tasks_api_client.get_task(task["id"], base_url=base) for task in summaries]
 
 
+def fetch_workflow_gate_owner_tasks(name: str, base_url: str | None = None) -> list[dict[str, Any]]:
+    """Fetch active tasks whose current outstanding gate is owned by ``name``."""
+    base = base_url or tasks_api_client.get_base_url()
+    summaries = tasks_api_client.list_tasks(
+        limit=200,
+        status=["open", "ready", "doing", "acceptance"],
+        workflow_gate_owner=name,
+        base_url=base,
+    )
+    return [tasks_api_client.get_task(task["id"], base_url=base) for task in summaries]
+
+
+def _current_outstanding_gate_for_owner(
+    task: dict[str, Any], owner: str
+) -> dict[str, Any] | None:
+    """Return only the exact current-stage outstanding gate owned by ``owner``."""
+    expected_gate = CURRENT_GATE_BY_STATUS.get(str(task.get("status") or "").lower())
+    if expected_gate is None:
+        return None
+    owner_key = owner.strip().casefold()
+    return next(
+        (
+            gate
+            for gate in task.get("workflowGates") or []
+            if str(gate.get("state") or "").lower() == "outstanding"
+            and str(gate.get("gate") or "").lower() == expected_gate
+            and str(gate.get("owner") or "").strip().casefold() == owner_key
+        ),
+        None,
+    )
+
+
+def _build_workflow_gate_items(
+    gate_owner: str,
+    tasks: list[dict[str, Any]],
+    seen_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Surface gate-owner fallback only while the attention stack is empty."""
+    items: list[dict[str, Any]] = []
+    for task in tasks:
+        task_id = str(task.get("id") or "")
+        if not task_id or task_id in seen_ids:
+            continue
+        # Any populated attention stack is authoritative, even when Ash appears
+        # in the gate plane. Only position 0 acts until that stack is cleared.
+        if task.get("attentionOwners"):
+            continue
+        gate = _current_outstanding_gate_for_owner(task, gate_owner)
+        if gate is None:
+            continue
+        items.append(
+            {
+                "kind": "workflowGate",
+                "actionable": True,
+                "id": task_id,
+                "title": task.get("title"),
+                "taskType": task.get("taskType"),
+                "status": task.get("status"),
+                "priority": task.get("priority"),
+                "classification": "ACTIONABLE",
+                "reason": f"current {gate['gate']} gate is owned by {gate_owner}",
+                "workflowGate": gate.get("gate"),
+                "workflowGateOwner": gate_owner,
+                "topAttentionOwner": None,
+            }
+        )
+    return items
+
+
 def fetch_attention_owner_tasks(name: str, base_url: str | None = None) -> list[dict[str, Any]]:
     """Fetch active tasks where ``name`` is a current attention owner.
 
@@ -656,7 +733,7 @@ def build_unified_queue(
     task_items: list[dict[str, Any]],
     tech_design_approvals: list[dict[str, Any]],
     github_queue: dict[str, list[dict[str, Any]]],
-    attention_pages: list[dict[str, Any]] | None = None,
+    routed_task_items: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """Normalize every read-only heartbeat input into one deterministic queue."""
     items: list[dict[str, Any]] = []
@@ -686,8 +763,8 @@ def build_unified_queue(
                 **item,
             }
         )
-    for item in attention_pages or []:
-        items.append({**item, "kind": "attentionPage", "actionable": True})
+    for item in routed_task_items or []:
+        items.append({**item, "actionable": True})
 
     def sort_key(item: dict[str, Any]) -> tuple[Any, ...]:
         actionable_rank = 0 if item.get("actionable") else 1
@@ -712,6 +789,8 @@ def build_work_queue(
     delivery_prs: dict[str, dict[str, Any]] | None = None,
     attention_owner_tasks: list[dict[str, Any]] | None = None,
     attention_owner: str | None = None,
+    workflow_gate_owner_tasks: list[dict[str, Any]] | None = None,
+    workflow_gate_owner: str | None = None,
 ) -> dict[str, Any]:
     task_queue = build_queue(
         tasks,
@@ -726,8 +805,17 @@ def build_work_queue(
         attention_items = _build_attention_page_items(
             attention_owner, attention_owner_tasks, seen_ids
         )
+    routed_ids = seen_ids | {item["id"] for item in attention_items}
+    workflow_gate_items: list[dict[str, Any]] = []
+    if workflow_gate_owner and workflow_gate_owner_tasks:
+        workflow_gate_items = _build_workflow_gate_items(
+            workflow_gate_owner, workflow_gate_owner_tasks, routed_ids
+        )
     queue = build_unified_queue(
-        task_queue["items"], approvals, github_queue, attention_items
+        task_queue["items"],
+        approvals,
+        github_queue,
+        [*attention_items, *workflow_gate_items],
     )
     return {
         "queue": queue,
@@ -738,6 +826,8 @@ def build_work_queue(
         **github_queue,
         "attentionOwner": attention_owner,
         "attentionPages": attention_items,
+        "workflowGateOwner": workflow_gate_owner,
+        "workflowGateTasks": workflow_gate_items,
     }
 
 
@@ -769,13 +859,16 @@ def main() -> None:
     args = build_parser().parse_args()
     agent_key = args.assignee.lower()
     if agent_key not in GITHUB_IDENTITIES:
-        raise SystemExit(f"unsupported agent {args.assignee!r}; expected Rowan, Ivy, Quinn, or Tom")
+        raise SystemExit(
+            f"unsupported agent {args.assignee!r}; expected Rowan, Ivy, Quinn, Ash, or Tom"
+        )
     tasks = fetch_agent_tasks(args.assignee)
     approvals = fetch_pending_tech_design_approvals() if agent_key == "quinn" else []
     github_prs = fetch_github_prs(args.assignee)
     delivery_prs = fetch_linked_delivery_prs(args.assignee, tasks, github_prs)
     attention_owner = args.attention_owner or args.assignee
     attention_owner_tasks = fetch_attention_owner_tasks(attention_owner)
+    workflow_gate_owner_tasks = fetch_workflow_gate_owner_tasks(args.assignee)
     queue = build_work_queue(
         tasks,
         args.assignee,
@@ -784,6 +877,8 @@ def main() -> None:
         delivery_prs,
         attention_owner_tasks=attention_owner_tasks,
         attention_owner=attention_owner,
+        workflow_gate_owner_tasks=workflow_gate_owner_tasks,
+        workflow_gate_owner=args.assignee,
     )
     if args.json:
         print(json.dumps(queue, indent=2))
@@ -800,6 +895,10 @@ def main() -> None:
         print(f"Authored PRs with requested changes: {len(queue['authoredPrFeedback'])}")
         print(f"Merge candidates: {len(queue['mergeCandidates'])}")
         print(f"Attention pages for {attention_owner}: {len(queue['attentionPages'])}")
+        print(
+            f"Current workflow gates for {args.assignee}: "
+            f"{len(queue['workflowGateTasks'])}"
+        )
 
 
 if __name__ == "__main__":

--- a/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
+++ b/agents/skills/ops/tasks-api/scripts/test_agent_task_queue.py
@@ -1,5 +1,6 @@
 import importlib.util
 import pathlib
+import sys
 import unittest
 from unittest.mock import patch
 
@@ -276,6 +277,8 @@ class AgentTaskQueueTest(unittest.TestCase):
                 "mergeCandidates",
                 "attentionOwner",
                 "attentionPages",
+                "workflowGateOwner",
+                "workflowGateTasks",
             },
         )
 
@@ -454,6 +457,93 @@ class AgentTaskQueueTest(unittest.TestCase):
 
 
     # ---- attentionOwners paging (task d8fbe750) ----
+
+    def test_workflow_gate_owner_tasks_calls_current_gate_filter(self):
+        with patch.object(
+            agent_task_queue.tasks_api_client, "list_tasks", return_value=[]
+        ) as list_tasks, patch.object(
+            agent_task_queue.tasks_api_client,
+            "get_base_url",
+            return_value="http://test/api/v1",
+        ):
+            agent_task_queue.fetch_workflow_gate_owner_tasks("Ash")
+
+        kwargs = list_tasks.call_args.kwargs
+        self.assertEqual("Ash", kwargs["workflow_gate_owner"])
+        self.assertEqual(
+            ["open", "ready", "doing", "acceptance"], kwargs["status"]
+        )
+        self.assertEqual(200, kwargs["limit"])
+
+    def test_empty_attention_current_ash_gate_is_actionable(self):
+        gated = implementation_task(
+            attentionOwners=[],
+            workflowGates=[
+                {"owner": "Ash", "state": "outstanding", "gate": "qa_agent"}
+            ],
+        )
+        queue = agent_task_queue.build_work_queue(
+            [],
+            "Ash",
+            [],
+            [],
+            workflow_gate_owner_tasks=[gated],
+            workflow_gate_owner="Ash",
+        )
+        self.assertEqual("workflowGate", queue["topCandidate"]["kind"])
+        self.assertEqual("qa_agent", queue["topCandidate"]["workflowGate"])
+        self.assertEqual(1, len(queue["workflowGateTasks"]))
+
+    def test_top_attention_owner_suppresses_gate_fallback(self):
+        gated = implementation_task(
+            attentionOwners=["Rowan", "Tom"],
+            workflowGates=[
+                {"owner": "Ash", "state": "outstanding", "gate": "qa_agent"}
+            ],
+        )
+        items = agent_task_queue._build_workflow_gate_items("Ash", [gated], set())
+        self.assertEqual([], items)
+
+    def test_stale_and_future_gates_are_suppressed(self):
+        stale = implementation_task(
+            id="stale",
+            status="doing",
+            attentionOwners=[],
+            workflowGates=[
+                {"owner": "Ash", "state": "outstanding", "gate": "tech_design"}
+            ],
+        )
+        future = implementation_task(
+            id="future",
+            status="doing",
+            attentionOwners=[],
+            workflowGates=[
+                {"owner": "Ash", "state": "outstanding", "gate": "accepted"}
+            ],
+        )
+        approved = implementation_task(
+            id="approved",
+            status="doing",
+            attentionOwners=[],
+            workflowGates=[
+                {"owner": "Ash", "state": "approved", "gate": "qa_agent"}
+            ],
+        )
+        self.assertEqual(
+            [],
+            agent_task_queue._build_workflow_gate_items(
+                "Ash", [stale, future, approved], set()
+            ),
+        )
+
+    def test_ash_cli_identity_is_supported(self):
+        self.assertEqual(
+            ("ashstoffer", "~/.config/gh-ash", "ASH_GITHUB_TOKEN"),
+            agent_task_queue.GITHUB_IDENTITIES["ash"],
+        )
+        with patch.object(sys, "argv", ["agent_task_queue.py", "--assignee", "Ash"]),              patch.object(agent_task_queue, "fetch_agent_tasks", return_value=[]),              patch.object(agent_task_queue, "fetch_github_prs", return_value=[]),              patch.object(agent_task_queue, "fetch_linked_delivery_prs", return_value={}),              patch.object(agent_task_queue, "fetch_attention_owner_tasks", return_value=[]),              patch.object(agent_task_queue, "fetch_workflow_gate_owner_tasks", return_value=[]),              patch.object(agent_task_queue, "print_human"), \
+             patch("builtins.print"):
+            agent_task_queue.main()
 
     def test_attention_owner_tasks_calls_list_with_attention_owner_filter(self):
         with patch.object(

--- a/docs/systems/tasks.md
+++ b/docs/systems/tasks.md
@@ -163,7 +163,7 @@ Task responses include:
 - Not a substitute for explicit workflow gates. When a handoff is understood well enough to encode as a `TaskApproval` gate, that gate is the source of truth.
 - Not an incident lifecycle. Attention ownership is a durable signal for possible future incident ingest, but this feature does not implement incident processing.
 
-**How to use it.** `attentionOwners` is authoritative for who acts next even when the task also has an assignee or structured gate. Those other planes remain separate role/context slots: assignee says who delivers, and approvals/workflow gates say who is eligible to decide a gate. They do not override position 0. OpenClaw/runtime blockers route to Quinn at position 0. Legacy bracketed comments (including `[openclaw-needed]`) may remain as audit history but never route work.
+**How to use it.** A populated `attentionOwners` stack is authoritative for who acts next even when the task also has an assignee or structured gate. Those other planes remain separate role/context slots: assignee says who delivers, and approvals/workflow gates say who is eligible to decide a gate. They do not override position 0. When the attention stack is empty, the owner of the exact current outstanding gate is the actionable fallback (`doing → qa_agent` for Ash); stale, approved, and future-stage gates are dormant. OpenClaw/runtime blockers route to Quinn at position 0. Legacy bracketed comments (including `[openclaw-needed]`) may remain as audit history but never route work.
 
 Example: delivery assignee `Rowan`, QA gate/context owner `Ash`, and `attentionOwners=["Rowan", "Tom"]`. Both Rowan occurrences are meaningful across role slots; Ash remains visible; Tom is a dormant last resort. After agent escalation is exhausted, `attentionOwners=["Tom"]` makes Tom the actionable terminal human owner.
 
@@ -251,7 +251,7 @@ The API surfaces each plane independently:
 
 Discovery filters on `GET /tasks`:
 
-- `?workflowGateOwner=<name>` — tasks whose persisted active handoff role currently resolves to `<name>`. This filter does not infer work from task type, status, lifecycle, or approval rows.
+- `?workflowGateOwner=<name>` — tasks whose configured gate owner matches `<name>`, whose task type requires that gate, whose current status makes that gate actionable, and whose structured approval is still outstanding. The filter mirrors the derived `workflowGates` response; it does not use the legacy persisted handoff role.
 - `?attentionOwner=<name>` — tasks whose position-0 `TaskAttentionOwner` matches (case-insensitive).
 
 The two filters combine via AND: a UI can show "Quinn's outstanding gates AND the attention requests Quinn raised" without conflating the two planes. `?workflowGateOwner` and `?attentionOwner` never create or remove `TaskAttentionOwner` rows; they are pure read filters.
@@ -259,7 +259,7 @@ The two filters combine via AND: a UI can show "Quinn's outstanding gates AND th
 **Non-replacement guarantees** (enforced by the API and asserted by tests):
 
 - `attentionOwners` is fully independent of `task.blocked` and `dependencyBlocked`. Clearing attention owners does not declare the task unblocked.
-- `attentionOwners` is independent of `TaskApproval` rows. The discovery queue surfaces gate-owned handoffs through `workflowGateOwner`; it does not also create duplicate attention requests for the same action.
+- `attentionOwners` is independent of `TaskApproval` rows. The discovery queue surfaces the exact current outstanding gate through `workflowGateOwner` only when the attention stack is empty; it does not create duplicate attention requests. Any populated stack suppresses gate fallback and leaves position 0 authoritative.
 - Resolving one attention owner (PATCH replacement) does not affect other attention owners, workflow-gate ownership, dependencies, or `task.blocked`.
 - Changing `taskType` does not retroactively create or remove attention-owner rows; attention is decoupled from task-type policy.
 

--- a/services/tasks-api/src/routes/tasks.ts
+++ b/services/tasks-api/src/routes/tasks.ts
@@ -162,7 +162,7 @@ tasksRouter.get('/tasks', async (req, res, next) => {
       ...(blocked !== undefined ? { blocked: blocked === 'true' } : {}),
       ...attentionOwnerFilter,
       ...(workflowGateOwnerRequested
-        ? { AND: workflowGateOwnerFilter.length > 0 ? workflowGateOwnerFilter : [{ id: { equals: '' } }] }
+        ? { AND: workflowGateOwnerFilter.length > 0 ? workflowGateOwnerFilter : [{ id: { in: [] } }] }
         : {})
     };
 

--- a/services/tasks-api/src/routes/tasks/_deps.ts
+++ b/services/tasks-api/src/routes/tasks/_deps.ts
@@ -1,6 +1,5 @@
 import { prisma } from '../../lib/prisma.ts';
 import { badRequest } from '../../lib/http.ts';
-import { workflowHandoffRolesForOwner } from '../../config/workflowHandoffs.ts';
 import { loadRequiredApprovalsConfig } from '../../config/requiredApprovals.ts';
 import { buildMapTaskOptions, type MapTaskOptions } from './_mapper.ts';
 
@@ -24,23 +23,41 @@ export function mapTaskOptionsFor(task): MapTaskOptions {
 }
 
 /**
- * Build a Prisma `where` fragment for `?workflowGateOwner=OWNER` discovery
- * filtering. A task matches when its `taskType` requires at least one
- * approval type owned by OWNER (per the loaded config), AND no approved
- * row exists for any of those types — i.e. at least one of OWNER's gates
- * is still outstanding.
- *
- * Returned shape: an `AND: [...]` array suitable for merging into an
- * existing `where` clause. Returns an empty array when OWNER does not own
- * any approval type (no required gates, no discovery surface).
- *
- * Free-form owners that don't match `validAssignees` are still queried —
- * the discovery queue should not silently drop unknown names. Server-side
- * `console.warn` is acceptable noise; see the tech design.
+ * Build a Prisma `where` fragment for `?workflowGateOwner=OWNER` discovery.
+ * This mirrors `mapTask.workflowGates`: the task type must require the gate,
+ * the task must be at that gate's actionable status, and no active approval
+ * may satisfy it. The legacy persisted `workflowHandoffRoleId` is not the gate
+ * source and notably has no Ash role.
  */
 export function buildWorkflowGateOwnerWhere(owner: string): Array<Record<string, unknown>> {
-  const roleIds = workflowHandoffRolesForOwner(owner);
-  return roleIds.length > 0 ? [{ workflowHandoffRoleId: { in: roleIds } }] : [];
+  const config = loadRequiredApprovalsConfig();
+  const ownerKey = owner.trim().toLowerCase();
+  const actionableStatusByApprovalType: Record<string, string> = {
+    spec: 'open',
+    tech_design: 'ready',
+    qa_agent: 'doing',
+    accepted: 'acceptance'
+  };
+  const gates = Object.entries(config.owners)
+    .filter(([approvalType, configuredOwner]) =>
+      configuredOwner.trim().toLowerCase() === ownerKey
+      && actionableStatusByApprovalType[approvalType]
+    )
+    .map(([approvalType]) => {
+      const taskTypes = Object.entries(config.mappings)
+        .filter(([, required]) => required.includes(approvalType))
+        .map(([taskType]) => taskType);
+      return {
+        status: actionableStatusByApprovalType[approvalType],
+        taskType: { in: taskTypes },
+        approvals: {
+          none: { type: approvalType, state: 'approved', revokedAt: null }
+        }
+      };
+    })
+    .filter((clause) => clause.taskType.in.length > 0);
+
+  return gates.length > 0 ? [{ OR: gates }] : [];
 }
 
 export async function connectTags(tagNames) {

--- a/services/tasks-api/test/workflowGatesRouteLayer.test.ts
+++ b/services/tasks-api/test/workflowGatesRouteLayer.test.ts
@@ -414,25 +414,25 @@ describe('GET /api/v1/tasks — discovery filters', () => {
     prismaMock.$transaction.mockImplementation(async (callback) => callback(prismaMock));
   });
 
-  it.each([
-    ['Quinn', ['tech_design_approver']],
-    ['Tom', ['product_spec_approver', 'qa_verifier']]
-  ])('?workflowGateOwner=%s filters directly by persisted role ids', async (owner, roleIds) => {
-    prismaMock.task.findMany.mockResolvedValue([]);
+  it.each(['Ash', 'Quinn', 'Tom'])(
+    '?workflowGateOwner=%s filters by the exact current outstanding derived gate',
+    async (owner) => {
+      prismaMock.task.findMany.mockResolvedValue([]);
 
-    await authedRequest(createApp()).get('/api/v1/tasks').query({ workflowGateOwner: owner });
+      await authedRequest(createApp()).get('/api/v1/tasks').query({ workflowGateOwner: owner });
 
-    const where = prismaMock.task.findMany.mock.calls[0][0].where;
-    expect(where.AND).toEqual([{ workflowHandoffRoleId: { in: roleIds } }]);
-  });
+      const where = prismaMock.task.findMany.mock.calls[0][0].where;
+      expect(where.AND).toEqual(buildWorkflowGateOwnerWhere(owner));
+    }
+  );
 
-  it('?workflowGateOwner with no configured roles returns zero tasks instead of broadening', async () => {
+  it('?workflowGateOwner with no configured gates returns zero tasks safely', async () => {
     prismaMock.task.findMany.mockResolvedValue([]);
 
     await authedRequest(createApp()).get('/api/v1/tasks').query({ workflowGateOwner: 'Rowan' });
 
     const where = prismaMock.task.findMany.mock.calls[0][0].where;
-    expect(where.AND).toEqual([{ id: { equals: '' } }]);
+    expect(where.AND).toEqual([{ id: { in: [] } }]);
   });
 
   it('?attentionOwner=Tom scopes to tasks where Tom is the top slot', async () => {
@@ -609,9 +609,29 @@ describe('explicit workflow handoffs', () => {
     expect(normalizeWorkflowHandoff({ roleId: 'qa_verifier', reason: '' })).toBeNull();
   });
 
-  it('filters owner queues by persisted role id, case-insensitively', () => {
-    expect(buildWorkflowGateOwnerWhere('quinn')).toEqual([{ workflowHandoffRoleId: { in: ['tech_design_approver'] } }]);
-    expect(buildWorkflowGateOwnerWhere('Tom')).toEqual([{ workflowHandoffRoleId: { in: ['product_spec_approver', 'qa_verifier'] } }]);
+  it('filters owner queues by exact current outstanding derived gate', () => {
+    expect(buildWorkflowGateOwnerWhere('ash')).toEqual([{ OR: [{
+      status: 'doing',
+      taskType: { in: ['feature', 'code', 'content'] },
+      approvals: { none: { type: 'qa_agent', state: 'approved', revokedAt: null } }
+    }] }]);
+    expect(buildWorkflowGateOwnerWhere('quinn')).toEqual([{ OR: [{
+      status: 'ready',
+      taskType: { in: ['feature', 'code'] },
+      approvals: { none: { type: 'tech_design', state: 'approved', revokedAt: null } }
+    }] }]);
+    expect(buildWorkflowGateOwnerWhere('Tom')).toEqual([{ OR: [
+      {
+        status: 'open',
+        taskType: { in: ['feature', 'content'] },
+        approvals: { none: { type: 'spec', state: 'approved', revokedAt: null } }
+      },
+      {
+        status: 'acceptance',
+        taskType: { in: ['feature', 'code', 'content'] },
+        approvals: { none: { type: 'accepted', state: 'approved', revokedAt: null } }
+      }
+    ] }]);
     expect(buildWorkflowGateOwnerWhere('Nobody')).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary
- Add Ash as a supported unified-queue identity and discover her exact current outstanding gate work.
- Keep a populated `attentionOwners` stack authoritative; gate-owner fallback is actionable only when the stack is empty, the gate is outstanding, and it matches the task's current stage.
- Align `workflowGateOwner` API filtering with derived workflow gates instead of legacy persisted handoff roles, fixing Ash queries that previously returned 500.
- Update Ash operating docs and shared Tasks guidance for gate fallback and blocker routing.

## System Spec
`docs/systems/tasks.md`

## Test plan
- [x] Verify empty attention plus current `doing → qa_agent` gate surfaces Ash as actionable.
- [x] Verify any top attention owner suppresses Ash's gate fallback.
- [x] Verify stale, future-stage, and approved gates remain dormant.
- [x] Verify `--assignee Ash` uses Ash's GitHub identity and credentials.
- [x] Verify Tasks API gate-owner queries use current status, required task type, configured owner, and outstanding approval state.
- [x] Run 73 Python queue/client/definition tests, agent-definition sync, and 374 Tasks API tests.
- [x] Read-only validation confirms task `6350f444` matches the new Ash workflow-gate queue item; task state was not mutated.