### PR TITLE
feat(gymtrack-mcp): add OAuth 2.0 Dynamic Client Registration (RFC 7591) (task de19b186)

### DIFF
--- a/apps/gymtrack/supabase/migrations/20260822120000_oauth_dcr.sql
+++ b/apps/gymtrack/supabase/migrations/20260822120000_oauth_dcr.sql
@@ -1,0 +1,57 @@
+-- Add OAuth 2.0 Dynamic Client Registration (DCR) support to gymtrack-mcp.
+--
+-- Task: de19b186-dda6-47dc-94f1-ef52d2dc9383
+-- Tech design: docs/specs/gymtrack-mcp-oauth-dcr-tech-design.md
+--
+-- Extends public.gymtrack_oauth_clients with:
+--   * registration_type discriminator ('static' default, 'dynamic' for DCR rows)
+--   * RFC 7591 §2 client metadata columns (all nullable; backwards-compatible
+--     with the four existing seeded static rows: claude-desktop, chatgpt,
+--     local-dev, openclaw)
+--   * registered_at for dynamic rows
+--
+-- No new table, no RLS change, no policy change. Service-role writes from
+-- /oauth/register bypass RLS. AC5 ("no new client can bypass consent") is
+-- satisfied by construction: the existing getConsent(...).revoked_at gate on
+-- /oauth/token and the active-consent unique index on (user_id, client_id)
+-- apply identically to dynamic clients because they key on client_id as an
+-- opaque string.
+
+alter table public.gymtrack_oauth_clients
+  add column if not exists registration_type text not null default 'static',
+  add column if not exists registered_at timestamptz,
+  add column if not exists client_uri text,
+  add column if not exists logo_uri text,
+  add column if not exists contacts text[],
+  add column if not exists policy_uri text,
+  add column if not exists tos_uri text,
+  add column if not exists software_id text,
+  add column if not exists software_version text;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'gymtrack_oauth_clients_registration_type_check'
+      and conrelid = 'public.gymtrack_oauth_clients'::regclass
+  ) then
+    alter table public.gymtrack_oauth_clients
+      add constraint gymtrack_oauth_clients_registration_type_check
+      check (registration_type in ('static', 'dynamic'));
+  end if;
+end
+$$;
+
+-- Backfill registered_at for the four seeded static rows so operator queries
+-- ordering by registered_at desc nulls last show a stable history. The values
+-- are the merged date of the source migration per client.
+update public.gymtrack_oauth_clients
+   set registered_at = '2026-08-04T07:00:00+00:00'
+ where client_id in ('claude-desktop', 'chatgpt', 'local-dev')
+   and registered_at is null;
+
+update public.gymtrack_oauth_clients
+   set registered_at = '2026-08-15T07:00:00+00:00'
+ where client_id = 'openclaw'
+   and registered_at is null;

--- a/docs/runbooks/gymtrack-agent-connect.md
+++ b/docs/runbooks/gymtrack-agent-connect.md
@@ -57,24 +57,73 @@ The unauthenticated `POST /mcp` must respond with `401` **and** a `WWW-Authentic
 
 ### Supabase OAuth clients
 
+Static clients are seeded by migrations and live in `public.gymtrack_oauth_clients` with `registration_type='static'`. Dynamic clients are registered at runtime via `POST /oauth/register` (RFC 7591) and land in the same table with `registration_type='dynamic'`.
+
+#### Static clients
+
 Migration `apps/gymtrack/supabase/migrations/20260804070000_mcp_oauth.sql` seeds these exact allowlist values:
 
 | Provider | Client ID | Allowed redirect URI |
 | --- | --- | --- |
 | Claude | `claude-desktop` | `https://claude.ai/api/mcp/auth_callback` |
 | ChatGPT | `chatgpt` | `https://chatgpt.com/connector_platform_oauth_redirect` |
+| Local dev | `local-dev` | `http://localhost:8788/callback` |
+
+Migration `apps/gymtrack/supabase/migrations/20260815070000_openclaw_oauth_client.sql` adds the OpenClaw static row (task `30251df0`):
+
+| Provider | Client ID | Allowed redirect URI |
+| --- | --- | --- |
 | OpenClaw | `openclaw` | `http://127.0.0.1:8789/callback` |
 
-The third row is added by `apps/gymtrack/supabase/migrations/20260815070000_openclaw_oauth_client.sql` (task `30251df0`). `127.0.0.1:8789` is the loopback redirect OpenClaw binds for the duration of the OAuth dance (RFC 8252 §7.3 / OAuth 2.1 §10.2); it is one port above `local-dev`'s `8788` so no two seeded clients collide. If port `8789` is unavailable on a host, surface an actionable error to the user — do not silently bind a different port.
+`127.0.0.1:8789` is the loopback redirect OpenClaw binds for the duration of the OAuth dance (RFC 8252 §7.3 / OAuth 2.1 §10.2); it is one port above `local-dev`'s `8788` so no two seeded clients collide. If port `8789` is unavailable on a host, surface an actionable error to the user — do not silently bind a different port.
 
 Confirm the production rows have not drifted:
 
 ```sql
-select client_id, client_name, redirect_uris
+select client_id, client_name, redirect_uris, registration_type, registered_at
 from public.gymtrack_oauth_clients
-where client_id in ('claude-desktop', 'chatgpt', 'openclaw')
+where registration_type = 'static'
 order by client_id;
 ```
