### PR TITLE
fix(pr-open): verify reviewer request registered; fix direct-ask routing gap

### DIFF
--- a/agents/skills/dev/pr-open/SKILL.md
+++ b/agents/skills/dev/pr-open/SKILL.md
@@ -41,6 +41,8 @@ gh api user --jq '.login'
 
 If `gh pr create` fails with an auth/scope error (`Resource not accessible...`, `createPullRequest`, `Bad credentials`, etc.), fix the opener's GitHub token/config or escalate. Do **not** retry with another agent's token/account; that makes the PR unreviewable by that agent and breaks the opener-reviewer-merge split.
 
+**A PR with no requested reviewer is invisible to every heartbeat's review queue** — nobody's `reviewRequests` will ever surface it, no matter how long it sits open. Treat "reviewer(s) actually requested" as a checked postcondition of opening a PR, not just an intention: `--reviewer` can silently fail to register (typo'd login, self-request, revoked collaborator access) even when `gh pr create` itself exits 0.
+
 ```bash
 gh pr create \
   --repo Stoffer-Industries/sindustries \
@@ -67,6 +69,21 @@ No system spec change — <substantive reason, e.g. "CI-only fix, no user-facing
 EOF
 )"
 ```
+
+**Mandatory: verify the reviewer request actually registered, immediately after creating the PR.** Do not treat PR-open as complete until this check passes.
+
+```bash
+gh pr view <number> --repo Stoffer-Industries/sindustries --json reviewRequests \
+  --jq '.reviewRequests | length'
+```
+
+If this prints `0`, the PR is currently unreviewable by anyone's heartbeat queue. Fix it before moving on — re-add the intended reviewer(s) from the routing table in `agents/skills/dev/pr-process/SKILL.md`:
+
+```bash
+gh pr edit <number> --repo Stoffer-Industries/sindustries --add-reviewer <reviewer-github-username>
+```
+
+Then re-run the `reviewRequests` check above to confirm it's non-zero before considering the PR opened.
 
 **`## System Spec` is a documentation convention, not a lobster gate.** Note the path to the spec file you wrote or updated (`docs/systems/<file>.md`), or a short reason why none was touched. Nothing parses or blocks on this section — it's judgment-based, not automated, because doc content is too varied to check reliably in code.
 

--- a/agents/skills/dev/pr-process/SKILL.md
+++ b/agents/skills/dev/pr-process/SKILL.md
@@ -94,5 +94,6 @@ Concrete patterns in our workflows:
 - **Content tasks:** Assignee opens (`--assignee <self>`, `--reviewer quinn,Stoff81`, `--label content-task`). Quinn and Tom review. Assignee merges after the required approvals.
 - **Code-garden tasks:** Assignee opens with `--label code-garden`, reviewer reviews against the code-garden guardrail (no behavior change). Assignee merges after approval.
 - **Cross-repo PRs (workspace repo, infra scripts):** same pattern — assignee opens, reviewer reviews, assignee merges after approval.
+- **Direct-ask PRs (Tom asked in chat, bypassing the task queue):** the `direct-ask` label describes *origin*, not reviewer routing — it does not replace the blocking reviewer. Quinn is still the blocking reviewer (`--reviewer quinn`); add Tom too (`--reviewer quinn,Stoff81`) for visibility since he's the one who asked. Do not request only Tom — he's not in any agent's `reviewRequests` heartbeat queue, so a Tom-only review request means nobody's automation will ever pick it up, and it relies entirely on Tom manually noticing.
 
 The reviewer never merges. The assignee owns getting the PR accepted and merged.


### PR DESCRIPTION
## Summary
- Three PRs opened in the last 24h (#503, #504, #508) had zero requested reviewers on GitHub. Confirmed via the GitHub timeline API that no `review_requested` event ever fired for any of them — the `--reviewer` flag was omitted at creation time, not stripped later. A PR with no requested reviewer never surfaces in any agent's `reviewRequests` heartbeat queue, so it sits invisible indefinitely.
- Two other PRs (#505, #507) requested only Tom instead of Quinn as blocking reviewer, tracing to a gap in `pr-process/SKILL.md`'s routing table: `direct-ask` had a label defined but no reviewer-routing row, so the opener defaulted to "the person who asked" instead of the documented blocking-reviewer convention.
- `pr-open/SKILL.md`: added a mandatory post-creation check (`gh pr view --json reviewRequests`) that must show a non-zero count before PR-open is considered complete, with a `gh pr edit --add-reviewer` fix-up step if it doesn't.
- `pr-process/SKILL.md`: added an explicit direct-ask row to the role-mapping table — Quinn remains blocking reviewer, Tom is visibility-only, never Tom-only.

## System Spec
No system spec change — this is agent-workflow documentation (SKILL.md files), not application behavior.

## Test plan
- [ ] Read through `pr-open/SKILL.md`'s new verification step and confirm the `gh pr view`/`gh pr edit` commands are correct and copy-pasteable.
- [ ] Confirm the new direct-ask row in `pr-process/SKILL.md` matches how you'd want direct-ask PRs routed going forward.
- No code/logic changes — diff is purely documentation guiding future agent behavior.

🤖 Generated with Claude Code