### PR TITLE
feat(retro): daily retro-fix skill + sharpen weekly RCA

### DIFF
--- a/agents/skills/ops/factory-retro/SKILL.md
+++ b/agents/skills/ops/factory-retro/SKILL.md
@@ -32,6 +32,15 @@ directly into the backlog as a `feature` task; Tom approves via the brain-spec f
 approves every other feature task. One task per run is intentional: keeps the backlog signal density
 high without spamming.
 
+**Relationship to `retro-daily-fix` (daily):** a separate daily cron already fixes the single
+highest-impact same-day retro-notes finding when it's a small, safely-scoped config/code fix
+(`agents/skills/ops/retro-daily-fix/SKILL.md`). That's the tactical loop — this skill is the
+strategic one. Assume some findings this week were already resolved same-day; focus this
+pass on **patterns that recur across multiple days or weeks**, and on findings the daily
+pass explicitly routed away as "not safely fixable" (infra, cross-agent, judgment calls) —
+those are exactly the ones that need a real root-cause writeup and a proper feature task
+rather than a one-line fix.
+
 **Known gap:** there is no global aggregation endpoint yet (that's task 6a5783a7, still in
 `doing` — a Postgres rollup fed by these same events). Until it ships, per-task gate-failure
 breakdown means iterating `GET /feature-task-analytics/tasks/:taskId/events` across the
@@ -131,6 +140,13 @@ Only run this step if Step 3's `total > 0`. Take the top 3 entries from `message
 suggestion. Do not write generic advice ("write better specs") — name the actual workflow
 rule, gate, and who owns the fix.
 
+**State the root cause, not just the symptom.** The failure message is the symptom (a gate
+blocked); the "Cause" column below is the root-cause category (quality vs capacity). For
+each of the 3 selected entries, write one sentence naming which category it is and why —
+"quality: task creation is producing incomplete descriptions" reads differently from
+"capacity: an approval queue is backed up," and the two need different fixes. A suggestion
+without a stated root cause is a guess dressed up as an action item.
+
 Use this lookup table for known failure patterns. If a top-3 message doesn't match anything
 below, write an ad-hoc suggestion referencing the literal gate + message text instead of
 forcing it into a bucket.
@@ -184,9 +200,10 @@ TASKS_API_BASE_URL=http://localhost:4001/api/v1 \
 
 Notes on what gets passed in:
 - **Title**: the pattern's `suggested-action` (one line, title-case). Truncate at 80 chars.
-- **Description**: includes the observation, the count ("3 occurrences this week"), the evidence
-  links (task IDs / PR numbers / file paths), and the original `pattern-slug` in a callout. Tom
-  approves via brain spec per the normal feature-task flow.
+- **Description**: includes the observation, the count ("3 occurrences this week"), a stated
+  **root cause** line (quality vs capacity, per Step 4 — not just the symptom restated), the
+  evidence links (task IDs / PR numbers / file paths), and the original `pattern-slug` in a
+  callout. Tom approves via brain spec per the normal feature-task flow.
 - **taskType**: `feature` — so it lands in the brain-spec approval queue, not the ops queue.
 - **priority**: `medium` by default. Promote to `high` only if the top pattern's `bad` tag comes
   with `severity: high` or equivalent in the retro-notes row.