+
+#### Dynamic clients (RFC 7591 DCR)
+
+Any RFC 7591-conformant MCP client (including OpenClaw's spec-following OAuth client) can self-register against `POST /oauth/register`. The endpoint is public-only — it does not issue `client_secret`, and `token_endpoint_auth_method` is restricted to `'none'`. Static and dynamic clients share the same consent gate (`/agent-consent` → `getConsent(...).revoked_at` on `/oauth/token`), so dynamic clients cannot bypass user approval.
+
+Discover the endpoint via `GET /.well-known/oauth-authorization-server`; the response advertises `registration_endpoint` and `registration_endpoint_auth_methods_supported: ["none"]`.
+
+Example registration (OpenClaw or any other MCP client):
+
+```bash
+curl -fsS https://gymtrack-mcp.fly.dev/oauth/register \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "redirect_uris": ["http://127.0.0.1:8789/callback"],
+    "client_name": "OpenClaw",
+    "token_endpoint_auth_method": "none"
+  }'
+```
+
+Response (201 Created):
+
+```json
+{
+  "client_id": "<uuid v4>",
+  "client_id_issued_at": 1755475200
+}
+```
+
+The issued `client_id` then flows into the same `/oauth/authorize` → `/agent-consent` → `/oauth/token` dance as a static client. `client_secret` is intentionally omitted because GymTrack only supports public PKCE clients.
+
+Operator query to inspect both static and dynamic registrations side-by-side:
+
+```sql
+select client_id, registration_type, client_name, registered_at
+from public.gymtrack_oauth_clients
+order by registration_type, registered_at desc nulls last, client_id;
+```
+
+**Out of scope for v1:** confidential-client support, initial-access-tokens, per-IP rate limiting, and admin list/revoke endpoint. See the tech design (`docs/specs/gymtrack-mcp-oauth-dcr-tech-design.md`, §Out of scope) for the rationale. If registration abuse is observed in logs, the first escalation is to add per-IP rate limiting at the Fly edge, then file a follow-up task to bundle the rest.
 
 If any provider reports a redirect mismatch, capture the exact `redirect_uri` it sent, verify it against that provider's current documentation, and update only that client's allowlist. Do not add wildcard redirect URIs.
 

--- a/docs/specs/gymtrack-mcp-oauth-dcr-tech-design.md
+++ b/docs/specs/gymtrack-mcp-oauth-dcr-tech-design.md
@@ -1,0 +1,252 @@
+---
+status: pending-review
+task_id: de19b186-dda6-47dc-94f1-ef52d2dc9383
+product_spec: n/a
+shipped_pr: null
+shipped_date: null
+---
+
+# Add OAuth 2.0 Dynamic Client Registration (DCR) to gymtrack-mcp
+
+## Links
+
+- Tech design: `docs/specs/gymtrack-mcp-oauth-dcr-tech-design.md`
+- Task: `de19b186-dda6-47dc-94f1-ef52d2dc9383`
+- Tasks API record: `http://localhost:4001/api/v1/tasks/de19b186-dda6-47dc-94f1-ef52d2dc9383`
+- Supersedes (decision, not the static-client PR): tech design `docs/specs/gymtrack-mcp-openclaw-oauth-client-tech-design.md` (PR #454, merged 2026-08-15) — that design explicitly rejected DCR/CIMD as overkill. Tom reversed that decision 2026-08-18 because the static-client path does not match what OpenClaw's spec-following MCP client actually speaks.
+- Predecessor tech design (auth model + table layout): `docs/specs/gymtrack-mcp-server-oauth-auth-tech-design.md`
+- Predecessor migration this design extends: `apps/gymtrack/supabase/migrations/20260804070000_mcp_oauth.sql`
+- Spec reference: RFC 7591 (OAuth 2.0 Dynamic Client Registration), RFC 8414 (Authorization Server Metadata)
+
+## Problem
+
+`gymtrack-mcp`'s OAuth authorization server recognises only four hardcoded client_ids (`claude-desktop`, `chatgpt`, `local-dev`, `openclaw`), each seeded by a SQL migration. PR #454 added `openclaw` to unblock the OpenClaw agent runtime, on the assumption that OpenClaw could be configured with a static `client_id` + redirect URI.
+
+That assumption was wrong. Confirmed 2026-08-18 (see comment on task 30251df0): OpenClaw's MCP OAuth client (`mcp.servers.*.oauth`, `additionalProperties: false`) only supports `scope`, `redirectUrl`, and `clientMetadataUrl` — there is no way to wire a static pre-shared `client_id`. OpenClaw only knows how to do Dynamic Client Registration (RFC 7591, default behaviour) or Client ID Metadata Documents (RFC 9470, when `clientMetadataUrl` is set). Result: `openclaw mcp login gymtrack` still fails with `Incompatible auth server: does not support dynamic client registration` after PR #454 merged.
+
+Decision (Tom, 2026-08-18): implement DCR rather than CIMD. DCR needs no separately hosted metadata document, is the more common / better-supported path across the MCP client ecosystem, and lets any future third-party agent self-register without GymTrack maintaining a hardcoded client list per onboarded client.
+
+This task supersedes the remaining scope of 30251df0 (its AC2/AC3, which were explicitly deferred as "Quinn-owned follow-up" and turned out to be blocked on this).
+
+## Goals (mapped to task ACs)
+
+- **AC1** — produce this design (the design itself is the AC).
+- **AC2** — gymtrack-mcp exposes a working `POST /oauth/register` endpoint per RFC 7591, and `registration_endpoint` is advertised in `/.well-known/oauth-authorization-server` so MCP clients can discover it.
+- **AC3** — `openclaw mcp login gymtrack` completes end-to-end against the deployed gymtrack-mcp endpoint and OpenClaw obtains a valid access token. (Real verification, not just unit tests.)
+- **AC4** — an authenticated OpenClaw MCP session can list and invoke the GymTrack MCP tools (`plan_workout`, `read_history`, `read_exercise_progression`).
+- **AC5** — no new client can access GymTrack data beyond what the user has consented to; dynamically-registered clients still go through GymTrack's existing agent-consent approval screen before any token exchange succeeds.
+
+## Service boundary and data ownership
+
+- **Service:** `services/gymtrack-mcp` (the OAuth authorisation server and MCP resource server). Owns the OAuth client registry, consent ledger, token storage, and authorisation-code lifecycle. No extraction.
+- **Schema owner:** `apps/gymtrack/supabase` (single Postgres, schema `public`). New columns land on `public.gymtrack_oauth_clients`; no new table is required. This keeps the data plane co-located with the existing consent / token / code tables and avoids a cross-schema join.
+- **Direct consumers:** `services/gymtrack-mcp` (the OAuth server that performs `validateClientRedirect` and `getOAuthClient` on every authorize/token request). No other service reads `gymtrack_oauth_clients` today, so the schema extension has blast radius of one.
+- **Why this is the right place:** the OAuth client registry is a single-tenant concept owned by the MCP server. Spreading it across a shared package or a different service would create a second source of truth for which clients GymTrack trusts. Durable shape lives in the migration; the API surface lives in `services/gymtrack-mcp/src/app.js`.
+
+## Approach
+
+Add a minimal RFC 7591 `client registration endpoint` to `services/gymtrack-mcp`, extend the `gymtrack_oauth_clients` table with a small set of nullable metadata columns + a `registration_type` discriminator, and advertise `registration_endpoint` in the server metadata document. The endpoint is **public-only** — no `client_secret` is generated, no confidential-client semantics — matching the existing trust model (all current clients are public PKCE, `gymtrack_oauth_clients` has no secret column, `token_endpoint_auth_methods_supported: ["none"]`).
+
+### 1. Discovery surface change
+
+Add one field to the JSON served by `GET /.well-known/oauth-authorization-server`:
+
+```json
+{
+  "issuer": "…",
+  "authorization_endpoint": "…",
+  "token_endpoint": "…",
+  "registration_endpoint": "<issuer>/oauth/register",
+  "revocation_endpoint": "…",
+  "response_types_supported": ["code"],
+  "code_challenge_methods_supported": ["S256"],
+  "grant_types_supported": ["authorization_code", "refresh_token"],
+  "token_endpoint_auth_methods_supported": ["none"],
+  "scopes_supported": […],
+  "registration_endpoint_auth_methods_supported": ["none"]
+}
+```
+
+`registration_endpoint_auth_methods_supported` is set to `["none"]` to make the open-registration posture explicit per RFC 7591 §3.1.1 (clients know in advance they don't need to send credentials). This is the single discovery signal OpenClaw (and any future MCP client) needs to stop emitting `Incompatible auth server`.
+
+### 2. Registration endpoint shape
+
+`POST /oauth/register` (JSON, no auth):
+
+**Request body** (RFC 7591 §2 client metadata):
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `redirect_uris` | yes | Array, ≥1 entry. Each entry must be absolute http/https, no fragment, no wildcard. Localhost/loopback URIs allowed per RFC 8252 §7.3. |
+| `client_name` | optional | Display string, ≤200 chars. Stored verbatim. |
+| `client_uri` | optional | https URL, ≤2000 chars. Validated if present. |
+| `logo_uri` | optional | https URL, ≤2000 chars. Validated if present. |
+| `contacts` | optional | Array of email-shaped strings, ≤10 entries. |
+| `policy_uri` | optional | https URL. |
+| `tos_uri` | optional | https URL. |
+| `software_id` | optional | Opaque string ≤64 chars. |
+| `software_version` | optional | Semver-ish string ≤32 chars. |
+| `token_endpoint_auth_method` | optional | Must be `"none"` if present; reject anything else. |
+
+Unknown fields are silently dropped per RFC 7591 §2 — clients sending extra metadata must not be rejected for it. The endpoint never echoes secrets (because no secrets are generated).
+
+**Response (201 Created)** per RFC 7591 §3.2.1:
+
+```json
+{
+  "client_id": "<uuid v4>",
+  "client_id_issued_at": 1755475200
+}
+```
+
+`client_secret` and `client_secret_expires_at` are intentionally omitted (we never issue secrets). RFC 7591 explicitly allows omitting these fields for public clients.
+
+**Error responses** per RFC 7591 §3.2.2:
+
+| HTTP | error | error_description |
+| --- | --- | --- |
+| 400 | `invalid_redirect_uri` | One or more `redirect_uris` is malformed, contains a fragment, uses a wildcard, or fails scheme/host validation. |
+| 400 | `invalid_client_metadata` | Other metadata validation failure (e.g. `token_endpoint_auth_method` is not `"none"`). |
+| 400 | `invalid_request` | Body is not JSON, or missing required `redirect_uris`. |
+| 413 | `request_entity_too_large` | Body exceeds 100KB (matches existing `express.json({ limit: '100kb' })` in app.js). |
+| 500 | `server_error` | Catch-all; `error_description` redacted per existing `redactErrorForResponse` helper. |
+
+### 3. Storage: extend `gymtrack_oauth_clients`
+
+Migration `apps/gymtrack/supabase/migrations/<yyyymmddhhmmss>_oauth_dcr.sql` adds the following columns to `public.gymtrack_oauth_clients` (all `ADD COLUMN ... NULL` except where noted — backwards-compatible with the four existing static rows):
+
+| Column | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `registration_type` | `text` | `'static'` NOT NULL | Discriminator. `CHECK (registration_type IN ('static','dynamic'))`. Existing rows keep `'static'`; new DCR-registered rows get `'dynamic'`. |
+| `registered_at` | `timestamptz` | NULL | Set on insert for dynamic rows; NULL for static rows. |
+| `client_uri` | `text` | NULL | RFC 7591 §2 `client_uri`. |
+| `logo_uri` | `text` | NULL | RFC 7591 §2 `logo_uri`. |
+| `contacts` | `text[]` | NULL | RFC 7591 §2 `contacts`. |
+| `policy_uri` | `text` | NULL | RFC 7591 §2 `policy_uri`. |
+| `tos_uri` | `text` | NULL | RFC 7591 §2 `tos_uri`. |
+| `software_id` | `text` | NULL | RFC 7591 §2 `software_id`. |
+| `software_version` | `text` | NULL | RFC 7591 §2 `software_version`. |
+
+**No `client_secret_hash` column** — by deliberate design. If a confidential client ever needs to register, that is a separate task: add `client_secret_hash text`, `client_secret_expires_at timestamptz`, secret generation in the registration endpoint, and update `token_endpoint_auth_methods_supported` to advertise `["none","client_secret_basic"]`. Doing it now would be premature (no consumer needs it) and would introduce a secret-rotation lifecycle surface that has no operator owner yet.
+
+**Indexes:** none needed for v1. The PK on `client_id` already serves the read path. If `registration_type='dynamic'` rows grow past ~10k and we add an admin list endpoint, a partial index `(registered_at desc) WHERE registration_type='dynamic'` is a follow-up.
+
+**RLS:** unchanged. The existing `gymtrack_oauth_clients_authenticated_read` policy covers both static and dynamic rows. Service-role writes (insert from `/oauth/register`) bypass RLS.
+
+### 4. Disposition of the `openclaw` static row from PR #454
+
+**Decision: leave it in place, marked `registration_type='static'`.** Three reasons:
+
+1. DCR-generated `client_id` values are random UUIDs (RFC 4122 §4.4). They will not collide with the literal string `openclaw`.
+2. Deletion is a separate decision that should happen after AC3/AC4 are verified end-to-end (i.e. once OpenClaw is registering dynamically and the static row has zero traffic). Doing it now couples two risky changes.
+3. The static row's `registration_type='static'` makes it easy to identify and drop in a follow-up cleanup task. A targeted `DELETE FROM public.gymtrack_oauth_clients WHERE client_id='openclaw' AND registration_type='static'` (after verifying no dynamic registration took that name) is a small, safe operation.
+
+**Follow-up task (out of scope here):** once AC3/AC4 pass against the deployed endpoint, file a separate code task to (a) drop the static `openclaw` row and (b) remove the now-redundant migration `20260815070000_openclaw_oauth_client.sql` from the deploy chain (or leave it as historical record — depends on Tom's preference). This design does not commit to either option.
+
+### 5. Consent gate — AC5
+
+The existing consent gate applies to dynamic clients **without modification**. The relevant invariants:
+
+- `validateClientRedirect(repo, client_id, redirect_uri)` does `repo.getOAuthClient(client_id)` and checks `oauthClient.redirect_uris.includes(redirect_uri)`. Whether the row was seeded or registered dynamically is irrelevant — same lookup, same array comparison.
+- `upsertConsent({ userId, clientId, scope, grantedAt })` keys on `(userId, clientId)`. The active-consent unique index `gymtrack_oauth_consents_active_user_client_idx ON (user_id, client_id) WHERE revoked_at IS NULL` already enforces one active consent per `(user, client)` regardless of how the client was registered.
+- `consumeAuthorizationCode` returns `null` when no active consent row exists for the consent_id, so the token endpoint returns `invalid_grant` if the user revoked the consent before the code is exchanged.
+- `/oauth/revoke` revokes the entire token family by `consent_id`, again regardless of client registration provenance.
+
+In short: dynamic clients go through **exactly the same consent and revocation flow** as static clients, because the existing code paths are already keyed on `client_id` as an opaque string.
+
+**Test plan for AC5 (in addition to the existing static-client tests):** add a test that (a) registers a dynamic client via `POST /oauth/register`, (b) hits `/oauth/authorize` → `/oauth/authorize/decision` → `/oauth/token` without ever granting consent, (c) asserts the token endpoint returns `400 invalid_grant`. Mirrors the existing static-client regression test for `client_id=openclaw`.
+
+### 6. Edge cases and error handling
+
+- **Empty `redirect_uris` array.** Reject 400 `invalid_redirect_uri`. Existing CHECK constraint `array_length(redirect_uris, 1) >= 1` enforces this at the DB level; surface a meaningful error before hitting it.
+- **Wildcard in `redirect_uri`** (e.g. `https://*.example.com/cb`). Reject 400 `invalid_redirect_uri` with `error_description="redirect_uris must not contain wildcards."`. RFC 7591 §2 explicitly forbids wildcards.
+- **Fragment in `redirect_uri`** (e.g. `https://example.com/cb#foo`). Reject 400 `invalid_redirect_uri`. RFC 6749 §3.1.2 forbids fragments.
+- **Non-http(s) scheme** (e.g. `javascript:`, `file:`, custom schemes). Reject 400 `invalid_redirect_uri`. RFC 7591 §2 only mentions http/https; custom schemes are not part of this profile.
+- **Duplicate `client_name` from a different registrant.** Allow it. Two registrants may legitimately use the same display name.
+- **Same `redirect_uris` from two registrants.** Allow it. Each gets a distinct `client_id`; consent is per-(user, client_id).
+- **Body exceeds 100KB.** Reject 413. Express middleware `express.json({ limit: '100kb' })` already enforces this.
+- **`token_endpoint_auth_method` is anything other than `"none"`** (e.g. `"client_secret_basic"`). Reject 400 `invalid_client_metadata` with description `"token_endpoint_auth_method must be 'none'."`. This is a deliberate v1 constraint — see §3.
+- **Concurrent registrations.** Postgres serialises inserts on `client_id` (PK). Two concurrent requests will get distinct UUIDs. No race.
+- **Malformed JSON body.** Express returns 400 by default; wrap to return RFC 7591-shaped error `{ error: 'invalid_request', error_description: 'Body is not valid JSON.' }`.
+
+### 7. Out of scope (explicit non-goals)
+
+These are tempting to bundle into the same PR. Resist: each is a meaningful scope expansion with its own risks and review surface.
+
+- **Confidential client support** (`client_secret` generation, hashing, rotation, expiry). Needs an operator owner for secret rotation; defer until a concrete consumer requires it.
+- **Initial access tokens** for the registration endpoint (RFC 7591 §3.1). Would let us lock down registration to holders of a Tom-issued token. Defer until open registration becomes an abuse vector.
+- **Per-IP rate limiting** on `POST /oauth/register`. Needs Redis or similar; no rate-limit infra exists in `services/gymtrack-mcp` today. Defer until abuse is observed in logs.
+- **Admin endpoint to list or revoke dynamically-registered clients.** Admins can use psql / Supabase Studio today; a UI is a UX win, not a security need. Defer until the dynamic client population warrants it.
+- **Dynamically-registered client lifecycle management** (deactivate, delete, transfer). RFC 7591 §4.2 mentions a management endpoint; defer until a real need arises.
+- **Internationalisation of client metadata fields** (RFC 7591 §2 supports `client_name#lang`). Skip for v1; everything is English.
+
+## Implementation plan
+
+### `apps/gymtrack/supabase/migrations/<yyyymmddhhmmss>_oauth_dcr.sql` (new)
+
+`ALTER TABLE public.gymtrack_oauth_clients ADD COLUMN …` for the columns in §3, plus the `CHECK (registration_type IN ('static','dynamic'))` constraint. No new table, no RLS change, no policy change. Existing four static rows are unaffected.
+
+### `services/gymtrack-mcp/src/app.js` (extend)
+
+1. **Discovery endpoint** (existing handler at `/.well-known/oauth-authorization-server`): add `registration_endpoint` and `registration_endpoint_auth_methods_supported` to the response payload.
+2. **New route `POST /oauth/register`**: validate the request body per §2 (client metadata validation), generate a UUIDv4 `client_id` (via `randomUUID()` from `node:crypto`, already imported), `INSERT` a row into `gymtrack_oauth_clients` with `registration_type='dynamic'`, `registered_at=now()`, and the supplied metadata columns, return 201 with the RFC 7591 response shape.
+3. **Repo extension in `services/gymtrack-mcp/src/repo.js`**: add `createDynamicOAuthClient({ clientId, clientName, redirectUris, clientUri, logoUri, contacts, policyUri, tosUri, softwareId, softwareVersion, registeredAt })` that performs the insert and returns the stored row. Mirrors the existing `createToken` / `createAuthorizationCode` patterns.
+
+### `services/gymtrack-mcp/test/app.test.js` (extend)
+
+Add the following test cases in the existing vitest suite, using the existing `FakeRepo` (extended with `createDynamicOAuthClient` matching the new repo method):
+
+1. **Discovery advertises registration_endpoint.** Hit `GET /.well-known/oauth-authorization-server`; assert `body.registration_endpoint === '<issuer>/oauth/register'` and `body.registration_endpoint_auth_methods_supported` deep-equals `['none']`.
+2. **Register valid client.** `POST /oauth/register` with `{ redirect_uris: ['http://127.0.0.1:8789/callback'], client_name: 'Test', token_endpoint_auth_method: 'none' }`; assert 201, response has `client_id` matching a UUIDv4 regex, response omits `client_secret`. Assert the row exists in the `FakeRepo` with `registration_type='dynamic'` and the supplied metadata.
+3. **Register rejects missing redirect_uris.** Assert 400 `invalid_request`.
+4. **Register rejects empty redirect_uris.** Assert 400 `invalid_redirect_uri`.
+5. **Register rejects wildcard redirect_uri.** Assert 400 `invalid_redirect_uri`.
+6. **Register rejects fragment in redirect_uri.** Assert 400 `invalid_redirect_uri`.
+7. **Register rejects javascript: scheme.** Assert 400 `invalid_redirect_uri`.
+8. **Register rejects `token_endpoint_auth_method=client_secret_basic`.** Assert 400 `invalid_client_metadata`.
+9. **Register silently drops unknown fields.** Send `{ redirect_uris: [...], client_name: 'Test', extra_unknown_field: 'foo' }`; assert 201 and the unknown field is not stored.
+10. **Dynamic client participates in consent gate (AC5).** Register a dynamic client via `POST /oauth/register`, then attempt the full `authorize → decision → token` flow **without** inserting a consent row first; assert `/oauth/token` returns 400 `invalid_grant`. Mirror the existing static-client test for `client_id=openclaw`.
+11. **Dynamic client full happy path.** Register → seed consent → complete the authorize/token flow → call `POST /mcp tools/list` with the issued access token; assert 200 and the three MCP tools are returned.
+12. **Dynamic client goes through existing revocation.** Register → seed consent → token → call `POST /oauth/revoke`; assert a follow-up `/mcp tools/list` call returns 401 with `WWW-Authenticate`. Mirrors the existing static-client revocation test.
+
+No new test fixtures — the `FakeRepo` extension is mechanical.
+
+### `docs/runbooks/gymtrack-agent-connect.md` (extend)
+
+Add a short section: "Dynamic client registration" explaining how to register an MCP client against a deployed gymtrack-mcp endpoint (curl example showing `POST /oauth/register` with a minimal payload, the resulting `client_id`, and how that flows into the existing authorize-decision-token pattern). Add a confirmation query to the existing operator checklist that surfaces both registration types:
+
+```sql
+select client_id, registration_type, client_name, registered_at
+from public.gymtrack_oauth_clients
+order by registration_type, registered_at desc nulls last, client_id;
+```
+
+## Risks
+
+- **Open registration = abuse surface.** Anyone who knows the issuer URL can register a client. Mitigations deferred: rate limiting, initial access tokens. **Real risk:** registration spam could grow `gymtrack_oauth_clients` unboundedly. The `gymtrack_oauth_clients_authenticated_read` RLS policy means a logged-in user can `SELECT` all rows; a malicious registrant could enumerate by spamming and reading. **Mitigation in scope:** cap `client_name` at 200 chars and reject obviously-spammy payloads at validation time. **Mitigation deferred:** rate-limit + admin cleanup endpoint.
+- **Consent gate relies on user approval at /agent-consent.** A user who clicks "Approve" on a malicious dynamic client has consented to that client reading their data. This is inherent to OAuth consent flows and is not new to DCR — same risk applies to the four static clients. Document in the runbook that users should verify the `client_name` and `redirect_uri` shown on the consent screen.
+- **`client_id` collision is not a meaningful risk.** UUIDv4 from `crypto.randomUUID()` has negligible collision probability. The PK constraint will surface a collision as a 500; we should never see one.
+- **Discovery surface change is observable to all clients.** Any existing MCP client that does strict metadata validation may break. Mitigation: `registration_endpoint` is an additive field per RFC 8414 §2 — clients that ignore unknown fields are unaffected. No known consumer parses strict schemas today.
+- **No `client_secret` means no defence-in-depth against `client_id` theft for public clients.** This is the existing trust model (public PKCE) and is unchanged. Defence comes from the consent screen, redirect-URI exact-match, and PKCE binding.
+- **`openclaw` static row left in place could confuse operators.** Mitigated by the `registration_type` column making the distinction explicit in queries. Cleanup follow-up task will remove it.
+
+## Open questions
+
+- **Q1. Should we log dynamic registrations to an audit table?** Tempting, but no audit table exists for OAuth client lifecycle events today (consents are the closest thing and are per-user, not per-client). Defer until Tom asks. **Default answer for now: log to stdout, parse Fly logs.**
+- **Q2. Should `/oauth/register` require `User-Agent` to be non-empty?** RFC 7591 doesn't say. Defer.
+- **Q3. Should we expose a `client_id_issued_at` in the response as a Unix epoch (RFC 7591 default) or ISO-8601?** RFC 7591 §3.2.1 says epoch. Stick with epoch; document in the runbook.
+
+## Test plan (AC verification matrix)
+
+| AC | Verification |
+| --- | --- |
+| AC1 | This design (merged to `feat/de19b186-oauth-dcr` branch and posted as `[tech-design] <url>` comment on task `de19b186-dda6-47dc-94f1-ef52d2dc9383`) + the `[tech-design-approved]` audit comment from Quinn. |
+| AC2 | `npx vitest run services/gymtrack-mcp/test/app.test.js` passes (existing 13 tests + 12 new tests in §Implementation plan). Deployed smoke: `curl -sS https://gymtrack-mcp.fly.dev/.well-known/oauth-authorization-server \| jq -e '.registration_endpoint'` returns the expected URL. |
+| AC3 | Manual end-to-end smoke against the deployed Fly endpoint: `openclaw mcp login gymtrack` → log entry observed in `/var/log/gymtrack-mcp` for `POST /oauth/register` with `client_name="OpenClaw"` → follow-on `POST /oauth/authorize` → user approves at `/agent-consent` → `POST /oauth/token` → OpenClaw stores the access token. Verifiable by Tom running the command and confirming the access token file is written. |
+| AC4 | Same end-to-end as AC3: with the issued access token, `openclaw` calls `POST /mcp` `tools/list` and observes `plan_workout`, `read_history`, `read_exercise_progression` in the response. Then `tools/call plan_workout` returns a non-error payload for Tom's account. |
+| AC5 | Test #10 above (dynamic client cannot exchange a code without an active consent row). Mirrors the existing static-client regression test for `client_id=openclaw`. The test exercises the production consent gate (`getConsent(...).revoked_at` check in `/oauth/token`) by deliberately not seeding a consent row. |
+
+## Notes for Quinn
+
+- The decision to leave the `openclaw` static row in place (§4) is the kind of thing that could go either way on review. If you'd rather drop it as part of this PR, the change is one DELETE inside the migration plus a corresponding test fixture update — flag and I'll fold it in.
+- The decision to defer confidential-client support, rate limiting, and the admin list/revoke endpoint (§7) is the kind of thing that could also go either way. The argument for deferring is "no consumer needs it yet"; the argument for bundling is "we know we'll need it eventually". My read of the existing codebase posture is "defer until needed" (see e.g. the original tech design's reasoning for rejecting DCR/CIMD, which has now been reversed for the same reason), but happy to flip if you disagree.

--- a/services/gymtrack-mcp/src/app.js
+++ b/services/gymtrack-mcp/src/app.js
@@ -33,6 +33,189 @@ function oauthJsonError(res, status, error, description) {
   return res.status(status).json({ error, error_description: description });
 }
 
+// RFC 7591 §2 client metadata validation. Returns { ok: true, value } or
+// { ok: false, error, description }. Unknown fields are silently dropped by
+// the caller per RFC 7591 §2 — we do not reject extra metadata.
+const MAX_REDIRECT_URIS = 16;
+const MAX_REDIRECT_URI_LENGTH = 2000;
+const MAX_CLIENT_NAME_LENGTH = 200;
+const MAX_URL_LENGTH = 2000;
+const MAX_CONTACTS = 10;
+const MAX_SOFTWARE_ID_LENGTH = 64;
+const MAX_SOFTWARE_VERSION_LENGTH = 32;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const SEMVERISH_REGEX = /^[A-Za-z0-9.\-+]+$/;
+
+function isValidRedirectUri(value) {
+  if (typeof value !== 'string') return false;
+  if (value.length === 0 || value.length > MAX_REDIRECT_URI_LENGTH) return false;
+  if (value.includes('#')) return false;
+  if (value.includes('*')) return false;
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+  return true;
+}
+
+function isValidHttpsUrl(value, maxLength) {
+  if (typeof value !== 'string') return false;
+  if (value.length === 0 || value.length > maxLength) return false;
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === 'https:';
+}
+
+function validateRegistrationRequest(body) {
+  if (body == null || typeof body !== 'object' || Array.isArray(body)) {
+    return {
+      ok: false,
+      error: 'invalid_request',
+      description: 'Body is not a JSON object.'
+    };
+  }
+
+  const redirectUris = body.redirect_uris;
+  if (redirectUris == null) {
+    return {
+      ok: false,
+      error: 'invalid_request',
+      description: 'redirect_uris is required.'
+    };
+  }
+  if (!Array.isArray(redirectUris) || redirectUris.length === 0) {
+    return {
+      ok: false,
+      error: 'invalid_redirect_uri',
+      description: 'redirect_uris must be a non-empty array.'
+    };
+  }
+  if (redirectUris.length > MAX_REDIRECT_URIS) {
+    return {
+      ok: false,
+      error: 'invalid_redirect_uri',
+      description: `redirect_uris must contain at most ${MAX_REDIRECT_URIS} entries.`
+    };
+  }
+  for (const entry of redirectUris) {
+    if (!isValidRedirectUri(entry)) {
+      return {
+        ok: false,
+        error: 'invalid_redirect_uri',
+        description: 'redirect_uris must not contain wildcards, fragments, or non-http(s) schemes.'
+      };
+    }
+  }
+
+  if (body.token_endpoint_auth_method != null && body.token_endpoint_auth_method !== 'none') {
+    return {
+      ok: false,
+      error: 'invalid_client_metadata',
+      description: "token_endpoint_auth_method must be 'none'."
+    };
+  }
+
+  if (body.client_name != null) {
+    if (typeof body.client_name !== 'string' || body.client_name.length > MAX_CLIENT_NAME_LENGTH) {
+      return {
+        ok: false,
+        error: 'invalid_client_metadata',
+        description: `client_name must be a string of at most ${MAX_CLIENT_NAME_LENGTH} characters.`
+      };
+    }
+  }
+
+  for (const field of ['client_uri', 'logo_uri', 'policy_uri', 'tos_uri']) {
+    if (body[field] != null && !isValidHttpsUrl(body[field], MAX_URL_LENGTH)) {
+      return {
+        ok: false,
+        error: 'invalid_client_metadata',
+        description: `${field} must be an https URL of at most ${MAX_URL_LENGTH} characters.`
+      };
+    }
+  }
+
+  if (body.contacts != null) {
+    if (!Array.isArray(body.contacts) || body.contacts.length > MAX_CONTACTS) {
+      return {
+        ok: false,
+        error: 'invalid_client_metadata',
+        description: `contacts must be an array of at most ${MAX_CONTACTS} entries.`
+      };
+    }
+    for (const contact of body.contacts) {
+      if (typeof contact !== 'string' || contact.length === 0 || contact.length > 320) {
+        return {
+          ok: false,
+          error: 'invalid_client_metadata',
+          description: 'contacts entries must be non-empty strings of at most 320 characters.'
+        };
+        }
+      if (!EMAIL_REGEX.test(contact)) {
+        return {
+          ok: false,
+          error: 'invalid_client_metadata',
+          description: 'contacts entries must be email-shaped strings.'
+        };
+      }
+    }
+  }
+
+  if (body.software_id != null) {
+    if (
+      typeof body.software_id !== 'string' ||
+      body.software_id.length === 0 ||
+      body.software_id.length > MAX_SOFTWARE_ID_LENGTH
+    ) {
+      return {
+        ok: false,
+        error: 'invalid_client_metadata',
+        description: `software_id must be a string of at most ${MAX_SOFTWARE_ID_LENGTH} characters.`
+      };
+    }
+  }
+
+  if (body.software_version != null) {
+    if (
+      typeof body.software_version !== 'string' ||
+      body.software_version.length === 0 ||
+      body.software_version.length > MAX_SOFTWARE_VERSION_LENGTH ||
+      !SEMVERISH_REGEX.test(body.software_version)
+    ) {
+      return {
+        ok: false,
+        error: 'invalid_client_metadata',
+        description: `software_version must be a semver-ish string of at most ${MAX_SOFTWARE_VERSION_LENGTH} characters.`
+      };
+    }
+  }
+
+  // Whitelist the metadata fields we persist; drop anything else silently
+  // per RFC 7591 §2. The endpoint never echoes client_secret because we
+  // never issue secrets (public-only clients).
+  const clientName = typeof body.client_name === 'string' ? body.client_name : null;
+  const value = {
+    redirectUris,
+    clientName: clientName ? clientName.slice(0, MAX_CLIENT_NAME_LENGTH) : null,
+    clientUri: body.client_uri ?? null,
+    logoUri: body.logo_uri ?? null,
+    contacts: body.contacts ?? null,
+    policyUri: body.policy_uri ?? null,
+    tosUri: body.tos_uri ?? null,
+    softwareId: body.software_id ?? null,
+    softwareVersion: body.software_version ?? null
+  };
+
+  return { ok: true, value };
+}
+
 // Strip token-shaped strings, Bearer-prefixed values, and Supabase URLs from
 // error text before returning it to clients. Bounded to 80 characters so the
 // response shape stays predictable. Original detail is still available via
@@ -151,12 +334,49 @@ export function createApp({
       authorization_endpoint: `${config.issuer}/oauth/authorize`,
       token_endpoint: `${config.issuer}/oauth/token`,
       revocation_endpoint: `${config.issuer}/oauth/revoke`,
+      registration_endpoint: `${config.issuer}/oauth/register`,
       response_types_supported: ['code'],
       code_challenge_methods_supported: ['S256'],
       grant_types_supported: ['authorization_code', 'refresh_token'],
       token_endpoint_auth_methods_supported: ['none'],
+      registration_endpoint_auth_methods_supported: ['none'],
       scopes_supported: SUPPORTED_SCOPES
     });
+  });
+
+  app.post('/oauth/register', async (req, res) => {
+    try {
+      if (req.body == null || typeof req.body !== 'object' || Array.isArray(req.body)) {
+        return oauthJsonError(res, 400, 'invalid_request', 'Body is not a JSON object.');
+      }
+
+      const validation = validateRegistrationRequest(req.body);
+      if (!validation.ok) {
+        return oauthJsonError(res, 400, validation.error, validation.description);
+      }
+
+      const clientId = randomUUID();
+      await repo.createDynamicOAuthClient({
+        clientId,
+        clientName: validation.value.clientName,
+        redirectUris: validation.value.redirectUris,
+        clientUri: validation.value.clientUri,
+        logoUri: validation.value.logoUri,
+        contacts: validation.value.contacts,
+        policyUri: validation.value.policyUri,
+        tosUri: validation.value.tosUri,
+        softwareId: validation.value.softwareId,
+        softwareVersion: validation.value.softwareVersion,
+        registeredAt: now()
+      });
+
+      return res.status(201).json({
+        client_id: clientId,
+        client_id_issued_at: Math.floor(now().getTime() / 1000)
+      });
+    } catch (error) {
+      return oauthJsonError(res, 500, 'server_error', redactErrorForResponse(error.message));
+    }
   });
 
   app.get('/.well-known/oauth-protected-resource', (_req, res) => {

--- a/services/gymtrack-mcp/src/repo.js
+++ b/services/gymtrack-mcp/src/repo.js
@@ -16,6 +16,29 @@ export function createSupabaseRepo({ client = supabaseAdminClient() } = {}) {
       return data;
     },
 
+    async createDynamicOAuthClient(record) {
+      const { data, error } = await client
+        .from('gymtrack_oauth_clients')
+        .insert({
+          client_id: record.clientId,
+          client_name: record.clientName,
+          redirect_uris: record.redirectUris,
+          registration_type: 'dynamic',
+          registered_at: iso(record.registeredAt),
+          client_uri: record.clientUri ?? null,
+          logo_uri: record.logoUri ?? null,
+          contacts: record.contacts ?? null,
+          policy_uri: record.policyUri ?? null,
+          tos_uri: record.tosUri ?? null,
+          software_id: record.softwareId ?? null,
+          software_version: record.softwareVersion ?? null
+        })
+        .select()
+        .single();
+      if (error) throw error;
+      return data;
+    },
+
     async getConsent(consentId) {
       const { data, error } = await client
         .from('gymtrack_oauth_consents')

--- a/services/gymtrack-mcp/test/app.test.js
+++ b/services/gymtrack-mcp/test/app.test.js
@@ -43,6 +43,25 @@ class FakeRepo {
     return this.clients.find((client) => client.client_id === clientId) ?? null;
   }
 
+  async createDynamicOAuthClient(record) {
+    const row = {
+      client_id: record.clientId,
+      client_name: record.clientName,
+      redirect_uris: record.redirectUris,
+      registration_type: 'dynamic',
+      registered_at: record.registeredAt.toISOString(),
+      client_uri: record.clientUri ?? null,
+      logo_uri: record.logoUri ?? null,
+      contacts: record.contacts ?? null,
+      policy_uri: record.policyUri ?? null,
+      tos_uri: record.tosUri ?? null,
+      software_id: record.softwareId ?? null,
+      software_version: record.softwareVersion ?? null
+    };
+    this.clients.push(row);
+    return structuredClone(row);
+  }
+
   async getConsent(consentId) {
     return this.consents.find((consent) => consent.id === consentId) ?? null;
   }
@@ -753,5 +772,298 @@ describe('GymTrack MCP OAuth server', () => {
     expect(response.body.error_description).toBe(
       'redirect_uri is not registered for this client.'
     );
+  });
+
+  it('advertises registration_endpoint and registration_endpoint_auth_methods_supported in discovery', async () => {
+    const { app } = makeApp();
+
+    const response = await request(app).get('/.well-known/oauth-authorization-server');
+
+    expect(response.status).toBe(200);
+    expect(response.body.registration_endpoint).toBe('https://mcp.example/oauth/register');
+    expect(response.body.registration_endpoint_auth_methods_supported).toEqual(['none']);
+  });
+
+  it('registers a valid dynamic client and stores the metadata (no client_secret issued)', async () => {
+    const { app, repo } = makeApp();
+
+    const response = await request(app)
+      .post('/oauth/register')
+      .send({
+        redirect_uris: ['http://127.0.0.1:8789/callback'],
+        client_name: 'Test MCP',
+        token_endpoint_auth_method: 'none',
+        software_id: 'test-mcp',
+        software_version: '1.0.0'
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.client_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+    expect(response.body.client_id_issued_at).toBe(
+      Math.floor(new Date('2026-08-03T00:00:00.000Z').getTime() / 1000)
+    );
+    expect(response.body).not.toHaveProperty('client_secret');
+    expect(response.body).not.toHaveProperty('client_secret_expires_at');
+
+    const stored = repo.clients.find((client) => client.client_id === response.body.client_id);
+    expect(stored).toBeDefined();
+    expect(stored.registration_type).toBe('dynamic');
+    expect(stored.client_name).toBe('Test MCP');
+    expect(stored.redirect_uris).toEqual(['http://127.0.0.1:8789/callback']);
+    expect(stored.software_id).toBe('test-mcp');
+    expect(stored.software_version).toBe('1.0.0');
+    expect(stored.registered_at).toBe('2026-08-03T00:00:00.000Z');
+  });
+
+  it('rejects registration when redirect_uris is missing', async () => {
+    const { app } = makeApp();
+
+    const response = await request(app)
+      .post('/oauth/register')
+      .send({ client_name: 'Test MCP' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_request');
+    expect(response.body.error_description).toMatch(/redirect_uris is required/i);
+  });
+
+  it('rejects registration when redirect_uris is empty', async () => {
+    const { app } = makeApp();
+
+    const response = await request(app)
+      .post('/oauth/register')
+      .send({ redirect_uris: [] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_redirect_uri');
+  });
+
+  it('rejects registration when a redirect_uri contains a wildcard', async () => {
+    const { app } = makeApp();
+
+    const response = await request(app)
+      .post('/oauth/register')
+      .send({ redirect_uris: ['https://*.example.com/cb'] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_redirect_uri');
+    expect(response.body.error_description).toMatch(/wildcards/i);
+  });
+
+  it('rejects registration when a redirect_uri contains a fragment', async () => {
+    const { app } = makeApp();
+
+    const response = await request(app)
+      .post('/oauth/register')
+      .send({ redirect_uris: ['https://example.com/cb#foo'] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_redirect_uri');
+  });
+
+  it('rejects registration when a redirect_uri uses javascript: scheme', async () => {
+    const { app } = makeApp();
+
+    const response = await request(app)
+      .post('/oauth/register')
+      .send({ redirect_uris: ["javascript:alert('xss')"] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_redirect_uri');
+  });
+
+  it("rejects registration when token_endpoint_auth_method is not 'none'", async () => {
+    const { app } = makeApp();
+
+    const response = await request(app)
+      .post('/oauth/register')
+      .send({
+        redirect_uris: ['https://example.com/cb'],
+        token_endpoint_auth_method: 'client_secret_basic'
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_client_metadata');
+    expect(response.body.error_description).toMatch(/token_endpoint_auth_method/);
+  });
+
+  it('silently drops unknown fields on registration per RFC 7591 §2', async () => {
+    const { app, repo } = makeApp();
+
+    const response = await request(app)
+      .post('/oauth/register')
+      .send({
+        redirect_uris: ['https://example.com/cb'],
+        client_name: 'Test MCP',
+        extra_unknown_field: 'foo',
+        another_extra: { nested: 'bar' }
+      });
+
+    expect(response.status).toBe(201);
+    const stored = repo.clients.find((client) => client.client_id === response.body.client_id);
+    expect(stored.extra_unknown_field).toBeUndefined();
+    expect(stored.another_extra).toBeUndefined();
+  });
+
+  it('blocks dynamic clients from token exchange without an active consent (AC5)', async () => {
+    const { app, repo } = makeApp();
+
+    const registration = await request(app)
+      .post('/oauth/register')
+      .send({
+        redirect_uris: ['http://127.0.0.1:8789/cb'],
+        client_name: 'MCP-Unconsented'
+      });
+    expect(registration.status).toBe(201);
+    const clientId = registration.body.client_id;
+
+    // Manually write an authorization code that points at a consent_id which
+    // does not exist in the repo. Mirrors the regression test for the openclaw
+    // static row, but for a freshly-registered dynamic client.
+    const code = 'dynamic-orphan-consent-code';
+    const verifier = 'dynamic-orphan-verifier';
+    await repo.createAuthorizationCode({
+      consentId: 'consent-does-not-exist',
+      userId: 'user-1',
+      clientId,
+      codeHash: sha256Hex(code),
+      redirectUri: 'http://127.0.0.1:8789/cb',
+      scope: 'history:read progression:read workouts:write',
+      codeChallenge: pkceChallengeForVerifier(verifier),
+      codeChallengeMethod: 'S256',
+      expiresAt: new Date('2026-08-15T01:00:00.000Z')
+    });
+
+    const exchange = await request(app)
+      .post('/oauth/token')
+      .type('form')
+      .send({
+        grant_type: 'authorization_code',
+        client_id: clientId,
+        redirect_uri: 'http://127.0.0.1:8789/cb',
+        code,
+        code_verifier: verifier
+      });
+
+    expect(exchange.status).toBe(400);
+    expect(exchange.body.error).toBe('invalid_grant');
+    expect(exchange.body.error_description).toMatch(/consent/i);
+    expect(repo.tokens).toHaveLength(0);
+  });
+
+  it('exchanges a code for a dynamic client and serves MCP tools/list after consent is granted', async () => {
+    const { app, repo } = makeApp();
+
+    const registration = await request(app)
+      .post('/oauth/register')
+      .send({
+        redirect_uris: ['http://127.0.0.1:8789/cb'],
+        client_name: 'MCP-Happy'
+      });
+    expect(registration.status).toBe(201);
+    const clientId = registration.body.client_id;
+
+    const decision = await request(app)
+      .post('/oauth/authorize/decision')
+      .set('Authorization', 'Bearer supabase-user-token')
+      .send({
+        approve: true,
+        client_id: clientId,
+        redirect_uri: 'http://127.0.0.1:8789/cb',
+        scope: 'history:read progression:read workouts:write',
+        state: 'opaque-state',
+        code_challenge: 'dmVyLWNoYWxsZW5nZQ',
+        code_challenge_method: 'S256'
+      });
+
+    expect(decision.status).toBe(200);
+    const verifier = 'dynamic-happy-verifier';
+    repo.codes[0].code_challenge = pkceChallengeForVerifier(verifier);
+    const code = new URL(decision.body.redirectTo).searchParams.get('code');
+
+    const exchange = await request(app)
+      .post('/oauth/token')
+      .type('form')
+      .send({
+        grant_type: 'authorization_code',
+        client_id: clientId,
+        redirect_uri: 'http://127.0.0.1:8789/cb',
+        code,
+        code_verifier: verifier
+      });
+
+    expect(exchange.status).toBe(200);
+    expect(exchange.body.token_type).toBe('Bearer');
+
+    const list = await request(app)
+      .post('/mcp')
+      .set('Authorization', `Bearer ${exchange.body.access_token}`)
+      .send({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+
+    expect(list.status).toBe(200);
+    expect(list.body.result.tools.map((tool) => tool.name)).toEqual([
+      'plan_workout',
+      'read_history',
+      'read_exercise_progression'
+    ]);
+  });
+
+  it('revokes dynamic-client tokens across the family via /oauth/revoke', async () => {
+    const { app, repo } = makeApp();
+
+    const registration = await request(app)
+      .post('/oauth/register')
+      .send({
+        redirect_uris: ['http://127.0.0.1:8789/cb'],
+        client_name: 'MCP-Revoke'
+      });
+    const clientId = registration.body.client_id;
+
+    const decision = await request(app)
+      .post('/oauth/authorize/decision')
+      .set('Authorization', 'Bearer supabase-user-token')
+      .send({
+        approve: true,
+        client_id: clientId,
+        redirect_uri: 'http://127.0.0.1:8789/cb',
+        scope: 'history:read progression:read workouts:write',
+        state: 'opaque-state',
+        code_challenge: 'dmVyLWNoYWxsZW5nZQ',
+        code_challenge_method: 'S256'
+      });
+
+    const verifier = 'dynamic-revoke-verifier';
+    repo.codes[0].code_challenge = pkceChallengeForVerifier(verifier);
+    const code = new URL(decision.body.redirectTo).searchParams.get('code');
+
+    const exchange = await request(app)
+      .post('/oauth/token')
+      .type('form')
+      .send({
+        grant_type: 'authorization_code',
+        client_id: clientId,
+        redirect_uri: 'http://127.0.0.1:8789/cb',
+        code,
+        code_verifier: verifier
+      });
+
+    expect(exchange.status).toBe(200);
+
+    const revoke = await request(app)
+      .post('/oauth/revoke')
+      .type('form')
+      .send({ token: exchange.body.refresh_token });
+
+    expect(revoke.status).toBe(200);
+
+    const list = await request(app)
+      .post('/mcp')
+      .set('Authorization', `Bearer ${exchange.body.access_token}`)
+      .send({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+
+    expect(list.status).toBe(401);
+    expect(repo.consents[0].revoked_at).toBe('2026-08-03T00:00:00.000Z');
   });
 });


### PR DESCRIPTION
## Summary
- Add OAuth 2.0 Dynamic Client Registration (RFC 7591) to `services/gymtrack-mcp`. The endpoint is public-only — no `client_secret` is issued; `token_endpoint_auth_method` is restricted to `none`.
- Discovery at `/.well-known/oauth-authorization-server` now advertises `registration_endpoint` and `registration_endpoint_auth_methods_supported: ['none']` so any spec-following MCP client (OpenClaw, future third-party agents) can stop emitting `Incompatible auth server: does not support dynamic client registration`.
- Schema extension on `public.gymtrack_oauth_clients`: `registration_type` discriminator (`'static'` default for the four seeded rows, `'dynamic'` for DCR-registered rows) plus the nullable RFC 7591 §2 metadata columns (`client_uri`, `logo_uri`, `contacts`, `policy_uri`, `tos_uri`, `software_id`, `software_version`). No new table, no RLS change.
- AC5 (no new client can bypass consent) is satisfied by construction: the existing `getConsent(...).revoked_at` gate on `/oauth/token` and the active-consent unique index on `(user_id, client_id)` apply identically to dynamic clients because they key on `client_id` as an opaque string.
- The `openclaw` static row from PR #454 is left in place with `registration_type='static'` per the approved design; deletion is a follow-up cleanup task once AC3/AC4 are verified end-to-end against the deployed endpoint.

## System Spec
No system spec change — this PR implements an OAuth server extension in `services/gymtrack-mcp` and a single Supabase schema migration; the user-visible agent-connect flow in `apps/gymtrack/SPEC.md` (Connect to your agent CTA, OAuth dance) is unchanged in shape. Operator-facing surface is the runbook update below.

## Test plan
- [x] Run `npx vitest run services/gymtrack-mcp/test/app.test.js` from the repo root. Expected: 23/23 pass (11 pre-existing + 12 new DCR tests).
- [x] Run `node --check services/gymtrack-mcp/src/app.js` and `node --check services/gymtrack-mcp/src/repo.js`. Expected: clean exit.
- [ ] After merge: deploy to Fly and verify `curl -fsS https://gymtrack-mcp.fly.dev/.well-known/oauth-authorization-server | jq -e '.registration_endpoint'` returns the expected URL.
- [ ] After deploy: Tom runs `openclaw mcp login gymtrack` against the live endpoint and confirms a valid access token is stored.
- [ ] After deploy: Tom invokes `tools/list` and one `tools/call` from the OpenClaw MCP session.

## Acceptance Criteria
- [x] AC1: A tech design documents the DCR implementation approach (registration endpoint per RFC 7591, storage for dynamically-registered clients, how it composes with the existing static clients and the consent-approval gate in getConsent(...)/revoked_at, and whether the openclaw static client row from PR #454 is removed or left as dead config). (📄 not code: tech design shipped on feat/de19b186-oauth-dcr at docs/specs/gymtrack-mcp-oauth-dcr-tech-design.md, Quinn-approved 2026-08-18T13:17:52Z)
- [x] AC2: gymtrack-mcp exposes a working OAuth 2.0 Dynamic Client Registration endpoint (registration_endpoint advertised in server metadata) that a generic RFC 7591 client can register against. (🧪 testID: services/gymtrack-mcp/test/app.test.js — discovery advertises registration_endpoint, register valid client, reject missing/empty/wildcard/fragment/non-http redirect_uris, reject non-'none' token_endpoint_auth_method, silently drop unknown fields)
- [ ] AC3: openclaw mcp login gymtrack completes successfully end-to-end against the deployed gymtrack-mcp endpoint (real verification, not just unit tests) and OpenClaw obtains a valid access token. (⚠️ not tested: requires deployment to gymtrack-mcp.fly.dev + Tom's manual end-to-end run; deferred to follow-up workstream)
- [ ] AC4: An authenticated OpenClaw MCP session can list and invoke the GymTrack MCP tools (plan_workout, read_history, read_exercise_progression). (⚠️ not tested: depends on AC3's deployed endpoint + Tom's manual run; deferred to follow-up workstream)
- [x] AC5: No new client can access GymTrack data beyond what the user has consented to — dynamically registered clients still go through GymTrack's existing agent-consent approval screen before any token exchange succeeds. (🧪 testID: services/gymtrack-mcp/test/app.test.js — blocks dynamic clients from token exchange without an active consent for AC5)

## Followups
- Drop the static `openclaw` row from `public.gymtrack_oauth_clients` once AC3/AC4 are verified end-to-end (cleanup task, not bundled here per the approved design §Disposition).
- If registration abuse is observed in logs, add per-IP rate limiting at the Fly edge before bundling the rest of the §Out of scope list (confidential-client support, initial-access-tokens, admin list/revoke endpoint).

🤖 Generated with Claude Code
