### PR TITLE
docs(ivy,lox): document per-agent Tasks API tokens

### DIFF
--- a/agents/definitions/ivy/TOOLS.md
+++ b/agents/definitions/ivy/TOOLS.md
@@ -47,6 +47,11 @@ Ivy has different names in different systems — use the right one per system, n
 - **Tasks API `assignee` value:** `Ivy` (capitalized first name — NOT the GitHub login; e.g. `?assignee=Ivy`, not `?assignee=ivystoffer`)
 - **Telegram account:** not yet a dedicated bot account — if this changes, record it here
 
+## Tasks API
+
+- **Credential env:** `IVY_TASKS_API_APPROVAL_TOKEN`, stored in `~/.openclaw/.env`. Pass it as `token=` to `tasks_api_client.py`'s `api_request`/`service_token_env` helpers (or as the bearer token on raw `curl`/`httpx` calls) so comments and writes attribute to `Ivy`, not Quinn.
+- **Do not fall back to the shared `TASKS_API_APPROVAL_TOKEN`** for your own actions — that one authenticates as Quinn. It existed server-side (`TASKS_API_APPROVAL_SERVICE_CREDENTIALS`, actor `Ivy`) before this env var was added on 2026-08-21; if a session predates that, comments and writes will show up misattributed to Quinn — same bug class Rowan hit and logged in retro-notes (`tasks-api-actor-attribution-quinn-default`, 2026-08-21).
+
 ## GitHub
 
 - **Account:** ivystoffer

--- a/agents/definitions/lox/TOOLS.md
+++ b/agents/definitions/lox/TOOLS.md
@@ -39,6 +39,11 @@ Lox has different names in different systems — use the right one per system, n
 - **Tasks API `assignee` value:** `Lox` (capitalized first name — NOT a GitHub login; e.g. `?assignee=Lox`)
 - **Telegram account:** `lox` (`channels.telegram.accounts.lox`)
 
+## Tasks API
+
+- **Credential env:** `LOX_TASKS_API_APPROVAL_TOKEN`, stored in `~/.openclaw/.env`. Pass it as `token=` to `tasks_api_client.py`'s `api_request`/`service_token_env` helpers (or as the bearer token on raw `curl`/`httpx` calls) so comments and writes attribute to `Lox`, not Quinn.
+- **Do not fall back to the shared `TASKS_API_APPROVAL_TOKEN`** for your own actions — that one authenticates as Quinn. It existed server-side (`TASKS_API_APPROVAL_SERVICE_CREDENTIALS`, actor `Lox`) before this env var was added on 2026-08-21; if a session predates that, comments and writes will show up misattributed to Quinn — same bug class Rowan hit and logged in retro-notes (`tasks-api-actor-attribution-quinn-default`, 2026-08-21).
+
 ## Why Separate?
 
 Skills are shared. Your setup is yours. Keeping them apart means you can update skills without losing your notes, and share skills without leaking your infrastructure.


### PR DESCRIPTION
## Summary
- Documents `IVY_TASKS_API_APPROVAL_TOKEN` and `LOX_TASKS_API_APPROVAL_TOKEN` in their respective `TOOLS.md`, mirroring #499's fix for Rowan.

## Why
Tom asked "do we need to do the same for other agents" after #499 — checked, and yes: both Ivy and Lox already had actors provisioned server-side in `TASKS_API_APPROVAL_SERVICE_CREDENTIALS` (same as Rowan was), but no agent-side env var existed for either, and neither TOOLS.md referenced the token. Same bug class, same fix. Quinn added both env vars to `~/.openclaw/.env` today; this closes the loop in docs.

## Test plan
- [x] Docs-only change, no code paths touched.

🤖 Generated with Claude Code