--- a/agents/skills/ops/retro-daily-fix/SKILL.md
+++ b/agents/skills/ops/retro-daily-fix/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: retro-daily-fix
+description: "Daily pass over yesterday's retro-notes (brain/ops/retro-notes/YYYY-MM-DD.md): picks the single highest-impact 'bad' pattern with a suggested-action, re-verifies it's still live, and fixes it directly (config/data) or via a PR (code/docs) — the same-day tactical loop. Complements the weekly factory-retro, which does cross-week RCA and creates feature tasks for structural issues this can't reach."
+---
+
+# Retro Daily Fix
+
+The retro-notes system (`agents/skills/retro-notes/SKILL.md`) is a firehose of small, dated
+observations — agents append a row whenever they hit the same shape of friction twice. Most
+rows never get acted on same-day; they sit until the weekly `factory-retro` pass aggregates
+them into a feature task, which Tom then has to approve and someone has to implement. For a
+row whose fix is a one-line config change or a small, well-scoped code fix, that's a lot of
+latency for something that could just be done.
+
+This skill closes that gap: read yesterday's file, pick the ONE highest-impact actionable
+`bad` row, and actually resolve it — same day, no task-admin round-trip, following the same
+discipline used on 2026-08-21 for the `tasks-api-actor-attribution-quinn-default` finding
+(found in retro-notes → root cause confirmed live → fixed directly with a doc/PR follow-up).
+
+**Relationship to `factory-retro` (weekly):** this skill does the tactical single-item fix;
+factory-retro does the cross-week pattern analysis, root-cause writeups, and auto-creates a
+feature task for the structural issue behind a recurring pattern. A pattern this skill fixed
+outright shouldn't need a feature task later; a pattern this skill *can't* safely act on
+(infra, another agent's runtime, anything needing human judgment) is exactly the kind of
+thing factory-retro's weekly RCA should catch if it keeps recurring.
+
+**One fix per run, same reasoning as factory-retro's one-task-per-run:** keeps the daily
+digest readable and keeps Quinn from batching up unreviewed changes.
+
+---
+
+## Step 0 — Locate yesterday's file
+
+```bash
+YESTERDAY=$(TZ=Pacific/Auckland date -v-1d +%Y-%m-%d 2>/dev/null || TZ=Pacific/Auckland date -d yesterday +%Y-%m-%d)
+cat "/Users/quinnstoffer/.openclaw/workspace/brain/ops/retro-notes/${YESTERDAY}.md" 2>/dev/null
+```
+
+If the file doesn't exist, or exists with no `bad`-tagged rows: output `"✅ No actionable
+findings in yesterday's retro-notes ($YESTERDAY)."` and stop. Don't reach into older files —
+this skill is deliberately scoped to yesterday only; older unresolved rows are the weekly
+pass's job.
+
+---
+
+## Step 1 — Pick the top candidate
+
+Parse rows in the same shape `factory-retro` Step 0 uses: `date`, `agent`, `good|bad`,
+`pattern-slug`, observation, optional `suggested-action`, optional `| evidence: ...`.
+
+Filter to `bad` rows with a `suggested-action`. If none qualify (all `good`, or all missing a
+suggested-action): output `"✅ Yesterday's findings are informational only — nothing with a
+concrete suggested-action to act on."` and stop.
+
+Rank by, in order:
+1. Explicit severity if present in the row (`high` > `medium` > default).
+2. Whether the row cites a specific, checkable evidence artifact (file path, task ID, PR
+   number) — prefer rows you can actually verify over vague ones.
+3. Earlier-logged row wins ties (first blocker of the day is usually still the most acute).
+
+Take the single top row. If two rows are genuinely tied on all three, prefer the one whose
+fix looks smaller in scope (safer for an unattended daily pass) — do not attempt the larger
+one "for efficiency."
+
+---
+
+## Step 2 — Re-verify it's still real
+
+Do not act on the retro-note's text alone — it's a snapshot from whenever it was written,
+and may already be stale by the next morning. Re-check live state for whatever the row
+actually claims:
+
+- If it names a task: `GET /tasks/:id` and check current status/approvals/comments.
+- If it names a file/config: read the current file, not just the diff quoted in the row.
+- If it names a PR: `gh pr view <n>` for current state.
+- If it names an env var or credential: check presence (not the value) the same way — don't
+  print secrets into the report.
+
+If the condition no longer holds (someone already fixed it, the task moved on, the PR
+merged): stop here, report `"Yesterday's top finding (<pattern-slug>) was already resolved
+before this run — no action taken."` Do not manufacture work.
+
+If it's still live, proceed. If verification is inconclusive (can't tell either way): treat
+this as **not safely fixable** and fall through to the routing case in Step 3, don't guess.
+
+---
+
+## Step 3 — Classify and fix
+
+**Direct fix** (env var / credential wiring in `~/.openclaw/.env`, a Tasks API state
+correction via `tasks_api_client.py`, a workspace-only file under
+`/Users/quinnstoffer/.openclaw/workspace/` outside `codebases/sindustries/`): apply it
+directly, then verify the fix actually took (re-read the value / re-fetch the task / re-run
+the check that would have caught the original problem).
+
+**Code/docs fix inside the sindustries repo:**
+1. `infra/guards/sindustries-worktree.sh <descriptive-branch-name>` — never edit inside
+   `codebases/sindustries/` directly, and never work on bare `main`.
+2. Make the minimal change that resolves the specific finding. Don't use this pass to also
+   clean up adjacent things you notice — one fix, one PR, matching the row's actual scope.
+3. Commit as `quinnstoffer`, push, open a PR with Tom as the reviewer (`gh pr create ...
+   --reviewer Stoff81`). Reference the retro-notes finding and evidence in the PR body.
+4. **Never merge or self-approve.** This skill's job ends at "PR is open and correct" — same
+   rule as every other Quinn-authored PR.
+
+**Not safely fixable by Quinn** (infra changes that are Lox's domain, another agent's runtime
+or credentials, anything where the "fix" requires a judgment call beyond mechanically
+applying what the row already specifies): don't attempt it. Post the finding, the reason it's
+out of scope, and who should own it (Lox for infra, Rowan for larger code changes, Tom for
+anything needing a product/business call) in the daily report instead. This is a legitimate,
+expected outcome — not a failure of the run.
+
+Remove the worktree after pushing (`git worktree remove`), same as any other Quinn PR.
+
+---
+
+## Step 4 — Report
+
+Deliver the same way `factory-retro` does — output the summary and let Quinn decide whether
+to message Tom directly, or let the cron's own delivery handle it.
+
+```
+🔧 Daily Retro Fix — <yesterday's date>
+
+Top finding: <pattern-slug> (<agent> — bad)
+<one-line observation from the row>
+
+Status: <Fixed directly | PR opened | Already resolved | Not safely fixable — routed to <owner>>
+<what was done, or why not, in 1-3 sentences>
+<PR link if one was opened>
+
+No other rows actioned this run (one fix per day, by design).
+```
+
+If Step 0 or Step 1 stopped early, output just that message and nothing else.


