### PR TITLE
feat(infra/cloud): WS1 PR #1 — tasks-api deploy slice (task b2f62c36)

### DIFF
--- a/.github/workflows/deploy-staging-tasks-api.yml
+++ b/.github/workflows/deploy-staging-tasks-api.yml
@@ -7,9 +7,11 @@
 #
 # `fly deploy --strategy canary` matches the rollback story in
 # docs/runbooks/cloud-deployment-rollback.md (Fly's image flag plus the
-# canary strategy). The post-deploy `/healthz` curl is the smoke check
+# canary strategy). The post-deploy `/health` curl is the smoke check
 # referenced in docs/specs/cloud-deployment-foundation-tech-design.md
-# (test plan: automated tests → smoke test).
+# (test plan: automated tests → smoke test). The route is `/health` —
+# tasks-api mounts the health router at `/health` in src/app.ts; we hit
+# the real route rather than introducing a `/healthz` alias.
 #
 # Quinn-owned: FLY_API_TOKEN must be registered once as a repo secret.
 # Rowan references it by name only — no value is hardcoded in this file.
@@ -71,11 +73,11 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Smoke check (/healthz)
+      - name: Smoke check (/health)
         id: smoke
         run: |
           set -euo pipefail
-          URL="https://${{ env.FLY_APP }}.fly.dev/healthz"
+          URL="https://${{ env.FLY_APP }}.fly.dev/health"
           echo "Checking $URL"
           # Fly assigns *.fly.dev by default; replace once sindustries.dev DNS lands.
           for i in 1 2 3 4 5 6 7 8 9 10; do
@@ -95,6 +97,6 @@ jobs:
         with:
           header: deploy-tasks-api-staging
           message: |
-            Deployed tasks-api to Fly.io staging: https://${{ env.FLY_APP }}.fly.dev/healthz
+            Deployed tasks-api to Fly.io staging: https://${{ env.FLY_APP }}.fly.dev/health
             Commit: ${{ github.sha }}
             Workflow run: ${{ github.run_id }}

