### PR TITLE
docs(rowan): document ROWAN_TASKS_API_APPROVAL_TOKEN

### DIFF
--- a/agents/definitions/rowan/TOOLS.md
+++ b/agents/definitions/rowan/TOOLS.md
@@ -40,6 +40,11 @@ Rowan has different names in different systems — use the right one per system,
 - **Tasks API `assignee` value:** `Rowan` (capitalized first name — NOT the GitHub login; e.g. `?assignee=Rowan`, not `?assignee=rowanstoffer`)
 - **Telegram account:** `rowan` (`channels.telegram.accounts.rowan`)
 
+## Tasks API
+
+- **Credential env:** `ROWAN_TASKS_API_APPROVAL_TOKEN`, stored in `~/.openclaw/.env`. Pass it as `token=` to `tasks_api_client.py`'s `api_request`/`service_token_env` helpers (or as the bearer token on raw `curl`/`httpx` calls) so comments and writes attribute to `Rowan`, not Quinn.
+- **Do not fall back to the shared `TASKS_API_APPROVAL_TOKEN`** for your own actions — that one authenticates as Quinn. It existed server-side (`TASKS_API_APPROVAL_SERVICE_CREDENTIALS`, actor `Rowan`) before this env var was added on 2026-08-21; if a session predates that, `[implementer-prs]` comments and similar writes will show up misattributed to Quinn — same bug class as PR #497's comment on task `782d778e`.
+
 ## GitHub
 
 - **Account:** rowanstoffer


### PR DESCRIPTION
## Summary
- Documents `ROWAN_TASKS_API_APPROVAL_TOKEN` in `agents/definitions/rowan/TOOLS.md`, mirroring the existing Ash pattern.

## Why
The server-side credential (actor `Rowan`) already existed in `TASKS_API_APPROVAL_SERVICE_CREDENTIALS`, but Rowan's own TOOLS.md never referenced it, so his sessions defaulted to the shared `TASKS_API_APPROVAL_TOKEN` — every task comment/write he made attributed to Quinn instead of himself (e.g. PR #497's `[implementer-prs]` comment on task `782d778e`). Quinn added the env var to `~/.openclaw/.env` today; this closes the loop so future Rowan sessions actually pick it up.

## Test plan
- [x] Docs-only change, no code paths touched.

🤖 Generated with Claude Code