### PR DESCRIPTION
## Summary
- New `agents/skills/ops/retro-daily-fix/SKILL.md`: reads **yesterday's** `brain/ops/retro-notes/YYYY-MM-DD.md`, picks the single highest-impact `bad` pattern with a `suggested-action`, re-verifies it's still live against current state, and fixes it same-day — directly for config/data changes, via a PR (Tom as blocking reviewer, never self-merged) for code/docs, or routes it to the right owner (Lox for infra, Rowan for larger code, Tom for judgment calls) if it's not safely fixable unattended. One fix per run, same reasoning as factory-retro's one-task-per-run.
- Updated `agents/skills/ops/factory-retro/SKILL.md` (weekly): added a "relationship to daily" note so the weekly pass assumes same-day findings may already be resolved and focuses on cross-day/cross-week recurrence and anything the daily pass routed away. Also strengthened Step 4 and the Step 5 auto-created task description to require an explicit stated root cause (quality vs capacity), not just a restated symptom.

## Why
Tom's ask after today's `ROWAN_TASKS_API_APPROVAL_TOKEN` fix (found via retro-notes, root-caused, fixed same session): retro-notes findings shouldn't all have to wait for the weekly aggregation → feature-task → Tom-approval round trip when the fix is small and safe. This adds the daily tactical loop while keeping the weekly pass focused on genuine structural RCA.

## Follow-up (not in this PR)
Once merged, I'll register the actual daily cron (mirroring the existing "Factory Retro - Weekly" cron: isolated session, `agentTurn` payload pointing at this new skill, `toolsAllow: [read, write, exec, edit, apply_patch, process, message]`) so its first run finds the skill file on `main`.

## Test plan
- [x] Docs/skill-only change, no code paths touched.
- [ ] First live daily run will exercise the actual logic — flagging since this is process/skill content, not something a test suite covers.

🤖 Generated with Claude Code