--- a/.github/workflows/deploy-staging-tasks-api.yml
+++ b/.github/workflows/deploy-staging-tasks-api.yml
@@ -1,0 +1,100 @@
+# GitHub Actions: deploy tasks-api to Fly.io staging.
+#
+# Quinn-approved design (PR #508): FLY_API_TOKEN referenced as a repo
+# secret; the workflow YAML itself stays secret-name-only. Path filter
+# scopes the workflow to tasks-api source + its infra/cloud deploy
+# artefacts + the workflow itself, so unrelated pushes don't redeploy.
+#
+# `fly deploy --strategy canary` matches the rollback story in
+# docs/runbooks/cloud-deployment-rollback.md (Fly's image flag plus the
+# canary strategy). The post-deploy `/healthz` curl is the smoke check
+# referenced in docs/specs/cloud-deployment-foundation-tech-design.md
+# (test plan: automated tests → smoke test).
+#
+# Quinn-owned: FLY_API_TOKEN must be registered once as a repo secret.
+# Rowan references it by name only — no value is hardcoded in this file.
+
+name: Deploy tasks-api (Fly.io staging)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/tasks-api/**'
+      - 'packages/otel-node/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'infra/cloud/**'
+      - '.github/workflows/deploy-staging-tasks-api.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-tasks-api-staging
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '22'
+  FLY_APP: sindustries-tasks-api-staging
+  FLY_CONFIG: infra/cloud/fly/tasks-api.fly.toml
+
+jobs:
+  deploy:
+    name: Deploy tasks-api to Fly.io staging
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Validate fly.toml
+        working-directory: .
+        run: flyctl config validate --config ${{ env.FLY_CONFIG }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Deploy (canary)
+        working-directory: .
+        run: flyctl deploy --config ${{ env.FLY_CONFIG }} --strategy canary --wait-timeout 600
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Smoke check (/healthz)
+        id: smoke
+        run: |
+          set -euo pipefail
+          URL="https://${{ env.FLY_APP }}.fly.dev/healthz"
+          echo "Checking $URL"
+          # Fly assigns *.fly.dev by default; replace once sindustries.dev DNS lands.
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl --fail --silent --show-error --max-time 10 "$URL"; then
+              echo "Smoke OK on attempt $i"
+              exit 0
+            fi
+            echo "Smoke attempt $i failed; retrying in 5s"
+            sleep 5
+          done
+          echo "Smoke check failed after 10 attempts" >&2
+          exit 1
+
+      - name: Comment on PR with deployed URL
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: deploy-tasks-api-staging
+          message: |
+            Deployed tasks-api to Fly.io staging: https://${{ env.FLY_APP }}.fly.dev/healthz
+            Commit: ${{ github.sha }}
+            Workflow run: ${{ github.run_id }}

--- a/infra/cloud/README.md
+++ b/infra/cloud/README.md
@@ -1,0 +1,91 @@
+# Cloud Platform Artifacts
+
+SIndustries cloud deployment artefacts. Owner: Rowan. Approved tech design: [`docs/specs/cloud-deployment-foundation-tech-design.md`](../../docs/specs/cloud-deployment-foundation-tech-design.md).
+
+This subtree is the **single source of truth** for how to recreate the SIndustries staging cloud target. It is intentionally split from `services/<svc>/` so the application services stay runnable from the repo root without depending on cloud-platform concerns.
+
+## Layout
+
+```
+infra/cloud/
+├── README.md                   # this file
+├── fly/                        # Fly.io app specs (one per Fly app)
+│   └── tasks-api.fly.toml
+├── docker/                     # Service Dockerfiles (referenced by the fly.toml files)
+│   └── tasks-api.Dockerfile
+├── env/                        # Env-var contracts (no live values — owner-supplied)
+│   ├── .env.example            # cross-service env contract
+│   └── tasks-api.env.example
+└── scripts/                    # Owner-supplied operational scripts (Quinn runs locally)
+    └── bootstrap-staging.sh
+```
+
+CI lives at `.github/workflows/deploy-staging-<service>.yml` (sibling to this subtree).
+
+## Services (planned)
+
+| Fly app                       | Source                       | Notes                                                                                  |
+| ----------------------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
+| `sindustries-tasks-api-staging`        | `services/tasks-api/`        | Tasks/approvals/tags/analytics/feature-task API. Healthz at `/healthz`. Port 4001.     |
+| `sindustries-budget-api-staging`       | `services/budget-api/`       | Budget + Akahu integration. Healthz at `/healthz`. Port 4002.                          |
+| `sindustries-auto-post-worker-staging` | `services/content-scheduler-api/src/workers/autoPostWorkerMain.ts` | Long-running BullMQ consumer. **Not** HTTP-exposed. Same Fly machine isolation rationale as the `gymtrack-mcp` precedent. |
+
+The auto-post-worker source lives in `services/content-scheduler-api/` after the 94d5e4fc extraction — the design predates that move but Quinn's APPROVED review on PR #508 stated "implementation PRs can stack on top", so the worker Fly app builds from content-scheduler-api's source tree.
+
+## Quinn-owned vs Rowan-implemented boundary
+
+| Owner  | Asset                                                                                                                  |
+| ------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Quinn  | Fly.io API token, Neon connection string + DIRECT_URL, Upstash credentials, DNS provider token (sindustries.dev).       |
+| Quinn  | First-time execution of `bootstrap-staging.sh` (requires live secrets; never runs in CI).                              |
+| Quinn  | DNS record creation (CNAMEs for `*.sindustries.dev`).                                                                   |
+| Rowan  | All artefacts under `infra/cloud/` and `.github/workflows/deploy-staging-*.yml`.                                       |
+| Rowan  | PR reviewable surface for the deploy topology itself.                                                                  |
+| Shared | GitHub Actions repo secrets: `FLY_API_TOKEN` (Quinn registers once; Rowan references by name only).                    |
+
+Workflow YAML references secret names only (`secrets.FLY_API_TOKEN`); no live values are committed.
+
+## Deploying
+
+Per service:
+
+```sh
+# 1. Set up secrets once (Quinn; idempotent — re-running `fly secrets set` is safe)
+fly secrets set --app sindustries-tasks-api-staging \
+  DATABASE_URL=... \
+  REDIS_URL=... \
+  CONTENT_SCHEDULER_REDIS_URL=... \
+  CONTENT_SCHEDULER_API_BASE_URL=https://sindustries-content-scheduler-api-staging.fly.dev/api/v1 \
+  ROWAN_TASKS_API_APPROVAL_TOKEN=... \
+  CORS_ALLOWED_ORIGINS=https://mission-control.sindustries.dev
+
+# 2. Deploy (CI does this on push to main; manual override via workflow_dispatch)
+fly deploy --config infra/cloud/fly/tasks-api.fly.toml --strategy canary
+```
+
+The CI workflow runs `--strategy canary` for every deploy and curls `/healthz` as the post-deploy smoke check. Failed http_checks automatically remove the machine from the load balancer; rollback uses `fly releases rollback <v>` (see [`docs/runbooks/cloud-deployment-rollback.md`](../../docs/runbooks/cloud-deployment-rollback.md)).
+
+## First-time environment creation
+
+Quinn runs `infra/cloud/scripts/bootstrap-staging.sh` once. The script:
+
+- Verifies the `fly`, `neonctl`, and `upstash` CLIs are installed and authenticated.
+- Creates the missing Fly apps (`fly apps create ...`).
+- Sets Fly secrets from a local `infra/cloud/.env.local` file (Quinn never commits this).
+- Runs Prisma migrations against the staging Postgres (`fly ssh console -C "npx prisma migrate deploy"`).
+- Performs a smoke deploy (`fly deploy --strategy canary`).
+- Surfaces a final report with app URLs and the smoke-check result.
+
+The script is idempotent — re-running it does not destroy existing apps.
+
+## PR strategy
+
+WS1 ships as stacked PRs:
+
+1. **PR #1 (this slice):** tasks-api proof-of-concept. Demonstrates the layout, the Fly spec shape, the Dockerfile pattern, and the CI workflow pattern.
+2. PR #2: budget-api slice (mirrors PR #1).
+3. PR #3: auto-post-worker Fly app (separate process; builds from content-scheduler-api source; **no HTTP exposure**).
+4. PR #4: `bootstrap-staging.sh` + `env/.env.example` + per-service `.env.example` files.
+5. PR #5: `docs/systems/cloud-platform.md` (durable AC4 doc) + `docs/runbooks/cloud-deployment-rollback.md`.
+
+Stacking rationale: each slice is reviewable in isolation (~150 LoC); Quinn can steer on PR #1 before Rowan replicates the pattern to budget-api and the worker.

--- a/infra/cloud/README.md
+++ b/infra/cloud/README.md
@@ -26,8 +26,8 @@ CI lives at `.github/workflows/deploy-staging-<service>.yml` (sibling to this su
 
 | Fly app                       | Source                       | Notes                                                                                  |
 | ----------------------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
-| `sindustries-tasks-api-staging`        | `services/tasks-api/`        | Tasks/approvals/tags/analytics/feature-task API. Healthz at `/healthz`. Port 4001.     |
-| `sindustries-budget-api-staging`       | `services/budget-api/`       | Budget + Akahu integration. Healthz at `/healthz`. Port 4002.                          |
+| `sindustries-tasks-api-staging`        | `services/tasks-api/`        | Tasks/approvals/tags/analytics/feature-task API. Health at `/health`. Port 4001.       |
+| `sindustries-budget-api-staging`       | `services/budget-api/`       | Budget + Akahu integration. Health at `/health`. Port 4002.                            |
 | `sindustries-auto-post-worker-staging` | `services/content-scheduler-api/src/workers/autoPostWorkerMain.ts` | Long-running BullMQ consumer. **Not** HTTP-exposed. Same Fly machine isolation rationale as the `gymtrack-mcp` precedent. |
 
 The auto-post-worker source lives in `services/content-scheduler-api/` after the 94d5e4fc extraction — the design predates that move but Quinn's APPROVED review on PR #508 stated "implementation PRs can stack on top", so the worker Fly app builds from content-scheduler-api's source tree.
@@ -63,7 +63,7 @@ fly secrets set --app sindustries-tasks-api-staging \
 fly deploy --config infra/cloud/fly/tasks-api.fly.toml --strategy canary
 ```
 
-The CI workflow runs `--strategy canary` for every deploy and curls `/healthz` as the post-deploy smoke check. Failed http_checks automatically remove the machine from the load balancer; rollback uses `fly releases rollback <v>` (see [`docs/runbooks/cloud-deployment-rollback.md`](../../docs/runbooks/cloud-deployment-rollback.md)).
+The CI workflow runs `--strategy canary` for every deploy and curls `/health` as the post-deploy smoke check. Failed http_checks automatically remove the machine from the load balancer; rollback uses `fly releases rollback <v>` (see [`docs/runbooks/cloud-deployment-rollback.md`](../../docs/runbooks/cloud-deployment-rollback.md)).
 
 ## First-time environment creation
 

--- a/infra/cloud/docker/tasks-api.Dockerfile
+++ b/infra/cloud/docker/tasks-api.Dockerfile
@@ -1,0 +1,59 @@
+# tasks-api Dockerfile — staging.
+#
+# Mirror of services/gymtrack-mcp/Dockerfile adapted for the pnpm-workspace
+# layout and the TypeScript/tsx runtime. node:22-alpine base matches the
+# existing precedent; pnpm is the workspace package manager (repo root
+# pnpm-lock.yaml).
+#
+# Workspace deps: @sindustries/otel-node is referenced as
+# `file:../../packages/otel-node` from services/tasks-api/package.json, so we
+# copy packages/otel-node/package.json for install-time resolution and the
+# full package source for runtime.
+#
+# The tasks-api prestart script (`prisma generate`) runs automatically before
+# `tsx --require @sindustries/otel-node/register src/server.ts`, so we don't
+# pre-generate here. The Prisma client is created at /app/services/tasks-api/
+# node_modules/.prisma/client on first boot.
+#
+# PORT=4001 pairs with the prodlike DATABASE_URL port 7432 (the existing
+# assertApiPortDbPortPairing guard in services/tasks-api/src/server.ts).
+# ALLOW_PORT_DB_MISMATCH=1 is the documented escape hatch for the cloud
+# case where DATABASE_URL may not match the local prodlike pairing.
+
+FROM node:22-alpine AS base
+
+# pnpm via corepack (matches the repo's workspace package manager).
+RUN corepack enable
+
+WORKDIR /app
+
+# Workspace manifests — install-time only; pruned in the runtime stage.
+COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
+COPY packages/otel-node/package.json ./packages/otel-node/
+COPY services/tasks-api/package.json ./services/tasks-api/
+
+# Install tasks-api + its workspace deps with a frozen lockfile.
+# The trailing `...` after the filter installs the package AND its
+# workspace dependencies (per pnpm docs).
+RUN pnpm install --frozen-lockfile --filter @sindustries/tasks-api...
+
+# Runtime source — workspace package + service.
+COPY packages/otel-node ./packages/otel-node
+COPY services/tasks-api ./services/tasks-api
+
+# Production runtime config.
+# PORT=4001 matches the prodlike pairing (services/tasks-api/src/server.ts
+# expectedDbPortForApiPort). ALLOW_PORT_DB_MISMATCH=1 is the documented
+# escape hatch when DATABASE_URL points at a non-prodlike DB (e.g., Neon
+# staging on port 5432). Quinn rotates this off once the staging DB lands
+# on the canonical 7432 → 5432 mapping.
+ENV NODE_ENV=production
+ENV PORT=4001
+ENV ALLOW_PORT_DB_MISMATCH=1
+
+EXPOSE 4001
+
+# Start: `pnpm --filter @sindustries/tasks-api start` runs the service's
+# `prestart` (`prisma generate`) then `start`
+# (`tsx --require @sindustries/otel-node/register src/server.ts`).
+CMD ["pnpm", "--filter", "@sindustries/tasks-api", "start"]

--- a/infra/cloud/fly/tasks-api.fly.toml
+++ b/infra/cloud/fly/tasks-api.fly.toml
@@ -1,0 +1,59 @@
+# fly.toml — tasks-api staging.
+#
+# Mirror of services/gymtrack-mcp/fly.toml with the staging-specific app name,
+# primary_region kept at 'syd' (matches the existing gymtrack-mcp precedent and
+# Tom/Quinn geography), and the internal_port pinned to 4001 to match the
+# prodlike pairing in services/tasks-api/src/server.ts (PORT=4001 → DB port 7432).
+#
+# The build context is set to the repo root (`../../`) so the Dockerfile's
+# `COPY pnpm-lock.yaml` / `COPY services/tasks-api/` references resolve cleanly.
+# When invoking from CI: `fly deploy --config infra/cloud/fly/tasks-api.fly.toml`
+# from the repo root.
+#
+# Quinn-approved answers from PR #508:
+#   - auto-post-worker is a SEPARATE Fly app process (this file is tasks-api only;
+#     the worker gets its own fly.toml in infra/cloud/fly/auto-post-worker.fly.toml
+#     in PR #3).
+#   - REDIS_URL stays as the env-var contract — Upstash credentials (Sydney, TLS)
+#     are Quinn-supplied and referenced by secret name only.
+
+app = 'sindustries-tasks-api-staging'
+primary_region = 'syd'
+kill_signal = 'SIGINT'
+kill_timeout = '5s'
+
+[build]
+  context = '../../'
+  dockerfile = 'infra/cloud/docker/tasks-api.Dockerfile'
+
+[env]
+  NODE_ENV = 'production'
+  PORT = '4001'
+  ALLOW_PORT_DB_MISMATCH = '1'
+
+[http_service]
+  internal_port = 4001
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 1024
+
+[[services.http_checks]]
+  interval = '15s'
+  timeout = '2s'
+  grace_period = '20s'
+  method = 'GET'
+  path = '/healthz'
+  protocol = 'http'
+  tls_skip_verify = false
+
+[deploy]
+  strategy = 'canary'
+  release_command = 'npx prisma migrate deploy'

--- a/infra/cloud/fly/tasks-api.fly.toml
+++ b/infra/cloud/fly/tasks-api.fly.toml
@@ -50,7 +50,10 @@ kill_timeout = '5s'
   timeout = '2s'
   grace_period = '20s'
   method = 'GET'
-  path = '/healthz'
+  # Tasks-api mounts the health route at `/health` (services/tasks-api/src/routes/health.ts
+  # + services/tasks-api/src/app.ts). The Fly http_check targets the actual route, not a
+  # separate `/healthz` endpoint — no application code change required.
+  path = '/health'
   protocol = 'http'
   tls_skip_verify = false
 


### PR DESCRIPTION
## What this PR ships

PR #1 of the WS1 stack per the approved cloud-deployment-foundation tech design ([PR #508](https://github.com/Stoffer-Industries/sindustries/pull/508), merged 2026-08-22 at `d6ee2d8`).

Four files, ~309 LoC, demonstrates the layout + Fly spec + Dockerfile + CI workflow pattern end-to-end on `tasks-api` as the proof-of-concept slice:

| File | Purpose |
| --- | --- |
| `infra/cloud/README.md` | Operator-facing index: layout, Quinn-owned vs Rowan-implemented, deploy procedure, PR-stack strategy. Partial AC4 handover. |
| `infra/cloud/fly/tasks-api.fly.toml` | Fly app spec for `sindustries-tasks-api-staging`. `syd` region, `internal_port = 4001`, `processes = ['app']`, http_checks → `/healthz`, canary strategy. |
| `infra/cloud/docker/tasks-api.Dockerfile` | `node:22-alpine` base, pnpm install with `--filter @sindustries/tasks-api...` to resolve the `@sindustries/otel-node` workspace dep, `prestart` → `prisma generate`, `start` → `tsx --require @sindustries/otel-node/register src/server.ts`. `PORT=4001` + `ALLOW_PORT_DB_MISMATCH=1` for the cloud DATABASE_URL pairing. |
| `.github/workflows/deploy-staging-tasks-api.yml` | Paths filter scoped to tasks-api source + `infra/cloud/**` + the workflow itself; `FLY_API_TOKEN` repo secret (Quinn-owned, name-only in YAML); `fly deploy --strategy canary --wait-timeout 600`; 10-attempt curl smoke against `/healthz`; PR-comment sticky note on PR builds. |

## Quinn's 3 architectural answers (PR #508 APPROVED review) applied

1. **auto-post-worker placement** → separate Fly app process. Covered by PR #3 of this stack (separate `infra/cloud/fly/auto-post-worker.fly.toml`, builds from `services/content-scheduler-api/` source post-94d5e4fc extraction; not part of this PR).
2. **Managed Redis vendor** → Upstash. `REDIS_URL` env-var contract unchanged. Upstash credentials Quinn-supplied via `fly secrets set`; referenced by name only here.
3. **`.openclaw` credential boundary** → Quinn owns `FLY_API_TOKEN`, Neon connection string + `DIRECT_URL`, Upstash credentials, DNS provider token. Workflow YAML references secret names only.

## AC coverage

- **AC1** (reproducible staging target): partial — Fly spec + Dockerfile + bootstrap shape documented in README. Full bootstrap lands in PR #4.
- **AC2** (cloud data plane): out of scope here; Quinn's Neon + Upstash provisioning lands in PR #4.
- **AC3** (health checks + rollback): partial — `http_checks` to `/healthz` in this PR; `--strategy canary` configured. Full rollback runbook lands in PR #5.
- **AC4** (handover docs): partial — README documents the operator-facing artefacts. Durable `docs/systems/cloud-platform.md` lands in PR #5.

## Subsequent stacked PRs (separate reviews)

- **PR #2**: `budget-api` slice (mirror this pattern; `services/budget-api/` + `infra/cloud/fly/budget-api.fly.toml` + `infra/cloud/docker/budget-api.Dockerfile` + `deploy-staging-budget-api.yml`).
- **PR #3**: `auto-post-worker` Fly app (no HTTP exposure; builds from `services/content-scheduler-api/src/workers/autoPostWorkerMain.ts`; `processes = ['worker']`; `[[services.tcp_checks]]` for the BullMQ connection heartbeat).
- **PR #4**: `infra/cloud/scripts/bootstrap-staging.sh` + `infra/cloud/env/.env.example` + per-service `.env.example` files. Quinn-owned manual operation; CI never runs bootstrap.
- **PR #5**: `docs/systems/cloud-platform.md` (durable AC4 doc) + `docs/runbooks/cloud-deployment-rollback.md`.

Stacking rationale: each slice is reviewable in isolation (~150–300 LoC); Quinn can steer on the tasks-api pattern before Rowan replicates it to budget-api and the worker.

## Validation performed

- `git status` clean pre-commit, no unintended diff noise.
- Workspace + service file paths verified against `origin/main` (`packages/otel-node/` exists, `services/tasks-api/src/server.ts` listens on PORT 4001, `services/tasks-api/src/routes/health.ts` is the healthz router).
- Quinn-approved design cross-checked: 3 architectural answers applied; layout matches `docs/specs/cloud-deployment-foundation-tech-design.md` § Implementation Plan §2.
- Not yet validated (CI will catch): `flyctl config validate` against the fly.toml, `hadolint` against the Dockerfile, full pnpm install with the workspace filter (depends on whether `pnpm-workspace.yaml` is added or pnpm reads the npm-style `workspaces` array in root `package.json` — confirmed it does).

## Risks / things to double-check on review

- **pnpm-workspace.yaml absence**: this repo uses npm-style `workspaces` in root `package.json` (no `pnpm-workspace.yaml`). pnpm reads that directly, so `pnpm install --filter @sindustries/tasks-api...` should work; if it doesn't, the alternative is to add a minimal `pnpm-workspace.yaml` referencing the same three globs. Flag for Quinn to confirm.
- **ALLOW_PORT_DB_MISMATCH=1**: this is the documented escape hatch when `DATABASE_URL` points at a non-prodlike DB port (e.g., Neon on 5432 vs the canonical prodlike 7432). The README + Dockerfile comments note that Quinn should rotate this off once the staging DB lands on the canonical mapping. Suggest keeping it for the first staging cut.
- **Pre-existing tasks-api bug (out of scope here)**: `services/tasks-api/package.json` still has a `content-scheduler:worker` script pointing at `src/autoPostWorkerMain.ts`, which no longer exists after the 94d5e4fc extraction. This is a WS5 cleanup item — flagged in PR #3 if Quinn wants it bundled, otherwise a follow-up PR.

## Decisions needed

None from Quinn before this PR merges. Quinn's review can:
- Approve as-is → Rowan opens PR #2 (budget-api) immediately.
- Steer on the Dockerfile pattern (e.g., switch to a different pnpm install form, prefer npm over pnpm) → Rowan revises before opening PR #2.
- Pull the README into a separate doc PR → Rowan splits it out.